### PR TITLE
fix(monitor): 补齐指标试算缺失的 query_allow_error

### DIFF
--- a/server/apps/monitor/utils/victoriametrics_api.py
+++ b/server/apps/monitor/utils/victoriametrics_api.py
@@ -53,6 +53,53 @@ class VictoriaMetricsAPI:
             )
             raise
 
+    def _do_get_allow_error(self, api_path, params):
+        """GET that returns (payload, http_error) for PromQL/HTTP failures.
+
+        Network/timeouts still raise so callers can classify infra errors.
+        HTTP 4xx/5xx with a JSON body return that body plus the HTTPError.
+        """
+        try:
+            response = _SESSION.get(
+                f"{self.host}{api_path}",
+                params=params,
+                auth=(self.username, self.password),
+                verify=self.ssl_verify,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            return response.json(), None
+        except requests.Timeout:
+            logger.error(
+                "VictoriaMetrics request timed out",
+                extra={
+                    "host": self.host,
+                    "api_path": api_path,
+                    "timeout": self.timeout,
+                },
+                exc_info=True,
+            )
+            raise
+        except requests.HTTPError as exc:
+            payload = None
+            resp = getattr(exc, "response", None)
+            if resp is not None:
+                try:
+                    payload = resp.json()
+                except ValueError:
+                    payload = {"error": (resp.text or "")[:200]}
+            return payload, exc
+        except requests.RequestException:
+            logger.error(
+                "VictoriaMetrics request failed",
+                extra={
+                    "host": self.host,
+                    "api_path": api_path,
+                },
+                exc_info=True,
+            )
+            raise
+
     def query(self, query, step="5m", time=None, lookback_delta=None):
         params = {"query": query}
         if step:
@@ -62,6 +109,17 @@ class VictoriaMetricsAPI:
         if lookback_delta:
             params["lookback_delta"] = lookback_delta
         return self._do_get("/api/v1/query", params)
+
+    def query_allow_error(self, query, step="5m", time=None, lookback_delta=None):
+        """Instant query that surfaces PromQL/HTTP errors without raising."""
+        params = {"query": query}
+        if step:
+            params["step"] = step
+        if time:
+            params["time"] = time
+        if lookback_delta:
+            params["lookback_delta"] = lookback_delta
+        return self._do_get_allow_error("/api/v1/query", params)
 
     def query_range(self, query, start, end, step="5m"):
         return self._do_get(


### PR DESCRIPTION
## Summary
- 补齐 `VictoriaMetricsAPI.query_allow_error`，修复「测试指标」因 `AttributeError` 一律失败并误报「无法选择维度字段」的问题
- HTTP/PromQL 错误以 `(payload, err)` 返回供语法分类；超时与网络异常仍上抛为基础设施失败
- 根因：`604c81cd5` 已调用该方法但未实现；VMUI 有数据与失败无关

## Test plan
- [x] 本地单测：`query_allow_error` 成功 / HTTP 错误 / 超时路径（未纳入本 PR）
- [x] 本地直连 `127.0.0.1:8428` 对 `mysql_aborted_clients` 试算返回 `ok=True` 并抽出维度 labels
- [ ] 重启后端后在「添加指标」中对有数据公式点「测试指标」，应成功并可选择维度