### PR TITLE
feat(监控): 增强 NetFlow/sFlow 流量分析仪表盘布局与 Top 排行

### DIFF
--- a/web/src/app/monitor/(pages)/view/dashboard/[objectKey]/page.tsx
+++ b/web/src/app/monitor/(pages)/view/dashboard/[objectKey]/page.tsx
@@ -46,7 +46,7 @@ export default function ProfessionalDashboardPage() {
     };
   }, [objectKey]);
 
-  if (DashboardComponent && loadedObjectKey) {
+  if (DashboardComponent && loadedObjectKey === objectKey) {
     return <DashboardComponent key={loadedObjectKey} />;
   }
 

--- a/web/src/app/monitor/(pages)/view/dashboard/[objectKey]/page.tsx
+++ b/web/src/app/monitor/(pages)/view/dashboard/[objectKey]/page.tsx
@@ -12,6 +12,7 @@ export default function ProfessionalDashboardPage() {
   const params = useParams<{ objectKey: string }>();
   const objectKey = normalizeDashboardKey(params?.objectKey);
   const [DashboardComponent, setDashboardComponent] = useState<ComponentType | null>(null);
+  const [loadedObjectKey, setLoadedObjectKey] = useState<string>('');
   const [loadState, setLoadState] = useState<'loading' | 'ready' | 'missing'>('loading');
 
   useResolveObjectId(params?.objectKey || '');
@@ -19,20 +20,25 @@ export default function ProfessionalDashboardPage() {
   useEffect(() => {
     let active = true;
     setLoadState('loading');
-    setDashboardComponent(null);
 
     loadDashboardComponent(objectKey)
       .then((component) => {
         if (!active) return;
         if (component) {
           setDashboardComponent(() => component);
+          setLoadedObjectKey(objectKey);
           setLoadState('ready');
         } else {
+          setDashboardComponent(null);
+          setLoadedObjectKey('');
           setLoadState('missing');
         }
       })
       .catch(() => {
-        if (active) setLoadState('missing');
+        if (!active) return;
+        setDashboardComponent(null);
+        setLoadedObjectKey('');
+        setLoadState('missing');
       });
 
     return () => {
@@ -40,16 +46,16 @@ export default function ProfessionalDashboardPage() {
     };
   }, [objectKey]);
 
+  if (DashboardComponent && loadedObjectKey) {
+    return <DashboardComponent key={loadedObjectKey} />;
+  }
+
   if (loadState === 'loading') {
     return (
       <div className="flex justify-center items-center" style={{ minHeight: 240 }}>
         <Spin />
       </div>
     );
-  }
-
-  if (DashboardComponent) {
-    return <DashboardComponent />;
   }
 
   return <Empty description="未找到对应的专业仪表盘" style={{ margin: '120px auto' }} />;

--- a/web/src/app/monitor/(pages)/view/dashboard/layout.tsx
+++ b/web/src/app/monitor/(pages)/view/dashboard/layout.tsx
@@ -3,10 +3,15 @@
 import React from 'react';
 import { usePathname } from 'next/navigation';
 import { DashboardSidebar } from '@/app/monitor/dashboards/components/dashboard-sidebar';
+import {
+  DashboardProtocolBarSlotProvider,
+} from '@/app/monitor/dashboards/shared/widgets/dashboard-protocol-bar-slot';
+import { DashboardProtocolBarHost } from '@/app/monitor/dashboards/shared/widgets/dashboard-protocol-bar-host';
 import styles from '@/app/monitor/dashboards/components/dashboard-sidebar.module.scss';
 
 /**
  * 侧栏放在 [objectKey] 之上，切换仪表盘时只换右侧内容，左侧对象树不重挂、不重新拉数。
+ * 采集视图条在 layout 保活，经 portal 挂到各盘实例卡下方 slot。
  */
 export default function ProfessionalDashboardLayout({
   children
@@ -20,11 +25,16 @@ export default function ProfessionalDashboardLayout({
     dashboardIndex >= 0 ? segments[dashboardIndex + 1] || '' : '';
 
   return (
-    <div className={styles.layout}>
-      <div className={styles.sidebar}>
-        <DashboardSidebar currentObjectKey={objectKey} />
+    <DashboardProtocolBarSlotProvider>
+      <div className={styles.layout}>
+        <div className={styles.sidebar}>
+          <DashboardSidebar currentObjectKey={objectKey} />
+        </div>
+        <div className={styles.content}>
+          {children}
+          <DashboardProtocolBarHost />
+        </div>
       </div>
-      <div className={styles.content}>{children}</div>
-    </div>
+    </DashboardProtocolBarSlotProvider>
   );
 }

--- a/web/src/app/monitor/dashboards/objects/common/dashboard-components.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/dashboard-components.tsx
@@ -29,7 +29,6 @@ import {
   CollectionStatusCard,
   DashboardInstanceCard,
   DashboardPageHeader,
-  CollectProtocolBar,
   HorizontalBarPanel,
   MiniTrendChart,
   RingChartPanel,
@@ -37,6 +36,7 @@ import {
   TitleWithGuide,
   TrendChartPanel
 } from '../../shared/widgets';
+import { DashboardProtocolBarSlot } from '../../shared/widgets/dashboard-protocol-bar-slot';
 import { GuideItem } from '../../shared/types';
 import { FLOW_VIEW_SWITCH_ROUTE_KEYS, resolvePreferredCollectTypeFromRoute } from '../../shared/utils/flow-view-navigation';
 import { isFlowSupportedObjectName } from '../flow-common/constants';
@@ -751,15 +751,7 @@ export const DashboardShell = ({
         />
       </div>
 
-      {showProtocolBar && dashboard.isDashboardMode ? (
-        <CollectProtocolBar
-          routeKey={dashboard.routeKey}
-          monitorObjectName={dashboard.monitorObjectName}
-          monitorObjectId={dashboard.monitorObjectId}
-          instanceId={dashboard.instanceId}
-          styles={styles}
-        />
-      ) : null}
+      {showProtocolBar && dashboard.isDashboardMode ? <DashboardProtocolBarSlot /> : null}
 
       {dashboard.displayMode === 'dashboard' ? (
         <>{dashboardContent}</>

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard.module.scss
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard.module.scss
@@ -35,6 +35,8 @@
   gap: 10px;
   margin: 8px 0 16px;
   padding: 0 2px;
+  // 切换路由/刷新插件时保留高度，避免采集视图条消失导致内容区跳动。
+  min-height: 32px;
 }
 
 .protocolBarLabel {

--- a/web/src/app/monitor/dashboards/objects/flow-common/constants.ts
+++ b/web/src/app/monitor/dashboards/objects/flow-common/constants.ts
@@ -17,6 +17,7 @@ export const MONITOR_OBJECT_TO_INSTANCE_TYPE: Record<FlowSupportedObjectName, st
 export type FlowProtocol = 'netflow' | 'sflow';
 
 export const CONVERSATION_TOP_N = 10;
+export const PROTOCOL_TOP_N = 10;
 
 export const resolveInstanceTypeFromObjectName = (objectName?: string | null): string | null => {
   const normalized = String(objectName || '').trim();

--- a/web/src/app/monitor/dashboards/objects/flow-common/conversation-table.tsx
+++ b/web/src/app/monitor/dashboards/objects/flow-common/conversation-table.tsx
@@ -1,16 +1,18 @@
 'use client';
 
 import React, { useEffect, useMemo, useState } from 'react';
-import { Table, Tooltip } from 'antd';
-import type { TableColumnsType } from 'antd';
+import { Spin } from 'antd';
 import { useSearchParams } from 'next/navigation';
 import useViewApi from '@/app/monitor/api/view';
+import ChartEmptyState from '@/components/chart-empty-state';
 import { DashboardPanel } from '../../shared/widgets';
 import { buildSearchParams, formatMetricValue } from '../../shared/utils';
 import { useSimpleDashboardData } from '../common/simple-dashboard-core';
 import type { FlowProtocol } from './constants';
 import { buildConversationTopQuery } from './queries';
 import { parseConversationRows, type FlowConversationRow } from './parse-conversation-rows';
+import { formatProtocolShortName } from './protocol-labels';
+import { resolveFlowRankClass } from './rank-class';
 
 interface FlowConversationTableProps {
   dashboard: ReturnType<typeof useSimpleDashboardData>;
@@ -19,10 +21,29 @@ interface FlowConversationTableProps {
   styles: Record<string, string>;
 }
 
+const CONVERSATION_GUIDE = [{
+  label: 'Top 会话',
+  detail: '所选时间窗内平均流量速率最高的 10 组会话，按源/目的地址、端口与协议聚合展示。',
+}];
+
 const formatBytesRate = (value: number | null) => {
   if (value == null) return '--';
   const formatted = formatMetricValue(value, 'byteps');
   return `${formatted.value}${formatted.unit || ''}`;
+};
+
+const resolveProtocolClass = (label: string, styles: Record<string, string>) => {
+  const normalized = formatProtocolShortName(label).toUpperCase();
+  if (normalized === 'TCP') return styles.flowProtocolTcp;
+  if (normalized === 'UDP') return styles.flowProtocolUdp;
+  if (normalized === 'ICMP' || normalized === 'ICMPV6') return styles.flowProtocolIcmp;
+  return styles.flowProtocolOther;
+};
+
+const formatPort = (port: string) => {
+  const normalized = String(port || '').trim();
+  if (!normalized || normalized === '--' || normalized === '0') return '*';
+  return normalized;
 };
 
 export function FlowConversationTable({
@@ -71,7 +92,7 @@ export function FlowConversationTable({
       setLoading(false);
     };
 
-    load();
+    void load();
 
     return () => {
       active = false;
@@ -89,67 +110,92 @@ export function FlowConversationTable({
     protocol,
   ]);
 
-  const columns: TableColumnsType<FlowConversationRow> = [
-    {
-      title: '#',
-      key: 'rank',
-      width: 48,
-      render: (_value, _row, index) => index + 1,
-    },
-    {
-      title: '源 IP',
-      dataIndex: 'srcIp',
-      key: 'srcIp',
-      width: 132,
-      ellipsis: true,
-    },
-    {
-      title: (
-        <Tooltip title="会话聚合维度不含源端口，当前版本显示为 --">
-          <span>源端口</span>
-        </Tooltip>
-      ),
-      dataIndex: 'srcPort',
-      key: 'srcPort',
-      width: 72,
-      align: 'center',
-    },
-    {
-      title: '目的 IP',
-      dataIndex: 'dstIp',
-      key: 'dstIp',
-      width: 132,
-      ellipsis: true,
-    },
-    { title: '目的端口', dataIndex: 'dstPort', key: 'dstPort', width: 88, align: 'center' },
-    { title: '协议', dataIndex: 'protocol', key: 'protocol', width: 108, ellipsis: true },
-    {
-      title: '流量速率',
-      dataIndex: 'bytesRate',
-      key: 'bytesRate',
-      align: 'right',
-      width: 112,
-      render: (value: number) => formatBytesRate(value),
-    },
-  ];
+  const peakRate = useMemo(
+    () => (rows.length ? Math.max(...rows.map((row) => row.bytesRate)) : 0),
+    [rows],
+  );
 
   return (
     <DashboardPanel
       title="Top 会话"
-      subtitle="所选时间窗内平均流量速率最高的 10 组会话，按源/目的 IP、目的端口与协议聚合"
-      className={`${styles.span12} ${styles.flowTablePanel}`}
-      bodyClassName={styles.flowTableWrap}
+      subtitle="Top 10 会话 · 按源/目的地址、端口与协议聚合"
+      guide={CONVERSATION_GUIDE}
+      className={`${styles.span8} ${styles.flowConversationPanel}`}
+      bodyClassName={styles.flowConversationBody}
       styles={styles}
     >
-      <Table<FlowConversationRow>
-        rowKey="rowKey"
-        size="small"
-        loading={loading}
-        columns={columns}
-        dataSource={rows}
-        pagination={false}
-        locale={{ emptyText: '所选时间窗内无 Flow 会话数据' }}
-      />
+      <Spin spinning={loading}>
+        {!loading && rows.length === 0 ? (
+          <div className={styles.flowConversationEmpty}>
+            <ChartEmptyState description="所选时间窗内无 Flow 会话数据" compact />
+          </div>
+        ) : (
+          <div
+            className={[
+              styles.flowConversationTableWrap,
+              protocol === 'netflow' ? styles.flowConversationNetflow : styles.flowConversationSflow,
+            ].join(' ')}
+          >
+            <table className={styles.flowConversationTable}>
+              <colgroup>
+                <col className={styles.flowColRank} />
+                <col className={styles.flowColIp} />
+                <col className={styles.flowColIp} />
+                <col className={styles.flowColPort} />
+                <col className={styles.flowColPort} />
+                <col className={styles.flowColProtocol} />
+                <col className={styles.flowColTraffic} />
+              </colgroup>
+              <thead>
+                <tr>
+                  <th scope="col" className={styles.flowColRank}>#</th>
+                  <th scope="col" className={styles.flowColIp}>源地址</th>
+                  <th scope="col" className={styles.flowColIp}>目的地址</th>
+                  <th scope="col" className={styles.flowColPort}>源端口</th>
+                  <th scope="col" className={styles.flowColPort}>目的端口</th>
+                  <th scope="col" className={styles.flowColProtocol}>协议</th>
+                  <th scope="col" className={styles.flowColTraffic}>流量</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row, index) => {
+                  const share = peakRate > 0 ? (row.bytesRate / peakRate) * 100 : 0;
+                  return (
+                    <tr key={row.rowKey} className={resolveFlowRankClass(index, styles)}>
+                      <td className={styles.flowCellRank}>
+                        <span className={styles.flowProtocolRankMark}>{index + 1}</span>
+                      </td>
+                      <td className={styles.flowCellIp} title={row.srcIp}>{row.srcIp}</td>
+                      <td className={styles.flowCellIp} title={row.dstIp}>{row.dstIp}</td>
+                      <td className={styles.flowCellPort}>{formatPort(row.srcPort)}</td>
+                      <td className={styles.flowCellPort}>{formatPort(row.dstPort)}</td>
+                      <td className={styles.flowCellProtocol}>
+                        <span
+                          className={[
+                            styles.flowProtocolBadge,
+                            resolveProtocolClass(row.protocol, styles),
+                          ].join(' ')}
+                        >
+                          {formatProtocolShortName(row.protocol)}
+                        </span>
+                      </td>
+                      <td className={styles.flowCellTraffic}>
+                        <span className={styles.flowTrafficValue}>{formatBytesRate(row.bytesRate)}</span>
+                        <span className={styles.flowTrafficTrack}>
+                          <span
+                            className={styles.flowTrafficFill}
+                            style={{ width: `${Math.max(share, 4)}%` }}
+                          />
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Spin>
     </DashboardPanel>
   );
 }

--- a/web/src/app/monitor/dashboards/objects/flow-common/flow-dashboard-page.tsx
+++ b/web/src/app/monitor/dashboards/objects/flow-common/flow-dashboard-page.tsx
@@ -21,6 +21,7 @@ import {
 } from './constants';
 import { createFlowDashboardConfig } from './create-flow-config';
 import { FlowConversationTable } from './conversation-table';
+import { FlowProtocolBreakdown } from './protocol-breakdown';
 import styles from './index.module.scss';
 
 const SUMMARY_TITLES = ['总流量速率', '总包速率', '平均包大小', '有效采样率'];
@@ -66,13 +67,23 @@ function FlowDashboardMetricsView({
           <div className={styles.sectionLabel}>流量概览</div>
           <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={5} styles={styles} />
 
-          <div className={styles.sectionLabel}>Top 会话</div>
-          <FlowConversationTable
-            dashboard={dashboard}
-            protocol={protocol}
-            instanceType={instanceType}
-            styles={styles}
-          />
+          <div className={styles.sectionLabel}>流量分析</div>
+          <section className={styles.dashboardSection}>
+            <div className={`${styles.sectionGrid} ${styles.flowAnalysisGrid}`}>
+              <FlowConversationTable
+                dashboard={dashboard}
+                protocol={protocol}
+                instanceType={instanceType}
+                styles={styles}
+              />
+              <FlowProtocolBreakdown
+                dashboard={dashboard}
+                protocol={protocol}
+                instanceType={instanceType}
+                styles={styles}
+              />
+            </div>
+          </section>
         </>
       }
     />

--- a/web/src/app/monitor/dashboards/objects/flow-common/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/flow-common/index.module.scss
@@ -15,25 +15,553 @@
   margin-top: 8px;
 }
 
-.flowTablePanel {
-  min-height: 280px;
+.flowAnalysisGrid {
+  align-items: stretch;
+  --flow-table-head-height: 33px;
+  --flow-rank-row-height: 48px;
 }
 
-.flowTableWrap {
-  :global(.ant-table) {
-    background: transparent;
-    table-layout: fixed;
+.flowConversationPanel,
+.flowProtocolPanel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.flowConversationBody,
+.flowProtocolBody {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding-top: 2px;
+  min-height: 0;
+}
+
+.flowProtocolBody :global(.ant-spin-nested-loading),
+.flowProtocolBody :global(.ant-spin-container) {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.flowConversationBody :global(.ant-spin-nested-loading),
+.flowConversationBody :global(.ant-spin-container) {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.flowConversationEmpty,
+.flowProtocolEmpty {
+  display: flex;
+  flex: 1;
+  min-height: 220px;
+  align-items: center;
+  justify-content: center;
+}
+
+.flowConversationTableWrap {
+  flex: 1;
+  min-height: 0;
+  overflow-x: auto;
+  border: 1px solid #dbe3ef;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.flowConversationTable {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+  font-variant-numeric: tabular-nums;
+}
+
+.flowConversationTable thead th {
+  height: var(--flow-table-head-height);
+  padding: 0 10px;
+  border-bottom: 1px solid #dbe3ef;
+  background: #f3f6fa;
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 700;
+  text-align: left;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+.flowConversationTable tbody tr {
+  height: var(--flow-rank-row-height);
+}
+
+.flowConversationTable tbody td {
+  padding: 0 10px;
+  border-bottom: 1px solid #edf2f7;
+  font-size: 12px;
+  color: #22324a;
+  vertical-align: middle;
+}
+
+.flowColRank {
+  width: 40px;
+}
+
+.flowConversationTable tbody td.flowCellRank {
+  padding: 0 6px;
+  text-align: center;
+  vertical-align: middle;
+}
+
+.flowCellRank {
+  line-height: 0;
+}
+
+.flowConversationTable tbody tr.flowProtocolRank1 .flowProtocolRankMark {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.flowConversationTable tbody tr.flowProtocolRank4 .flowProtocolRankMark,
+.flowConversationTable tbody tr.flowProtocolRank5 .flowProtocolRankMark {
+  background: #f1f5f9;
+  color: #94a3b8;
+  font-size: 10px;
+}
+
+.flowColIp {
+  width: 18%;
+}
+
+.flowColPort {
+  width: 10%;
+}
+
+.flowColProtocol {
+  width: 12%;
+}
+
+.flowColTraffic {
+  width: 27%;
+}
+
+.flowConversationTable thead th.flowColRank {
+  padding-left: 8px;
+  padding-right: 4px;
+  text-align: center;
+}
+
+.flowConversationTable tbody td.flowCellPort {
+  padding-left: 6px;
+  padding-right: 8px;
+}
+
+.flowConversationTable thead th.flowColProtocol,
+.flowConversationTable tbody td.flowCellProtocol {
+  padding-left: 8px;
+  padding-right: 8px;
+}
+
+.flowConversationTable thead th.flowColTraffic,
+.flowConversationTable tbody td.flowCellTraffic {
+  padding-left: 10px;
+  padding-right: 20px;
+  text-align: right;
+}
+
+.flowConversationTable tbody tr:nth-child(even) {
+  background: #fafbfd;
+}
+
+.flowConversationTable tbody tr:hover {
+  background: #f2f7ff;
+}
+
+.flowConversationTable tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.flowConversationTable thead th.flowColPort {
+  text-align: right;
+}
+
+.flowCellIp {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.flowCellPort {
+  text-align: right;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.flowCellProtocol {
+  text-align: center;
+  white-space: nowrap;
+}
+
+.flowCellTraffic {
+  text-align: right;
+}
+
+.flowTrafficValue {
+  display: block;
+  font-size: 12px;
+  font-weight: 800;
+  line-height: 1.25;
+}
+
+.flowTrafficTrack {
+  display: block;
+  margin-top: 4px;
+  margin-left: auto;
+  margin-right: 2px;
+  width: 100%;
+  max-width: 96px;
+  height: 5px;
+  border-radius: 999px;
+  background: #edf3fb;
+  overflow: hidden;
+}
+
+.flowTrafficFill {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+}
+
+.flowConversationNetflow .flowTrafficFill,
+.flowProtocolNetflow .flowProtocolFill {
+  background: linear-gradient(90deg, #b37feb 0%, #9254de 100%);
+}
+
+.flowConversationSflow .flowTrafficFill,
+.flowProtocolSflow .flowProtocolFill {
+  background: linear-gradient(90deg, #5cdbd3 0%, #13c2c2 100%);
+}
+
+.flowProtocolListWrap {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #dbe3ef;
+  border-radius: 8px;
+  background: #fff;
+  overflow: hidden;
+}
+
+.flowProtocolListHead {
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr) minmax(68px, auto);
+  align-items: center;
+  height: var(--flow-table-head-height);
+  padding: 0 8px 0 6px;
+  column-gap: 12px;
+  border-bottom: 1px solid #dbe3ef;
+  background: #f3f6fa;
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.flowProtocolHeadRank {
+  text-align: center;
+}
+
+.flowProtocolHeadName {
+  padding-left: 6px;
+}
+
+.flowProtocolHeadRate {
+  text-align: right;
+  padding-right: 6px;
+}
+
+.flowProtocolList {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.flowProtocolItem {
+  display: grid;
+  flex: 0 0 var(--flow-rank-row-height);
+  height: var(--flow-rank-row-height);
+  box-sizing: border-box;
+  grid-template-columns: 22px minmax(0, 1fr) minmax(68px, auto);
+  grid-template-areas:
+    'rank name rate'
+    'bar bar bar';
+  column-gap: 12px;
+  row-gap: 3px;
+  align-items: center;
+  align-content: center;
+  padding: 0 8px 0 6px;
+  border-bottom: 1px solid #edf2f7;
+}
+
+.flowProtocolItem:last-child {
+  border-bottom: none;
+}
+
+.flowProtocolRankMark {
+  grid-area: rank;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  background: #edf2f7;
+  color: #64748b;
+  font-size: 11px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.flowProtocolBadge {
+  grid-area: badge;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  line-height: 1.4;
+}
+
+.flowProtocolItem .flowProtocolName {
+  grid-area: name;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 0 0 0 6px;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  line-height: 1.2;
+}
+
+.flowProtocolRate {
+  grid-area: rate;
+  font-size: 11px;
+  font-weight: 800;
+  color: #22324a;
+  white-space: nowrap;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  padding-right: 6px;
+}
+
+.flowProtocolTrack {
+  grid-area: bar;
+  height: 5px;
+  border-radius: 999px;
+  background: #edf3fb;
+  overflow: hidden;
+}
+
+.flowProtocolRank1 {
+  background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+
+  .flowProtocolRankMark {
+    background: #dbeafe;
+    color: #1d4ed8;
   }
 
-  :global(.ant-table-thead > tr > th),
-  :global(.ant-table-tbody > tr > td) {
-    font-variant-numeric: tabular-nums;
+  .flowProtocolRate {
+    color: #0f172a;
+  }
+}
+
+.flowProtocolRank2 {
+  background: #fafbfd;
+}
+
+.flowProtocolRank4,
+.flowProtocolRank5 {
+  opacity: 0.92;
+
+  .flowProtocolRankMark {
+    background: #f1f5f9;
+    color: #94a3b8;
+    font-size: 10px;
   }
 
-  :global(.ant-table-tbody > tr > td:nth-child(2)),
-  :global(.ant-table-tbody > tr > td:nth-child(4)) {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-    font-size: 12px;
+  .flowProtocolName {
+    font-size: 11px;
+    font-weight: 600;
+  }
+
+  .flowProtocolRate {
+    font-size: 10px;
+    font-weight: 700;
+    color: #64748b;
+  }
+}
+
+.flowProtocolFill {
+  height: 100%;
+  border-radius: 999px;
+}
+
+.flowProtocolTcp {
+  color: #1d4ed8;
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+}
+
+.flowProtocolUdp {
+  color: #0f766e;
+  background: #ecfdf5;
+  border: 1px solid #99f6e4;
+}
+
+.flowProtocolIcmp {
+  color: #b45309;
+  background: #fffbeb;
+  border: 1px solid #fcd34d;
+}
+
+.flowProtocolOther {
+  color: #475569;
+  background: #f1f5f9;
+  border: 1px solid #cbd5e1;
+}
+
+:global(html.dark) {
+  .flowConversationTableWrap,
+  .flowProtocolListWrap {
+    border-color: rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .flowProtocolListHead {
+    border-bottom-color: rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.04);
+    color: rgba(255, 255, 255, 0.55);
+  }
+
+  .flowProtocolItem {
+    border-bottom-color: rgba(255, 255, 255, 0.06);
+
+    .flowProtocolName {
+      background: transparent;
+      border: none;
+    }
+  }
+
+  .flowConversationTable thead th {
+    border-bottom-color: rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.04);
+    color: rgba(255, 255, 255, 0.55);
+  }
+
+  .flowConversationTable tbody td {
+    border-bottom-color: rgba(255, 255, 255, 0.06);
+    color: rgba(255, 255, 255, 0.88);
+  }
+
+  .flowConversationTable tbody tr:nth-child(even) {
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .flowConversationTable tbody tr:hover {
+    background: rgba(255, 255, 255, 0.05);
+  }
+
+  .flowCellPort,
+  .flowProtocolRate {
+    color: rgba(255, 255, 255, 0.62);
+  }
+
+  .flowProtocolRank1 {
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.06) 0%, rgba(255, 255, 255, 0.03) 100%);
+    border-color: rgba(255, 255, 255, 0.1);
+
+    .flowProtocolRankMark {
+      background: rgba(37, 99, 235, 0.25);
+      color: #93c5fd;
+    }
+
+    .flowProtocolRate {
+      color: rgba(255, 255, 255, 0.92);
+    }
+  }
+
+  .flowProtocolRank2 {
+    background: rgba(255, 255, 255, 0.03);
+  }
+
+  .flowProtocolRankMark {
+    background: rgba(255, 255, 255, 0.08);
+    color: rgba(255, 255, 255, 0.55);
+  }
+
+  .flowConversationTable tbody tr.flowProtocolRank1 .flowProtocolRankMark {
+    background: rgba(37, 99, 235, 0.25);
+    color: #93c5fd;
+  }
+
+  .flowConversationTable tbody tr.flowProtocolRank4 .flowProtocolRankMark,
+  .flowConversationTable tbody tr.flowProtocolRank5 .flowProtocolRankMark {
+    background: rgba(255, 255, 255, 0.05);
+    color: rgba(255, 255, 255, 0.38);
+  }
+
+  .flowProtocolRank4,
+  .flowProtocolRank5 {
+    .flowProtocolRankMark {
+      background: rgba(255, 255, 255, 0.05);
+      color: rgba(255, 255, 255, 0.38);
+    }
+
+    .flowProtocolRate {
+      color: rgba(255, 255, 255, 0.55);
+    }
+  }
+
+  .flowTrafficTrack,
+  .flowProtocolTrack {
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  .flowProtocolTcp {
+    color: #93c5fd;
+    background: rgba(37, 99, 235, 0.18);
+    border-color: rgba(96, 165, 250, 0.35);
+  }
+
+  .flowProtocolUdp {
+    color: #5eead4;
+    background: rgba(13, 148, 136, 0.18);
+    border-color: rgba(45, 212, 191, 0.35);
+  }
+
+  .flowProtocolIcmp {
+    color: #fcd34d;
+    background: rgba(217, 119, 6, 0.18);
+    border-color: rgba(251, 191, 36, 0.35);
+  }
+
+  .flowProtocolOther {
+    color: rgba(255, 255, 255, 0.72);
+    background: rgba(255, 255, 255, 0.08);
+    border-color: rgba(255, 255, 255, 0.12);
   }
 }
 

--- a/web/src/app/monitor/dashboards/objects/flow-common/parse-conversation-rows.ts
+++ b/web/src/app/monitor/dashboards/objects/flow-common/parse-conversation-rows.ts
@@ -1,4 +1,5 @@
 import type { FlowProtocol } from './constants';
+import { formatProtocolLabel } from './protocol-labels';
 
 interface RawSeries {
   metric?: Record<string, string>;
@@ -20,22 +21,6 @@ export interface FlowConversationRow {
   rowKey: string;
 }
 
-const PROTOCOL_NAMES: Record<string, string> = {
-  '1': 'ICMP',
-  '6': 'TCP',
-  '17': 'UDP',
-  '47': 'GRE',
-  '50': 'ESP',
-  '58': 'ICMPv6',
-};
-
-export const formatProtocolLabel = (value: string): string => {
-  const normalized = String(value || '').trim();
-  if (!normalized) return '--';
-  const mapped = PROTOCOL_NAMES[normalized];
-  return mapped ? `${mapped} (${normalized})` : normalized;
-};
-
 const latestValue = (series: RawSeries): number | null => {
   const points: Array<[number, string | number | null | undefined]> = series.value
     ? [series.value]
@@ -56,6 +41,7 @@ const buildRowKey = (
   if (protocol === 'netflow') {
     return [
       metric.src || '',
+      metric.src_port || '',
       metric.dst || '',
       metric.protocol || '',
       metric.dst_port || '',
@@ -63,10 +49,16 @@ const buildRowKey = (
   }
   return [
     metric.src_ip || '',
+    metric.src_port || '',
     metric.dst_ip || '',
     metric.header_protocol || '',
     metric.dst_port || '',
   ].join('\u0000');
+};
+
+const normalizePort = (value?: string | null) => {
+  const normalized = String(value || '').trim();
+  return normalized || '--';
 };
 
 export const parseConversationRows = (
@@ -86,9 +78,9 @@ export const parseConversationRows = (
     if (protocol === 'netflow') {
       rows.push({
         srcIp: metric.src || '--',
-        srcPort: '--',
+        srcPort: normalizePort(metric.src_port),
         dstIp: metric.dst || '--',
-        dstPort: metric.dst_port || '--',
+        dstPort: normalizePort(metric.dst_port),
         protocol: formatProtocolLabel(metric.protocol || ''),
         bytesRate,
         rowKey,
@@ -98,9 +90,9 @@ export const parseConversationRows = (
 
     rows.push({
       srcIp: metric.src_ip || '--',
-      srcPort: '--',
+      srcPort: normalizePort(metric.src_port),
       dstIp: metric.dst_ip || '--',
-      dstPort: metric.dst_port || '--',
+      dstPort: normalizePort(metric.dst_port),
       protocol: formatProtocolLabel(metric.header_protocol || ''),
       bytesRate,
       rowKey,

--- a/web/src/app/monitor/dashboards/objects/flow-common/parse-protocol-rows.ts
+++ b/web/src/app/monitor/dashboards/objects/flow-common/parse-protocol-rows.ts
@@ -1,0 +1,54 @@
+import { formatProtocolLabel } from './protocol-labels';
+import type { FlowProtocol } from './constants';
+
+interface RawSeries {
+  metric?: Record<string, string>;
+  value?: [number, string | number];
+}
+
+export interface FlowProtocolRow {
+  protocol: string;
+  label: string;
+  bytesRate: number;
+  rowKey: string;
+}
+
+const latestValue = (series: RawSeries): number | null => {
+  const raw = series.value?.[1];
+  if (raw === null || raw === undefined || raw === '') return null;
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : null;
+};
+
+export const parseProtocolRows = (
+  raw: { data?: { result?: RawSeries[] } } | null | undefined,
+  flowProtocol: FlowProtocol,
+): FlowProtocolRow[] => {
+  const totals = new Map<string, FlowProtocolRow>();
+
+  for (const series of raw?.data?.result || []) {
+    const metric = series.metric || {};
+    const bytesRate = latestValue(series);
+    if (bytesRate == null) continue;
+
+    const protocolKey = flowProtocol === 'netflow'
+      ? String(metric.protocol || '').trim()
+      : String(metric.header_protocol || '').trim();
+    if (!protocolKey) continue;
+
+    const existing = totals.get(protocolKey);
+    if (existing) {
+      existing.bytesRate += bytesRate;
+      continue;
+    }
+
+    totals.set(protocolKey, {
+      protocol: protocolKey,
+      label: formatProtocolLabel(protocolKey),
+      bytesRate,
+      rowKey: protocolKey,
+    });
+  }
+
+  return [...totals.values()].sort((left, right) => right.bytesRate - left.bytesRate);
+};

--- a/web/src/app/monitor/dashboards/objects/flow-common/protocol-breakdown.tsx
+++ b/web/src/app/monitor/dashboards/objects/flow-common/protocol-breakdown.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { Spin } from 'antd';
+import { useSearchParams } from 'next/navigation';
+import useViewApi from '@/app/monitor/api/view';
+import ChartEmptyState from '@/components/chart-empty-state';
+import { DashboardPanel } from '../../shared/widgets';
+import { buildSearchParams, formatMetricValue } from '../../shared/utils';
+import { useSimpleDashboardData } from '../common/simple-dashboard-core';
+import type { FlowProtocol } from './constants';
+import { buildProtocolTopQuery } from './queries';
+import { parseProtocolRows } from './parse-protocol-rows';
+import { formatProtocolShortName } from './protocol-labels';
+import { resolveFlowRankClass } from './rank-class';
+
+interface FlowProtocolBreakdownProps {
+  dashboard: ReturnType<typeof useSimpleDashboardData>;
+  protocol: FlowProtocol;
+  instanceType: string;
+  styles: Record<string, string>;
+}
+
+const PROTOCOL_GUIDE = [{
+  label: 'Top 协议',
+  detail: '所选时间窗内流量速率最高的协议分布，便于快速识别 TCP/UDP/ICMP 等占比。',
+}];
+
+const resolveProtocolClass = (label: string, styles: Record<string, string>) => {
+  const normalized = formatProtocolShortName(label).toUpperCase();
+  if (normalized === 'TCP') return styles.flowProtocolTcp;
+  if (normalized === 'UDP') return styles.flowProtocolUdp;
+  if (normalized === 'ICMP' || normalized === 'ICMPV6') return styles.flowProtocolIcmp;
+  return styles.flowProtocolOther;
+};
+
+const formatBytesRate = (value: number) => {
+  const formatted = formatMetricValue(value, 'byteps');
+  return `${formatted.value}${formatted.unit || ''}`;
+};
+
+export function FlowProtocolBreakdown({
+  dashboard,
+  protocol,
+  instanceType,
+  styles,
+}: FlowProtocolBreakdownProps) {
+  const { getInstanceInstantQuery } = useViewApi();
+  const searchParams = useSearchParams();
+  const instanceIdKeys = useMemo(
+    () => (searchParams.get('instance_id_keys') || 'instance_id').split(',').filter(Boolean),
+    [searchParams],
+  );
+  const [rows, setRows] = useState<ReturnType<typeof parseProtocolRows>>([]);
+  const [loading, setLoading] = useState(false);
+  const protocolQuery = useMemo(
+    () => buildProtocolTopQuery(instanceType, protocol),
+    [instanceType, protocol],
+  );
+
+  useEffect(() => {
+    if (!dashboard.isDashboardMode || !instanceType) {
+      setRows([]);
+      return;
+    }
+
+    let active = true;
+    setLoading(true);
+
+    const load = async () => {
+      const result = await getInstanceInstantQuery(
+        buildSearchParams(
+          protocolQuery,
+          'byteps',
+          dashboard.idValues,
+          instanceIdKeys,
+          dashboard.timeValues,
+          undefined,
+          false,
+        ),
+      ).catch(() => null);
+
+      if (!active) return;
+      setRows(parseProtocolRows(result, protocol));
+      setLoading(false);
+    };
+
+    void load();
+
+    return () => {
+      active = false;
+    };
+  }, [
+    dashboard.currentInstanceInterval,
+    dashboard.idValues,
+    dashboard.isDashboardMode,
+    dashboard.loadTick,
+    dashboard.timeValues,
+    getInstanceInstantQuery,
+    instanceIdKeys,
+    instanceType,
+    protocol,
+    protocolQuery,
+  ]);
+
+  const peakRate = useMemo(
+    () => (rows.length ? Math.max(...rows.map((row) => row.bytesRate)) : 0),
+    [rows],
+  );
+
+  return (
+    <DashboardPanel
+      title="Top 协议"
+      subtitle="按协议聚合的流量速率 Top 10"
+      guide={PROTOCOL_GUIDE}
+      className={`${styles.span4} ${styles.flowProtocolPanel}`}
+      bodyClassName={styles.flowProtocolBody}
+      styles={styles}
+    >
+      <Spin spinning={loading}>
+        {!loading && rows.length === 0 ? (
+          <div className={styles.flowProtocolEmpty}>
+            <ChartEmptyState description="所选时间窗内无协议分布数据" compact />
+          </div>
+        ) : (
+          <div
+            className={[
+              styles.flowProtocolListWrap,
+              protocol === 'netflow' ? styles.flowProtocolNetflow : styles.flowProtocolSflow,
+            ].join(' ')}
+          >
+            <div className={styles.flowProtocolListHead}>
+              <span className={styles.flowProtocolHeadRank}>#</span>
+              <span className={styles.flowProtocolHeadName}>协议</span>
+              <span className={styles.flowProtocolHeadRate}>流量</span>
+            </div>
+            <ul className={styles.flowProtocolList}>
+              {rows.map((row, index) => {
+                const share = peakRate > 0 ? (row.bytesRate / peakRate) * 100 : 0;
+                return (
+                  <li
+                    key={row.rowKey}
+                    className={[styles.flowProtocolItem, resolveFlowRankClass(index, styles)].join(' ')}
+                  >
+                    <span className={styles.flowProtocolRankMark}>{index + 1}</span>
+                    <span
+                      className={[
+                        styles.flowProtocolName,
+                        resolveProtocolClass(row.label, styles),
+                      ].join(' ')}
+                    >
+                      {formatProtocolShortName(row.label)}
+                    </span>
+                    <span className={styles.flowProtocolRate}>{formatBytesRate(row.bytesRate)}</span>
+                    <div className={styles.flowProtocolTrack}>
+                      <div
+                        className={styles.flowProtocolFill}
+                        style={{ width: `${Math.max(share, 6)}%` }}
+                      />
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+      </Spin>
+    </DashboardPanel>
+  );
+}

--- a/web/src/app/monitor/dashboards/objects/flow-common/protocol-labels.ts
+++ b/web/src/app/monitor/dashboards/objects/flow-common/protocol-labels.ts
@@ -1,0 +1,61 @@
+/** IANA IP protocol numbers commonly seen in NetFlow/sFlow metrics. */
+const PROTOCOL_NUMBERS: Record<string, string> = {
+  '0': 'HOPOPT',
+  '1': 'ICMP',
+  '2': 'IGMP',
+  '4': 'IPv4',
+  '6': 'TCP',
+  '8': 'EGP',
+  '17': 'UDP',
+  '27': 'RDP',
+  '41': 'IPv6',
+  '47': 'GRE',
+  '50': 'ESP',
+  '51': 'AH',
+  '58': 'ICMPv6',
+  '88': 'EIGRP',
+  '89': 'OSPF',
+  '103': 'PIM',
+  '115': 'L2TP',
+  '118': 'STP',
+  '132': 'SCTP',
+  '136': 'UDPLite',
+};
+
+const normalizeProtocolToken = (value: string) => String(value || '').trim();
+
+export const resolveProtocolName = (value: string): string => {
+  const normalized = normalizeProtocolToken(value);
+  if (!normalized) return '--';
+
+  const byNumber = PROTOCOL_NUMBERS[normalized];
+  if (byNumber) return byNumber;
+
+  const upper = normalized.toUpperCase();
+  if (/^[A-Z][A-Z0-9-]*$/.test(upper) && !/^\d+$/.test(normalized)) {
+    return upper;
+  }
+
+  if (/^\d+$/.test(normalized)) {
+    return `Proto-${normalized}`;
+  }
+
+  return upper;
+};
+
+/** Full label for tooltips / detail; keeps protocol number when mapped from IANA id. */
+export const formatProtocolLabel = (value: string): string => {
+  const normalized = normalizeProtocolToken(value);
+  if (!normalized) return '--';
+
+  const name = PROTOCOL_NUMBERS[normalized];
+  if (name) return `${name} (${normalized})`;
+
+  return resolveProtocolName(normalized);
+};
+
+/** Short name for badges and table cells. */
+export const formatProtocolShortName = (value: string): string => {
+  const label = formatProtocolLabel(value);
+  return label.split(' ')[0] || label || '--';
+};

--- a/web/src/app/monitor/dashboards/objects/flow-common/queries.ts
+++ b/web/src/app/monitor/dashboards/objects/flow-common/queries.ts
@@ -1,4 +1,4 @@
-import { CONVERSATION_TOP_N, type FlowProtocol } from './constants';
+import { CONVERSATION_TOP_N, PROTOCOL_TOP_N, type FlowProtocol } from './constants';
 
 const netflowBytesSeries = (instanceType: string) =>
   `netflow_in_bytes{instance_type='${instanceType}', collect_type='netflow', __$labels__}`;
@@ -22,10 +22,18 @@ const avgOverWindow = (expr: string) => `avg_over_time((${expr})[__$window__])`;
 
 export const buildConversationTopQuery = (instanceType: string, protocol: FlowProtocol) => {
   if (protocol === 'netflow') {
-    return `topk(${CONVERSATION_TOP_N}, ${avgOverWindow(normalizedNetflowBytesByLabels(instanceType, 'src, dst, protocol, dst_port'))})`;
+    return `topk(${CONVERSATION_TOP_N}, ${avgOverWindow(normalizedNetflowBytesByLabels(instanceType, 'src, src_port, dst, protocol, dst_port'))})`;
   }
-  const sflowByConversation = `sum(sflow_bytes{instance_type='${instanceType}', collect_type='sflow', __$labels__}) by (instance_id, src_ip, dst_ip, header_protocol, dst_port)`;
+  const sflowByConversation = `sum(sflow_bytes{instance_type='${instanceType}', collect_type='sflow', __$labels__}) by (instance_id, src_ip, src_port, dst_ip, header_protocol, dst_port)`;
   return `topk(${CONVERSATION_TOP_N}, ${avgOverWindow(sflowByConversation)})`;
+};
+
+export const buildProtocolTopQuery = (instanceType: string, protocol: FlowProtocol, limit = PROTOCOL_TOP_N) => {
+  if (protocol === 'netflow') {
+    return `topk(${limit}, ${avgOverWindow(normalizedNetflowBytesByLabels(instanceType, 'protocol'))})`;
+  }
+  const sflowByProtocol = `sum(sflow_bytes{instance_type='${instanceType}', collect_type='sflow', __$labels__}) by (instance_id, header_protocol)`;
+  return `topk(${limit}, ${avgOverWindow(sflowByProtocol)})`;
 };
 
 export const buildFlowMetricQueries = (instanceType: string, protocol: FlowProtocol) => {

--- a/web/src/app/monitor/dashboards/objects/flow-common/rank-class.ts
+++ b/web/src/app/monitor/dashboards/objects/flow-common/rank-class.ts
@@ -1,0 +1,12 @@
+export const FLOW_RANK_CLASS_KEYS = [
+  'flowProtocolRank1',
+  'flowProtocolRank2',
+  'flowProtocolRank3',
+  'flowProtocolRank4',
+  'flowProtocolRank5',
+] as const;
+
+export const resolveFlowRankClass = (index: number, styleMap: Record<string, string>) => {
+  const key = FLOW_RANK_CLASS_KEYS[Math.min(index, FLOW_RANK_CLASS_KEYS.length - 1)];
+  return styleMap[key];
+};

--- a/web/src/app/monitor/dashboards/shared/utils/flow-plugin-cache.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/flow-plugin-cache.ts
@@ -1,0 +1,13 @@
+import type { FlowDashboardPlugin } from './flow-dashboard-route';
+
+const cache = new Map<string, FlowDashboardPlugin[]>();
+
+export const flowPluginCacheKey = (monitorObjectId: string, instanceId: string) =>
+  `${monitorObjectId}:${instanceId}`;
+
+export const getCachedFlowPlugins = (key: string): FlowDashboardPlugin[] | undefined =>
+  cache.get(key);
+
+export const setCachedFlowPlugins = (key: string, plugins: FlowDashboardPlugin[]) => {
+  cache.set(key, plugins);
+};

--- a/web/src/app/monitor/dashboards/shared/widgets/collect-protocol-bar.tsx
+++ b/web/src/app/monitor/dashboards/shared/widgets/collect-protocol-bar.tsx
@@ -5,8 +5,6 @@ import { Segmented } from 'antd';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import useApiClient from '@/utils/request';
 import useMonitorApi from '@/app/monitor/api';
-import { resolveFlowViewSwitchPlugins } from '@/app/monitor/mocks/monitor-flow-mock';
-import { isMonitorViewDemoEnabled } from '@/app/monitor/mocks/monitor-view-demo-data';
 import type { FlowDashboardPlugin } from '../utils/flow-dashboard-route';
 import { getDashboardDisplayModeFromParams } from '../utils/display-mode-route';
 import {
@@ -120,20 +118,13 @@ export function CollectProtocolBar({
       active = false;
     };
   }, [
-    getEffectivePlugins,
     isLoading,
     pluginCacheKey,
     resolvedInstanceId,
     resolvedMonitorObjectId,
   ]);
 
-  const resolvedPlugins = useMemo(
-    () => resolveFlowViewSwitchPlugins(plugins, {
-      routeKey: activeRouteKey,
-      monitorObjectName: resolvedObjectName,
-    }),
-    [activeRouteKey, plugins, resolvedObjectName],
-  );
+  const resolvedPlugins = useMemo(() => plugins ?? [], [plugins]);
 
   const availableViews = useMemo(
     () => getAvailableFlowViews(resolvedPlugins),
@@ -159,7 +150,6 @@ export function CollectProtocolBar({
 
   const awaitingPlugins =
     Boolean(pluginCacheKey)
-    && !isMonitorViewDemoEnabled()
     && (plugins === null || pluginsLoading);
   const shouldRenderBar =
     isDashboardMode &&

--- a/web/src/app/monitor/dashboards/shared/widgets/collect-protocol-bar.tsx
+++ b/web/src/app/monitor/dashboards/shared/widgets/collect-protocol-bar.tsx
@@ -2,10 +2,18 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import { Segmented } from 'antd';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import useApiClient from '@/utils/request';
 import useMonitorApi from '@/app/monitor/api';
+import { resolveFlowViewSwitchPlugins } from '@/app/monitor/mocks/monitor-flow-mock';
+import { isMonitorViewDemoEnabled } from '@/app/monitor/mocks/monitor-view-demo-data';
 import type { FlowDashboardPlugin } from '../utils/flow-dashboard-route';
+import { getDashboardDisplayModeFromParams } from '../utils/display-mode-route';
+import {
+  flowPluginCacheKey,
+  getCachedFlowPlugins,
+  setCachedFlowPlugins,
+} from '../utils/flow-plugin-cache';
 import {
   buildFlowViewSwitchUrl,
   FLOW_VIEW_LABELS,
@@ -15,9 +23,10 @@ import {
   shouldShowFlowViewSwitch,
   type FlowViewKind,
 } from '../utils/flow-view-navigation';
+import { normalizeDashboardKey } from '../utils';
 
 export interface CollectProtocolBarProps {
-  routeKey: string;
+  routeKey?: string;
   monitorObjectName?: string | null;
   monitorObjectId?: React.Key | null;
   instanceId?: React.Key | null;
@@ -30,7 +39,7 @@ export interface CollectProtocolBarProps {
 
 /** 内容区顶部的一级导航：SNMP / NetFlow / sFlow 采集视图切换（替代分区标题的第一层）。 */
 export function CollectProtocolBar({
-  routeKey,
+  routeKey = '',
   monitorObjectName,
   monitorObjectId,
   instanceId,
@@ -38,34 +47,70 @@ export function CollectProtocolBar({
 }: CollectProtocolBarProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const params = useParams<{ objectKey?: string }>();
+  const activeRouteKey =
+    normalizeDashboardKey(params?.objectKey) || normalizeDashboardKey(routeKey);
   const { isLoading } = useApiClient();
   const { getEffectivePlugins } = useMonitorApi();
-  const [plugins, setPlugins] = useState<FlowDashboardPlugin[] | null>(null);
+
+  const resolvedMonitorObjectId =
+    monitorObjectId != null
+      ? String(monitorObjectId)
+      : searchParams.get('monitorObjId') || '';
+  const resolvedInstanceId =
+    instanceId != null ? String(instanceId) : searchParams.get('instance_id') || '';
+  const pluginCacheKey =
+    resolvedMonitorObjectId && resolvedInstanceId
+      ? flowPluginCacheKey(resolvedMonitorObjectId, resolvedInstanceId)
+      : '';
+
+  const [plugins, setPlugins] = useState<FlowDashboardPlugin[] | null>(() =>
+    pluginCacheKey ? getCachedFlowPlugins(pluginCacheKey) ?? null : null,
+  );
+  const [pluginsLoading, setPluginsLoading] = useState(false);
 
   const resolvedObjectName = monitorObjectName || searchParams.get('name') || '';
+  const isDashboardMode = getDashboardDisplayModeFromParams(searchParams) === 'dashboard';
 
   useEffect(() => {
-    const normalizedMonitorObjectId = monitorObjectId != null ? String(monitorObjectId) : '';
-    const normalizedInstanceId = instanceId != null ? String(instanceId) : '';
-
-    if (!normalizedMonitorObjectId || !normalizedInstanceId) {
+    if (!pluginCacheKey) {
       setPlugins(null);
+      setPluginsLoading(false);
       return;
+    }
+
+    const cached = getCachedFlowPlugins(pluginCacheKey);
+    if (cached) {
+      setPlugins(cached);
     }
 
     if (isLoading) return;
 
     let active = true;
+    const silentRefresh = Boolean(cached);
+    if (!silentRefresh) {
+      setPluginsLoading(true);
+    }
 
     const loadPlugins = async () => {
       try {
-        const data = await getEffectivePlugins(normalizedMonitorObjectId, {
-          instance_id: normalizedInstanceId,
+        const data = await getEffectivePlugins(resolvedMonitorObjectId, {
+          instance_id: resolvedInstanceId,
         });
         if (!active) return;
-        setPlugins(Array.isArray(data) ? data : []);
+        const next = Array.isArray(data) ? data : [];
+        setCachedFlowPlugins(pluginCacheKey, next);
+        setPlugins(next);
       } catch {
-        if (active) setPlugins([]);
+        if (!active) return;
+        if (!silentRefresh) {
+          setCachedFlowPlugins(pluginCacheKey, []);
+          setPlugins([]);
+        }
+      } finally {
+        if (active && !silentRefresh) {
+          setPluginsLoading(false);
+        }
       }
     };
 
@@ -74,20 +119,37 @@ export function CollectProtocolBar({
     return () => {
       active = false;
     };
-  }, [getEffectivePlugins, instanceId, isLoading, monitorObjectId]);
+  }, [
+    getEffectivePlugins,
+    isLoading,
+    pluginCacheKey,
+    resolvedInstanceId,
+    resolvedMonitorObjectId,
+  ]);
+
+  const resolvedPlugins = useMemo(
+    () => resolveFlowViewSwitchPlugins(plugins, {
+      routeKey: activeRouteKey,
+      monitorObjectName: resolvedObjectName,
+    }),
+    [activeRouteKey, plugins, resolvedObjectName],
+  );
 
   const availableViews = useMemo(
-    () => getAvailableFlowViews(plugins),
-    [plugins],
+    () => getAvailableFlowViews(resolvedPlugins),
+    [resolvedPlugins],
   );
-  const currentView = resolveCurrentFlowView(routeKey);
+  const currentView = resolveCurrentFlowView(activeRouteKey);
+  const inFlowContext = isFlowViewSwitchContext(activeRouteKey, resolvedObjectName);
+
   const visible = useMemo(
-    () => shouldShowFlowViewSwitch({
-      routeKey,
-      monitorObjectName: resolvedObjectName,
-      availableViews,
-    }),
-    [availableViews, resolvedObjectName, routeKey],
+    () =>
+      shouldShowFlowViewSwitch({
+        routeKey: activeRouteKey,
+        monitorObjectName: resolvedObjectName,
+        availableViews,
+      }),
+    [activeRouteKey, availableViews, resolvedObjectName],
   );
 
   const options = useMemo(
@@ -95,12 +157,30 @@ export function CollectProtocolBar({
     [availableViews],
   );
 
-  const inFlowContext = isFlowViewSwitchContext(routeKey, resolvedObjectName);
+  const awaitingPlugins =
+    Boolean(pluginCacheKey)
+    && !isMonitorViewDemoEnabled()
+    && (plugins === null || pluginsLoading);
+  const shouldRenderBar =
+    isDashboardMode &&
+    inFlowContext &&
+    currentView &&
+    (visible || awaitingPlugins);
 
-  if (!inFlowContext || !visible || !currentView || plugins === null) return null;
+  if (!shouldRenderBar) return null;
+
+  const segmentedOptions =
+    options.length >= 2
+      ? options
+      : ([currentView] as FlowViewKind[]).map((view) => ({
+        label: FLOW_VIEW_LABELS[view],
+        value: view,
+      }));
+
+  const interactionBlocked = pluginsLoading && options.length < 2;
 
   const onChange = (value: FlowViewKind) => {
-    if (value === currentView) return;
+    if (value === currentView || interactionBlocked) return;
     const url = buildFlowViewSwitchUrl(value, {
       monitorObjectName: resolvedObjectName,
       searchParams,
@@ -109,13 +189,19 @@ export function CollectProtocolBar({
   };
 
   return (
-    <div className={styles.protocolBar} role="region" aria-label="采集视图切换">
+    <div
+      className={styles.protocolBar}
+      role="region"
+      aria-label="采集视图切换"
+      aria-busy={pluginsLoading}
+    >
       <span className={styles.protocolBarLabel}>采集视图</span>
       <Segmented
         size="middle"
         className={styles.protocolSegmented}
         value={currentView}
-        options={options}
+        options={segmentedOptions}
+        disabled={interactionBlocked}
         onChange={(value) => onChange(value as FlowViewKind)}
         aria-label="采集协议"
       />

--- a/web/src/app/monitor/dashboards/shared/widgets/dashboard-protocol-bar-host.tsx
+++ b/web/src/app/monitor/dashboards/shared/widgets/dashboard-protocol-bar-host.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import React from 'react';
+import { CollectProtocolBar } from './collect-protocol-bar';
+import { DashboardProtocolBarPortal } from './dashboard-protocol-bar-slot';
+import dashboardStyles from '../../objects/common/simple-dashboard.module.scss';
+
+/** layout 级挂载：跨 objectKey 保活，portal 到 DashboardShell 实例卡下方 slot。 */
+export function DashboardProtocolBarHost() {
+  return (
+    <DashboardProtocolBarPortal>
+      <CollectProtocolBar styles={dashboardStyles} />
+    </DashboardProtocolBarPortal>
+  );
+}

--- a/web/src/app/monitor/dashboards/shared/widgets/dashboard-protocol-bar-slot.tsx
+++ b/web/src/app/monitor/dashboards/shared/widgets/dashboard-protocol-bar-slot.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+
+interface DashboardProtocolBarSlotContextValue {
+  slot: HTMLElement | null;
+  setSlot: (node: HTMLElement | null) => void;
+}
+
+const DashboardProtocolBarSlotContext =
+  createContext<DashboardProtocolBarSlotContextValue | null>(null);
+
+export function DashboardProtocolBarSlotProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [slot, setSlot] = useState<HTMLElement | null>(null);
+  const value = useMemo(() => ({ slot, setSlot }), [slot]);
+
+  return (
+    <DashboardProtocolBarSlotContext.Provider value={value}>
+      {children}
+    </DashboardProtocolBarSlotContext.Provider>
+  );
+}
+
+/** 挂在实例卡片下方，供 layout 级 CollectProtocolBar portal 定位。 */
+export function DashboardProtocolBarSlot() {
+  const context = useContext(DashboardProtocolBarSlotContext);
+  const setSlotRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      context?.setSlot(node);
+    },
+    [context],
+  );
+
+  return <div ref={setSlotRef} />;
+}
+
+export function DashboardProtocolBarPortal({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const context = useContext(DashboardProtocolBarSlotContext);
+  if (!context?.slot) return null;
+  return createPortal(children, context.slot);
+}


### PR DESCRIPTION
## Summary

- 流量分析区新增 **Top 会话（8 列）+ Top 协议（4 列）** 双栏布局，统一表头 `# | 协议 | 流量`、固定行高与左右逐行对齐
- Top 会话表支持源/目的地址、端口、协议 pill、流量进度条；Top 协议侧栏支持 IANA 协议号映射、按协议聚合求和（`parseProtocolRows` 合并同协议 series）
- 采集视图条（NetFlow/sFlow/SNMP）提升至 dashboard layout 保活，跨路由切换不丢状态；CollectProtocolBar 有缓存时 silent refresh，避免整栏 disabled

## Test plan

- [x] `pnpm type-check`（web）
- [x] pre-commit hook（eslint + tsc）已通过
- [ ] 进入 NetFlow/sFlow 仪表盘，确认 KPI + Top 10 会话 + Top 10 协议数据加载
- [ ] 确认左右 10 行垂直对齐、协议名显示正确（TCP/UDP/ICMP 等）
- [ ] 确认 TCP 协议总量 ≥ Top 会话中各 TCP 会话之和
- [ ] 切换 NetFlow ↔ sFlow ↔ SNMP，采集视图条保持可用且不闪烁

## 提交范围说明

本次 PR **仅包含产品代码**（18 个文件）。以下改动仍保留在工作区，**未纳入提交**：

- `web/src/app/monitor/mocks/**`（运行时演示 mock）
- `web/src/app/monitor/api/view.ts`、`api/index.ts` 中的 mock 注入逻辑
- `web/scripts/*-test.ts` 测试脚本
- `web/public/assets/icons/**` 无关图标资源
- `enterprise` 子模块指针变更