### PR TITLE
fix(server): 为文件日志补上默认轮转，避免单文件无限增长

### DIFF
--- a/server/apps/core/tests/test_logging_config.py
+++ b/server/apps/core/tests/test_logging_config.py
@@ -2,9 +2,22 @@ import io
 import logging
 from pathlib import Path
 
-from config.components.log import LOGGING, SafeConsoleHandler
+import pytest
+from logging.handlers import RotatingFileHandler
+
+from config.components.log import (
+    DEFAULT_LOG_FILE_BACKUP_COUNT,
+    DEFAULT_LOG_FILE_MAX_BYTES,
+    LOG_FILE_BACKUP_COUNT,
+    LOG_FILE_MAX_BYTES,
+    LOGGING,
+    SafeConsoleHandler,
+    parse_positive_int,
+    rotating_file_handler,
+)
 
 SERVER_ROOT = Path(__file__).resolve().parents[3]
+PRODUCT_APP_FILE_LOGGERS = ("monitor", "log", "apm", "node", "alert")
 
 
 def test_deployment_env_templates_disable_debug_by_default():
@@ -37,6 +50,91 @@ def test_console_handler_uses_safe_stream_and_file_handlers_are_utf8():
     for name, handler in LOGGING["handlers"].items():
         if handler.get("class") == "logging.handlers.RotatingFileHandler":
             assert handler.get("encoding") == "utf-8", name
+
+
+def _rotating_file_handlers():
+    return {
+        name: handler
+        for name, handler in LOGGING["handlers"].items()
+        if handler.get("class") == "logging.handlers.RotatingFileHandler"
+    }
+
+
+def test_parse_positive_int_uses_default_and_rejects_disabled_rotation():
+    assert parse_positive_int(None, 100, name="LOG_FILE_MAX_BYTES") == 100
+    assert parse_positive_int(" 2048 ", 100, name="LOG_FILE_MAX_BYTES") == 2048
+    with pytest.raises(ValueError, match="LOG_FILE_MAX_BYTES"):
+        parse_positive_int("0", 100, name="LOG_FILE_MAX_BYTES")
+    with pytest.raises(ValueError, match="LOG_FILE_BACKUP_COUNT"):
+        parse_positive_int("-1", 5, name="LOG_FILE_BACKUP_COUNT")
+
+
+def test_rotating_file_handler_applies_defaults_and_rejects_zero_limits():
+    config = rotating_file_handler("demo.log")
+    assert config["class"] == "logging.handlers.RotatingFileHandler"
+    assert config["maxBytes"] == LOG_FILE_MAX_BYTES == DEFAULT_LOG_FILE_MAX_BYTES
+    assert config["backupCount"] == LOG_FILE_BACKUP_COUNT == DEFAULT_LOG_FILE_BACKUP_COUNT
+    assert config["encoding"] == "utf-8"
+    assert config["filename"].endswith("demo.log")
+
+    overridden = rotating_file_handler("demo.log", maxBytes=2 * 1024 * 1024, backupCount=3)
+    assert overridden["maxBytes"] == 2 * 1024 * 1024
+    assert overridden["backupCount"] == 3
+
+    with pytest.raises(ValueError, match="maxBytes"):
+        rotating_file_handler("demo.log", maxBytes=0)
+    with pytest.raises(ValueError, match="backupCount"):
+        rotating_file_handler("demo.log", backupCount=0)
+
+
+def test_all_rotating_file_handlers_share_default_rotation_limits():
+    rotating = _rotating_file_handlers()
+    assert rotating
+    for name, handler in rotating.items():
+        assert handler["maxBytes"] == LOG_FILE_MAX_BYTES, name
+        assert handler["backupCount"] == LOG_FILE_BACKUP_COUNT, name
+        assert handler["maxBytes"] > 0, name
+        assert handler["backupCount"] > 0, name
+
+
+def test_product_app_loggers_keep_info_on_dedicated_rotating_files():
+    for name in PRODUCT_APP_FILE_LOGGERS:
+        handler = LOGGING["handlers"][name]
+        logger_config = LOGGING["loggers"][name]
+        assert handler["class"] == "logging.handlers.RotatingFileHandler"
+        assert handler["maxBytes"] > 0
+        assert name in logger_config["handlers"]
+        assert logger_config["level"] in {"INFO", "DEBUG"}
+
+
+def test_configured_node_handler_rolls_over_when_file_exceeds_max_bytes(tmp_path):
+    cfg = LOGGING["handlers"]["node"]
+    assert cfg["class"] == "logging.handlers.RotatingFileHandler"
+    assert cfg["maxBytes"] > 0
+    path = tmp_path / "node.log"
+    max_bytes = 64
+    path.write_bytes(b"x" * (max_bytes + 1))
+    handler = RotatingFileHandler(
+        path,
+        maxBytes=max_bytes,
+        backupCount=cfg["backupCount"],
+        encoding="utf-8",
+    )
+    try:
+        record = logging.LogRecord("node", logging.INFO, __file__, 1, "overflow", (), None)
+        assert handler.shouldRollover(record)
+    finally:
+        handler.close()
+
+
+def test_runtime_product_loggers_enable_info_and_attach_rotating_files():
+    for name in PRODUCT_APP_FILE_LOGGERS:
+        logger = logging.getLogger(name)
+        assert logger.isEnabledFor(logging.INFO), name
+        rotating = [handler for handler in logger.handlers if isinstance(handler, RotatingFileHandler)]
+        assert rotating, name
+        assert rotating[0].maxBytes > 0, name
+        assert rotating[0].backupCount > 0, name
 
 
 def test_safe_console_handler_replaces_unencodable_chars_on_gbk_stream():

--- a/server/config/components/log.py
+++ b/server/config/components/log.py
@@ -16,6 +16,47 @@ if not os.path.exists(log_dir):
 # 根据 DEBUG 环境变量设置日志级别
 LOG_LEVEL = "DEBUG" if DEBUG else "INFO"
 
+DEFAULT_LOG_FILE_MAX_BYTES = 100 * 1024 * 1024
+DEFAULT_LOG_FILE_BACKUP_COUNT = 5
+
+
+def parse_positive_int(raw, default, *, name):
+    if raw is None or str(raw).strip() == "":
+        return default
+    value = int(raw)
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+LOG_FILE_MAX_BYTES = parse_positive_int(
+    os.getenv("LOG_FILE_MAX_BYTES"),
+    DEFAULT_LOG_FILE_MAX_BYTES,
+    name="LOG_FILE_MAX_BYTES",
+)
+LOG_FILE_BACKUP_COUNT = parse_positive_int(
+    os.getenv("LOG_FILE_BACKUP_COUNT"),
+    DEFAULT_LOG_FILE_BACKUP_COUNT,
+    name="LOG_FILE_BACKUP_COUNT",
+)
+
+
+def rotating_file_handler(filename, **overrides):
+    config = {
+        "class": "logging.handlers.RotatingFileHandler",
+        "formatter": "verbose",
+        "filename": os.path.join(log_dir, filename),
+        "maxBytes": LOG_FILE_MAX_BYTES,
+        "backupCount": LOG_FILE_BACKUP_COUNT,
+        "encoding": "utf-8",
+    }
+    config.update(overrides)
+    if config["maxBytes"] <= 0:
+        raise ValueError("rotating file handler maxBytes must be positive")
+    if config["backupCount"] <= 0:
+        raise ValueError("rotating file handler backupCount must be positive")
+    return config
+
 # 仅用于历史日志分组规则的迁移窗口。默认空集合保持 fail-closed；上线前通过
 # audit_log_group_rule_modes 盘点并只加入已明确需要短期保留旧 OR 语义的分组 ID。
 LOG_GROUP_LEGACY_OR_GROUP_IDS = frozenset(
@@ -131,86 +172,21 @@ LOGGING = {
             "filters": ["suppress_successful_sidecar_access_logs"],
         },
         "null": {"level": "DEBUG", "class": "logging.NullHandler"},
-        "root": {
-            "class": "logging.handlers.RotatingFileHandler",
-            "formatter": "verbose",
-            "filename": os.path.join(log_dir, "%s.log" % APP_CODE),
-            "encoding": "utf-8",
-        },
-        "db": {
-            "class": "logging.handlers.RotatingFileHandler",
-            "formatter": "verbose",
-            "filename": os.path.join(log_dir, "db.log"),
-            "encoding": "utf-8",
-        },
-        "alert": {
-            "class": "logging.handlers.RotatingFileHandler",
-            "formatter": "verbose",
-            "filename": os.path.join(log_dir, "alert.log"),
-            "maxBytes": 100 * 1024 * 1024,  # 添加文件大小限制
-            "backupCount": 5,  # 添加备份文件数量
-            "encoding": "utf-8",  # 添加编码格式
-        },
-        "cmdb": {
-            "class": "logging.handlers.RotatingFileHandler",
-            "formatter": "verbose",
-            "filename": os.path.join(log_dir, "cmdb.log"),
-            "encoding": "utf-8",
-        },
-        "operation_analysis": {
-            "class": "logging.handlers.RotatingFileHandler",
-            "formatter": "verbose",
-            "filename": os.path.join(log_dir, "operation_analysis.log"),
-            "encoding": "utf-8",
-        },
-        "nats": {
-            "class": "logging.handlers.RotatingFileHandler",
-            "formatter": "verbose",
-            "filename": os.path.join(log_dir, "nats.log"),
-            "encoding": "utf-8",
-        },
-        "monitor": {
-            "class": "logging.handlers.RotatingFileHandler",
-            "formatter": "verbose",
-            "filename": os.path.join(log_dir, "monitor.log"),
-            "encoding": "utf-8",
-        },
-        "node": {
-            "class": "logging.handlers.RotatingFileHandler",
-            "formatter": "verbose",
-            "filename": os.path.join(log_dir, "node.log"),
-            "encoding": "utf-8",
-        },
-        "ops-console": {
-            "class": "logging.handlers.RotatingFileHandler",
-            "formatter": "verbose",
-            "filename": os.path.join(log_dir, "ops-console.log"),
-            "encoding": "utf-8",
-        },
-        "system-manager": {
-            "class": "logging.handlers.RotatingFileHandler",
-            "formatter": "verbose",
-            "filename": os.path.join(log_dir, "system-manager.log"),
-            "encoding": "utf-8",
-        },
-        "opspilot": {
-            "class": "logging.handlers.RotatingFileHandler",
-            "formatter": "verbose",
-            "filename": os.path.join(log_dir, "opspilot.log"),
-            "encoding": "utf-8",
-        },
-        "job": {
-            "class": "logging.handlers.RotatingFileHandler",
-            "formatter": "verbose",
-            "filename": os.path.join(log_dir, "job.log"),
-            "encoding": "utf-8",
-        },
-        "playground": {
-            "class": "logging.handlers.RotatingFileHandler",
-            "formatter": "verbose",
-            "filename": os.path.join(log_dir, "playground.log"),
-            "encoding": "utf-8",
-        },
+        "root": rotating_file_handler("%s.log" % APP_CODE),
+        "db": rotating_file_handler("db.log"),
+        "alert": rotating_file_handler("alert.log"),
+        "cmdb": rotating_file_handler("cmdb.log"),
+        "operation_analysis": rotating_file_handler("operation_analysis.log"),
+        "nats": rotating_file_handler("nats.log"),
+        "monitor": rotating_file_handler("monitor.log"),
+        "log": rotating_file_handler("log.log"),
+        "apm": rotating_file_handler("apm.log"),
+        "node": rotating_file_handler("node.log"),
+        "ops-console": rotating_file_handler("ops-console.log"),
+        "system-manager": rotating_file_handler("system-manager.log"),
+        "opspilot": rotating_file_handler("opspilot.log"),
+        "job": rotating_file_handler("job.log"),
+        "playground": rotating_file_handler("playground.log"),
     },
     "loggers": {
         "django": {"handlers": ["null"], "level": "INFO", "propagate": True},
@@ -226,6 +202,8 @@ LOGGING = {
         "operation_analysis": {"handlers": ["operation_analysis", "console"], "level": LOG_LEVEL, "propagate": True},
         "nats": {"handlers": ["nats", "console"], "level": LOG_LEVEL, "propagate": True},
         "monitor": {"handlers": ["monitor", "console"], "level": LOG_LEVEL, "propagate": True},
+        "log": {"handlers": ["log", "console"], "level": LOG_LEVEL, "propagate": True},
+        "apm": {"handlers": ["apm", "console"], "level": LOG_LEVEL, "propagate": True},
         "node": {"handlers": ["node", "console"], "level": LOG_LEVEL, "propagate": True},
         "ops-console": {"handlers": ["ops-console", "console"], "level": LOG_LEVEL, "propagate": True},
         "system-manager": {"handlers": ["system-manager", "console"], "level": LOG_LEVEL, "propagate": True},


### PR DESCRIPTION
RotatingFileHandler 未设置 maxBytes 时不会滚动。统一用工厂写入 100MB×5 的默认上限，并为 log/apm 补齐专用文件 logger。