### PR TITLE
bugfix: 建立监控指标用户态受控查询

### DIFF
--- a/mobile/scripts/mobile-monitor-assets-test.mjs
+++ b/mobile/scripts/mobile-monitor-assets-test.mjs
@@ -496,7 +496,11 @@ test('监控请求始终带 objectId 且指标按视口懒加载', async () => {
   assert.match(adapter, /monitor_instance\/\$\{objectId\}\/list/);
   assert.match(adapter, /add_metrics:\s*true/);
   assert.match(adapter, /effective_plugins/);
-  assert.match(adapter, /metrics_instance\/query_range/);
+  assert.match(adapter, /metrics_instance\/query_by_metric_range/);
+  assert.match(adapter, /monitor_object_id:\s*monitorObjectId/);
+  assert.match(adapter, /metric_id:\s*metricId/);
+  assert.match(adapter, /instance_ids:\s*\[instanceId\]/);
+  assert.doesNotMatch(adapter, /metrics_instance\/query_range/);
   assert.match(card, /IntersectionObserver/);
   assert.doesNotMatch(panel, /localStorage/);
 });

--- a/mobile/src/app/monitor/detail/page.tsx
+++ b/mobile/src/app/monitor/detail/page.tsx
@@ -340,7 +340,8 @@ function MonitorDetailContent() {
                               <MetricCard
                                 key={`${metric.id}-${pluginId}-${range}`}
                                 metric={metric}
-                                idValues={idValues}
+                                monitorObjectId={objectId}
+                                instanceId={instanceId}
                                 rangeMinutes={range}
                                 interval={interval}
                                 onOpen={sheetIndex >= 0 ? () => setMetricSheetIndex(sheetIndex) : undefined}
@@ -417,7 +418,8 @@ function MonitorDetailContent() {
         open={metricSheetIndex != null}
         metrics={sheetMetrics}
         activeIndex={metricSheetIndex ?? 0}
-        idValues={idValues}
+        monitorObjectId={objectId}
+        instanceId={instanceId}
         rangeMinutes={range}
         interval={interval}
         onClose={() => setMetricSheetIndex(null)}

--- a/mobile/src/features/monitor/adapter.ts
+++ b/mobile/src/features/monitor/adapter.ts
@@ -1,4 +1,4 @@
-import { apiGet } from '@/api/request';
+import { apiGet, apiPost } from '@/api/request';
 import type { MetricGroup, MetricRangeResult, MonitorInstance, MonitorMetric, MonitorObject, MonitorPlugin, MonitorRecentViewsConfig, MonitorRecentViewsResolution, PageResult } from './model';
 import type { MonitorUnitListItem } from './unit-label';
 import {
@@ -208,11 +208,26 @@ export async function listMetricDefinition(objectId: number, pluginId: number, s
   return { groups: groups.sort((a, b) => a.order - b.order), metrics: metrics.sort((a, b) => a.order - b.order) };
 }
 
-export async function queryMetricRange(query: string, unit: string, rangeMinutes: number, collectionInterval?: number | null, signal?: AbortSignal): Promise<MetricRangeResult> {
+export async function queryMetricRange(
+  monitorObjectId: number,
+  metricId: number,
+  instanceId: string,
+  unit: string,
+  rangeMinutes: number,
+  collectionInterval?: number | null,
+  signal?: AbortSignal,
+): Promise<MetricRangeResult> {
   const end = Date.now(); const start = end - rangeMinutes * 60_000;
   const step = Math.max(Math.ceil(((end - start) / 1000) / 100), collectionInterval || 0, 1);
-  const raw = record(unwrap<unknown>(await apiGet('/monitor/api/metrics_instance/query_range/', {
-    query, source_unit: unit, query_budget: 'card', start, end, step,
+  const raw = record(unwrap<unknown>(await apiPost('/monitor/api/metrics_instance/query_by_metric_range/', {
+    monitor_object_id: monitorObjectId,
+    metric_id: metricId,
+    instance_ids: [instanceId],
+    source_unit: unit,
+    card_budget: true,
+    start,
+    end,
+    step,
     ...(collectionInterval ? { detect_gaps: true, collection_interval: collectionInterval } : {}),
   }, { signal })));
   const data = record(raw.data);

--- a/mobile/src/features/monitor/metric-card.tsx
+++ b/mobile/src/features/monitor/metric-card.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { RedoOutline } from 'antd-mobile-icons';
 import { buildSeriesPath, buildSeriesSinglePoint } from './metric-chart-utils';
-import { buildMetricQuery, metricSeriesPoints, type MonitorMetric } from './model';
+import { metricSeriesPoints, type MonitorMetric } from './model';
 import { getMonitorUnitList, queryMetricRange } from './adapter';
 import { resolveMonitorUnitLabel } from './unit-label';
 import { useTranslation } from '@/utils/i18n';
@@ -11,13 +11,14 @@ import styles from './monitor.module.css';
 
 interface Props {
   metric: MonitorMetric;
-  idValues: string[];
+  monitorObjectId: number;
+  instanceId: string;
   rangeMinutes: number;
   interval: number | null;
   onOpen?: () => void;
 }
 
-export default function MetricCard({ metric, idValues, rangeMinutes, interval, onOpen }: Props) {
+export default function MetricCard({ metric, monitorObjectId, instanceId, rangeMinutes, interval, onOpen }: Props) {
   const { t } = useTranslation();
   const ref = useRef<HTMLElement>(null);
   const [visible, setVisible] = useState(false);
@@ -55,7 +56,7 @@ export default function MetricCard({ metric, idValues, rangeMinutes, interval, o
     if (!visible) return;
     const controller = new AbortController();
     setStatus('loading');
-    queryMetricRange(buildMetricQuery(metric, idValues), metric.unit, rangeMinutes, interval, controller.signal)
+    queryMetricRange(monitorObjectId, metric.id, instanceId, metric.unit, rangeMinutes, interval, controller.signal)
       .then((result) => {
         if (controller.signal.aborted) return;
         setSeries(metricSeriesPoints(result));
@@ -67,7 +68,7 @@ export default function MetricCard({ metric, idValues, rangeMinutes, interval, o
         if (error instanceof Error && error.name !== 'AbortError') setStatus('error');
       });
     return () => controller.abort();
-  }, [idValues, interval, metric, rangeMinutes, retryToken, visible]);
+  }, [instanceId, interval, metric, monitorObjectId, rangeMinutes, retryToken, visible]);
 
   // Match Web overview / sheet: resolve from unitList by unit_id; do not pass query echo as displayUnit.
   const unitLabel = useMemo(

--- a/mobile/src/features/monitor/metric-chart-sheet.tsx
+++ b/mobile/src/features/monitor/metric-chart-sheet.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from '@/utils/i18n';
 import { getMonitorUnitList, queryMetricRange } from './adapter';
 import type { GapInterval } from './gap-intervals';
 import MetricSheetEcharts from './metric-sheet-echarts';
-import { buildMetricQuery, metricSeriesPoints, type MonitorMetric } from './model';
+import { metricSeriesPoints, type MonitorMetric } from './model';
 import { resolveMonitorUnitLabel } from './unit-label';
 import styles from './monitor.module.css';
 
@@ -17,7 +17,8 @@ interface Props {
   open: boolean;
   metrics: MonitorMetric[];
   activeIndex: number;
-  idValues: string[];
+  monitorObjectId: number;
+  instanceId: string;
   rangeMinutes: number;
   interval: number | null;
   onClose: () => void;
@@ -26,13 +27,15 @@ interface Props {
 
 function MetricSheetPane({
   metric,
-  idValues,
+  monitorObjectId,
+  instanceId,
   rangeMinutes,
   interval,
   onUnitChange,
 }: {
   metric: MonitorMetric;
-  idValues: string[];
+  monitorObjectId: number;
+  instanceId: string;
   rangeMinutes: number;
   interval: number | null;
   onUnitChange?: (unit: string) => void;
@@ -53,7 +56,7 @@ function MetricSheetPane({
   useEffect(() => {
     const controller = new AbortController();
     setStatus('loading');
-    queryMetricRange(buildMetricQuery(metric, idValues), metric.unit, rangeMinutes, interval, controller.signal)
+    queryMetricRange(monitorObjectId, metric.id, instanceId, metric.unit, rangeMinutes, interval, controller.signal)
       .then((result) => {
         if (controller.signal.aborted) return;
         setSeries(metricSeriesPoints(result));
@@ -67,7 +70,7 @@ function MetricSheetPane({
         if (error instanceof Error && error.name !== 'AbortError') setStatus('error');
       });
     return () => controller.abort();
-  }, [idValues, interval, metric, onUnitChange, rangeMinutes, retryToken]);
+  }, [instanceId, interval, metric, monitorObjectId, onUnitChange, rangeMinutes, retryToken]);
 
   if (status === 'loading') {
     return <MobileSkeleton label={t('common.loading')} variant="metrics" rows={1} compact />;
@@ -118,7 +121,8 @@ export default function MetricChartSheet({
   open,
   metrics,
   activeIndex,
-  idValues,
+  monitorObjectId,
+  instanceId,
   rangeMinutes,
   interval,
   onClose,
@@ -203,7 +207,8 @@ export default function MetricChartSheet({
             <MetricSheetPane
               key={`${metric.id}-${rangeMinutes}-${interval ?? 'na'}`}
               metric={metric}
-              idValues={idValues}
+              monitorObjectId={monitorObjectId}
+              instanceId={instanceId}
               rangeMinutes={rangeMinutes}
               interval={interval}
               onUnitChange={handleUnitChange}

--- a/server/apps/monitor/nats/contracts.py
+++ b/server/apps/monitor/nats/contracts.py
@@ -18,8 +18,6 @@ MONITOR_NATS_HANDLER_NAMES = frozenset(
         "get_host_resource_top",
         "get_monitor_statistics",
         "get_network_device_resource_top",
-        "mm_query",
-        "mm_query_range",
         "monitor_ingest_from_source",
         "monitor_instance_metrics",
         "monitor_metrics",
@@ -30,6 +28,7 @@ MONITOR_NATS_HANDLER_NAMES = frozenset(
         "query_latest_interface_metrics",
         "query_monitor_alert_segments",
         "query_monitor_data_by_metric",
+        "query_metric_range_scoped",
         "search_monitor_policies",
     }
 )

--- a/server/apps/monitor/nats/monitor.py
+++ b/server/apps/monitor/nats/monitor.py
@@ -41,6 +41,7 @@ from apps.monitor.serializers.monitor_metrics import MetricGroupSerializer, Metr
 from apps.monitor.serializers.monitor_object import MonitorObjectSerializer, MonitorObjectTypeSerializer
 from apps.monitor.serializers.monitor_policy import MonitorPolicySerializer
 from apps.monitor.serializers.plugin import MonitorPluginSerializer
+from apps.monitor.services.authorized_metric_query import AuthorizedMetricQueryError, AuthorizedMetricQueryService
 from apps.monitor.services.host_dashboard import (
     HOST_OBJECT_NAME,
     HostMetricRangeService,
@@ -799,6 +800,9 @@ def query_monitor_data_by_metric(query_data: dict, *args, **kwargs):
 
     if not isinstance(instance_ids, list):
         return {"result": False, "data": [], "message": "instance_ids 必须是列表"}
+    instance_ids = list(dict.fromkeys(str(instance_id) for instance_id in instance_ids if instance_id not in (None, "")))
+    if not instance_ids:
+        return {"result": False, "data": [], "message": "instance_ids 不能为空"}
 
     user_info = kwargs.get("user_info", {})
 
@@ -829,20 +833,16 @@ def query_monitor_data_by_metric(query_data: dict, *args, **kwargs):
 
     authorized_qs = _get_authorized_instance_queryset(permission)
 
-    # 如果指定了实例ID，需要进行权限验证和过滤
-    if instance_ids:
-        # 获取有权限的实例ID
-        authorized_instances = list(
-            authorized_qs.filter(
-                id__in=instance_ids,
-                monitor_object=monitor_obj,
-                is_deleted=False,
-            ).values_list("id", flat=True)
-        )
-
-        if not authorized_instances:
-            return {"result": False, "data": [], "message": "没有权限访问指定的实例"}
-        instance_ids = authorized_instances
+    authorized_instances = list(
+        authorized_qs.filter(
+            id__in=instance_ids,
+            monitor_object=monitor_obj,
+            is_deleted=False,
+        ).values_list("id", flat=True)
+    )
+    if set(authorized_instances) != set(instance_ids):
+        return {"result": False, "data": [], "message": "没有权限访问指定的实例"}
+    instance_ids = authorized_instances
 
     authorized_instance_ids = set(
         authorized_qs.filter(monitor_object=monitor_obj, is_deleted=False).values_list(
@@ -1337,14 +1337,44 @@ def query_latest_interface_metrics(instance_ids=None, *args, **kwargs):
 
 
 @nats_client.register
-def mm_query_range(query: str, time_range: list, step="5m", *args, **kwargs):
+def query_metric_range_scoped(
+    monitor_object_id,
+    metric_id,
+    instance_ids: list,
+    time_range: list,
+    step="5m",
+    *args,
+    **kwargs,
+):
+    """按 NATS 请求携带的用户态执行受控指标范围查询。"""
     try:
         start_time, end_time = parse_rfc3339_range_utc(time_range)
     except ValueError as exc:
         return {"result": False, "data": [], "message": str(exc)}
-    start_time = rfc3339_to_timestamp(start_time)
-    end_time = rfc3339_to_timestamp(end_time)
-    resp = VictoriaMetricsAPI().query_range(query, start_time, end_time, step)
+
+    user_info = kwargs.get("user_info") or {}
+    user = _normalize_permission_user(
+        user_info.get("user"),
+        domain=user_info.get("domain"),
+    )
+    try:
+        resp = AuthorizedMetricQueryService(
+            user=user,
+            current_team=user_info.get("team"),
+            include_children=bool(user_info.get("include_children", False)),
+        ).query_range(
+            {
+                "monitor_object_id": monitor_object_id,
+                "metric_id": metric_id,
+                "instance_ids": instance_ids,
+                "start": int(rfc3339_to_timestamp(start_time)) * 1000,
+                "end": int(rfc3339_to_timestamp(end_time)) * 1000,
+                "step": step,
+            }
+        )
+    except AuthorizedMetricQueryError as exc:
+        return {"result": False, "data": [], "message": str(exc)}
+
     if resp.get("status") == "success":
         _result = resp["data"]["result"]
         if _result:
@@ -1357,23 +1387,6 @@ def mm_query_range(query: str, time_range: list, step="5m", *args, **kwargs):
             data.append({"name": _value[0], "value": _value[1]})
         return {"result": True, "data": data, "message": ""}
     return _build_vm_query_failure_result(resp, "查询时间范围指标数据失败")
-
-
-@nats_client.register
-def mm_query(query: str, step="5m", *args, **kwargs):
-    resp = VictoriaMetricsAPI().query(query, step)
-    if resp.get("status") == "success":
-        _result = resp["data"]["result"]
-        if _result:
-            values = _result[0].get("value", [])
-        else:
-            values = []
-            # 格式转换给单值
-        data = []
-        if values:
-            data.append({"name": values[0], "value": values[-1]})
-        return {"result": True, "data": data, "message": ""}
-    return _build_vm_query_failure_result(resp, "查询单个指标数据失败")
 
 
 @nats_client.register

--- a/server/apps/monitor/services/authorized_metric_query.py
+++ b/server/apps/monitor/services/authorized_metric_query.py
@@ -1,0 +1,293 @@
+import re
+from dataclasses import dataclass
+
+from apps.core.utils.permission_utils import get_permission_rules, permission_filter
+from apps.monitor.constants.permission import PermissionConstants
+from apps.monitor.models import Metric, MonitorInstance
+from apps.monitor.services.metrics import Metrics
+from apps.monitor.utils.dimension import parse_instance_id
+
+ALLOWED_AGGREGATIONS = {
+    "AVG": None,
+    "SUM": "sum",
+    "MAX": "max",
+    "MIN": "min",
+    "COUNT": "count",
+}
+ALLOWED_FILTER_OPERATORS = {"=", "!=", "=~", "!~"}
+
+
+class AuthorizedMetricQueryError(ValueError):
+    def __init__(self, message: str, *, code: str):
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class AuthorizedMetricQuery:
+    metric: Metric
+    instance_ids: tuple[str, ...]
+    query: str
+    start: int
+    end: int
+    step: str
+    detect_gaps: bool
+    collection_interval: int | None
+    card_budget: bool
+
+
+def _escape_label_value(value) -> str:
+    return str(value).replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _metric_instance_id_keys(metric: Metric) -> list[str]:
+    keys = metric.instance_id_keys or getattr(metric.monitor_object, "instance_id_keys", None) or []
+    normalized = [str(key).strip() for key in keys if key is not None and str(key).strip()]
+    if not normalized:
+        raise AuthorizedMetricQueryError(
+            "监控指标缺少实例标识契约",
+            code="metric_instance_keys_missing",
+        )
+    return normalized
+
+
+def _instance_matchers(instance_ids: tuple[str, ...], keys: list[str]) -> list[str]:
+    values_by_key = {key: set() for key in keys}
+    for instance_id in instance_ids:
+        values = parse_instance_id(instance_id)
+        if len(values) < len(keys):
+            raise AuthorizedMetricQueryError(
+                "监控实例标识与指标契约不匹配",
+                code="instance_identity_invalid",
+            )
+        for index, key in enumerate(keys):
+            value = values[index]
+            if value in (None, ""):
+                raise AuthorizedMetricQueryError(
+                    "监控实例标识与指标契约不匹配",
+                    code="instance_identity_invalid",
+                )
+            values_by_key[key].add(str(value))
+
+    matchers = []
+    for key, values in values_by_key.items():
+        escaped_values = [_escape_label_value(re.escape(value)) for value in sorted(values)]
+        matchers.append(f'{key}=~"{"|".join(escaped_values)}"')
+    return matchers
+
+
+def _allowed_dimensions(metric: Metric) -> set[str]:
+    allowed = set()
+    for item in metric.dimensions or []:
+        if isinstance(item, dict):
+            name = item.get("name")
+        else:
+            name = item
+        if name is not None and str(name).strip():
+            allowed.add(str(name).strip())
+    return allowed
+
+
+def _filter_matchers(metric: Metric, filters) -> list[str]:
+    if filters in (None, ""):
+        return []
+    if not isinstance(filters, list):
+        raise AuthorizedMetricQueryError("filters 必须是列表", code="filters_invalid")
+
+    allowed = _allowed_dimensions(metric)
+    matchers = []
+    for item in filters:
+        if not isinstance(item, dict):
+            raise AuthorizedMetricQueryError("filters 元素必须是对象", code="filters_invalid")
+        label = str(item.get("label") or "").strip()
+        operator = str(item.get("operator") or "").strip()
+        value = item.get("value")
+        if not label or label not in allowed:
+            raise AuthorizedMetricQueryError("筛选维度未在指标中声明", code="filter_label_invalid")
+        if operator not in ALLOWED_FILTER_OPERATORS:
+            raise AuthorizedMetricQueryError("筛选操作符不受支持", code="filter_operator_invalid")
+        if value in (None, ""):
+            raise AuthorizedMetricQueryError("筛选值不能为空", code="filter_value_invalid")
+        matchers.append(f'{label}{operator}"{_escape_label_value(value)}"')
+    return matchers
+
+
+def _build_query(metric: Metric, instance_ids: tuple[str, ...], filters, aggregation) -> str:
+    template = metric.query or ""
+    if "__$labels__" not in template:
+        raise AuthorizedMetricQueryError(
+            "监控指标不支持受控实例查询",
+            code="metric_template_not_scoped",
+        )
+
+    instance_keys = _metric_instance_id_keys(metric)
+    matchers = _instance_matchers(instance_ids, instance_keys)
+    matchers.extend(_filter_matchers(metric, filters))
+    query = template.replace("__$labels__", ", ".join(matchers))
+
+    aggregation_name = str(aggregation or "AVG").upper()
+    if aggregation_name not in ALLOWED_AGGREGATIONS:
+        raise AuthorizedMetricQueryError("汇聚方式不受支持", code="aggregation_invalid")
+    aggregation_func = ALLOWED_AGGREGATIONS[aggregation_name]
+    if aggregation_func:
+        query = f'{aggregation_func}({query}) by ({", ".join(instance_keys)})'
+    return query
+
+
+def _normalize_bool(value, *, field: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value in (None, "", 0, "0", "false", "False"):
+        return False
+    if value in (1, "1", "true", "True"):
+        return True
+    raise AuthorizedMetricQueryError(f"{field} 必须是布尔值", code=f"{field}_invalid")
+
+
+class AuthorizedMetricQueryService:
+    def __init__(self, *, user, current_team, include_children: bool):
+        self.user = user
+        self.current_team = current_team
+        self.include_children = include_children
+
+    def _prepare(self, payload: dict) -> AuthorizedMetricQuery:
+        if not isinstance(payload, dict):
+            raise AuthorizedMetricQueryError("请求体必须是对象", code="payload_invalid")
+        if self.user is None or self.current_team in (None, ""):
+            raise AuthorizedMetricQueryError(
+                "缺少用户或组织信息",
+                code="query_identity_required",
+            )
+        if "query" in payload:
+            raise AuthorizedMetricQueryError(
+                "受控查询不接受原始 PromQL",
+                code="raw_query_not_allowed",
+            )
+
+        monitor_object_id = payload.get("monitor_object_id")
+        metric_id = payload.get("metric_id")
+        raw_instance_ids = payload.get("instance_ids")
+        if monitor_object_id in (None, "") or metric_id in (None, ""):
+            raise AuthorizedMetricQueryError(
+                "monitor_object_id 和 metric_id 不能为空",
+                code="metric_context_required",
+            )
+        if not isinstance(raw_instance_ids, list) or not raw_instance_ids:
+            raise AuthorizedMetricQueryError(
+                "instance_ids 不能为空",
+                code="instance_ids_required",
+            )
+
+        instance_ids = tuple(dict.fromkeys(str(value) for value in raw_instance_ids if value not in (None, "")))
+        if not instance_ids:
+            raise AuthorizedMetricQueryError(
+                "instance_ids 不能为空",
+                code="instance_ids_required",
+            )
+
+        metric = Metric.objects.select_related("monitor_object").filter(id=metric_id, monitor_object_id=monitor_object_id).first()
+        if metric is None:
+            raise AuthorizedMetricQueryError(
+                "监控对象或指标不存在",
+                code="metric_not_found",
+            )
+
+        if getattr(self.user, "is_superuser", False):
+            authorized_qs = MonitorInstance.objects.all()
+        else:
+            permission = get_permission_rules(
+                self.user,
+                self.current_team,
+                "monitor",
+                f"{PermissionConstants.INSTANCE_MODULE}.{monitor_object_id}",
+                include_children=self.include_children,
+            )
+            authorized_qs = permission_filter(
+                MonitorInstance,
+                permission,
+                team_key="monitorinstanceorganization__organization__in",
+                id_key="id__in",
+            )
+
+        authorized_ids = set(
+            authorized_qs.filter(
+                id__in=instance_ids,
+                monitor_object_id=monitor_object_id,
+                is_deleted=False,
+            ).values_list("id", flat=True)
+        )
+        if authorized_ids != set(instance_ids):
+            raise AuthorizedMetricQueryError(
+                "无权访问所选监控实例",
+                code="monitor_instance_forbidden",
+            )
+
+        try:
+            start = int(payload.get("start"))
+            end = int(payload.get("end"))
+        except (TypeError, ValueError) as exc:
+            raise AuthorizedMetricQueryError(
+                "start 和 end 必须是毫秒时间戳",
+                code="time_range_invalid",
+            ) from exc
+        if start >= end:
+            raise AuthorizedMetricQueryError(
+                "start 必须小于 end",
+                code="time_range_invalid",
+            )
+
+        step = str(payload.get("step") or "5m")
+        try:
+            Metrics.parse_step_to_seconds(step)
+        except ValueError as exc:
+            raise AuthorizedMetricQueryError(str(exc), code="step_invalid") from exc
+
+        collection_interval = payload.get("collection_interval")
+        if collection_interval not in (None, ""):
+            try:
+                collection_interval = int(collection_interval)
+            except (TypeError, ValueError) as exc:
+                raise AuthorizedMetricQueryError(
+                    "collection_interval 必须是整数",
+                    code="collection_interval_invalid",
+                ) from exc
+            if collection_interval <= 0:
+                raise AuthorizedMetricQueryError(
+                    "collection_interval 必须大于 0",
+                    code="collection_interval_invalid",
+                )
+        else:
+            collection_interval = None
+
+        return AuthorizedMetricQuery(
+            metric=metric,
+            instance_ids=instance_ids,
+            query=_build_query(
+                metric,
+                instance_ids,
+                payload.get("filters"),
+                payload.get("aggregation"),
+            ),
+            start=start,
+            end=end,
+            step=step,
+            detect_gaps=_normalize_bool(payload.get("detect_gaps"), field="detect_gaps"),
+            collection_interval=collection_interval,
+            card_budget=_normalize_bool(payload.get("card_budget"), field="card_budget"),
+        )
+
+    def query_range(self, payload: dict) -> dict:
+        prepared = self._prepare(payload)
+        return Metrics.get_metrics_range(
+            prepared.query,
+            prepared.start,
+            prepared.end,
+            prepared.step,
+            detect_gaps=prepared.detect_gaps,
+            collection_interval_seconds=prepared.collection_interval,
+            card_budget=prepared.card_budget,
+        )
+
+    def query_instant(self, payload: dict) -> dict:
+        prepared = self._prepare(payload)
+        return Metrics.get_metrics(prepared.query, time=prepared.end / 1000.0)

--- a/server/apps/monitor/tests/test_authorized_metric_query_service.py
+++ b/server/apps/monitor/tests/test_authorized_metric_query_service.py
@@ -1,0 +1,265 @@
+from types import SimpleNamespace
+
+import pytest
+
+from apps.monitor.models import Metric, MetricGroup, MonitorInstance, MonitorObject, MonitorPlugin
+from apps.monitor.services.authorized_metric_query import AuthorizedMetricQueryError, AuthorizedMetricQueryService
+
+pytestmark = pytest.mark.django_db
+
+
+def _build_metric_contract():
+    monitor_object = MonitorObject.objects.create(
+        name="AuthorizedQueryObject",
+        level="base",
+        instance_id_keys=["instance_id"],
+    )
+    plugin = MonitorPlugin.objects.create(name="AuthorizedQueryPlugin")
+    group = MetricGroup.objects.create(
+        monitor_object=monitor_object,
+        monitor_plugin=plugin,
+        name="AuthorizedQueryGroup",
+    )
+    metric = Metric.objects.create(
+        monitor_object=monitor_object,
+        monitor_plugin=plugin,
+        metric_group=group,
+        name="cpu_usage",
+        query="cpu_usage{__$labels__}",
+        instance_id_keys=["instance_id"],
+        dimensions=[{"name": "mode"}],
+        unit="percent",
+    )
+    allowed = MonitorInstance.objects.create(
+        id="('allowed-host',)",
+        name="allowed-host",
+        monitor_object=monitor_object,
+    )
+    denied = MonitorInstance.objects.create(
+        id="('denied-host',)",
+        name="denied-host",
+        monitor_object=monitor_object,
+    )
+    return monitor_object, metric, allowed, denied
+
+
+def _service(mocker, allowed_instance):
+    mocker.patch(
+        "apps.monitor.services.authorized_metric_query.get_permission_rules",
+        return_value={"data": "permission"},
+    )
+    mocker.patch(
+        "apps.monitor.services.authorized_metric_query.permission_filter",
+        side_effect=lambda model, permission, **kwargs: model.objects.filter(id=allowed_instance.id),
+    )
+    return AuthorizedMetricQueryService(
+        user=SimpleNamespace(username="viewer", domain="domain.com", is_superuser=False),
+        current_team="1",
+        include_children=False,
+    )
+
+
+def test_range_query_uses_server_metric_template_and_authorized_instances(mocker):
+    monitor_object, metric, allowed, _ = _build_metric_contract()
+    service = _service(mocker, allowed)
+    vm_query = mocker.patch(
+        "apps.monitor.services.authorized_metric_query.Metrics.get_metrics_range",
+        return_value={"status": "success", "data": {"result": []}},
+    )
+
+    result = service.query_range(
+        {
+            "monitor_object_id": monitor_object.id,
+            "metric_id": metric.id,
+            "instance_ids": [allowed.id],
+            "filters": [{"label": "mode", "operator": "=", "value": "idle"}],
+            "aggregation": "SUM",
+            "start": 1000,
+            "end": 61000,
+            "step": "60s",
+        }
+    )
+
+    assert result == {"status": "success", "data": {"result": []}}
+    vm_query.assert_called_once_with(
+        'sum(cpu_usage{instance_id=~"allowed\\\\-host", mode="idle"}) by (instance_id)',
+        1000,
+        61000,
+        "60s",
+        detect_gaps=False,
+        collection_interval_seconds=None,
+        card_budget=False,
+    )
+
+
+def test_mixed_authorized_and_denied_instances_fail_before_vm_query(mocker):
+    monitor_object, metric, allowed, denied = _build_metric_contract()
+    service = _service(mocker, allowed)
+    vm_query = mocker.patch("apps.monitor.services.authorized_metric_query.Metrics.get_metrics_range")
+
+    with pytest.raises(AuthorizedMetricQueryError) as exc_info:
+        service.query_range(
+            {
+                "monitor_object_id": monitor_object.id,
+                "metric_id": metric.id,
+                "instance_ids": [allowed.id, denied.id],
+                "start": 1000,
+                "end": 61000,
+                "step": "60s",
+            }
+        )
+
+    assert exc_info.value.code == "monitor_instance_forbidden"
+    assert str(exc_info.value) == "无权访问所选监控实例"
+    vm_query.assert_not_called()
+
+
+def test_query_requires_explicit_instance_ids(mocker):
+    monitor_object, metric, allowed, _ = _build_metric_contract()
+    service = _service(mocker, allowed)
+    vm_query = mocker.patch("apps.monitor.services.authorized_metric_query.Metrics.get_metrics_range")
+
+    with pytest.raises(AuthorizedMetricQueryError) as exc_info:
+        service.query_range(
+            {
+                "monitor_object_id": monitor_object.id,
+                "metric_id": metric.id,
+                "instance_ids": [],
+                "start": 1000,
+                "end": 61000,
+                "step": "60s",
+            }
+        )
+
+    assert exc_info.value.code == "instance_ids_required"
+    vm_query.assert_not_called()
+
+
+def test_raw_query_field_is_rejected_before_vm_query(mocker):
+    monitor_object, metric, allowed, _ = _build_metric_contract()
+    service = _service(mocker, allowed)
+    vm_query = mocker.patch("apps.monitor.services.authorized_metric_query.Metrics.get_metrics_range")
+
+    with pytest.raises(AuthorizedMetricQueryError) as exc_info:
+        service.query_range(
+            {
+                "monitor_object_id": monitor_object.id,
+                "metric_id": metric.id,
+                "instance_ids": [allowed.id],
+                "start": 1000,
+                "end": 61000,
+                "step": "60s",
+                "query": 'secret_metric{instance_id="denied-host"}',
+            }
+        )
+
+    assert exc_info.value.code == "raw_query_not_allowed"
+    vm_query.assert_not_called()
+
+
+def test_missing_identity_fails_before_permission_or_vm_query(mocker):
+    monitor_object, metric, allowed, _ = _build_metric_contract()
+    permission = mocker.patch("apps.monitor.services.authorized_metric_query.get_permission_rules")
+    vm_query = mocker.patch("apps.monitor.services.authorized_metric_query.Metrics.get_metrics_range")
+    service = AuthorizedMetricQueryService(
+        user=None,
+        current_team=None,
+        include_children=False,
+    )
+
+    with pytest.raises(AuthorizedMetricQueryError) as exc_info:
+        service.query_range(
+            {
+                "monitor_object_id": monitor_object.id,
+                "metric_id": metric.id,
+                "instance_ids": [allowed.id],
+                "start": 1000,
+                "end": 61000,
+                "step": "60s",
+            }
+        )
+
+    assert exc_info.value.code == "query_identity_required"
+    permission.assert_not_called()
+    vm_query.assert_not_called()
+
+
+def test_all_metric_template_selectors_receive_authorized_scope(mocker):
+    monitor_object, metric, allowed, _ = _build_metric_contract()
+    metric.query = "left_metric{__$labels__} / right_metric{__$labels__}"
+    metric.save(update_fields=["query"])
+    service = _service(mocker, allowed)
+    vm_query = mocker.patch(
+        "apps.monitor.services.authorized_metric_query.Metrics.get_metrics_range",
+        return_value={"status": "success", "data": {"result": []}},
+    )
+
+    service.query_range(
+        {
+            "monitor_object_id": monitor_object.id,
+            "metric_id": metric.id,
+            "instance_ids": [allowed.id],
+            "start": 1000,
+            "end": 61000,
+            "step": "60s",
+            "detect_gaps": True,
+            "collection_interval": 60,
+            "card_budget": True,
+        }
+    )
+
+    query = vm_query.call_args.args[0]
+    assert query.count('instance_id=~"allowed\\\\-host"') == 2
+    assert vm_query.call_args.kwargs == {
+        "detect_gaps": True,
+        "collection_interval_seconds": 60,
+        "card_budget": True,
+    }
+
+
+def test_undeclared_filter_is_rejected_before_vm_query(mocker):
+    monitor_object, metric, allowed, _ = _build_metric_contract()
+    service = _service(mocker, allowed)
+    vm_query = mocker.patch("apps.monitor.services.authorized_metric_query.Metrics.get_metrics_range")
+
+    with pytest.raises(AuthorizedMetricQueryError) as exc_info:
+        service.query_range(
+            {
+                "monitor_object_id": monitor_object.id,
+                "metric_id": metric.id,
+                "instance_ids": [allowed.id],
+                "filters": [{"label": "organization", "operator": "=", "value": "2"}],
+                "start": 1000,
+                "end": 61000,
+                "step": "60s",
+            }
+        )
+
+    assert exc_info.value.code == "filter_label_invalid"
+    vm_query.assert_not_called()
+
+
+def test_instant_query_uses_server_template_and_range_end_as_eval_time(mocker):
+    monitor_object, metric, allowed, _ = _build_metric_contract()
+    service = _service(mocker, allowed)
+    vm_query = mocker.patch(
+        "apps.monitor.services.authorized_metric_query.Metrics.get_metrics",
+        return_value={"status": "success", "data": {"result": []}},
+    )
+
+    result = service.query_instant(
+        {
+            "monitor_object_id": monitor_object.id,
+            "metric_id": metric.id,
+            "instance_ids": [allowed.id],
+            "start": 1000,
+            "end": 61000,
+            "step": "60s",
+        }
+    )
+
+    assert result["status"] == "success"
+    vm_query.assert_called_once_with(
+        'cpu_usage{instance_id=~"allowed\\\\-host"}',
+        time=61.0,
+    )

--- a/server/apps/monitor/tests/test_authorized_metric_query_view.py
+++ b/server/apps/monitor/tests/test_authorized_metric_query_view.py
@@ -1,0 +1,121 @@
+import json
+
+import pytest
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.core.exceptions.base_app_exception import UnauthorizedException
+from apps.monitor.models import Metric, MetricGroup, MonitorInstance, MonitorObject, MonitorPlugin
+from apps.monitor.views.metrics_instance import MetricsInstanceViewSet
+
+pytestmark = pytest.mark.django_db
+
+
+def _setup_query_contract():
+    monitor_object = MonitorObject.objects.create(
+        name="AuthorizedViewObject",
+        level="base",
+        instance_id_keys=["instance_id"],
+    )
+    plugin = MonitorPlugin.objects.create(name="AuthorizedViewPlugin")
+    group = MetricGroup.objects.create(
+        monitor_object=monitor_object,
+        monitor_plugin=plugin,
+        name="AuthorizedViewGroup",
+    )
+    metric = Metric.objects.create(
+        monitor_object=monitor_object,
+        monitor_plugin=plugin,
+        metric_group=group,
+        name="cpu_usage",
+        query="cpu_usage{__$labels__}",
+        instance_id_keys=["instance_id"],
+        unit="percent",
+    )
+    allowed = MonitorInstance.objects.create(
+        id="('allowed-view-host',)",
+        name="allowed-view-host",
+        monitor_object=monitor_object,
+    )
+    denied = MonitorInstance.objects.create(
+        id="('denied-view-host',)",
+        name="denied-view-host",
+        monitor_object=monitor_object,
+    )
+    return monitor_object, metric, allowed, denied
+
+
+def _request(user, payload):
+    request = APIRequestFactory().post(
+        "/monitor/api/metrics_instance/query_by_metric_range/",
+        payload,
+        format="json",
+    )
+    request.COOKIES["current_team"] = "1"
+    force_authenticate(request, user=user)
+    return request
+
+
+def test_authorized_range_view_uses_authenticated_request_scope(authenticated_user, mocker):
+    monitor_object, metric, allowed, _ = _setup_query_contract()
+    mocker.patch(
+        "apps.monitor.services.authorized_metric_query.get_permission_rules",
+        return_value={"data": "permission"},
+    )
+    mocker.patch(
+        "apps.monitor.services.authorized_metric_query.permission_filter",
+        side_effect=lambda model, permission, **kwargs: model.objects.filter(id=allowed.id),
+    )
+    vm_query = mocker.patch(
+        "apps.monitor.services.authorized_metric_query.Metrics.get_metrics_range",
+        return_value={"status": "success", "data": {"result": []}},
+    )
+    view = MetricsInstanceViewSet.as_view({"post": "query_by_metric_range"})
+
+    response = view(
+        _request(
+            authenticated_user,
+            {
+                "monitor_object_id": monitor_object.id,
+                "metric_id": metric.id,
+                "instance_ids": [allowed.id],
+                "start": 1000,
+                "end": 61000,
+                "step": "60s",
+            },
+        )
+    )
+
+    assert response.status_code == 200
+    assert json.loads(response.content)["result"] is True
+    vm_query.assert_called_once()
+
+
+def test_authorized_range_view_rejects_mixed_scope_without_vm_call(authenticated_user, mocker):
+    monitor_object, metric, allowed, denied = _setup_query_contract()
+    mocker.patch(
+        "apps.monitor.services.authorized_metric_query.get_permission_rules",
+        return_value={"data": "permission"},
+    )
+    mocker.patch(
+        "apps.monitor.services.authorized_metric_query.permission_filter",
+        side_effect=lambda model, permission, **kwargs: model.objects.filter(id=allowed.id),
+    )
+    vm_query = mocker.patch("apps.monitor.services.authorized_metric_query.Metrics.get_metrics_range")
+    view = MetricsInstanceViewSet.as_view({"post": "query_by_metric_range"})
+
+    with pytest.raises(UnauthorizedException, match="无权访问所选监控实例"):
+        view(
+            _request(
+                authenticated_user,
+                {
+                    "monitor_object_id": monitor_object.id,
+                    "metric_id": metric.id,
+                    "instance_ids": [allowed.id, denied.id],
+                    "start": 1000,
+                    "end": 61000,
+                    "step": "60s",
+                },
+            )
+        )
+
+    vm_query.assert_not_called()

--- a/server/apps/monitor/tests/test_nats_monitor_handlers.py
+++ b/server/apps/monitor/tests/test_nats_monitor_handlers.py
@@ -36,8 +36,6 @@ EXPECTED_MONITOR_NATS_HANDLER_NAMES = frozenset(
         "get_host_resource_top",
         "get_monitor_statistics",
         "get_network_device_resource_top",
-        "mm_query",
-        "mm_query_range",
         "monitor_ingest_from_source",
         "monitor_instance_metrics",
         "monitor_metrics",
@@ -48,6 +46,7 @@ EXPECTED_MONITOR_NATS_HANDLER_NAMES = frozenset(
         "query_latest_interface_metrics",
         "query_monitor_alert_segments",
         "query_monitor_data_by_metric",
+        "query_metric_range_scoped",
         "search_monitor_policies",
     }
 )
@@ -84,10 +83,7 @@ def test_monitor_nats_handler_contract_matches_runtime_registry():
         for registration in default_registry.registry.values()
         if registration["func"].__module__.startswith("apps.monitor.nats.")
     }
-    expected_subjects = {
-        f"{settings.NATS_NAMESPACE}.{handler_name}"
-        for handler_name in MONITOR_NATS_HANDLER_NAMES
-    }
+    expected_subjects = {f"{settings.NATS_NAMESPACE}.{handler_name}" for handler_name in MONITOR_NATS_HANDLER_NAMES}
 
     assert runtime_handler_names - MONITOR_NATS_PERMISSION_HANDLER_NAMES == MONITOR_NATS_HANDLER_NAMES
     assert expected_subjects <= default_registry.registry.keys()
@@ -174,31 +170,6 @@ class TestMonitorObjectInstancesHandler:
         assert out["data"][0]["permission"] == ["View"]
 
 
-class TestMmQuery:
-    def test_success(self, mocker):
-        vm = mocker.patch("apps.monitor.nats.monitor.VictoriaMetricsAPI")
-        vm.return_value.query.return_value = {
-            "status": "success",
-            "data": {"result": [{"value": [1700000000, "42"]}]},
-        }
-        out = nm.mm_query("up")
-        assert out["result"] is True
-        assert out["data"] == [{"name": 1700000000, "value": "42"}]
-
-    def test_empty_result(self, mocker):
-        vm = mocker.patch("apps.monitor.nats.monitor.VictoriaMetricsAPI")
-        vm.return_value.query.return_value = {"status": "success", "data": {"result": []}}
-        out = nm.mm_query("up")
-        assert out["result"] is True and out["data"] == []
-
-    def test_failure(self, mocker):
-        vm = mocker.patch("apps.monitor.nats.monitor.VictoriaMetricsAPI")
-        vm.return_value.query.return_value = {"status": "error", "error": "boom"}
-        out = nm.mm_query("up")
-        assert out["result"] is False
-        assert "boom" in out["message"]
-
-
 class TestHostResourceTop:
     def test_returns_ranked_rows_for_metric_type(self, mocker):
         instance = SimpleNamespace(id="host-1", name="host-1", ip="10.0.0.1", interval=300)
@@ -230,33 +201,34 @@ class TestHostResourceTop:
         vm.assert_not_called()
 
 
-class TestMmQueryRange:
+class TestQueryMetricRangeScoped:
     def test_success(self, mocker):
-        vm = mocker.patch("apps.monitor.nats.monitor.VictoriaMetricsAPI")
-        vm.return_value.query_range.return_value = {
+        service = mocker.patch("apps.monitor.nats.monitor.AuthorizedMetricQueryService")
+        service.return_value.query_range.return_value = {
             "status": "success",
             "data": {"result": [{"values": [[1, "10"], [2, "20"]]}]},
         }
-        out = nm.mm_query_range(
-            "up",
+        out = nm.query_metric_range_scoped(
+            8,
+            42,
+            ["host-1"],
             ["2026-01-01T00:00:00.000Z", "2026-01-01T00:10:00.000Z"],
+            user_info={"user": "viewer", "domain": "domain.com", "team": 1},
         )
 
         assert out["result"] is True
         assert out["data"] == [{"name": 1, "value": "10"}, {"name": 2, "value": "20"}]
-        vm.return_value.query_range.assert_called_once_with(
-            "up",
-            "1767225600",
-            "1767226200",
-            "5m",
-        )
+        service.return_value.query_range.assert_called_once()
 
     def test_failure(self, mocker):
-        vm = mocker.patch("apps.monitor.nats.monitor.VictoriaMetricsAPI")
-        vm.return_value.query_range.return_value = {"status": "error", "message": "down"}
-        out = nm.mm_query_range(
-            "up",
+        service = mocker.patch("apps.monitor.nats.monitor.AuthorizedMetricQueryService")
+        service.return_value.query_range.return_value = {"status": "error", "message": "down"}
+        out = nm.query_metric_range_scoped(
+            8,
+            42,
+            ["host-1"],
             ["2026-01-01T00:00:00.000Z", "2026-01-01T00:10:00.000Z"],
+            user_info={"user": "viewer", "domain": "domain.com", "team": 1},
         )
         assert out["result"] is False
 
@@ -269,14 +241,14 @@ class TestMmQueryRange:
         ],
     )
     def test_invalid_time_range_returns_error_without_query(self, mocker, time_range):
-        vm = mocker.patch("apps.monitor.nats.monitor.VictoriaMetricsAPI")
+        service = mocker.patch("apps.monitor.nats.monitor.AuthorizedMetricQueryService")
 
-        result = nm.mm_query_range("up", time_range)
+        result = nm.query_metric_range_scoped(8, 42, ["host-1"], time_range)
 
         assert result["result"] is False
         assert result["data"] == []
         assert "time range" in result["message"]
-        vm.assert_not_called()
+        service.assert_not_called()
 
 
 class TestQueryMonitorDataByMetric:
@@ -309,15 +281,25 @@ class TestQueryMonitorDataByMetric:
 
     def test_missing_user_info(self):
         out = nm.query_monitor_data_by_metric(
-            {"monitor_obj_id": 1, "metric": "cpu", "start": 1, "end": 2},
+            {"monitor_obj_id": 1, "metric": "cpu", "start": 1, "end": 2, "instance_ids": ["host-1"]},
             user_info={},
         )
         assert out["result"] is False
 
+    def test_empty_instance_ids_fail_closed(self, mocker):
+        vm = mocker.patch("apps.monitor.nats.monitor.Metrics.get_metrics_range")
+        out = nm.query_monitor_data_by_metric(
+            {"monitor_obj_id": 1, "metric": "cpu", "start": 1, "end": 2, "instance_ids": []},
+            user_info={"user": "viewer", "team": 1},
+        )
+        assert out["result"] is False
+        assert "instance_ids" in out["message"]
+        vm.assert_not_called()
+
     def test_object_or_metric_not_found(self, mocker):
         mocker.patch("apps.monitor.nats.monitor.get_permission_rules", return_value={"team": [1]})
         out = nm.query_monitor_data_by_metric(
-            {"monitor_obj_id": 999999, "metric": "cpu", "start": 1, "end": 2},
+            {"monitor_obj_id": 999999, "metric": "cpu", "start": 1, "end": 2, "instance_ids": ["host-1"]},
             user_info={"user": SimpleNamespace(username="u", domain="d"), "team": 1},
         )
         assert out["result"] is False
@@ -343,7 +325,7 @@ class TestQueryMonitorDataByMetric:
             },
         )
         out = nm.query_monitor_data_by_metric(
-            {"monitor_obj_id": obj.id, "metric": "cpu", "start": 1, "end": 2},
+            {"monitor_obj_id": obj.id, "metric": "cpu", "start": 1, "end": 2, "instance_ids": ["('h1',)"]},
             user_info={"user": SimpleNamespace(username="u", domain="d"), "team": 1},
         )
         assert out["result"] is True
@@ -414,7 +396,7 @@ class TestQueryMonitorDataByMetric:
         )
 
         out = nm.query_monitor_data_by_metric(
-            {"monitor_obj_id": obj.id, "metric": "cpu", "start": 1, "end": 2},
+            {"monitor_obj_id": obj.id, "metric": "cpu", "start": 1, "end": 2, "instance_ids": ["('h1',)"]},
             user_info={"user": SimpleNamespace(username="u", domain="d"), "team": 1},
         )
 

--- a/server/apps/monitor/views/metrics_instance.py
+++ b/server/apps/monitor/views/metrics_instance.py
@@ -3,19 +3,77 @@ from typing import Optional
 from rest_framework import viewsets
 from rest_framework.decorators import action
 
-from apps.core.exceptions.base_app_exception import BaseAppException, UnauthorizedException
+from apps.core.exceptions.base_app_exception import BaseAppException, UnauthorizedException, ValidationAppException
 from apps.core.logger import monitor_logger as logger
 from apps.core.utils.permission_utils import get_permission_rules, permission_filter
+from apps.core.utils.team_utils import get_current_team
 from apps.core.utils.web_utils import WebUtils
 from apps.monitor.constants.permission import PermissionConstants
 from apps.monitor.models import MonitorInstance
 from apps.monitor.models.monitor_metrics import Metric
+from apps.monitor.services.authorized_metric_query import AuthorizedMetricQueryError, AuthorizedMetricQueryService
 from apps.monitor.services.metrics import Metrics as MetricsService
 from apps.monitor.utils.unit_converter import UnitConverter
-from apps.core.utils.team_utils import get_current_team
 
 
 class MetricsInstanceViewSet(viewsets.ViewSet):
+    @staticmethod
+    def _authorized_query_service(request):
+        current_team = get_current_team(request)
+        if current_team in (None, ""):
+            raise BaseAppException("current_team is required")
+        return AuthorizedMetricQueryService(
+            user=request.user,
+            current_team=current_team,
+            include_children=request.COOKIES.get("include_children", "0") == "1",
+        )
+
+    @staticmethod
+    def _raise_authorized_query_error(exc: AuthorizedMetricQueryError):
+        if exc.code in {"monitor_instance_forbidden", "query_identity_required"}:
+            raise UnauthorizedException(str(exc))
+        raise ValidationAppException(str(exc))
+
+    @action(methods=["post"], detail=False, url_path="query_by_metric_range")
+    def query_by_metric_range(self, request):
+        """按当前用户实例权限执行服务端指标模板的范围查询。"""
+        try:
+            data = self._authorized_query_service(request).query_range(request.data)
+        except AuthorizedMetricQueryError as exc:
+            self._raise_authorized_query_error(exc)
+
+        source_unit = request.data.get("source_unit")
+        target_unit = request.data.get("unit")
+        auto_convert = request.data.get("auto_convert_unit", True)
+        if isinstance(auto_convert, str):
+            auto_convert = auto_convert.lower() == "true"
+        if source_unit:
+            if target_unit:
+                data = self._apply_unit_conversion(data, source_unit, target_unit)
+            elif auto_convert:
+                data = self._apply_unit_conversion(data, source_unit)
+        return WebUtils.response_success(data)
+
+    @action(methods=["post"], detail=False, url_path="query_by_metric")
+    def query_by_metric(self, request):
+        """按当前用户实例权限执行服务端指标模板的即时查询。"""
+        try:
+            data = self._authorized_query_service(request).query_instant(request.data)
+        except AuthorizedMetricQueryError as exc:
+            self._raise_authorized_query_error(exc)
+
+        source_unit = request.data.get("source_unit")
+        target_unit = request.data.get("unit")
+        auto_convert = request.data.get("auto_convert_unit", True)
+        if isinstance(auto_convert, str):
+            auto_convert = auto_convert.lower() == "true"
+        if source_unit:
+            if target_unit:
+                data = self._apply_unit_conversion(data, source_unit, target_unit)
+            elif auto_convert:
+                data = self._apply_unit_conversion(data, source_unit)
+        return WebUtils.response_success(data)
+
     @action(methods=["get"], detail=False, url_path="query")
     def get_metrics(self, request):
         """

--- a/server/apps/operation_analysis/support-files/source_api.json
+++ b/server/apps/operation_analysis/support-files/source_api.json
@@ -185,6 +185,60 @@
     ]
 },
 {
+    "key": "受控监控指标趋势::monitor/query_metric_range_scoped",
+    "name": "受控监控指标趋势",
+    "desc": "按当前用户、组织、监控对象、指标和实例权限查询范围数据，不接受原始 PromQL",
+    "rest_api": "monitor/query_metric_range_scoped",
+    "tag": ["monitor"],
+    "chart_type": ["line", "bar"],
+    "params": [
+      {
+        "name": "monitor_object_id",
+        "type": "string",
+        "value": "",
+        "alias_name": "监控对象ID",
+        "filterType": "params",
+        "required": true
+      },
+      {
+        "name": "metric_id",
+        "type": "string",
+        "value": "",
+        "alias_name": "指标ID",
+        "filterType": "params",
+        "required": true
+      },
+      {
+        "name": "instance_ids",
+        "type": "string",
+        "value": [],
+        "alias_name": "实例ID",
+        "filterType": "params",
+        "required": true
+      },
+      {
+        "name": "time_range",
+        "type": "timeRange",
+        "value": 10080,
+        "alias_name": "时间范围",
+        "filterType": "fixed",
+        "required": true
+      },
+      {
+        "name": "step",
+        "type": "string",
+        "value": "5m",
+        "alias_name": "查询步长",
+        "filterType": "params",
+        "required": true
+      }
+    ],
+    "field_schema": [
+      {"key": "name", "title": "时间", "value_type": "datetime"},
+      {"key": "value", "title": "指标值", "value_type": "number"}
+    ]
+},
+{
     "key": "主机指标趋势::monitor/get_host_metric_range",
     "name": "主机指标趋势",
     "desc": "按所选主机查询单一指标趋势，一主机一线；未选主机不退化为全量",

--- a/server/apps/rpc/monitor.py
+++ b/server/apps/rpc/monitor.py
@@ -148,23 +148,6 @@ class MonitorOperationAnaRpc(BaseOperationAnaRpc):
         """
         return self.client.run("query_monitor_data_by_metric", query_data=query_data, **kwargs)
 
-    def query_range(self, query: str, time_range: str, step="5m", **kwargs):
-        """查询时间范围内的指标数据
-        query: 指标查询语句
-        start: 开始时间（UTC时间戳）
-        end: 结束时间（UTC时间戳）
-        step: 数据采集间隔，默认为5分钟
-        """
-        return self.client.run("mm_query_range", query=query, time_range=time_range, step=step, **kwargs)
-
-    def query(self, query: str, step="5m", **kwargs):
-        """查询单点指标数据
-        query: 指标查询语句
-        step: 数据采集间隔，默认为5分钟
-        time: 查询时间点（UTC时间戳），默认为当前时间
-        """
-        return self.client.run("mm_query", query=query, step=step, **kwargs)
-
     def query_monitor_alert_segments(self, query_data: dict, **kwargs):
         """查询监控模块策略产生的异常段
         query_data: {

--- a/server/apps/rpc/tests/test_monitor_forwarding.py
+++ b/server/apps/rpc/tests/test_monitor_forwarding.py
@@ -3,6 +3,7 @@
 覆盖 Monitor（permission/NATS 形态）与 MonitorOperationAnaRpc（OperationAnalysisRpc）
 两个客户端的方法名 + 参数转发契约。替换 self.client 为记录器，不触达真实 NATS。
 """
+
 import pydantic.root_model  # noqa
 import pytest
 
@@ -152,16 +153,6 @@ def test_query_monitor_data_by_metric(ana_rpc):
     qd = {"metric": "cpu"}
     ana_rpc.query_monitor_data_by_metric(qd)
     assert _last(ana_rpc.client) == ("query_monitor_data_by_metric", (), {"query_data": qd})
-
-
-def test_query_range_默认step(ana_rpc):
-    ana_rpc.query_range("up", "1h")
-    assert _last(ana_rpc.client) == ("mm_query_range", (), {"query": "up", "time_range": "1h", "step": "5m"})
-
-
-def test_query_默认step(ana_rpc):
-    ana_rpc.query("up")
-    assert _last(ana_rpc.client) == ("mm_query", (), {"query": "up", "step": "5m"})
 
 
 def test_query_monitor_alert_segments(ana_rpc):

--- a/server/scripts/create_mysql_monitor_dashboard.sh
+++ b/server/scripts/create_mysql_monitor_dashboard.sh
@@ -29,8 +29,8 @@ OA_CREATED_BY="${OA_CREATED_BY:-admin}"
 
 OA_DASHBOARD_NAME="${OA_DASHBOARD_NAME:-MySQL-${MYSQL_INSTANCE_NAME}-趋势}"
 OA_DASHBOARD_DESC="${OA_DASHBOARD_DESC:-MySQL 自动导入趋势图}"
-OA_EXISTING_DATASOURCE_NAME="${OA_EXISTING_DATASOURCE_NAME:-查询时间范围内的指标数据}"
-OA_EXISTING_DATASOURCE_REST_API="${OA_EXISTING_DATASOURCE_REST_API:-monitor/mm_query_range}"
+OA_EXISTING_DATASOURCE_NAME="${OA_EXISTING_DATASOURCE_NAME:-受控监控指标趋势}"
+OA_EXISTING_DATASOURCE_REST_API="${OA_EXISTING_DATASOURCE_REST_API:-monitor/query_metric_range_scoped}"
 OA_DATASOURCE_KEY="${OA_DATASOURCE_KEY:-${OA_EXISTING_DATASOURCE_NAME}::${OA_EXISTING_DATASOURCE_REST_API}}"
 
 OA_WIDGET_ID="${OA_WIDGET_ID:-mysql-monitor-widget}"
@@ -58,6 +58,8 @@ MONITOR_REQUEST_YAML="${WORKDIR}/monitor-request.yaml"
 MONITOR_RESULT_YAML="${WORKDIR}/monitor-result.yaml"
 OA_IMPORT_YAML="${WORKDIR}/oa-import.yaml"
 INSTANCE_LABEL_FILE="${WORKDIR}/instance-label.txt"
+INSTANCE_ID_FILE="${WORKDIR}/instance-id.txt"
+METRIC_ID_FILE="${WORKDIR}/metric-id.txt"
 
 DJANGO_PYTHON="${DJANGO_PYTHON:-${VENV_PYTHON_DEFAULT}}"
 
@@ -239,13 +241,22 @@ parse_monitor_result() {
     cd "${SERVER_DIR}"
     RESULT_YAML="${MONITOR_RESULT_YAML}" \
     INSTANCE_LABEL_FILE="${INSTANCE_LABEL_FILE}" \
+    INSTANCE_ID_FILE="${INSTANCE_ID_FILE}" \
+    METRIC_ID_FILE="${METRIC_ID_FILE}" \
+    MYSQL_MONITOR_OBJECT_ID="${MYSQL_MONITOR_OBJECT_ID}" \
+    MYSQL_MONITOR_PLUGIN_ID="${MYSQL_MONITOR_PLUGIN_ID}" \
+    OA_QUERY_METRIC="${OA_QUERY_METRIC}" \
     "${DJANGO_PYTHON}" manage.py shell <<'PY'
 import os
 import sys
 import yaml
 
+from apps.monitor.models import Metric
+
 path = os.environ["RESULT_YAML"]
 label_out = os.environ["INSTANCE_LABEL_FILE"]
+instance_id_out = os.environ["INSTANCE_ID_FILE"]
+metric_id_out = os.environ["METRIC_ID_FILE"]
 with open(path, "r", encoding="utf-8") as f:
     data = yaml.safe_load(f) or {}
 
@@ -268,18 +279,40 @@ if not label_values:
 with open(label_out, "w", encoding="utf-8") as f:
     f.write(str(label_values[0]).strip())
 
+with open(instance_id_out, "w", encoding="utf-8") as f:
+    f.write(str(instance["instance_id"]).strip())
+
+metric_id = (
+    Metric.objects.filter(
+        monitor_object_id=int(os.environ["MYSQL_MONITOR_OBJECT_ID"]),
+        monitor_plugin_id=int(os.environ["MYSQL_MONITOR_PLUGIN_ID"]),
+        name=os.environ["OA_QUERY_METRIC"],
+    )
+    .values_list("id", flat=True)
+    .first()
+)
+if metric_id is None:
+    print("metric not found for authorized query")
+    sys.exit(1)
+with open(metric_id_out, "w", encoding="utf-8") as f:
+    f.write(str(metric_id))
+
 print(f"instance_label={label_values[0]}")
 PY
   ) || fail "monitor result validation failed"
 
 INSTANCE_LABEL="$(cat "${INSTANCE_LABEL_FILE}")"
+  INSTANCE_ID="$(cat "${INSTANCE_ID_FILE}")"
+  OA_METRIC_ID="$(cat "${METRIC_ID_FILE}")"
   assert_nonempty "${INSTANCE_LABEL}" "INSTANCE_LABEL"
+  assert_nonempty "${INSTANCE_ID}" "INSTANCE_ID"
+  assert_nonempty "${OA_METRIC_ID}" "OA_METRIC_ID"
 
   if [[ -z "${OA_QUERY_EXPR}" ]]; then
     OA_QUERY_EXPR="${OA_QUERY_METRIC}{instance_id=\"${INSTANCE_LABEL}\"}"
   fi
 
-  export OA_QUERY_EXPR
+  export OA_QUERY_EXPR INSTANCE_ID OA_METRIC_ID
   log "resolved instance label: ${INSTANCE_LABEL}"
   log "effective query expr: ${OA_QUERY_EXPR}"
 }
@@ -329,6 +362,81 @@ wait_metric_ready() {
 
 render_dashboard_yaml() {
   log "rendering operation analysis import yaml"
+  OA_VIEW_SETS_YAML="$(
+    OA_DATASOURCE_KEY="${OA_DATASOURCE_KEY}" \
+    OA_WIDGET_ID="${OA_WIDGET_ID}" \
+    OA_WIDGET_TITLE="${OA_WIDGET_TITLE}" \
+    OA_WIDGET_DESC="${OA_WIDGET_DESC}" \
+    OA_WIDGET_X="${OA_WIDGET_X}" \
+    OA_WIDGET_Y="${OA_WIDGET_Y}" \
+    OA_WIDGET_W="${OA_WIDGET_W}" \
+    OA_WIDGET_H="${OA_WIDGET_H}" \
+    OA_CHART_TYPE="${OA_CHART_TYPE}" \
+    MYSQL_MONITOR_OBJECT_ID="${MYSQL_MONITOR_OBJECT_ID}" \
+    OA_METRIC_ID="${OA_METRIC_ID}" \
+    INSTANCE_ID="${INSTANCE_ID}" \
+    OA_QUERY_TIME_RANGE="${OA_QUERY_TIME_RANGE}" \
+    OA_QUERY_STEP="${OA_QUERY_STEP}" \
+    python3 <<'PY'
+import os
+import textwrap
+import yaml
+
+widget = {
+    "i": os.environ["OA_WIDGET_ID"],
+    "x": int(os.environ["OA_WIDGET_X"]),
+    "y": int(os.environ["OA_WIDGET_Y"]),
+    "w": int(os.environ["OA_WIDGET_W"]),
+    "h": int(os.environ["OA_WIDGET_H"]),
+    "name": os.environ["OA_WIDGET_TITLE"],
+    "description": os.environ["OA_WIDGET_DESC"],
+    "valueConfig": {
+        "chartType": os.environ["OA_CHART_TYPE"],
+        "dataSource": os.environ["OA_DATASOURCE_KEY"],
+        "dataSourceParams": [
+            {
+                "name": "monitor_object_id",
+                "type": "string",
+                "value": os.environ["MYSQL_MONITOR_OBJECT_ID"],
+                "alias_name": "monitor_object_id",
+                "filterType": "params",
+            },
+            {
+                "name": "metric_id",
+                "type": "string",
+                "value": os.environ["OA_METRIC_ID"],
+                "alias_name": "metric_id",
+                "filterType": "params",
+            },
+            {
+                "name": "instance_ids",
+                "type": "string",
+                "value": [os.environ["INSTANCE_ID"]],
+                "alias_name": "instance_ids",
+                "filterType": "params",
+            },
+            {
+                "name": "time_range",
+                "type": "timeRange",
+                "value": int(os.environ["OA_QUERY_TIME_RANGE"]),
+                "alias_name": "time_range",
+                "filterType": "fixed",
+            },
+            {
+                "name": "step",
+                "type": "string",
+                "value": os.environ["OA_QUERY_STEP"],
+                "alias_name": "step",
+                "filterType": "params",
+            },
+        ],
+    },
+}
+
+print(textwrap.indent(yaml.safe_dump([widget], allow_unicode=True, sort_keys=False).rstrip(), "      "))
+PY
+  )"
+  export OA_VIEW_SETS_YAML
   render_template "${TEMPLATE_DIR}/mysql_operation_analysis_dashboard.yaml.tpl" "${OA_IMPORT_YAML}"
 }
 

--- a/server/scripts/monitor-manifest.actual-test.yaml
+++ b/server/scripts/monitor-manifest.actual-test.yaml
@@ -1,13 +1,15 @@
 version: 1
 
+# 真实验证前请在安全的本地副本中替换下方环境占位符，禁止提交实际凭据。
+
 defaults:
   group_ids: [1]
   interval: 10
   oa:
     enabled: false
     target_directory_id: 1
-    datasource_name: "查询时间范围内的指标数据"
-    datasource_rest_api: "monitor/mm_query_range"
+    datasource_name: "受控监控指标趋势"
+    datasource_rest_api: "monitor/query_metric_range_scoped"
     created_by: "admin"
 
 registrations:
@@ -72,7 +74,7 @@ registrations:
           enabled: true
           auth_type: password
           username: root
-          password: CW@roger1117!@#
+          password: "${MONITOR_MANIFEST_SSH_PASSWORD}"
           port: 22
           os: linux
           cpu_architecture: x86_64
@@ -106,5 +108,5 @@ registrations:
         host: 10.11.24.61
         port: 3306
         username: root
-        ENV_PASSWORD: "EmTmZ2l48qbt"
+        ENV_PASSWORD: "${MONITOR_MANIFEST_MYSQL_PASSWORD}"
         node_ip: 10.11.27.147

--- a/server/scripts/run_monitor_manifest.sh
+++ b/server/scripts/run_monitor_manifest.sh
@@ -121,8 +121,8 @@ for i, item in enumerate(registrations or []):
             "target_directory_id": effective_oa.get("target_directory_id", ""),
             "dashboard_name": effective_oa.get("dashboard_name", f"{item.get('key')}-dashboard"),
             "dashboard_desc": effective_oa.get("dashboard_desc", "Auto-created from monitor manifest"),
-            "datasource_name": effective_oa.get("datasource_name", "查询时间范围内的指标数据"),
-            "datasource_rest_api": effective_oa.get("datasource_rest_api", "monitor/mm_query_range"),
+            "datasource_name": effective_oa.get("datasource_name", "受控监控指标趋势"),
+            "datasource_rest_api": effective_oa.get("datasource_rest_api", "monitor/query_metric_range_scoped"),
             "created_by": effective_oa.get("created_by", "admin"),
         }
         existing = shared_dashboard_configs.get(effective_dashboard_key)
@@ -893,6 +893,52 @@ print(labels[0])
 PY
 }
 
+extract_first_instance_id() {
+  local result_file="$1"
+
+  RESULT_FILE="${result_file}" "${DJANGO_PYTHON}" <<'PY'
+import os
+import sys
+import yaml
+
+with open(os.environ["RESULT_FILE"], "r", encoding="utf-8") as f:
+    data = yaml.safe_load(f) or {}
+
+instances = ((data.get("result") or {}).get("instances") or [])
+if not instances or not instances[0].get("instance_id"):
+    sys.exit(1)
+print(instances[0]["instance_id"])
+PY
+}
+
+resolve_metric_id() {
+  (
+    cd "${SERVER_DIR}"
+    MYSQL_MONITOR_OBJECT_ID="${MYSQL_MONITOR_OBJECT_ID}" \
+    MYSQL_MONITOR_PLUGIN_ID="${MYSQL_MONITOR_PLUGIN_ID}" \
+    OA_QUERY_METRIC="${OA_QUERY_METRIC}" \
+    "${DJANGO_PYTHON}" manage.py shell <<'PY'
+import os
+import sys
+
+from apps.monitor.models import Metric
+
+metric_id = (
+    Metric.objects.filter(
+        monitor_object_id=int(os.environ["MYSQL_MONITOR_OBJECT_ID"]),
+        monitor_plugin_id=int(os.environ["MYSQL_MONITOR_PLUGIN_ID"]),
+        name=os.environ["OA_QUERY_METRIC"],
+    )
+    .values_list("id", flat=True)
+    .first()
+)
+if metric_id is None:
+    sys.exit(1)
+print(metric_id)
+PY
+  )
+}
+
 probe_metric_once() {
   OA_QUERY_EXPR="${OA_QUERY_EXPR}" OA_QUERY_STEP="${OA_QUERY_STEP}" METRIC_READY_LOOKBACK_SECONDS="${METRIC_READY_LOOKBACK_SECONDS}" SERVER_DIR="${SERVER_DIR}" \
   "${DJANGO_PYTHON}" <<'PY'
@@ -976,8 +1022,8 @@ for key, value in {
     "OA_TARGET_DIRECTORY_ID": oa.get("target_directory_id", ""),
     "OA_DASHBOARD_NAME": oa.get("dashboard_name", f"{reg['key']}-dashboard"),
     "OA_DASHBOARD_DESC": oa.get("dashboard_desc", "Auto-created from monitor manifest"),
-    "OA_EXISTING_DATASOURCE_NAME": oa.get("datasource_name", "查询时间范围内的指标数据"),
-    "OA_EXISTING_DATASOURCE_REST_API": oa.get("datasource_rest_api", "monitor/mm_query_range"),
+    "OA_EXISTING_DATASOURCE_NAME": oa.get("datasource_name", "受控监控指标趋势"),
+    "OA_EXISTING_DATASOURCE_REST_API": oa.get("datasource_rest_api", "monitor/query_metric_range_scoped"),
     "OA_CREATED_BY": oa.get("created_by", "admin"),
     "OA_QUERY_METRIC": oa.get("query_metric", "mysql_threads_connected"),
     "OA_QUERY_EXPR": oa.get("query_expr", ""),
@@ -1028,10 +1074,24 @@ doc = {
             "dataSource": os.environ["OA_DATASOURCE_KEY"],
             "dataSourceParams": [
                 {
-                    "name": "query",
+                    "name": "monitor_object_id",
                     "type": "string",
-                    "value": os.environ["OA_QUERY_EXPR"],
-                    "alias_name": "query",
+                    "value": os.environ["MYSQL_MONITOR_OBJECT_ID"],
+                    "alias_name": "monitor_object_id",
+                    "filterType": "params",
+                },
+                {
+                    "name": "metric_id",
+                    "type": "string",
+                    "value": os.environ["OA_METRIC_ID"],
+                    "alias_name": "metric_id",
+                    "filterType": "params",
+                },
+                {
+                    "name": "instance_ids",
+                    "type": "string",
+                    "value": [os.environ["INSTANCE_ID"]],
+                    "alias_name": "instance_ids",
                     "filterType": "params",
                 },
                 {
@@ -1076,6 +1136,8 @@ queue_operation_analysis_widget() {
   fi
 
   INSTANCE_LABEL="$(extract_first_instance_label "${result_file}")" || return 1
+  INSTANCE_ID="$(extract_first_instance_id "${result_file}")" || return 1
+  OA_METRIC_ID="$(resolve_metric_id)" || return 1
   if [[ -z "${OA_QUERY_EXPR}" ]]; then
     if [[ -z "${OA_QUERY_METRIC}" ]]; then
       return 1
@@ -1086,7 +1148,7 @@ queue_operation_analysis_widget() {
   OA_REGISTRATION_KEY="${key}"
 
   export OA_QUERY_EXPR OA_QUERY_STEP OA_QUERY_TIME_RANGE OA_WIDGET_ID OA_WIDGET_TITLE OA_WIDGET_DESC OA_WIDGET_X OA_WIDGET_Y OA_WIDGET_W OA_WIDGET_H OA_CHART_TYPE OA_DASHBOARD_NAME OA_DASHBOARD_DESC OA_DATASOURCE_KEY
-  export OA_EXISTING_DATASOURCE_NAME OA_EXISTING_DATASOURCE_REST_API OA_CREATED_BY OA_TARGET_DIRECTORY_ID INSTANCE_LABEL OA_DASHBOARD_KEY OA_REGISTRATION_KEY OA_WIDGET_X_EXPLICIT OA_WIDGET_Y_EXPLICIT
+  export OA_EXISTING_DATASOURCE_NAME OA_EXISTING_DATASOURCE_REST_API OA_CREATED_BY OA_TARGET_DIRECTORY_ID INSTANCE_LABEL INSTANCE_ID OA_METRIC_ID OA_DASHBOARD_KEY OA_REGISTRATION_KEY OA_WIDGET_X_EXPLICIT OA_WIDGET_Y_EXPLICIT
 
   log "waiting metric for operation_analysis: ${key}"
   wait_metric_ready || return 1

--- a/web/scripts/monitor-search-plugin-scope-test.ts
+++ b/web/scripts/monitor-search-plugin-scope-test.ts
@@ -97,10 +97,10 @@ const hostParams = buildSearchQueryParams({
   timeRange: { timeRange: [100000, 460000], originValue: 0 },
 });
 
-assert.equal(
-  hostParams.query,
-  '100 - cpu_usage_idle{cpu="cpu-total", instance_type="os", instance_id=~"MTVmOTFiYTM5ODZk"}'
-);
+assert.equal(hostParams.query, undefined);
+assert.equal(hostParams.monitor_object_id, 8);
+assert.equal(hostParams.metric_id, 125);
+assert.deepEqual(hostParams.instance_ids, [hostInstance.instance_id]);
 assert.equal(hostParams.source_unit, 'percent');
 assert.equal(hostParams.start, 100000);
 assert.equal(hostParams.end, 460000);
@@ -122,10 +122,10 @@ const remoteParams = buildSearchQueryParams({
   timeRange: { timeRange: [100000, 460000], originValue: 0 },
 });
 
-assert.equal(
-  remoteParams.query,
-  'host_cpu_usage_percent_gauge{instance_type="os", instance_id=~"MTVmOTFiYTM5ODZk"}'
-);
+assert.equal(remoteParams.query, undefined);
+assert.equal(remoteParams.monitor_object_id, 8);
+assert.equal(remoteParams.metric_id, 494);
+assert.deepEqual(remoteParams.instance_ids, [hostInstance.instance_id]);
 
 assert.deepEqual(buildSearchTimeQueryParams({ timeRange: [], originValue: 15 }), {
   origin: '15',

--- a/web/src/app/monitor/(pages)/search/page.tsx
+++ b/web/src/app/monitor/(pages)/search/page.tsx
@@ -35,7 +35,7 @@ import {
 import { parseSearchTimeQueryParams } from '@/app/monitor/utils/searchTimeQuery';
 
 const SearchView: React.FC = () => {
-  const { get } = useApiClient();
+  const { post } = useApiClient();
   const { t } = useTranslation();
   const { findUnitNameById } = useUnitTransform();
   const searchParams = useSearchParams();
@@ -141,10 +141,10 @@ const SearchView: React.FC = () => {
           instances,
           timeRange: _timeRange
         });
-        const responseData = await get(
-          '/monitor/api/metrics_instance/query_range/',
+        const responseData = await post(
+          '/monitor/api/metrics_instance/query_by_metric_range/',
+          params,
           {
-            params,
             signal: abortController.signal
           }
         );

--- a/web/src/app/monitor/(pages)/search/searchQueryLogic.ts
+++ b/web/src/app/monitor/(pages)/search/searchQueryLogic.ts
@@ -7,10 +7,7 @@ import type {
   QueryGroup,
   SearchParams
 } from '@/app/monitor/types/search';
-import {
-  getRecentTimeRange,
-  mergeViewQueryKeyValues
-} from '@/app/monitor/utils/common';
+import { getRecentTimeRange } from '@/app/monitor/utils/common';
 import { buildGapDetectionParams } from '@/app/monitor/utils/gapIntervals';
 import { calculateQueryStep } from '@/app/monitor/utils/queryStep';
 
@@ -135,16 +132,21 @@ export const buildSearchQueryParams = ({
   const selectedInstances = instances.filter((item) =>
     group.instanceIds.includes(item.instance_id)
   );
-  const queryValues: string[][] = selectedInstances.map(
-    (item) => item.instance_id_values
-  );
-  const querykeys: string[] = metricItem?.instance_id_keys || [];
-  const queryList = queryValues.map((values) => ({
-    keys: querykeys,
-    values
-  }));
   const params: SearchParams = {
-    query: '',
+    monitor_object_id: group.object,
+    metric_id: metricItem?.id,
+    instance_ids: selectedInstances.map((item) => item.instance_id),
+    aggregation: group.aggregation || 'AVG',
+    filters: group.conditions
+      .filter(
+        (condition) =>
+          condition.label && condition.condition && condition.value
+      )
+      .map((condition) => ({
+        label: String(condition.label),
+        operator: String(condition.condition),
+        value: condition.value
+      })),
     source_unit: metricItem?.unit || ''
   };
   const recentTimeRange = getRecentTimeRange(timeRange);
@@ -160,30 +162,5 @@ export const buildSearchQueryParams = ({
       collectionInterval
     );
   }
-  let query = '';
-  if (group.instanceIds.length) {
-    query += mergeViewQueryKeyValues(queryList);
-  }
-  if (group.conditions.length) {
-    const conditionQueries = group.conditions
-      .map((condition) => {
-        if (condition.label && condition.condition && condition.value) {
-          return `${condition.label}${condition.condition}"${condition.value}"`;
-        }
-        return '';
-      })
-      .filter(Boolean);
-    if (conditionQueries.length) {
-      if (query) query += ',';
-      query += conditionQueries.join(',');
-    }
-  }
-  let finalQuery = (metricItem?.query || '').replace(/__\$labels__/g, query);
-  if (group.aggregation && group.aggregation !== 'AVG') {
-    const aggFunc = group.aggregation.toLowerCase();
-    const byClause = querykeys.length ? ` by (${querykeys.join(',')})` : '';
-    finalQuery = `${aggFunc}(${finalQuery})${byClause}`;
-  }
-  params.query = finalQuery;
   return buildGapDetectionParams(params, collectionInterval);
 };

--- a/web/src/app/monitor/types/search.ts
+++ b/web/src/app/monitor/types/search.ts
@@ -28,7 +28,16 @@ export interface SearchParams {
   end?: number;
   start?: number;
   step?: number;
-  query: string;
+  query?: string;
+  monitor_object_id?: React.Key;
+  metric_id?: React.Key;
+  instance_ids?: string[];
+  filters?: Array<{
+    label: string;
+    operator: string;
+    value: string;
+  }>;
+  aggregation?: string;
   source_unit?: string;
   auto_convert_unit?: boolean;
   detect_gaps?: boolean;


### PR DESCRIPTION
## 问题

监控指标查询本应在服务端把当前用户、组织和实例权限作为不可绕过的边界。此前 Web 与 Mobile 会把最终 PromQL 直接提交给 REST，NATS 也保留 `mm_query` / `mm_query_range` 裸查询；修改请求即可绕过页面选择范围。

本 PR 是 #4638 的用户态安全首片：先建立受控查询主链，迁移指标搜索页、Mobile 和 OA/MySQL 脚本，并删除无消费者的 NATS 裸查询。对象仪表盘中的特殊组合查询留在后续切片迁移，因此本 PR 不关闭 Issue。

## 根因（设计层）

旧契约把授权责任交给客户端拼接 PromQL。后端虽然拥有登录用户、当前组织和实例权限，却没有参与查询构造；聚合表达式还可能丢失实例标签，使查询后过滤无法可靠恢复归属。

## 怎么修的

- 新增用户态受控查询服务，只接收监控对象、指标、实例、维度和时间范围；PromQL 从可信 `Metric.query` 模板生成。
- 请求实例与服务端授权集合必须完全一致；混入任一无权或不存在实例时整包拒绝，且不调用 VictoriaMetrics。
- 原始 `query` 字段、未声明维度、不支持的汇聚方式和缺失实例均 fail-closed。
- 指标搜索页与 Mobile 改用结构化 POST，不再向接口传 PromQL。
- 删除 NATS `mm_query` / `mm_query_range` 和对应 RPC 包装器；OA/MySQL 脚本改用 `query_metric_range_scoped` 受控数据源。
- 现有 `query_monitor_data_by_metric` 同步收紧为必须显式实例，混合权限不再静默裁剪。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        W["Web 指标搜索\nsearch/page.tsx"]
        M["Mobile 指标卡\nadapter.ts"]
        O["OA / MySQL 大盘\nquery_metric_range_scoped"]
    end

    subgraph A["授权与查询构造"]
        C["对象 + 指标 + 实例上下文"]
        P["当前用户和组织权限交集"]
        Q["可信 Metric.query 模板"]
    end

    V["VictoriaMetrics"]
    D["统一拒绝\nVM 零调用"]

    W --> C
    M --> C
    O --> C
    C --> P
    P -->|"全部实例有权"| Q
    Q --> V
    P -. "任一实例无权" .-> D
```

## 影响范围

- 触及 Monitor、RPC、Operation Analysis 数据源定义、Web 指标搜索和 Mobile 监控详情。
- 授权场景保持现有 VictoriaMetrics 响应、单位转换、断点检测和序列预算语义。
- 用户已确认：没有内置或历史自定义 OA 画布依赖旧 NATS 裸查询，且禁止仓外 NATS 客户端调用；不保留管理员任意 PromQL。
- 残余边界：对象仪表盘仍有特殊组合 PromQL 依赖 REST `query` / `query_range`。后续迁移到服务端模板注册表并完成调用归零后，再删除这两个 REST 入口；Issue 保持 OPEN。

## 验证

- `apps/monitor/tests/test_authorized_metric_query_service.py`、`test_authorized_metric_query_view.py`、`test_nats_monitor_handlers.py` 与 RPC 转发测试：80 passed。
- Operation Analysis 内置同步、数据源校验和导入测试：111 passed。
- Web 监控查询步长、插件作用域与查询面板：通过，3 个组件测试 passed。
- Web 类型检查、Mobile 类型检查、触及文件 ESLint：通过；Mobile monitor-assets：42 passed。
- Shell 语法、JSON 结构、Black、isort、flake8、migration、requirements 与 diff-check：通过。
- 受控查询服务差异覆盖率：83%。

## 三轨门禁

- Standards：PASS。使用 ORM、服务端授权、显式资源上下文，无环境配置或原生 SQL。
- Spec：PASS（首片）。NATS 裸查询归零，Web 搜索和 Mobile 完成迁移；REST 特殊仪表盘残余已明确留在后续切片。
- Runtime Contract：PASS。授权实例正常；无权、混合权限、原始 query、未声明维度均可红并在 VM 调用前失败。

Refs #4638
