### PR TITLE
optimization: 统一 Husky 钩子到仓库根目录并启用 web type-check

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,6 @@
 #!/bin/sh
+# 仓库唯一 pre-commit 入口（web/mobile 的 prepare 均指向根目录 .husky）。
+# web 变更：变更文件 eslint + 全仓 pnpm type-check；mobile 同理。
 
 CHANGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR)
 

--- a/mobile/.husky/pre-commit
+++ b/mobile/.husky/pre-commit
@@ -1,5 +1,0 @@
-#!/bin/sh
-cd "$(dirname "$0")/.." || exit 1  # Change to mobile directory
-
-# Run lint and type-check
-pnpm lint && pnpm type-check

--- a/specs/capabilities/engineering-quality.md
+++ b/specs/capabilities/engineering-quality.md
@@ -17,7 +17,7 @@
 
 ## 2. 自动门禁(已落地,别绕过)
 
-- `.husky/pre-commit`:对 `web/`、`mobile/` staged 变更自动 lint/type-check。
+- `.husky/pre-commit`（仓库根目录唯一逻辑入口）：`web/`、`mobile/` staged 变更自动 eslint + type-check；`web/`、`mobile/` 的 `prepare` 注册根目录 `.husky`（`web/.husky/pre-commit` 仅转发到根钩子）。
 - `server/.pre-commit-config.yaml`:`black` + `isort` + `flake8` + `check_migrate` + `check_requirements`。
 - Python 行宽 **150**；`server/apps/` 日志走 `apps.core.logger` 的 `{app}_logger as logger`，`algorithms/` 等独立服务可用 `loguru`。
 


### PR DESCRIPTION
## Summary

- `web/`、`mobile/` 的 `prepare` 改为 `cd .. && husky`，统一注册仓库根目录 `.husky/pre-commit`
- 删除 `web/.husky/pre-commit`、`mobile/.husky/pre-commit` 重复钩子（此前 web 侧仅 eslint，无 type-check）
- 修复 Husky 以 `sh -e` 执行时，grep 无匹配导致 pre-commit 静默失败（`|| true`）
- 更新 `specs/capabilities/engineering-quality.md` 说明唯一钩子入口

## 行为变化

提交 staged 的 `web/**/*.ts(x)` 时：**变更文件 eslint + 全仓 `pnpm type-check`**（与镜像构建 #307 类 TS 错误同源检查）。

## 开发者说明

在 `web/` 或 `mobile/` 执行 `pnpm install` 后自动注册钩子，无需额外手动配置。

## Test plan

- [x] `sh -e .husky/pre-commit`（仅配置文件 staged）通过
- [x] staged `web/**/*.ts` 时出现 `Checking web project...` 并进入 type-check
- [x] `git commit` 在根钩子下可正常完成


Made with [Cursor](https://cursor.com)