### PR TITLE
fix(opspilot): 页面问答按使用率聚焦图表，采集超时仍保留 KPI

### DIFF
--- a/server/apps/opspilot/services/skill_channel_chat_service.py
+++ b/server/apps/opspilot/services/skill_channel_chat_service.py
@@ -34,7 +34,8 @@ PAGE_CONTEXT_FOCUSED_GUIDE = (
     "本轮用户问题是「{question}」，已定位到图表{names}。"
     "只根据本轮 <current_page> 中的截图与文字回答这一问，"
     "不要沿用上一问的结论、表格、图表名或时间范围。"
-    "截图上可能没有标题，以这段文字中的图表名与「时间筛选/横轴」说明为准。"
+    "截图上可能没有标题，以这段文字中的图表名、KPI 快照与「时间筛选/横轴」说明为准。"
+    "问使用率或容量时优先用 KPI 快照里的「指标名: 数值」，不要把吞吐、流量或错误速率图当成占用百分比。"
     "禁止回答、复述或续写历史对话里已经分析过的其它图表。"
 )
 # ~600px 截图按 OpenAI high-detail 估算：ceil(600/512)^2 * 170 + 85
@@ -150,7 +151,7 @@ def _is_generic_chart_title(title: str) -> bool:
     return (not text) or text == "图表" or bool(re.fullmatch(r"(value|series)\d*", text, re.I))
 
 
-# 标题与问法常共用的主题词；只匹配图名，不匹配图例，避免「CPU 使用时间」命中「资源使用趋势」里的 CPU 使用率。
+# 标题与问法常共用的主题词；图名级匹配不看图例，避免「CPU 使用时间」命中「资源使用趋势」里的 CPU 使用率。
 _CHART_TOPIC_MARKERS = (
     "时间分布",
     "使用时间",
@@ -163,10 +164,34 @@ _CHART_TOPIC_MARKERS = (
     "吞吐",
     "错误",
 )
+# 问法带了更细的度量词时，禁止只靠「磁盘/网络」这种粗主题命中另一类图（使用率 ≠ 吞吐）。
+_CHART_QUALIFIERS = (
+    "使用率",
+    "吞吐",
+    "错误",
+    "时间分布",
+    "使用时间",
+    "负载",
+)
 _QUESTION_TITLE_ALIASES = (
     ("使用时间", "时间分布"),
     ("时间分布", "使用时间"),
 )
+
+
+def _chart_qualifiers(text: str) -> set[str]:
+    found = {item for item in _CHART_QUALIFIERS if item in text}
+    if "使用时间" in found:
+        found.add("时间分布")
+    if "时间分布" in found:
+        found.add("使用时间")
+    return found
+
+
+def _qualifiers_conflict(left: str, right: str) -> bool:
+    left_quals = _chart_qualifiers(left)
+    right_quals = _chart_qualifiers(right)
+    return bool(left_quals and right_quals and left_quals.isdisjoint(right_quals))
 
 
 def chart_title_matches_question(title: str, question: str) -> bool:
@@ -185,24 +210,53 @@ def chart_title_matches_question(title: str, question: str) -> bool:
         return True
     if any(alias in q and target in t for alias, target in _QUESTION_TITLE_ALIASES):
         return True
+    if _qualifiers_conflict(t, q):
+        return False
+    question_quals = _chart_qualifiers(q)
+    if question_quals and not (question_quals & _chart_qualifiers(t)):
+        return False
     return any(marker in t and marker in q for marker in _CHART_TOPIC_MARKERS)
 
 
-def _visible_chart_titles(snapshot: dict) -> list[str]:
-    titles: list[str] = []
+def _caption_series_matches_question(caption: str, question: str) -> bool:
+    """序列里出现「磁盘使用率」这类完整度量时，允许命中综合趋势图。"""
+    cap = _normalize_chart_text(caption)
+    q = _normalize_chart_text(question)
+    if not cap or len(q) < 2:
+        return False
+    question_quals = _chart_qualifiers(q)
+    if not question_quals or not (question_quals & _chart_qualifiers(cap)):
+        return False
+    if _qualifiers_conflict(cap, q):
+        return False
+    return any(marker in cap and marker in q for marker in _CHART_TOPIC_MARKERS)
+
+
+def chart_matches_question(caption: str, question: str) -> bool:
+    title = _caption_title(caption)
+    if chart_title_matches_question(title, question):
+        return True
+    return _caption_series_matches_question(caption, question)
+
+
+def _visible_chart_captions(snapshot: dict) -> list[str]:
+    captions: list[str] = []
     for image in snapshot.get("images") or []:
-        title = _caption_title(str(image.get("caption") or ""))
-        if title and not _is_generic_chart_title(title):
-            titles.append(title)
+        caption = str(image.get("caption") or "").strip()
+        if caption and not _is_generic_chart_title(_caption_title(caption)):
+            captions.append(caption)
     for section in snapshot.get("sections") or []:
         if section.get("id") != "visible-charts":
             continue
         for line in str(section.get("content") or "").splitlines():
             text = line.split(".", 1)[-1].strip() if "." in line[:4] else line.strip()
-            title = _caption_title(text)
-            if title and not _is_generic_chart_title(title):
-                titles.append(title)
-    return titles
+            if text and not _is_generic_chart_title(_caption_title(text)):
+                captions.append(text)
+    return captions
+
+
+def _visible_chart_titles(snapshot: dict) -> list[str]:
+    return [_caption_title(caption) for caption in _visible_chart_captions(snapshot)]
 
 
 def _unique_titles(titles: list[str]) -> list[str]:
@@ -249,13 +303,14 @@ def _focus_page_context(question: str, snapshot: dict) -> dict:
     images = [item for item in (snapshot.get("images") or []) if isinstance(item, dict)]
     if not images or not str(question or "").strip():
         return snapshot
-    matched = _unique_titles([title for title in _visible_chart_titles(snapshot) if chart_title_matches_question(title, question)])
+    matched = _unique_titles([_caption_title(caption) for caption in _visible_chart_captions(snapshot) if chart_matches_question(caption, question)])
     if not matched:
         return snapshot
     kept = []
     for image in images:
-        title = _caption_title(str(image.get("caption") or ""))
-        if any(chart_title_matches_question(title, match) or chart_title_matches_question(match, title) or title == match for match in matched):
+        caption = str(image.get("caption") or "")
+        title = _caption_title(caption)
+        if title in matched or chart_matches_question(caption, question):
             kept.append(image)
     next_snapshot = {**snapshot, "images": kept, "_focused_titles": matched, "_focus_question": str(question or "").strip()}
     sections = []
@@ -864,6 +919,12 @@ def stream_skill_channel_chat(
         skill_prompt=params.get("skill_prompt") or "",
         chat_history=params.get("chat_history") or [],
     )
+    if not ingest_report:
+        logger.info(
+            "page_context absent: question=%s session_id=%s",
+            (persist_text or "")[:80],
+            session_id or "-",
+        )
     if ingest_report:
         log_page_context_ingest(ingest_report)
         ingest_kwargs["page_context_ingest"] = ingest_report

--- a/server/apps/opspilot/tests/test_skill_channel_page_context.py
+++ b/server/apps/opspilot/tests/test_skill_channel_page_context.py
@@ -130,6 +130,44 @@ class TestInjectPageContext:
         assert "禁止回答、复述或续写历史对话里已经分析过的其它图表" in text
         assert "不要沿用上一问的结论、表格、图表名或时间范围" in text
 
+    def test_disk_usage_question_keeps_resource_trend_not_throughput(self):
+        page_context = {
+            "sections": [
+                {
+                    "id": "dashboard-time-range",
+                    "label": "时间筛选",
+                    "content": "当前筛选: 最近15分钟\nKPI 快照:\n磁盘使用率: 82.9%\nCPU 使用率: 86.0%",
+                    "priority": 9,
+                },
+                {
+                    "id": "visible-charts",
+                    "label": "可见图表",
+                    "content": (
+                        "1. 资源使用趋势；序列: CPU 使用率, 内存使用率, 磁盘使用率, I/O Wait 占比；最新值: 86.0, 79.0, 82.9, 6.9\n" "2. 磁盘吞吐趋势；序列: 读吞吐, 写吞吐；最新值: 12.1, 8.4"
+                    ),
+                    "priority": 9,
+                },
+            ],
+            "images": [
+                {
+                    "caption": "资源使用趋势；序列: CPU 使用率, 内存使用率, 磁盘使用率, I/O Wait 占比；最新值: 86.0, 79.0, 82.9, 6.9",
+                    "dataUrl": _tiny_png_data_url(),
+                },
+                {
+                    "caption": "磁盘吞吐趋势；序列: 读吞吐, 写吞吐；最新值: 12.1, 8.4",
+                    "dataUrl": _tiny_png_data_url() + "A",
+                },
+            ],
+        }
+        result = chat_svc.inject_page_context("磁盘使用率高吗", page_context)
+        image_items = [item for item in result if item.get("type") == "image_url"]
+        assert len(image_items) == 1
+        text = result[-1]["message"]
+        assert "资源使用趋势" in text
+        assert "磁盘使用率: 82.9%" in text
+        assert "磁盘吞吐趋势" not in text
+        assert "《资源使用趋势》" in text
+
     def test_cpu_time_question_keeps_distribution_chart(self):
         page_context = {
             "sections": [
@@ -184,6 +222,15 @@ class TestInjectPageContext:
         }
         assert chat_svc.chart_title_matches_question("CPU 时间分布", "具体分析下CPU使用时间")
         assert not chat_svc.chart_title_matches_question("资源使用趋势", "具体分析下CPU使用时间")
+        assert not chat_svc.chart_title_matches_question("磁盘吞吐趋势", "磁盘使用率高吗")
+        assert chat_svc.chart_matches_question(
+            "资源使用趋势；序列: CPU 使用率, 内存使用率, 磁盘使用率, I/O Wait 占比；最新值: 86.0, 79.0, 82.9, 6.9",
+            "磁盘使用率高吗",
+        )
+        assert not chat_svc.chart_matches_question(
+            "磁盘吞吐趋势；序列: 读吞吐, 写吞吐；最新值: 12.1, 8.4",
+            "磁盘使用率高吗",
+        )
         result = chat_svc.inject_page_context("具体分析下CPU使用时间", page_context)
         image_items = [item for item in result if item.get("type") == "image_url"]
         assert len(image_items) == 1

--- a/web/src/app/monitor/(pages)/view/dashboard/__tests__/dashboard.pilot.test.ts
+++ b/web/src/app/monitor/(pages)/view/dashboard/__tests__/dashboard.pilot.test.ts
@@ -3,8 +3,10 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   buildDashboardCaption,
   buildDashboardCurrentTime,
+  getTextContext,
   isDecorativeDashboardChart,
   labelFromDashboardCard,
+  readDashboardKpiReadings,
   readDashboardPageDataStamp,
 } from '../dashboard.pilot';
 
@@ -79,7 +81,23 @@ describe('dashboard.pilot page data stamp', () => {
     const stamp = readDashboardPageDataStamp();
     expect(stamp.timeRangeLabel).toBe('最近6小时');
     expect(stamp.kpiFingerprint).toBe('86.2%|79.1%');
+    expect(stamp.kpiReadings).toEqual([]);
     expect(buildDashboardCurrentTime(stamp)).toBe('最近6小时::86.2%|79.1%::正常::运行正常');
+  });
+
+  it('reads labeled KPI values from stat cards', () => {
+    document.body.innerHTML = `
+      <div class="statCard">
+        <div class="statLabel"><span class="titleWithGuide"><span>磁盘使用率</span></span></div>
+        <div class="statValue">82.9%</div>
+      </div>
+      <div class="statCard">
+        <div class="statLabel"><span class="titleWithGuide"><span>CPU 使用率</span></span></div>
+        <div class="statValue">86.0%</div>
+      </div>
+    `;
+    expect(readDashboardKpiReadings()).toEqual(['磁盘使用率: 82.9%', 'CPU 使用率: 86.0%']);
+    expect(getTextContext().sections?.some((section) => section.content.includes('磁盘使用率: 82.9%'))).toBe(true);
   });
 
   it('changes currentTime when time filter label changes', () => {

--- a/web/src/app/monitor/(pages)/view/dashboard/dashboard.pilot.ts
+++ b/web/src/app/monitor/(pages)/view/dashboard/dashboard.pilot.ts
@@ -149,9 +149,29 @@ const dashboardIdentity = () => {
 export interface DashboardPageDataStamp {
   timeRangeLabel: string;
   kpiFingerprint: string;
+  kpiReadings: string[];
   collectionStatus: string;
   uptimeState: string;
 }
+
+const cardValue = (card: Element): string =>
+  cleanLabel(
+    card.querySelector('[class*="statValue"]')?.textContent
+    || card.querySelector('[class*="collectionStatusValue"]')?.textContent
+    || '',
+  );
+
+/** 卡片「指标名: 数值」，避免模型只看到 82.9% 却不知道是磁盘使用率。 */
+export const readDashboardKpiReadings = (): string[] =>
+  Array.from(document.querySelectorAll('[class*="statCard"]'))
+    .map((card) => {
+      const labelNode = card.querySelector('[class*="statLabel"]');
+      const label = labelNode ? titleFromNode(labelNode) : '';
+      const value = cardValue(card);
+      return label && value ? `${label}: ${value}` : '';
+    })
+    .filter(Boolean)
+    .slice(0, 8);
 
 /** 从仪表盘 DOM 读取时间筛选 + KPI 指纹，用于 currentTime 与 console 诊断。 */
 export const readDashboardPageDataStamp = (): DashboardPageDataStamp => {
@@ -169,7 +189,13 @@ export const readDashboardPageDataStamp = (): DashboardPageDataStamp => {
   const uptimeState = cleanLabel(
     document.querySelector('[class*="uptimeStatusMain"]')?.textContent || '',
   );
-  return { timeRangeLabel, kpiFingerprint, collectionStatus, uptimeState };
+  return {
+    timeRangeLabel,
+    kpiFingerprint,
+    kpiReadings: readDashboardKpiReadings(),
+    collectionStatus,
+    uptimeState,
+  };
 };
 
 export const buildDashboardCurrentTime = (stamp: DashboardPageDataStamp): string =>
@@ -185,23 +211,68 @@ export function getMessage(): PageContextMessage {
   return currentTime ? { title, currentTime } : { title };
 }
 
-export async function getContext(
-  toolkit: PageContextToolkit,
-): Promise<Partial<AiPageContext>> {
-  const { objectKey, objectName, instanceName, view, monitorObjId } = dashboardIdentity();
-  const stamp = readDashboardPageDataStamp();
-  const dataUpdatedAt = buildDashboardCurrentTime(stamp);
-
+const dashboardTextSections = (
+  stamp: DashboardPageDataStamp,
+  identity: ReturnType<typeof dashboardIdentity>,
+  dataUpdatedAt: string,
+) => {
   const lines = [
     `正在查看监控专业仪表盘`,
-    objectName ? `对象: ${objectName}` : '',
-    objectKey ? `objectKey: ${objectKey}` : '',
-    monitorObjId ? `monitorObjId: ${monitorObjId}` : '',
-    instanceName ? `实例: ${instanceName}` : '',
-    `视图: ${view}`,
+    identity.objectName ? `对象: ${identity.objectName}` : '',
+    identity.objectKey ? `objectKey: ${identity.objectKey}` : '',
+    identity.monitorObjId ? `monitorObjId: ${identity.monitorObjId}` : '',
+    identity.instanceName ? `实例: ${identity.instanceName}` : '',
+    `视图: ${identity.view}`,
     stamp.timeRangeLabel ? `时间筛选: ${stamp.timeRangeLabel}` : '',
     dataUpdatedAt ? `页面数据指纹: ${dataUpdatedAt}` : '',
   ].filter(Boolean);
+  return [
+    {
+      id: 'dashboard-identity',
+      label: '当前仪表盘',
+      content: lines.join('\n'),
+      priority: 10,
+    },
+    ...(stamp.timeRangeLabel || stamp.kpiReadings.length
+      ? [{
+        id: 'dashboard-time-range',
+        label: '时间筛选',
+        content: [
+          stamp.timeRangeLabel ? `当前筛选: ${stamp.timeRangeLabel}` : '',
+          stamp.kpiReadings.length
+            ? `KPI 快照:\n${stamp.kpiReadings.join('\n')}`
+            : stamp.kpiFingerprint
+              ? `KPI 快照: ${stamp.kpiFingerprint.replace(/\|/g, ' · ')}`
+              : '',
+          stamp.uptimeState ? `运行状态: ${stamp.uptimeState}` : '',
+          stamp.collectionStatus ? `采集状态: ${stamp.collectionStatus}` : '',
+        ].filter(Boolean).join('\n'),
+        priority: 9,
+      }]
+      : []),
+  ];
+};
+
+/** 截图超时仍能带上 KPI；问「磁盘使用率高吗」至少看得到 82.9%。 */
+export function getTextContext(): Partial<AiPageContext> {
+  const identity = dashboardIdentity();
+  const stamp = readDashboardPageDataStamp();
+  const dataUpdatedAt = buildDashboardCurrentTime(stamp);
+  return {
+    url: window.location.href,
+    app: 'monitor',
+    title: document.title || `${identity.objectName} 仪表盘`,
+    sections: dashboardTextSections(stamp, identity, dataUpdatedAt),
+    images: [],
+  };
+}
+
+export async function getContext(
+  toolkit: PageContextToolkit,
+): Promise<Partial<AiPageContext>> {
+  const stamp = readDashboardPageDataStamp();
+  const dataUpdatedAt = buildDashboardCurrentTime(stamp);
+  const base = getTextContext();
 
   const nodes = Array.from(document.querySelectorAll<HTMLElement>('[_echarts_instance_]')).filter(
     (dom) => !isDecorativeDashboardChart(dom),
@@ -211,14 +282,15 @@ export async function getContext(
   const ordered = [
     ...labeled.filter((item) => item.title),
     ...labeled.filter((item) => !item.title),
-  ];
-  const images: ChartSnapshot[] = [];
-  for (const item of ordered) {
-    if (images.length >= PAGE_CONTEXT_MAX_IMAGES) break;
-    const [shot] = await toolkit.captureEchartsFromDoms([item.dom], 1);
-    if (!shot) continue;
-    images.push(await applyDashboardLabel(shot, item));
-  }
+  ].slice(0, PAGE_CONTEXT_MAX_IMAGES);
+  const captured = await Promise.all(
+    ordered.map(async (item) => {
+      const [shot] = await toolkit.captureEchartsFromDoms([item.dom], 1);
+      if (!shot) return null;
+      return applyDashboardLabel(shot, item);
+    }),
+  );
+  const images = captured.filter((item): item is ChartSnapshot => Boolean(item));
 
   const chartLines = images.length
     ? images.map((image, index) => `${index + 1}. ${image.caption}`)
@@ -227,35 +299,16 @@ export async function getContext(
   console.info('[ai-page-context] page data updated at', dataUpdatedAt, {
     timeRange: stamp.timeRangeLabel || '(unknown)',
     kpi: stamp.kpiFingerprint,
+    kpiReadings: stamp.kpiReadings,
     collectionStatus: stamp.collectionStatus,
     uptimeState: stamp.uptimeState,
     charts: chartLines,
   });
 
   return {
-    url: window.location.href,
-    app: 'monitor',
-    title: document.title || `${objectName} 仪表盘`,
+    ...base,
     sections: [
-      {
-        id: 'dashboard-identity',
-        label: '当前仪表盘',
-        content: lines.join('\n'),
-        priority: 10,
-      },
-      ...(stamp.timeRangeLabel
-        ? [{
-          id: 'dashboard-time-range',
-          label: '时间筛选',
-          content: [
-            `当前筛选: ${stamp.timeRangeLabel}`,
-            stamp.kpiFingerprint ? `KPI 快照: ${stamp.kpiFingerprint.replace(/\|/g, ' · ')}` : '',
-            stamp.uptimeState ? `运行状态: ${stamp.uptimeState}` : '',
-            stamp.collectionStatus ? `采集状态: ${stamp.collectionStatus}` : '',
-          ].filter(Boolean).join('\n'),
-          priority: 9,
-        }]
-        : []),
+      ...(base.sections || []),
       ...(chartLines.length
         ? [{
           id: 'visible-charts',

--- a/web/src/components/ai-page-context/__tests__/registry.test.ts
+++ b/web/src/components/ai-page-context/__tests__/registry.test.ts
@@ -147,6 +147,30 @@ describe('ai-page-context registry', () => {
     expect(merged.images).toHaveLength(6);
   });
 
+  it('falls back to getTextContext when screenshots time out', async () => {
+    vi.useFakeTimers();
+    const registry = createPageContextRegistry({
+      getPathname: () => '/x',
+      timeoutMs: 20,
+      pilots: [
+        {
+          test: () => true,
+          load: async () => ({
+            getMessage: () => ({ title: 'k', currentTime: 't1' }),
+            getContext: () => new Promise(() => undefined),
+            getTextContext: () => ({
+              sections: [{ id: 'kpi', label: '时间筛选', content: '磁盘使用率: 82.9%', priority: 9 }],
+            }),
+          }),
+        },
+      ],
+    });
+    const pending = registry.collect();
+    await vi.advanceTimersByTimeAsync(30);
+    const snapshot = await pending;
+    expect(snapshot?.sections?.[0].content).toContain('磁盘使用率: 82.9%');
+  });
+
   it('skips timed-out providers and still returns other sources', async () => {
     vi.useFakeTimers();
     const registry = createPageContextRegistry({

--- a/web/src/components/ai-page-context/registry.ts
+++ b/web/src/components/ai-page-context/registry.ts
@@ -158,11 +158,29 @@ export const createPageContextRegistry = (options?: {
     ) {
       return { ...cached.content, title: cached.content.title || message.title };
     }
-    const content = await mod.getContext(toolkit, hint);
-    const next = { ...content, title: content.title || message.title };
-    if (message.currentTime) {
+    const loadFull = async () => {
+      const content = await mod.getContext(toolkit, hint);
+      return { ...content, title: content.title || message.title };
+    };
+    let next: Partial<AiPageContext>;
+    let textFallback = false;
+    try {
+      next = await withTimeout(loadFull(), timeoutMs);
+    } catch (error) {
+      console.warn('[ai-page-context] pilot timed out or failed', error);
+      if (typeof mod.getTextContext !== 'function') {
+        throw error;
+      }
+      const text = await Promise.resolve(mod.getTextContext());
+      if (!text?.sections?.length) {
+        throw error;
+      }
+      textFallback = true;
+      next = { ...text, title: text.title || message.title };
+    }
+    if (message.currentTime && !textFallback) {
       cache.set(message.title, { currentTime: message.currentTime, content: next });
-    } else {
+    } else if (!message.currentTime) {
       cache.delete(message.title);
     }
     return next;
@@ -184,7 +202,7 @@ export const createPageContextRegistry = (options?: {
 
     for (const pilot of matched) {
       tasks.push(
-        withTimeout(collectPilot(pilot, hint), timeoutMs).catch((error) => {
+        collectPilot(pilot, hint).catch((error) => {
           console.debug('[ai-page-context] pilot failed', error);
           return null;
         }),

--- a/web/src/components/ai-page-context/types.ts
+++ b/web/src/components/ai-page-context/types.ts
@@ -48,6 +48,8 @@ export interface AiPageContextPilotModule {
     toolkit: PageContextToolkit,
     hint?: PageContextCollectHint,
   ) => Promise<Partial<AiPageContext>>;
+  /** 截图超时仍可先带上 KPI / 身份等文字，避免整轮变成无页面快照。 */
+  getTextContext?: () => Partial<AiPageContext> | Promise<Partial<AiPageContext>>;
 }
 
 export interface AiPageContextPilot {
@@ -57,4 +59,4 @@ export interface AiPageContextPilot {
 
 export const PAGE_CONTEXT_TEXT_BUDGET = 8000;
 export const PAGE_CONTEXT_MAX_IMAGES = 6;
-export const PAGE_CONTEXT_PROVIDER_TIMEOUT_MS = 2000;
+export const PAGE_CONTEXT_PROVIDER_TIMEOUT_MS = 8000;


### PR DESCRIPTION
## Summary
- 问「磁盘使用率」时按度量词聚焦「资源使用趋势」，不再误配磁盘/网络吞吐图。
- 仪表盘 KPI 快照带上「指标名: 数值」；截图超时回退文字上下文，避免整轮丢掉当前页。
- 采集超时从 2s 提到 8s，并在缺少 page_context 时打日志便于核对。

## Test plan
- [ ] 主机仪表盘打开「最近1天」，问「磁盘使用率高吗」，应回答页面 KPI（如 82.9%），而不是吞吐图或「知识库没有数据」。
- [ ] 问「CPU 使用时间」仍只保留「CPU 时间分布」，不带上资源使用趋势。
- [ ] 问「磁盘吞吐」仍聚焦吞吐图。
- [ ] `pytest apps/opspilot/tests/test_skill_channel_page_context.py` 与 dashboard/registry vitest 通过。
