### PR TITLE
bugfix: 明确日志聚类无监督评估契约

### DIFF
--- a/algorithms/classify_log_server/EVALUATION_CONTRACT.md
+++ b/algorithms/classify_log_server/EVALUATION_CONTRACT.md
@@ -1,0 +1,22 @@
+# 日志聚类评估契约
+
+当前正式训练契约为 `log-clustering-unsupervised-v1`。
+
+## 正式支持范围
+
+BK-Lite Web、Server、数据集发布包和 `UniversalTrainer` 当前只传递日志样本，不传递标签或稳定 sample ID。因此正式训练、验证调参、测试评估和 MLflow 比较只允许以下无监督指标：
+
+- `template_quality_score`
+- `coverage_rate`
+- `template_diversity`
+- `num_templates`
+
+Trainer 会把 `evaluation_contract_version=log-clustering-unsupervised-v1` 写入 MLflow 参数和训练结果。不同评估契约的分数不得直接比较。
+
+## Ground truth 边界
+
+`LogDataLoader` 中的标签读写 helper 仅为历史实验代码兼容保留，不属于正式 Trainer 契约。显式向模型评估传入 `ground_truth` 会抛出稳定的 `supervised_evaluation_unsupported` 异常，不会静默忽略标签，也不会生成直接比较任意 cluster ID 的 GA、precision、recall 或 F1。
+
+## 未来带标签版本
+
+若产品正式支持带标签训练，应建立新版本 `TrainingDataset`，至少包含日志、标签、稳定 sample ID、train/val/test 切分和完整性摘要；预处理必须保持 sample ID 对齐，监督聚类指标应采用 ARI、NMI 或等价的编号置换不敏感指标，并使用新的 `evaluation_contract_version`。

--- a/algorithms/classify_log_server/classify_log_server/training/config/schema.py
+++ b/algorithms/classify_log_server/classify_log_server/training/config/schema.py
@@ -7,6 +7,8 @@ Configuration values should be stored in external JSON files.
 
 from typing import List
 
+from ..evaluation_contract import UNSUPERVISED_METRICS
+
 # Supported model types
 SUPPORTED_MODELS: List[str] = [
     "Spell",
@@ -15,9 +17,4 @@ SUPPORTED_MODELS: List[str] = [
 
 
 # Supported optimization metrics
-SUPPORTED_METRICS: List[str] = [
-    "template_quality_score",
-    "coverage_rate",
-    "template_diversity",
-    "num_templates",
-]
+SUPPORTED_METRICS: List[str] = list(UNSUPERVISED_METRICS)

--- a/algorithms/classify_log_server/classify_log_server/training/data_loader.py
+++ b/algorithms/classify_log_server/classify_log_server/training/data_loader.py
@@ -1,9 +1,12 @@
 """日志聚类训练的数据加载器"""
 
+import warnings
 from pathlib import Path
 from typing import List, Optional, Tuple
 
 from loguru import logger
+
+from .evaluation_contract import LEGACY_GROUND_TRUTH_WARNING
 
 
 class LogDataLoader:
@@ -46,7 +49,9 @@ class LogDataLoader:
         return logs
 
     def load_ground_truth(self, file_path: str) -> List[int]:
-        """从文件加载真实标签
+        """从文件加载实验性真实标签。
+
+        该 helper 仅为历史兼容保留，正式 Trainer 不消费其输出。
 
         每一行包含一个聚类 ID（整数）。
 
@@ -56,6 +61,11 @@ class LogDataLoader:
         Returns:
             聚类 ID 列表
         """
+        warnings.warn(
+            LEGACY_GROUND_TRUTH_WARNING,
+            FutureWarning,
+            stacklevel=2,
+        )
         file_path = Path(file_path)
         if not file_path.exists():
             raise FileNotFoundError(f"Ground truth file not found: {file_path}")
@@ -137,12 +147,19 @@ class LogDataLoader:
         logger.info(f"Saved {len(logs)} logs to {output_path}")
 
     def save_ground_truth(self, labels: List[int], output_path: str):
-        """保存真实标签到文件
+        """保存实验性真实标签到文件。
+
+        该 helper 仅为历史兼容保留，正式 Trainer 不消费其输出。
 
         Args:
             labels: 聚类 ID 列表
             output_path: 输出文件路径
         """
+        warnings.warn(
+            LEGACY_GROUND_TRUTH_WARNING,
+            FutureWarning,
+            stacklevel=2,
+        )
         output_path = Path(output_path)
         output_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/algorithms/classify_log_server/classify_log_server/training/evaluation_contract.py
+++ b/algorithms/classify_log_server/classify_log_server/training/evaluation_contract.py
@@ -1,0 +1,30 @@
+"""日志聚类正式评估契约。"""
+
+EVALUATION_CONTRACT_VERSION = "log-clustering-unsupervised-v1"
+
+UNSUPERVISED_METRICS = (
+    "template_quality_score",
+    "coverage_rate",
+    "template_diversity",
+    "num_templates",
+)
+
+LEGACY_GROUND_TRUTH_WARNING = " ".join(
+    (
+        "ground truth 标签 helper 不属于当前正式 Trainer 契约；",
+        "当前产品仅支持无监督评估，带标签训练需使用未来版本化 TrainingDataset",
+    )
+)
+
+
+class SupervisedEvaluationUnsupported(ValueError):
+    """当前正式训练数据契约不支持监督评估。"""
+
+    code = "supervised_evaluation_unsupported"
+
+
+def require_unsupervised_evaluation(ground_truth) -> None:
+    if ground_truth is not None:
+        raise SupervisedEvaluationUnsupported(
+            "当前正式训练契约仅支持无监督评估；ground truth 尚未纳入 " "Web、Server、数据集发布和稳定 sample ID 契约"
+        )

--- a/algorithms/classify_log_server/classify_log_server/training/models/base.py
+++ b/algorithms/classify_log_server/classify_log_server/training/models/base.py
@@ -99,25 +99,22 @@ class BaseLogClusterModel(ABC):
         
         Args:
             logs: 日志消息列表
-            ground_truth: 真实聚类标签（可选，用于监督评估）
+            ground_truth: 历史兼容参数；当前正式契约传入非 None 时必须拒绝
             prefix: 指标名称前缀（如 "train", "test", "val"）
             verbose: 是否输出详细日志
         
         Returns:
-            评估指标字典，建议包含以下指标：
+            无监督评估指标字典，建议包含以下指标：
             {
                 "num_templates": int,           # 模板数量
                 "coverage_rate": float,         # 覆盖率（解析成功率）
                 "template_diversity": float,    # 模板多样性（归一化熵）
-                # 如果提供 ground_truth，还应包含：
-                "grouping_accuracy": float,     # 分组准确率
-                "precision": float,             # 精确率
-                "recall": float,                # 召回率
-                "f1_score": float              # F1分数
+                "template_quality_score": float # 模板质量
             }
         
         Raises:
             RuntimeError: 模型未训练
+            SupervisedEvaluationUnsupported: 传入 ground_truth
         """
         pass
 

--- a/algorithms/classify_log_server/classify_log_server/training/models/spell_model.py
+++ b/algorithms/classify_log_server/classify_log_server/training/models/spell_model.py
@@ -1,13 +1,13 @@
 """用于日志聚类的 Spell 模型实现。"""
 
-from typing import Any, Dict, List, Optional, Tuple, Set
+from typing import Any, Dict, List, Optional, Set
 from collections import Counter, defaultdict
-from datetime import datetime
 import time
 
 import mlflow
 from loguru import logger
 
+from ..evaluation_contract import require_unsupervised_evaluation
 from .base import BaseLogClusterModel, ModelRegistry
 
 
@@ -304,7 +304,7 @@ class SpellModel(BaseLogClusterModel):
         
         Args:
             logs: 日志消息列表
-            ground_truth: 真实聚类标签（可选，用于监督评估）
+            ground_truth: 历史兼容参数；当前正式契约不支持监督评估
             prefix: 指标名称前缀（如 "train", "test", "val"）
             verbose: 是否输出详细日志
         
@@ -314,15 +314,12 @@ class SpellModel(BaseLogClusterModel):
             - coverage_rate: 覆盖率（解析成功率）
             - template_diversity: 模板多样性（归一化熵）
             - template_quality_score: 模板质量得分（如果有模板）
-            - grouping_accuracy: 分组准确率（如果有 ground_truth）
-            - precision: 精确率（如果有 ground_truth）
-            - recall: 召回率（如果有 ground_truth）
-            - f1_score: F1分数（如果有 ground_truth）
         
         Raises:
             RuntimeError: 模型未训练
         """
         self._check_fitted()
+        require_unsupervised_evaluation(ground_truth)
 
         if verbose:
             eval_mode = prefix if prefix else "default"
@@ -365,37 +362,10 @@ class SpellModel(BaseLogClusterModel):
         if self.templates:
             metrics["template_quality_score"] = self._compute_template_quality()
 
-        # 2. 计算监督指标（如果提供真实标签）
-        if ground_truth is not None:
-            # 分组准确率（GA）
-            if len(predictions) != len(ground_truth):
-                raise ValueError("预测结果和真实标签长度必须相同")
-            
-            correct = sum(1 for p, g in zip(predictions, ground_truth) if p == g)
-            metrics["grouping_accuracy"] = correct / len(predictions) if predictions else 0.0
-
-            # 解析准确率（PA）
-            # PA 通常通过比较预测模板和真实模板来计算
-            # 这里为简化，使用与 GA 相同的值（可进一步优化）
-            metrics["parsing_accuracy"] = metrics["grouping_accuracy"]
-
-            # 精确率和召回率
-            precision, recall = self._compute_precision_recall(predictions, ground_truth)
-            metrics["precision"] = precision
-            metrics["recall"] = recall
-            
-            # F1 分数
-            if precision + recall > 0:
-                metrics["f1_score"] = 2 * (precision * recall) / (precision + recall)
-            else:
-                metrics["f1_score"] = 0.0
-
-        # 3. 存储内部数据（用于后续分析）
+        # 2. 存储内部数据（用于后续分析）
         metrics['_predictions'] = predictions
-        if ground_truth is not None:
-            metrics['_ground_truth'] = ground_truth
 
-        # 4. 应用前缀（如果提供）
+        # 3. 应用前缀（如果提供）
         if prefix:
             metrics = {f"{prefix}_{k}" if not k.startswith('_') else k: v 
                        for k, v in metrics.items()}
@@ -406,52 +376,6 @@ class SpellModel(BaseLogClusterModel):
             logger.info(f"评估结果: {key_metrics}")
 
         return metrics
-
-    def _compute_precision_recall(
-        self, predictions: List[int], ground_truth: List[int]
-    ) -> tuple[float, float]:
-        """计算聚类的精确率和召回率
-        
-        Args:
-            predictions: 预测的聚类 ID
-            ground_truth: 真实聚类 ID
-        
-        Returns:
-            (精确率, 召回率) 元组
-        """
-        from collections import defaultdict
-
-        # 构建聚类映射
-        pred_clusters = defaultdict(set)
-        true_clusters = defaultdict(set)
-
-        for i, (p, g) in enumerate(zip(predictions, ground_truth)):
-            pred_clusters[p].add(i)
-            true_clusters[g].add(i)
-
-        # 计算真正例（TP）
-        tp = 0
-        for cluster in pred_clusters.values():
-            # 计算同一预测聚类中的配对数
-            for i in cluster:
-                for j in cluster:
-                    if i < j and ground_truth[i] == ground_truth[j]:
-                        tp += 1
-
-        # 预测聚类中的总配对数
-        pred_pairs = sum(
-            len(cluster) * (len(cluster) - 1) // 2 for cluster in pred_clusters.values()
-        )
-
-        # 真实聚类中的总配对数
-        true_pairs = sum(
-            len(cluster) * (len(cluster) - 1) // 2 for cluster in true_clusters.values()
-        )
-
-        precision = tp / pred_pairs if pred_pairs > 0 else 0.0
-        recall = tp / true_pairs if true_pairs > 0 else 0.0
-
-        return precision, recall
 
     def _compute_template_quality(self) -> float:
         """计算平均模板质量得分
@@ -855,7 +779,7 @@ class SpellModel(BaseLogClusterModel):
                 temp_model.fit(train_data, verbose=False, log_to_mlflow=False)
                 
                 # 验证集评估
-                val_metrics = temp_model.evaluate(val_data, ground_truth=None, verbose=False)
+                val_metrics = temp_model.evaluate(val_data, verbose=False)
                 
                 # 获取优化目标分数（越大越好，所以用负数作为 loss）
                 score = val_metrics.get(metric, val_metrics.get('template_quality_score', 0))

--- a/algorithms/classify_log_server/classify_log_server/training/trainer.py
+++ b/algorithms/classify_log_server/classify_log_server/training/trainer.py
@@ -9,6 +9,7 @@ import mlflow
 
 from .config.loader import TrainingConfig
 from .data_loader import LogDataLoader
+from .evaluation_contract import EVALUATION_CONTRACT_VERSION
 from .mlflow_utils import MLFlowUtils
 from .models.base import ModelRegistry
 from .models import SpellModel  # 导入具体模型以触发注册
@@ -110,9 +111,7 @@ class UniversalTrainer:
                     # 合并train+val评估最终训练数据
                     final_train_data = train_data + val_data
                     logger.info("评估最终训练数据拟合度（train+val样本内评估）...")
-                    final_train_metrics = self.model.evaluate(
-                        final_train_data, ground_truth=None
-                    )
+                    final_train_metrics = self.model.evaluate(final_train_data)
                     # 使用 MLFlowUtils 批量记录（自动过滤）
                     MLFlowUtils.log_metrics_batch(
                         final_train_metrics, prefix="final_train_"
@@ -133,7 +132,7 @@ class UniversalTrainer:
                 else:
                     # 无验证集，只评估训练集
                     logger.info("评估训练集拟合度（样本内评估）...")
-                    train_metrics = self.model.evaluate(train_data, ground_truth=None)
+                    train_metrics = self.model.evaluate(train_data)
                     # 使用 MLFlowUtils 批量记录
                     MLFlowUtils.log_metrics_batch(train_metrics, prefix="train_")
                     # 只输出数值统计指标到日志
@@ -148,7 +147,7 @@ class UniversalTrainer:
                 test_metrics = {}
                 if test_data:
                     logger.info("评估测试集...")
-                    test_metrics = self.model.evaluate(test_data, ground_truth=None)
+                    test_metrics = self.model.evaluate(test_data)
                     # 使用 MLFlowUtils 批量记录
                     MLFlowUtils.log_metrics_batch(test_metrics, prefix="test_")
                     # 只输出数值统计指标到日志
@@ -213,6 +212,7 @@ class UniversalTrainer:
                     "num_templates": self.model.get_num_templates(),
                     "run_id": run.info.run_id,
                     "best_params": best_params,
+                    "evaluation_contract_version": EVALUATION_CONTRACT_VERSION,
                 }
 
                 # 过滤测试集指标，只输出数值统计
@@ -381,6 +381,7 @@ class UniversalTrainer:
 
         # 递归展平嵌套配置（支持任意深度）
         flat_config = MLFlowUtils.flatten_dict(config_dict)
+        flat_config["evaluation_contract_version"] = EVALUATION_CONTRACT_VERSION
 
         MLFlowUtils.log_params_batch(flat_config)
         logger.debug(f"配置已记录到 MLflow，共 {len(flat_config)} 个参数")

--- a/algorithms/classify_log_server/tests/test_issue_4493_unsupervised_contract.py
+++ b/algorithms/classify_log_server/tests/test_issue_4493_unsupervised_contract.py
@@ -3,7 +3,10 @@ from unittest.mock import patch
 import pytest
 from classify_log_server.training.config.schema import SUPPORTED_METRICS
 from classify_log_server.training.data_loader import LogDataLoader
-from classify_log_server.training.evaluation_contract import EVALUATION_CONTRACT_VERSION, SupervisedEvaluationUnsupported
+from classify_log_server.training.evaluation_contract import (
+    EVALUATION_CONTRACT_VERSION,
+    SupervisedEvaluationUnsupported,
+)
 from classify_log_server.training.models.spell_model import SpellModel
 from classify_log_server.training.trainer import UniversalTrainer
 
@@ -89,7 +92,9 @@ def test_trainer_logs_evaluation_contract_version():
         {"to_dict": lambda self: {"model": {"type": "Spell"}}},
     )()
 
-    with patch("classify_log_server.training.trainer.MLFlowUtils.log_params_batch") as log_params:
+    with patch(
+        "classify_log_server.training.trainer.MLFlowUtils.log_params_batch"
+    ) as log_params:
         trainer._log_config()
 
     logged = log_params.call_args.args[0]

--- a/algorithms/classify_log_server/tests/test_issue_4493_unsupervised_contract.py
+++ b/algorithms/classify_log_server/tests/test_issue_4493_unsupervised_contract.py
@@ -1,0 +1,109 @@
+from unittest.mock import patch
+
+import pytest
+from classify_log_server.training.config.schema import SUPPORTED_METRICS
+from classify_log_server.training.data_loader import LogDataLoader
+from classify_log_server.training.evaluation_contract import EVALUATION_CONTRACT_VERSION, SupervisedEvaluationUnsupported
+from classify_log_server.training.models.spell_model import SpellModel
+from classify_log_server.training.trainer import UniversalTrainer
+
+EXPECTED_UNSUPERVISED_METRICS = {
+    "num_templates",
+    "coverage_rate",
+    "template_diversity",
+    "template_quality_score",
+}
+
+
+def _fitted_model():
+    model = SpellModel(tau=0.5)
+    model.fit(
+        [
+            "database connection failed host alpha",
+            "database connection failed host beta",
+            "user login succeeded account alice",
+            "user login succeeded account bob",
+        ],
+        verbose=False,
+        log_to_mlflow=False,
+    )
+    return model
+
+
+def test_supported_hyperopt_metrics_are_explicitly_unsupervised():
+    assert set(SUPPORTED_METRICS) == EXPECTED_UNSUPERVISED_METRICS
+    assert not {
+        "grouping_accuracy",
+        "parsing_accuracy",
+        "precision",
+        "recall",
+        "f1_score",
+    } & set(SUPPORTED_METRICS)
+
+
+def test_explicit_ground_truth_fails_fast_instead_of_returning_id_sensitive_score():
+    model = _fitted_model()
+
+    with pytest.raises(
+        SupervisedEvaluationUnsupported,
+        match="当前正式训练契约仅支持无监督评估",
+    ) as exc_info:
+        model.evaluate(
+            [
+                "database connection failed host gamma",
+                "user login succeeded account carol",
+            ],
+            ground_truth=[7, 3],
+            verbose=False,
+        )
+    assert exc_info.value.code == "supervised_evaluation_unsupported"
+
+
+def test_unsupervised_evaluation_never_exports_supervised_metric_names():
+    model = _fitted_model()
+
+    metrics = model.evaluate(
+        [
+            "database connection failed host gamma",
+            "user login succeeded account carol",
+        ],
+        verbose=False,
+    )
+
+    assert EXPECTED_UNSUPERVISED_METRICS <= set(metrics)
+    assert not {
+        "grouping_accuracy",
+        "parsing_accuracy",
+        "precision",
+        "recall",
+        "f1_score",
+        "_ground_truth",
+    } & set(metrics)
+
+
+def test_trainer_logs_evaluation_contract_version():
+    trainer = object.__new__(UniversalTrainer)
+    trainer.config = type(
+        "Config",
+        (),
+        {"to_dict": lambda self: {"model": {"type": "Spell"}}},
+    )()
+
+    with patch("classify_log_server.training.trainer.MLFlowUtils.log_params_batch") as log_params:
+        trainer._log_config()
+
+    logged = log_params.call_args.args[0]
+    assert logged["evaluation_contract_version"] == EVALUATION_CONTRACT_VERSION
+
+
+def test_legacy_ground_truth_loader_warns_that_trainer_does_not_consume_labels(
+    tmp_path,
+):
+    labels = tmp_path / "labels.txt"
+    labels.write_text("0\n1\n", encoding="utf-8")
+
+    with pytest.warns(
+        FutureWarning,
+        match="不属于当前正式 Trainer 契约",
+    ):
+        assert LogDataLoader().load_ground_truth(str(labels)) == [0, 1]

--- a/algorithms/classify_log_server/tests/test_issue_4616_incremental_template.py
+++ b/algorithms/classify_log_server/tests/test_issue_4616_incremental_template.py
@@ -18,6 +18,8 @@ def _load_spell_model():
     models = types.ModuleType(f"{root_name}.models")
     models.__path__ = []
     base = types.ModuleType(f"{root_name}.models.base")
+    evaluation_contract = types.ModuleType(f"{root_name}.evaluation_contract")
+    evaluation_contract.require_unsupervised_evaluation = lambda ground_truth: None
 
     class BaseLogClusterModel:
         def __init__(self, config=None):
@@ -49,6 +51,7 @@ def _load_spell_model():
         root_name: training,
         f"{root_name}.models": models,
         f"{root_name}.models.base": base,
+        f"{root_name}.evaluation_contract": evaluation_contract,
         "mlflow": mlflow,
         "loguru": loguru,
     }


### PR DESCRIPTION
## 问题

日志聚类正式产品链只发布日志样本，没有标签文件、稳定 sample ID 或切分对齐契约；Trainer 与 Hyperopt 实际始终执行无监督评估。但模型接口仍宣称支持 ground truth，并保留直接比较任意 cluster ID 的 GA、precision、recall 和 F1，容易让调用方误以为正式训练会使用真实标签，或产生对簇编号置换敏感的伪监督分数。

本 PR 按已确认的方案 B，把当前正式能力诚实收敛为无监督评估，不建设跨 Web/Server 的带标签训练能力。

## 根因

数据 loader 的历史实验 helper 与正式 Trainer 共用同一代码目录，却没有明确契约边界；模型评估接口又把未贯通的数据能力暴露成正式参数。配置、Trainer、MLflow 和模型文档因此缺少一个统一、可核验的评估版本。

## 怎么修的

- 新增固定契约 `log-clustering-unsupervised-v1`。
- 超参数优化指标统一来源于四个无监督指标：模板质量、覆盖率、模板多样性和模板数量。
- Trainer 与 Hyperopt 不再传递或宣称消费 ground truth。
- 训练结果和 MLflow 参数记录 `evaluation_contract_version`，避免未来不同口径分数混比。
- Spell 显式收到 ground truth 时抛出稳定 `supervised_evaluation_unsupported` 异常，不静默忽略标签。
- 删除直接比较 cluster ID 的 GA、parsing accuracy、precision、recall 和 F1 实现。
- 历史标签读写 helper 保持可调用，但发出用户可见的 `FutureWarning`，明确它不属于正式 Trainer 契约。
- 新增契约文档，说明未来带标签版本必须具备日志、标签、稳定 sample ID、切分完整性和编号置换不敏感指标。

## 调用链

```mermaid
flowchart TD
    subgraph T["数据入口"]
        T1["Web / Server 数据集\n仅日志文件"]
        T2["发布包\ntrain / val / test 日志"]
    end

    subgraph N["训练评估"]
        N1["UniversalTrainer\n无监督契约"]
        N2["Spell evaluate\n四项无监督指标"]
        N3["Hyperopt\n仅允许无监督目标"]
    end

    subgraph C["结果与边界"]
        C1["MLflow\nevaluation_contract_version"]
        C2["显式 ground truth\n稳定 fail-fast"]
    end

    T1 --> T2 --> N1
    N1 --> N2 --> C1
    N1 --> N3 --> C1
    N1 -. "传入标签" .-> C2
```

## 影响范围与兼容性

- 不修改 Web/Server 数据模型、数据集 ZIP、训练脚本、模型 artifact 或在线推理输出。
- 现有无标签训练、调参、模型加载和服务预测保持原行为。
- 显式调用实验性监督评估的代码将得到稳定异常；这是方案 B 确认的正式边界，不再返回误导性分数。
- 不新增依赖、环境变量、数据库迁移或部署配置。
- 若未来正式支持标签训练，应新建版本化 `TrainingDataset` 和新的评估契约，而不是恢复直接比较 cluster ID。

## 验证

- `tests/test_issue_4493_unsupervised_contract.py`：5 passed。
- `tests/test_issue_4616_incremental_template.py`：14 passed，旧模型 artifact 兼容。
- `tests/test_schema_and_predict.py`：28 passed，Spell 与服务预测契约不变。
- 模型加载、训练脚本安全和 checksum 三个文件：13 passed。
- 四组隔离清单累计 60 passed。全目录单进程存在既有模块桩互相污染；相关文件独立运行均通过。
- Python 编译、Black（新增文件）和 diff-check 通过。

## 三轨门禁

- Standards：PASS。改动仅限日志聚类算法与契约测试，无新增依赖或部署耦合。
- Spec：PASS。正式指标、显式标签错误、MLflow 版本、历史 helper 边界和未来 v2 条件均已收口。
- Runtime Contract：PASS。真实 Spell fit/evaluate 验证无监督结果；显式标签稳定失败；旧 artifact 与服务主路径通过。
- 综合评分：95/100。

部署配置介入：**否**。

Closes #4493
