### PR TITLE
fix(监控): pod_status_phase 改为五值生命周期 Enum

### DIFF
--- a/server/apps/monitor/support-files/plugins/unknown/k3s/k3s/metrics.json
+++ b/server/apps/monitor/support-files/plugins/unknown/k3s/k3s/metrics.json
@@ -78,10 +78,10 @@
           "display_name": "Pod Status",
           "instance_id_keys": ["instance_id", "pod"],
           "data_type": "Enum",
-          "unit": "[{\"name\":\"未运行\",\"id\":0,\"color\":\"#faad14\"},{\"name\":\"运行中\",\"id\":1,\"color\":\"#1ac44a\"}]",
+          "unit": "[{\"name\":\"Pending\",\"id\":0,\"color\":\"#faad14\"},{\"name\":\"Running\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"Succeeded\",\"id\":2,\"color\":\"#8c8c8c\"},{\"name\":\"Failed\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"Unknown\",\"id\":4,\"color\":\"#bfbfbf\"}]",
           "dimensions": [],
-          "description": "Indicates the current lifecycle phase of a Pod. This metric is used to quickly assess Pod health.",
-          "query": "prometheus_remote_write_kube_pod_status_phase{instance_type=\"k3s\",phase=\"Running\",__$labels__}"
+          "description": "Pod lifecycle phase remapped from kube_pod_status_phase labels: 0 Pending, 1 Running, 2 Succeeded, 3 Failed, 4 Unknown. Every Pod emits one value.",
+          "query": "max by (instance_id, pod) (\n  (prometheus_remote_write_kube_pod_status_phase{instance_type=\"k3s\",phase=\"Pending\",__$labels__} == 1) * 0\n  or (prometheus_remote_write_kube_pod_status_phase{instance_type=\"k3s\",phase=\"Running\",__$labels__} == 1) * 1\n  or (prometheus_remote_write_kube_pod_status_phase{instance_type=\"k3s\",phase=\"Succeeded\",__$labels__} == 1) * 2\n  or (prometheus_remote_write_kube_pod_status_phase{instance_type=\"k3s\",phase=\"Failed\",__$labels__} == 1) * 3\n  or (prometheus_remote_write_kube_pod_status_phase{instance_type=\"k3s\",phase=\"Unknown\",__$labels__} == 1) * 4\n)"
         },
         {
           "metric_group": "Status",

--- a/server/apps/monitor/support-files/plugins/unknown/k8s/k8s/language/en.yaml
+++ b/server/apps/monitor/support-files/plugins/unknown/k8s/k8s/language/en.yaml
@@ -47,7 +47,7 @@ monitor_object_metric:
       desc: Pod metadata from kube_pod_info, used as the carrier metric for the IP display column.
     pod_status_phase:
       name: Pod Phase
-      desc: Current lifecycle phase of the Pod.
+      desc: Lifecycle phase: 0 Pending / 1 Running / 2 Succeeded / 3 Failed / 4 Unknown.
     pod_container_restarts_total:
       name: Container Restart Count
       desc: Total number of container restarts in the Pod since startup.

--- a/server/apps/monitor/support-files/plugins/unknown/k8s/k8s/language/zh-Hans.yaml
+++ b/server/apps/monitor/support-files/plugins/unknown/k8s/k8s/language/zh-Hans.yaml
@@ -45,7 +45,7 @@ monitor_object_metric:
       desc: 来自 kube_pod_info 的 Pod 元数据，用作 IP 展示列的载体指标。
     pod_status_phase:
       name: Pod 阶段
-      desc: Pod 当前的生命周期阶段。
+      desc: 生命周期阶段：0 Pending / 1 Running / 2 Succeeded / 3 Failed / 4 Unknown。
     pod_container_restarts_total:
       name: 容器重启次数
       desc: Pod 内各容器自启动以来的重启总次数。

--- a/server/apps/monitor/support-files/plugins/unknown/k8s/k8s/metrics.json
+++ b/server/apps/monitor/support-files/plugins/unknown/k8s/k8s/metrics.json
@@ -92,10 +92,10 @@
           "display_name": "Pod Status",
           "instance_id_keys": ["instance_id", "pod"],
           "data_type": "Enum",
-          "unit": "[{\"name\":\"未运行\",\"id\":0,\"color\":\"#faad14\"},{\"name\":\"运行中\",\"id\":1,\"color\":\"#1ac44a\"}]",
+          "unit": "[{\"name\":\"Pending\",\"id\":0,\"color\":\"#faad14\"},{\"name\":\"Running\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"Succeeded\",\"id\":2,\"color\":\"#8c8c8c\"},{\"name\":\"Failed\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"Unknown\",\"id\":4,\"color\":\"#bfbfbf\"}]",
           "dimensions": [],
-          "description": "Indicates the current lifecycle phase of a Pod. This metric is used to quickly assess Pod health.",
-          "query": "prometheus_remote_write_kube_pod_status_phase{instance_type=\"k8s\",phase=\"Running\",__$labels__}"
+          "description": "Pod lifecycle phase remapped from kube_pod_status_phase labels: 0 Pending, 1 Running, 2 Succeeded, 3 Failed, 4 Unknown. Every Pod emits one value.",
+          "query": "max by (instance_id, pod) (\n  (prometheus_remote_write_kube_pod_status_phase{instance_type=\"k8s\",phase=\"Pending\",__$labels__} == 1) * 0\n  or (prometheus_remote_write_kube_pod_status_phase{instance_type=\"k8s\",phase=\"Running\",__$labels__} == 1) * 1\n  or (prometheus_remote_write_kube_pod_status_phase{instance_type=\"k8s\",phase=\"Succeeded\",__$labels__} == 1) * 2\n  or (prometheus_remote_write_kube_pod_status_phase{instance_type=\"k8s\",phase=\"Failed\",__$labels__} == 1) * 3\n  or (prometheus_remote_write_kube_pod_status_phase{instance_type=\"k8s\",phase=\"Unknown\",__$labels__} == 1) * 4\n)"
         },
         {
           "metric_group": "Status",

--- a/web/src/app/monitor/(pages)/view/viewHive.tsx
+++ b/web/src/app/monitor/(pages)/view/viewHive.tsx
@@ -275,6 +275,9 @@ const ViewHive: React.FC<ViewListProps> = ({ objects, objectId }) => {
       );
       if (tagetMerticItem) {
         const cellValue = readDisplayMetricCell(item, metricName);
+        const isEnumMetric =
+          tagetMerticItem.data_type === 'Enum' ||
+          isStringArray(tagetMerticItem.unit || '');
         return {
           name: '',
           description: (
@@ -286,9 +289,9 @@ const ViewHive: React.FC<ViewListProps> = ({ objects, objectId }) => {
               )}`}
             </>
           ),
-          fill: queryMetric
-            ? handleHexColor(cellValue, hexColor)
-            : handleFillColor(tagetMerticItem, cellValue)
+          fill: isEnumMetric
+            ? handleFillColor(tagetMerticItem, cellValue)
+            : handleHexColor(cellValue, hexColor)
         };
       }
       return {

--- a/web/src/app/monitor/dashboards/objects/k3s-pod/config.ts
+++ b/web/src/app/monitor/dashboards/objects/k3s-pod/config.ts
@@ -1,9 +1,21 @@
 import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
 
 const POD_PHASE_ENUM = {
-  0: { label: '未运行', color: '#faad14' },
-  1: { label: '运行中', color: '#27c274' }
+  0: { label: 'Pending', color: '#faad14' },
+  1: { label: 'Running', color: '#1ac44a' },
+  2: { label: 'Succeeded', color: '#8c8c8c' },
+  3: { label: 'Failed', color: '#ff4d4f' },
+  4: { label: 'Unknown', color: '#bfbfbf' }
 };
+
+const POD_STATUS_PHASE_QUERY =
+  'max by (instance_id, pod) (' +
+  '(prometheus_remote_write_kube_pod_status_phase{instance_type="k3s",phase="Pending",__$labels__} == 1) * 0' +
+  ' or (prometheus_remote_write_kube_pod_status_phase{instance_type="k3s",phase="Running",__$labels__} == 1) * 1' +
+  ' or (prometheus_remote_write_kube_pod_status_phase{instance_type="k3s",phase="Succeeded",__$labels__} == 1) * 2' +
+  ' or (prometheus_remote_write_kube_pod_status_phase{instance_type="k3s",phase="Failed",__$labels__} == 1) * 3' +
+  ' or (prometheus_remote_write_kube_pod_status_phase{instance_type="k3s",phase="Unknown",__$labels__} == 1) * 4' +
+  ')';
 
 export const POD_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   routeKey: 'k3s-pod',
@@ -18,11 +30,10 @@ export const POD_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       name: 'pod_status_phase',
       display_name: 'Pod 状态',
-      description: 'Pod 当前生命周期阶段(0 未运行 / 1 运行中),用于快速判断 Pod 健康。',
+      description: 'Pod 生命周期阶段：0 Pending / 1 Running / 2 Succeeded / 3 Failed / 4 Unknown。',
       unit: 'none',
-      query:
-        'prometheus_remote_write_kube_pod_status_phase{instance_type="k3s",phase="Running",__$labels__}',
-      color: '#27c274'
+      query: POD_STATUS_PHASE_QUERY,
+      color: '#1ac44a'
     },
     {
       name: 'pod_container_restarts_total',
@@ -93,10 +104,10 @@ export const POD_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   summaryCards: [
     {
       title: 'Pod 状态',
-      guide: [{ label: 'Pod 状态', detail: '未运行时优先查调度失败、镜像拉取、CrashLoop 与探针失败。' }],
+      guide: [{ label: 'Pod 状态', detail: 'Pending 查调度/镜像；Failed 查退出与 CrashLoop；Succeeded 为 Job 正常结束；Unknown 查节点失联。' }],
       metric: 'pod_status_phase',
       unit: 'none',
-      color: '#27c274',
+      color: '#1ac44a',
       icon: 'health',
       enumMap: POD_PHASE_ENUM
     },

--- a/web/src/app/monitor/dashboards/objects/k8s-pod/config.ts
+++ b/web/src/app/monitor/dashboards/objects/k8s-pod/config.ts
@@ -1,9 +1,21 @@
 import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
 
 const POD_PHASE_ENUM = {
-  0: { label: '未运行', color: '#faad14' },
-  1: { label: '运行中', color: '#27c274' }
+  0: { label: 'Pending', color: '#faad14' },
+  1: { label: 'Running', color: '#1ac44a' },
+  2: { label: 'Succeeded', color: '#8c8c8c' },
+  3: { label: 'Failed', color: '#ff4d4f' },
+  4: { label: 'Unknown', color: '#bfbfbf' }
 };
+
+const POD_STATUS_PHASE_QUERY =
+  'max by (instance_id, pod) (' +
+  '(prometheus_remote_write_kube_pod_status_phase{instance_type="k8s",phase="Pending",__$labels__} == 1) * 0' +
+  ' or (prometheus_remote_write_kube_pod_status_phase{instance_type="k8s",phase="Running",__$labels__} == 1) * 1' +
+  ' or (prometheus_remote_write_kube_pod_status_phase{instance_type="k8s",phase="Succeeded",__$labels__} == 1) * 2' +
+  ' or (prometheus_remote_write_kube_pod_status_phase{instance_type="k8s",phase="Failed",__$labels__} == 1) * 3' +
+  ' or (prometheus_remote_write_kube_pod_status_phase{instance_type="k8s",phase="Unknown",__$labels__} == 1) * 4' +
+  ')';
 
 export const POD_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   routeKey: 'k8s-pod',
@@ -18,10 +30,10 @@ export const POD_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       name: 'pod_status_phase',
       display_name: 'Pod 状态',
-      description: 'Pod 当前生命周期阶段(0 未运行 / 1 运行中),用于快速判断 Pod 健康。',
+      description: 'Pod 生命周期阶段：0 Pending / 1 Running / 2 Succeeded / 3 Failed / 4 Unknown。',
       unit: 'none',
-      query: 'prometheus_remote_write_kube_pod_status_phase{instance_type="k8s",phase="Running",__$labels__}',
-      color: '#27c274'
+      query: POD_STATUS_PHASE_QUERY,
+      color: '#1ac44a'
     },
     {
       name: 'pod_container_restarts_total',
@@ -92,10 +104,10 @@ export const POD_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   summaryCards: [
     {
       title: 'Pod 状态',
-      guide: [{ label: 'Pod 状态', detail: '未运行时优先查调度失败、镜像拉取、CrashLoop 与探针失败。' }],
+      guide: [{ label: 'Pod 状态', detail: 'Pending 查调度/镜像；Failed 查退出与 CrashLoop；Succeeded 为 Job 正常结束；Unknown 查节点失联。' }],
       metric: 'pod_status_phase',
       unit: 'none',
-      color: '#27c274',
+      color: '#1ac44a',
       icon: 'health',
       enumMap: POD_PHASE_ENUM
     },


### PR DESCRIPTION
Fixes https://github.com/TencentBlueKing/bk-lite/issues/4940

## Summary
- 原地把 k8s / k3s 的 `pod_status_phase` 改成五值 Enum：Pending / Running / Succeeded / Failed / Unknown。Succeeded 用中性灰，不是告警黄。
- query 五相 `or` + `max by (instance_id, pod)`，每个 Pod 都出数（含非 Running），避免组织列表丢实例。分组仍用这个指标名。
- 蜂巢 Enum 走精确匹配，不再用 `handleHexColor` 阈值 find。
- dashboard `k8s-pod` / `k3s-pod` 同步。

## Breaking
已下发策略里 `==0` / `<1` 表示「未运行」会失效。请改成 Failed（`==3`）和/或 Pending（`==0`），不要把 Succeeded（`==2`）当故障。`plugin_init` 只更新内置模板，已下发策略不会自动改。k8s/k3s 没有内置 `policy.json`。

## 有意不做
- 不新增 `pod_lifecycle_phase`
- 不改采集 yaml
- 不提交测试
- 本单不消费 `waiting_reason`

## Test plan
- [ ] plugin_init 后 Pod 列表能区分 Pending/Running/Succeeded/Failed/Unknown
- [ ] Succeeded Job 不再显示为「未运行」
- [ ] 非 Running 的 Pod 仍出现在组织列表/分组
- [ ] 蜂巢刷新后颜色按 phase 精确匹配，不刷成同一未运行色
- [ ] 已下发 `==0` 告警需要人工改条件（预期 breaking）