### PR TITLE
fix(监控): 精简 vLLM 看板文案并修正 TPM 单位展示

### DIFF
--- a/web/src/app/monitor/dashboards/objects/vllm/config.ts
+++ b/web/src/app/monitor/dashboards/objects/vllm/config.ts
@@ -32,7 +32,7 @@ export const VLLM_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       name: 'vllm_kv_cache_usage',
       display_name: 'KV 缓存占用',
-      description: '已使用 KV cache 块占比（0–100%）。多实例取 max。',
+      description: '已使用 KV cache 块占比（0–100%）。',
       unit: 'percent',
       query:
         'clamp_max(100 * max by (instance_id) (vllm:kv_cache_usage_perc_gauge{__$labels__}), 100)',
@@ -113,9 +113,9 @@ export const VLLM_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     },
     {
       name: 'vllm_input_tpm',
-      display_name: 'Input TPM',
-      description: '最近 5 分钟 prompt token 速率 × 60（tokens/min）。',
-      unit: 'counts',
+      display_name: '输入 TPM',
+      description: '最近 5 分钟 prompt token 吞吐。',
+      unit: 'tpm',
       // tokens/min = rate * 60；不要套用 Grafana Output TPM *6。
       query:
         'sum by (instance_id) (rate(vllm:prompt_tokens_total_counter{__$labels__}[5m])) * 60',
@@ -123,9 +123,9 @@ export const VLLM_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     },
     {
       name: 'vllm_output_tpm',
-      display_name: 'Output TPM',
-      description: '最近 5 分钟 generation token 速率 × 60（tokens/min）。',
-      unit: 'counts',
+      display_name: '输出 TPM',
+      description: '最近 5 分钟 generation token 吞吐。',
+      unit: 'tpm',
       // tokens/min = rate * 60；不要套用 Grafana Output TPM *6。
       query:
         'sum by (instance_id) (rate(vllm:generation_tokens_total_counter{__$labels__}[5m])) * 60',
@@ -210,7 +210,7 @@ export const VLLM_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       guide: [
         {
           label: '排队请求',
-          detail: '等待调度容量的请求数，持续非零说明吞吐已接近上限。'
+          detail: '等待调度的请求数。'
         }
       ],
       footer: [
@@ -229,7 +229,7 @@ export const VLLM_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       guide: [
         {
           label: 'TTFT P95',
-          detail: '首 token 时延 P95，抬升通常与排队、prefill 或 KV 压力相关。'
+          detail: '首 Token 时延 P95。'
         }
       ],
       footer: [
@@ -248,7 +248,7 @@ export const VLLM_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       guide: [
         {
           label: 'KV 缓存',
-          detail: 'KV cache 块占用取 max，接近 100% 时新请求更容易排队或抢占。'
+          detail: 'KV cache 最高占用。'
         }
       ],
       footer: [{ label: '排队请求', metric: 'vllm_requests_waiting', unit: 'counts' }]
@@ -264,7 +264,7 @@ export const VLLM_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       guide: [
         {
           label: 'TPOT P95',
-          detail: '逐 token 时延（ITL）P95，decode 阶段变慢时抬升。'
+          detail: '逐 Token 时延 P95。'
         }
       ],
       footer: [
@@ -283,12 +283,12 @@ export const VLLM_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       guide: [
         {
           label: 'QPS',
-          detail: '成功完成请求速率。Input/Output TPM 为 token/s × 60，不是 Grafana 的 ×6。'
+          detail: '成功完成请求速率。'
         }
       ],
       footer: [
-        { label: 'Input TPM', metric: 'vllm_input_tpm', unit: 'counts' },
-        { label: 'Output TPM', metric: 'vllm_output_tpm', unit: 'counts' }
+        { label: '输入 TPM', metric: 'vllm_input_tpm', unit: 'tpm' },
+        { label: '输出 TPM', metric: 'vllm_output_tpm', unit: 'tpm' }
       ]
     }
   ],
@@ -300,7 +300,7 @@ export const VLLM_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       guide: [
         {
           label: '队列趋势',
-          detail: '运行中与排队请求随时间变化，排队曲线抬升即需扩容或限流。'
+          detail: '运行中与排队请求趋势。'
         }
       ],
       series: [
@@ -325,7 +325,7 @@ export const VLLM_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       guide: [
         {
           label: '时延拆解',
-          detail: '排队、prefill、decode 与 TTFT 的 P95，用于定位首 token 变慢发生在哪一段。'
+          detail: '排队、Prefill、Decode 与 TTFT 的 P95。'
         }
       ],
       series: [
@@ -337,12 +337,12 @@ export const VLLM_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     },
     {
       title: 'KV 缓存占用',
-      subtitle: 'max 占用比例',
+      subtitle: '最高占用',
       metric: 'vllm_kv_cache_usage',
       guide: [
         {
           label: 'KV 缓存',
-          detail: '按 instance_id 取 max，避免 avg 掩盖单实例打满。'
+          detail: '按实例取最高 KV 占用。'
         }
       ],
       series: [
@@ -361,7 +361,7 @@ export const VLLM_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       guide: [
         {
           label: 'ITL / E2E',
-          detail: 'ITL（TPOT）与端到端时延同图对比，decode 变慢时 ITL 先抬升。'
+          detail: '逐 Token 与端到端时延。'
         }
       ],
       series: [
@@ -372,27 +372,27 @@ export const VLLM_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       ]
     },
     {
-      title: 'Input / Output TPM',
-      subtitle: 'token/s × 60',
+      title: '输入 / 输出 TPM',
+      subtitle: 'tpm',
       metric: 'vllm_output_tpm',
       guide: [
         {
           label: 'TPM',
-          detail: 'Input 与 Output 均为 sum(rate(...[5m])) * 60，不要使用 Grafana Output TPM 的 *6。'
+          detail: '输入与输出 tokens per minute。'
         }
       ],
       series: [
         {
           metric: 'vllm_input_tpm',
-          label: 'Input TPM',
+          label: '输入 TPM',
           color: '#13c2c2',
-          unit: 'counts'
+          unit: 'tpm'
         },
         {
           metric: 'vllm_output_tpm',
-          label: 'Output TPM',
+          label: '输出 TPM',
           color: '#27c274',
-          unit: 'counts'
+          unit: 'tpm'
         }
       ]
     },
@@ -403,7 +403,7 @@ export const VLLM_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       guide: [
         {
           label: '输入长度',
-          detail: '请求 prompt token 数分布，异常抬升可能带来 prefill 压力。'
+          detail: '请求 prompt token 数分布。'
         }
       ],
       series: [
@@ -483,7 +483,7 @@ export const VLLM_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       guide: [
         {
           label: '队列分布',
-          detail: '运行中与排队请求占比，排队段扩大表示调度压力升高。'
+          detail: '运行中与排队请求占比。'
         }
       ],
       segments: [

--- a/web/src/app/monitor/dashboards/objects/vllm/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/vllm/dashboard.tsx
@@ -26,7 +26,7 @@ const CHART_TITLES = [
   '时延拆解',
   'KV 缓存占用',
   'ITL / E2E',
-  'Input / Output TPM',
+  '输入 / 输出 TPM',
   '输入 Token 长度',
   '输出 Token 长度'
 ];
@@ -67,7 +67,7 @@ export default function VllmDashboardPage() {
       styles={styles}
       dashboardContent={
         <>
-          <div className={styles.sectionLabel}>队列</div>
+          <div className={styles.sectionLabel}>总览</div>
           <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={6} styles={styles} />
           <FlexiblePanelSection styles={styles}>
             {renderChart(queueTrend, styles.span8)}
@@ -87,17 +87,17 @@ export default function VllmDashboardPage() {
             ) : null}
           </FlexiblePanelSection>
 
-          <div className={styles.sectionLabel}>TTFT</div>
+          <div className={styles.sectionLabel}>时延拆解</div>
           <FlexiblePanelSection styles={styles}>
             {renderChart(latencyBreakdown, styles.span12)}
           </FlexiblePanelSection>
 
-          <div className={styles.sectionLabel}>KV</div>
+          <div className={styles.sectionLabel}>KV 缓存</div>
           <FlexiblePanelSection styles={styles}>
             {renderChart(kvTrend, styles.span12)}
           </FlexiblePanelSection>
 
-          <div className={styles.sectionLabel}>TPOT</div>
+          <div className={styles.sectionLabel}>吞吐</div>
           <FlexiblePanelSection styles={styles}>
             {renderChart(tpotTrend, styles.span6)}
             {renderChart(tpmTrend, styles.span6)}

--- a/web/src/app/monitor/dashboards/shared/types.ts
+++ b/web/src/app/monitor/dashboards/shared/types.ts
@@ -64,6 +64,7 @@ export type MetricUnit =
   | 'd'
   | 'cps'
   | 'pps'
+  | 'tpm'
   | 'hertz'
   | 'kilohertz'
   | 'megahertz'

--- a/web/src/app/monitor/dashboards/shared/utils/format.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/format.ts
@@ -119,6 +119,7 @@ export const formatMetricValue = (value: number, unit: MetricUnit): { value: str
   if (normalizedUnit === 'percent') return { value: value.toFixed(1), unit: '%' };
   if (normalizedUnit === 'msps') return { value: value >= 100 ? value.toFixed(0) : value.toFixed(1), unit: 'ms/s' };
   if (normalizedUnit === 'cps' || normalizedUnit === 'pps') return formatCountRate(value);
+  if (normalizedUnit === 'tpm') return { value: formatScaledValue(value), unit: 'tpm' };
   if (COUNT_UNITS.includes(normalizedUnit)) return formatAutoScaled(value, normalizedUnit, COUNT_UNITS, COUNT_LABELS, 1000);
   if (DATA_BITS_UNITS.includes(normalizedUnit)) return formatAutoScaled(value, normalizedUnit, DATA_BITS_UNITS, DATA_BITS_LABELS, 1000);
   if (DATA_BYTES_UNITS.includes(normalizedUnit)) return formatAutoScaled(value, normalizedUnit, DATA_BYTES_UNITS, DATA_BYTES_LABELS, 1024);


### PR DESCRIPTION
## Summary
- 看板分区改成短运维标题：总览 / 时延拆解 / KV 缓存 / 吞吐 / 单实例；去掉长排查说明和诊断表。
- TPM 标题改为「输入 TPM」「输出 TPM」，单位 `tpm`。查询仍是 `rate() * 60`，UI 不再出现 `x60` / `token/s × 60`。

## 有意不做
- PromQL、KPI 顺序、metrics.json / policy.json / toml 均未改
- 本地 mock 脚本不在本 PR

## Test plan
- [ ] 看板分区标题是运维短标题，无大段决策表
- [ ] 输入/输出 TPM 标题和单位正常，无 x60
- [ ] 数值仍按 token/min（rate*60）