### PR TITLE
fix(monitor): 注册 percentunit 修复 LLM 监控策略创建失败

### DIFF
--- a/server/apps/monitor/constants/unit_converter.py
+++ b/server/apps/monitor/constants/unit_converter.py
@@ -12,11 +12,11 @@ class UnitConverterConstants:
     # 单位体系定义（按照产品文档，只有同一体系的单位才能互相转换）
     # 每个体系包含单位序列（从小到大）和换算基数
     UNIT_SYSTEMS = {
-        # 百分比体系
+        # 百分比体系：percentunit 为 0.0–1.0 比例，percent 为 0–100
         'percent': {
-            'units': ['percent'],
+            'units': ['percentunit', 'percent'],
             'base': 1,
-            'display_units': ['%'],
+            'display_units': ['%', '%'],
         },
 
         # 计数体系（1000进制）
@@ -74,6 +74,7 @@ class UnitConverterConstants:
     UNIT_ID_TO_NAME = {
         # Base
         'none': 'none',
+        'percentunit': 'percentunit',
         'percent': 'percent',
 
         # Count
@@ -148,6 +149,7 @@ class UnitConverterConstants:
 
     # 展示单位映射（单位ID -> 展示格式）
     DISPLAY_UNIT_MAPPING = {
+        'percentunit': '%',
         'percent': '%',
         'counts': '',
         'thousand': 'K',
@@ -209,6 +211,7 @@ class UnitConverterConstants:
     UNIT_CATEGORY_MAPPING = {
         # Base 类别
         'none': 'Base',
+        'percentunit': 'Base',
         'percent': 'Base',
 
         # Count 类别
@@ -296,4 +299,3 @@ class UnitConverterConstants:
     PRECISION_LARGE_VALUE = 1  # 值 >= 100 时的精度
     PRECISION_MEDIUM_VALUE = 2  # 值 >= 10 时的精度
     PRECISION_SMALL_VALUE = 3  # 值 < 10 时的精度
-


### PR DESCRIPTION
## Summary
- 根因：vLLM / SGLang / llama-server 比例类指标（如 KV 缓存占用）使用 `percentunit`（0–1），自动建策略时 `calculation_unit` 校验报「结果单位无效」
- 修复：将 `percentunit` 注册进百分比单位体系（`UNIT_SYSTEMS` / 映射表），与现有 `UnitConverter` 换算逻辑对齐
- 验证：三套插件全部策略模板（含 percentunit / s / counts / cps）单位校验均通过

## Test plan
- [ ] 下发 vLLM 接入并勾选默认策略，确认不再出现 `calculation_unit:结果单位无效`
- [ ] 同样验证 SGLang、llama-server 接入建策略
- [ ] 抽查 KV/Token 占用类策略阈值仍按 0–1 比例语义（如 0.8 / 0.9）