### PR TITLE
fix(monitor): 防止分类 ID 误作 monitor_object_id 导致集成列表 500

### DIFF
--- a/server/apps/monitor/filters/id_filters.py
+++ b/server/apps/monitor/filters/id_filters.py
@@ -1,0 +1,17 @@
+"""Filter helpers that keep non-integer IDs out of ORM lookups."""
+
+
+def filter_positive_int_field(queryset, field_name: str, value):
+    """Apply an exact filter on an integer / FK-id field.
+
+    Empty values leave the queryset unchanged. Non-digit strings (e.g. a
+    monitor-object *type* id like ``Network Device`` mistakenly sent as
+    ``monitor_object_id``) must not reach the ORM — Django raises
+    ``ValueError`` and the API returns 500.
+    """
+    if value in (None, ""):
+        return queryset
+    value_str = str(value).strip()
+    if not value_str or not value_str.isdigit():
+        return queryset.none()
+    return queryset.filter(**{field_name: value_str})

--- a/server/apps/monitor/filters/monitor_metrics.py
+++ b/server/apps/monitor/filters/monitor_metrics.py
@@ -1,16 +1,33 @@
 from django.db.models import Q
 from django_filters import BaseInFilter, BooleanFilter, CharFilter, FilterSet, NumberFilter
 
+from apps.monitor.filters.id_filters import filter_positive_int_field
 from apps.monitor.models.monitor_metrics import Metric, MetricGroup
 from apps.monitor.utils.snmp_ifmib_capability import get_ifmib_metric_names_matching_keyword
 
 
 class MetricGroupFilter(FilterSet):
     monitor_object_name = CharFilter(field_name="monitor_object__name", lookup_expr="exact", label="指标对象名称")
-    monitor_object_id = CharFilter(field_name="monitor_object_id", lookup_expr="exact", label="指标对象ID")
-    monitor_plugin_id = CharFilter(field_name="monitor_plugin_id", lookup_expr="exact", label="插件ID")
+    monitor_object_id = CharFilter(
+        label="指标对象ID",
+        required=False,
+        method="filter_monitor_object_id",
+    )
+    monitor_plugin_id = CharFilter(
+        label="插件ID",
+        required=False,
+        method="filter_monitor_plugin_id",
+    )
     name = CharFilter(field_name="name", lookup_expr="exact", label="指标分组名称")
     keyword = CharFilter(method="filter_keyword", label="指标分组关键字")
+
+    @staticmethod
+    def filter_monitor_object_id(queryset, _name, value):
+        return filter_positive_int_field(queryset, "monitor_object_id", value)
+
+    @staticmethod
+    def filter_monitor_plugin_id(queryset, _name, value):
+        return filter_positive_int_field(queryset, "monitor_plugin_id", value)
 
     @staticmethod
     def filter_keyword(queryset, _name, value):
@@ -34,8 +51,16 @@ class CharInFilter(BaseInFilter, CharFilter):
 
 class MetricFilter(FilterSet):
     monitor_object_name = CharFilter(field_name="monitor_object__name", lookup_expr="exact", label="指标对象名称")
-    monitor_object_id = CharFilter(field_name="monitor_object_id", lookup_expr="exact", label="指标对象ID")
-    monitor_plugin_id = CharFilter(field_name="monitor_plugin_id", lookup_expr="exact", label="插件ID")
+    monitor_object_id = CharFilter(
+        label="指标对象ID",
+        required=False,
+        method="filter_monitor_object_id",
+    )
+    monitor_plugin_id = CharFilter(
+        label="插件ID",
+        required=False,
+        method="filter_monitor_plugin_id",
+    )
     id = NumberFilter(field_name="id", lookup_expr="exact", label="指标ID")
     id_in = NumberInFilter(field_name="id", lookup_expr="in", label="指标ID列表")
     name = CharFilter(field_name="name", lookup_expr="exact", label="指标名称")
@@ -43,6 +68,14 @@ class MetricFilter(FilterSet):
     keyword = CharFilter(method="filter_keyword", label="指标关键字")
     include_ifmib = BooleanFilter(method="filter_include_ifmib", label="是否包含IF-MIB指标")
     is_ifmib = BooleanFilter(field_name="is_ifmib", label="是否为IF-MIB指标")
+
+    @staticmethod
+    def filter_monitor_object_id(queryset, _name, value):
+        return filter_positive_int_field(queryset, "monitor_object_id", value)
+
+    @staticmethod
+    def filter_monitor_plugin_id(queryset, _name, value):
+        return filter_positive_int_field(queryset, "monitor_plugin_id", value)
 
     def filter_keyword(self, queryset, _name, value):
         keyword = str(value or "").strip()

--- a/server/apps/monitor/filters/monitor_metrics.py
+++ b/server/apps/monitor/filters/monitor_metrics.py
@@ -8,16 +8,8 @@ from apps.monitor.utils.snmp_ifmib_capability import get_ifmib_metric_names_matc
 
 class MetricGroupFilter(FilterSet):
     monitor_object_name = CharFilter(field_name="monitor_object__name", lookup_expr="exact", label="指标对象名称")
-    monitor_object_id = CharFilter(
-        label="指标对象ID",
-        required=False,
-        method="filter_monitor_object_id",
-    )
-    monitor_plugin_id = CharFilter(
-        label="插件ID",
-        required=False,
-        method="filter_monitor_plugin_id",
-    )
+    monitor_object_id = CharFilter(field_name="monitor_object_id", lookup_expr="exact", label="指标对象ID", method="filter_monitor_object_id")
+    monitor_plugin_id = CharFilter(field_name="monitor_plugin_id", lookup_expr="exact", label="插件ID", method="filter_monitor_plugin_id")
     name = CharFilter(field_name="name", lookup_expr="exact", label="指标分组名称")
     keyword = CharFilter(method="filter_keyword", label="指标分组关键字")
 
@@ -51,16 +43,8 @@ class CharInFilter(BaseInFilter, CharFilter):
 
 class MetricFilter(FilterSet):
     monitor_object_name = CharFilter(field_name="monitor_object__name", lookup_expr="exact", label="指标对象名称")
-    monitor_object_id = CharFilter(
-        label="指标对象ID",
-        required=False,
-        method="filter_monitor_object_id",
-    )
-    monitor_plugin_id = CharFilter(
-        label="插件ID",
-        required=False,
-        method="filter_monitor_plugin_id",
-    )
+    monitor_object_id = CharFilter(field_name="monitor_object_id", lookup_expr="exact", label="指标对象ID", method="filter_monitor_object_id")
+    monitor_plugin_id = CharFilter(field_name="monitor_plugin_id", lookup_expr="exact", label="插件ID", method="filter_monitor_plugin_id")
     id = NumberFilter(field_name="id", lookup_expr="exact", label="指标ID")
     id_in = NumberInFilter(field_name="id", lookup_expr="in", label="指标ID列表")
     name = CharFilter(field_name="name", lookup_expr="exact", label="指标名称")

--- a/server/apps/monitor/filters/monitor_object.py
+++ b/server/apps/monitor/filters/monitor_object.py
@@ -15,11 +15,7 @@ class MonitorObjectFilter(FilterSet):
 
 
 class MonitorObjectOrganizationRuleFilter(FilterSet):
-    monitor_object_id = CharFilter(
-        label="监控对象id",
-        required=False,
-        method="filter_monitor_object_id",
-    )
+    monitor_object_id = CharFilter(field_name="monitor_object_id", lookup_expr="exact", label="监控对象id", method="filter_monitor_object_id")
     name = CharFilter(field_name="name", lookup_expr="icontains", label="分组规则名称")
 
     @staticmethod

--- a/server/apps/monitor/filters/monitor_object.py
+++ b/server/apps/monitor/filters/monitor_object.py
@@ -1,5 +1,6 @@
-from django_filters import FilterSet, CharFilter, NumberFilter
+from django_filters import CharFilter, FilterSet, NumberFilter
 
+from apps.monitor.filters.id_filters import filter_positive_int_field
 from apps.monitor.models.monitor_object import MonitorObject, MonitorObjectOrganizationRule
 
 
@@ -14,8 +15,16 @@ class MonitorObjectFilter(FilterSet):
 
 
 class MonitorObjectOrganizationRuleFilter(FilterSet):
-    monitor_object_id = CharFilter(field_name="monitor_object_id", lookup_expr="exact", label="监控对象id")
+    monitor_object_id = CharFilter(
+        label="监控对象id",
+        required=False,
+        method="filter_monitor_object_id",
+    )
     name = CharFilter(field_name="name", lookup_expr="icontains", label="分组规则名称")
+
+    @staticmethod
+    def filter_monitor_object_id(queryset, _name, value):
+        return filter_positive_int_field(queryset, "monitor_object_id", value)
 
     class Meta:
         model = MonitorObjectOrganizationRule

--- a/server/apps/monitor/filters/monitor_policy.py
+++ b/server/apps/monitor/filters/monitor_policy.py
@@ -5,11 +5,7 @@ from apps.monitor.models.monitor_policy import MonitorPolicy
 
 
 class MonitorPolicyFilter(FilterSet):
-    monitor_object_id = CharFilter(
-        label="监控对象",
-        required=False,
-        method="filter_monitor_object_id",
-    )
+    monitor_object_id = CharFilter(field_name="monitor_object", lookup_expr="exact", label="监控对象", method="filter_monitor_object_id")
     name = CharFilter(field_name="name", lookup_expr="icontains", label="策略名称")
 
     @staticmethod

--- a/server/apps/monitor/filters/monitor_policy.py
+++ b/server/apps/monitor/filters/monitor_policy.py
@@ -1,11 +1,20 @@
-from django_filters import FilterSet, CharFilter
+from django_filters import CharFilter, FilterSet
 
+from apps.monitor.filters.id_filters import filter_positive_int_field
 from apps.monitor.models.monitor_policy import MonitorPolicy
 
 
 class MonitorPolicyFilter(FilterSet):
-    monitor_object_id = CharFilter(field_name="monitor_object", lookup_expr="exact", label="监控对象")
+    monitor_object_id = CharFilter(
+        label="监控对象",
+        required=False,
+        method="filter_monitor_object_id",
+    )
     name = CharFilter(field_name="name", lookup_expr="icontains", label="策略名称")
+
+    @staticmethod
+    def filter_monitor_object_id(queryset, _name, value):
+        return filter_positive_int_field(queryset, "monitor_object", value)
 
     class Meta:
         model = MonitorPolicy

--- a/server/apps/monitor/filters/plugin.py
+++ b/server/apps/monitor/filters/plugin.py
@@ -1,5 +1,6 @@
-from django_filters import FilterSet, CharFilter
+from django_filters import CharFilter, FilterSet
 
+from apps.monitor.filters.id_filters import filter_positive_int_field
 from apps.monitor.models import MonitorPlugin
 
 
@@ -25,10 +26,12 @@ class MonitorPluginFilter(FilterSet):
     template_id = CharFilter(field_name="template_id", lookup_expr="icontains", label="模板ID")
 
     def filter_monitor_object(self, queryset, name, value):
-        """自定义过滤方法：为空时返回全部，否则按监控对象ID过滤"""
-        if value:
-            return queryset.filter(monitor_object=value)
-        return queryset
+        """自定义过滤方法：为空时返回全部，否则按监控对象ID过滤。
+
+        monitor_object 主键为整型。非数字值（如误传分类 id「Network Device」）
+        不得落入 ORM，否则会 ValueError → 接口 500。
+        """
+        return filter_positive_int_field(queryset, "monitor_object", value)
 
     def filter_monitor_object_type(self, queryset, name, value):
         """按监控对象分类 ID 过滤（如 database），用于左侧树点一级分类看该类全部能力。"""

--- a/server/apps/monitor/views/monitor_alert.py
+++ b/server/apps/monitor/views/monitor_alert.py
@@ -12,6 +12,7 @@ from apps.core.utils.current_team_scope import resolve_current_team_data_scope
 from apps.core.utils.permission_utils import get_instance_permissions, get_permissions_rules
 from apps.core.utils.web_utils import WebUtils
 from apps.monitor.constants.permission import PermissionConstants
+from apps.monitor.filters.id_filters import filter_positive_int_field
 from apps.monitor.filters.monitor_alert import MonitorAlertFilter
 from apps.monitor.models import MonitorAlert, MonitorAlertMetricSnapshot, MonitorEvent, MonitorEventRawData, MonitorPolicy, PolicyInstanceBaseline
 from apps.monitor.serializers.monitor_alert import MonitorAlertSerializer, MonitorAlertUpdateSerializer
@@ -49,9 +50,7 @@ class AlertPermissionMixin:
         """
         scope = self._get_data_scope(request)
         policy_qs = (
-            MonitorPolicy.objects.filter(
-                policyorganization__organization__in=list(scope.data_team_ids)
-            )
+            MonitorPolicy.objects.filter(policyorganization__organization__in=list(scope.data_team_ids))
             .select_related("monitor_object")
             .prefetch_related("policyorganization_set")
             .distinct()
@@ -80,9 +79,7 @@ class AlertPermissionMixin:
         # policy_permissions 结构：{ object_type_id: {instance: [...], team: [...]}, "all": {...} }
         # "all" 键表示管理员级别权限（对全部对象类型生效），此时不能缩小范围。
         if "all" not in policy_permissions:
-            known_object_type_ids = [
-                int(k) for k in policy_permissions.keys() if k != "all" and str(k).isdigit()
-            ]
+            known_object_type_ids = [int(k) for k in policy_permissions.keys() if k != "all" and str(k).isdigit()]
             policy_qs = policy_qs.filter(monitor_object_id__in=known_object_type_ids)
 
         accessible_policy_ids = []
@@ -122,9 +119,7 @@ class AlertPermissionMixin:
             return {}
 
         if request.user.is_superuser:
-            return {
-                policy.id: PermissionConstants.DEFAULT_PERMISSION for policy in policies
-            }
+            return {policy.id: PermissionConstants.DEFAULT_PERMISSION for policy in policies}
 
         scope = self._get_data_scope(request)
         permissions_result = get_permissions_rules(
@@ -145,9 +140,7 @@ class AlertPermissionMixin:
         permission_map = {}
         for policy_obj in policies:
             monitor_object_id = str(policy_obj.monitor_object_id)
-            teams = {
-                org.organization for org in policy_obj.policyorganization_set.all()
-            }
+            teams = {org.organization for org in policy_obj.policyorganization_set.all()}
             permissions = get_instance_permissions(
                 monitor_object_id,
                 policy_obj.id,
@@ -190,8 +183,8 @@ class MonitorAlertViewSet(
     def list(self, request, *args, **kwargs):
         monitor_object_id = request.query_params.get("monitor_object_id", None)
         policy_qs = self.get_accessible_policy_queryset(request)
-        if monitor_object_id:
-            policy_qs = policy_qs.filter(monitor_object_id=monitor_object_id)
+        # 非法非数字 id（如分类名 Network Device）不得落入 ORM，否则 ValueError → 500
+        policy_qs = filter_positive_int_field(policy_qs, "monitor_object_id", monitor_object_id)
         policy_ids = policy_qs.values_list("id", flat=True)
 
         if not policy_ids:
@@ -269,16 +262,12 @@ class MonitorAlertViewSet(
         with transaction.atomic():
             # 权限范围先由 get_object 校验；状态转换必须锁内重读，避免扫描任务与
             # 两个手工关闭请求都基于同一个旧 new 状态重复落 lifecycle intent。
-            instance = MonitorAlert.objects.select_for_update().get(
-                pk=authorized_instance.pk
-            )
+            instance = MonitorAlert.objects.select_for_update().get(pk=authorized_instance.pk)
             # 锁等待期间组织关系、角色或策略归属都可能变化；始终以锁内时刻
             # 重新走权限过滤，禁止复用过期授权依据。
             instance = self.get_queryset().get(pk=instance.pk)
             old_status = instance.status
-            serializer = self.get_serializer(
-                instance, data=request.data, partial=partial
-            )
+            serializer = self.get_serializer(instance, data=request.data, partial=partial)
             serializer.is_valid(raise_exception=True)
             updated_data = serializer.validated_data
             if updated_data.get("status") == "closed":
@@ -350,12 +339,7 @@ class MonitorAlertViewSet(
         if alert_obj is None:
             return WebUtils.response_error("告警不存在", status_code=404)
 
-        policy_units = (
-            MonitorPolicy.objects.filter(id=alert_obj.policy_id)
-            .values("metric_unit", "calculation_unit", "threshold_unit")
-            .first()
-            or {}
-        )
+        policy_units = MonitorPolicy.objects.filter(id=alert_obj.policy_id).values("metric_unit", "calculation_unit", "threshold_unit").first() or {}
         metric_unit = policy_units.get("metric_unit") or ""
         calculation_unit = policy_units.get("calculation_unit") or ""
         threshold_unit = policy_units.get("threshold_unit") or ""
@@ -425,7 +409,6 @@ class MonitorAlertViewSet(
 
 
 class MonitorEventViewSet(AlertPermissionMixin, viewsets.ViewSet):
-
     @action(methods=["get"], detail=False, url_path="query/(?P<alert_id>[^/.]+)")
     def get_events(self, request, alert_id):
         """查询告警的事件列表 - 优化版：使用外键直接查询"""

--- a/server/apps/monitor/views/monitor_policy.py
+++ b/server/apps/monitor/views/monitor_policy.py
@@ -18,6 +18,7 @@ from apps.core.utils.web_utils import WebUtils
 from apps.monitor.constants.alert_policy import AlertConstants
 from apps.monitor.constants.database import DatabaseConstants
 from apps.monitor.constants.permission import PermissionConstants
+from apps.monitor.filters.id_filters import filter_positive_int_field
 from apps.monitor.filters.monitor_policy import MonitorPolicyFilter
 from apps.monitor.models import MonitorAlert, MonitorObject, PolicyOrganization, PolicyTemplate
 from apps.monitor.models.monitor_policy import MonitorPolicy
@@ -124,8 +125,8 @@ class MonitorPolicyViewSet(viewsets.ModelViewSet):
             return queryset
 
         monitor_object_id = self._get_monitor_object_id()
-        if monitor_object_id not in (None, ""):
-            queryset = queryset.filter(monitor_object_id=monitor_object_id)
+        # 非法非数字 id（如分类名 Network Device）不得落入 ORM，否则 ValueError → 500
+        queryset = filter_positive_int_field(queryset, "monitor_object_id", monitor_object_id)
 
         scope = self._get_data_scope()
         permission = self._get_effective_permission(monitor_object_id)

--- a/web/src/app/monitor/(pages)/integration/list/page.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/page.tsx
@@ -18,7 +18,10 @@ import { useTranslation } from '@/utils/i18n';
 import { getIconByObjectName, getPluginBrandIcon } from '@/app/monitor/utils/common';
 import { useRouter } from 'next/navigation';
 import { useMonitorObjectQuery } from '@/app/monitor/hooks/useMonitorObjectQuery';
-import { resolveMonitorObjectQueryId } from '@/app/monitor/utils/monitorObjectQuery';
+import {
+  isMonitorObjectTypeQueryKey,
+  resolveMonitorObjectQueryId
+} from '@/app/monitor/utils/monitorObjectQuery';
 import {
   ModalRef,
   TreeItem,
@@ -123,12 +126,7 @@ const Integration = () => {
     pluginAbortControllerRef.current?.abort();
   };
 
-  const isTypeNodeKey = (key: string) => {
-    const keyStr = String(key);
-    if (keyStr === 'all') return false;
-    // 叶子节点 key 为对象数字 id；一级分类 key 为 MonitorObjectType.id（如 database）
-    return objects.some((item) => String(item.type) === keyStr);
-  };
+  const isTypeNodeKey = (key: string) => isMonitorObjectTypeQueryKey(key);
 
   const handleObjectChange = async (id: string) => {
     const nextObjectType =

--- a/web/src/app/monitor/utils/monitorObjectQuery.ts
+++ b/web/src/app/monitor/utils/monitorObjectQuery.ts
@@ -21,6 +21,17 @@ export const isConcreteMonitorObjectId = (id: unknown): boolean => {
   return /^\d+$/.test(value);
 };
 
+/**
+ * 集成列表左侧树：一级分类 key 为 MonitorObjectType.id（非纯数字，
+ * 如 "Network Device"），叶子为监控对象数字 id。
+ * 判定不得依赖 objects 已加载，否则 URL 回退竞态会把分类 id 当成对象 id。
+ */
+export const isMonitorObjectTypeQueryKey = (id: unknown): boolean => {
+  const value = toMonitorIdString(id).trim();
+  if (!value || value === 'all') return false;
+  return !isConcreteMonitorObjectId(value);
+};
+
 export const readMonitorObjectQueryId = (
   params: Pick<URLSearchParams, 'get'> | null | undefined,
   preferredParam?: string


### PR DESCRIPTION
## Summary
- 修复集成列表在选中一级分类（如「网络设备」）后进入接入页再回退时，`monitor_plugin` 因 `monitor_object_id=Network Device` 触发 ORM `ValueError` 返回 500 的问题。
- 前端：`isMonitorObjectTypeQueryKey` 不依赖 `objects` 是否已加载，分类 key 正确走 `monitor_object_type`。
- 后端：抽取 `filter_positive_int_field`，插件/策略/指标/组织规则过滤及告警、策略 list 对非法整型 ID 返回空结果，不再 500。

## Test plan
- [ ] 集成列表选「网络设备」→ 搜索 → 点接入 → 浏览器回退，列表正常加载且无系统错误
- [ ] Network 面板请求应为 `monitor_object_type=Network Device`（或数字 `monitor_object_id`），不再出现非法字符串对象 ID 导致的 500
- [ ] 选具体叶子对象（如交换机）接入后回退仍正常
- [ ] 策略/告警/指标列表在正常数字 `monitor_object_id` 下行为不变

## 提交范围检查
- 仅包含上述 9 个修复文件；测试、图标、`.omo`、本地 `next-env.d.ts` 等未纳入本次 PR。