### PR TITLE
fix(monitor): percentunit 视图展示与策略阈值单位切换缩放

### DIFF
--- a/web/src/app/monitor/(pages)/event/strategy/detail/page.tsx
+++ b/web/src/app/monitor/(pages)/event/strategy/detail/page.tsx
@@ -62,7 +62,8 @@ import {
   resolveInitialMetricPluginId,
   resolveThresholdUnit,
   resolveUnitOnMetricSelect,
-  restoreCalculationUnitState
+  restoreCalculationUnitState,
+  scaleThresholdValuesForUnitChange
 } from './strategyDetailUtils';
 import { MetricExpressionRow } from './metricExpressionTypes';
 import {
@@ -904,6 +905,9 @@ const StrategyOperation = () => {
   };
 
   const handleThresholdUnitChange = (unit: string) => {
+    setThreshold((current) =>
+      scaleThresholdValuesForUnitChange(current, thresholdUnit, unit)
+    );
     setThresholdUnit(unit);
     form.validateFields(['threshold']);
   };

--- a/web/src/app/monitor/(pages)/event/strategy/detail/strategyDetailUtils.ts
+++ b/web/src/app/monitor/(pages)/event/strategy/detail/strategyDetailUtils.ts
@@ -266,6 +266,31 @@ export const resolveThresholdUnit = ({
 
 export const getThresholdUnitOnCalculationUnitChange = resolveThresholdUnit;
 
+/** percentunit(0–1) ↔ percent(0–100) 切换时的数值缩放因子；其他单位对返回 null。 */
+export const getPercentUnitScaleFactor = (
+  fromUnit: string | null | undefined,
+  toUnit: string | null | undefined
+): number | null => {
+  if (!fromUnit || !toUnit || fromUnit === toUnit) return null;
+  if (fromUnit === 'percentunit' && toUnit === 'percent') return 100;
+  if (fromUnit === 'percent' && toUnit === 'percentunit') return 0.01;
+  return null;
+};
+
+/** 阈值单位在 percentunit↔percent 间切换时同步缩放数值，避免误报/漏报。 */
+export const scaleThresholdValuesForUnitChange = <T extends { value: number | null }>(
+  thresholds: T[],
+  fromUnit: string | null | undefined,
+  toUnit: string | null | undefined
+): T[] => {
+  const factor = getPercentUnitScaleFactor(fromUnit, toUnit);
+  if (factor == null) return thresholds;
+  return thresholds.map((item) => ({
+    ...item,
+    value: item.value == null ? null : item.value * factor
+  }));
+};
+
 // 把 groupedUnitList (按 category 分组) 转为 Cascader 选项;
 // 一级 value = category 名,二级 value = unit_id,二级为叶子节点需 children=[] 以满足 CascaderItem 递归类型。
 // 单位表规模小 (<100),即便 O(N×M) 也可接受。

--- a/web/src/app/monitor/components/monitor-dashboard-widgets/runtime.ts
+++ b/web/src/app/monitor/components/monitor-dashboard-widgets/runtime.ts
@@ -130,6 +130,9 @@ export const formatMetricValue = (value: number, unit: MetricUnit): { value: str
   }
 
   if (unit === 'percent') return { value: value.toFixed(1), unit: '%' };
+  if (unit === 'percentunit') {
+    return { value: (value * 100).toFixed(1), unit: '%' };
+  }
   if (unit === 'msps') return { value: value >= 100 ? value.toFixed(0) : value.toFixed(1), unit: 'ms/s' };
   if (unit === 'cps') return formatCountRate(value);
   if (COUNT_UNITS.includes(unit)) return formatAutoScaled(value, unit, COUNT_UNITS, COUNT_LABELS, 1000);

--- a/web/src/app/monitor/components/monitor-dashboard-widgets/types.ts
+++ b/web/src/app/monitor/components/monitor-dashboard-widgets/types.ts
@@ -67,6 +67,7 @@ export interface MetricItem {
 export type MetricUnit =
   | 'none'
   | 'percent'
+  | 'percentunit'
   | 'counts'
   | 'thousand'
   | 'million'

--- a/web/src/app/monitor/dashboards/shared/types.ts
+++ b/web/src/app/monitor/dashboards/shared/types.ts
@@ -20,6 +20,7 @@ export interface ProfessionalDashboardRegistryItem extends ProfessionalDashboard
 export type MetricUnit =
   | 'none'
   | 'percent'
+  | 'percentunit'
   | 'counts'
   | 'thousand'
   | 'million'

--- a/web/src/app/monitor/dashboards/shared/utils/format.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/format.ts
@@ -117,6 +117,9 @@ export const formatMetricValue = (value: number, unit: MetricUnit): { value: str
   const normalizedUnit = unit === 'Bps' ? 'byteps' : unit;
 
   if (normalizedUnit === 'percent') return { value: value.toFixed(1), unit: '%' };
+  if (normalizedUnit === 'percentunit') {
+    return { value: (value * 100).toFixed(1), unit: '%' };
+  }
   if (normalizedUnit === 'msps') return { value: value >= 100 ? value.toFixed(0) : value.toFixed(1), unit: 'ms/s' };
   if (normalizedUnit === 'cps' || normalizedUnit === 'pps') return formatCountRate(value);
   if (normalizedUnit === 'tpm') return { value: formatScaledValue(value), unit: 'tpm' };

--- a/web/src/app/monitor/utils/formatMetricValue.ts
+++ b/web/src/app/monitor/utils/formatMetricValue.ts
@@ -2,6 +2,7 @@ const INTEGER_UNITS = new Set(['counts']);
 
 /**
  * 格式化监控指标数值：计数不补无意义的小数位，其余指标保持两位精度。
+ * percentunit 为 0–1 比例，展示前 ×100（与后端 UnitConverter 语义一致）。
  */
 export const formatMetricValue = (
   value: number | string,
@@ -9,7 +10,10 @@ export const formatMetricValue = (
 ): string => {
   const numericValue = Number(value);
   if (Number.isNaN(numericValue)) return String(value);
-  return INTEGER_UNITS.has(unit)
-    ? String(numericValue)
-    : numericValue.toFixed(2);
+  if (INTEGER_UNITS.has(unit)) {
+    return String(numericValue);
+  }
+  const displayValue =
+    unit === 'percentunit' ? numericValue * 100 : numericValue;
+  return displayValue.toFixed(2);
 };


### PR DESCRIPTION
## Summary
- 监控视图/`formatMetricValue` 与仪表盘 formatter 对 `percentunit`（0–1）展示前 ×100，避免概览卡显示成 `0.85 %`
- 策略编辑页在阈值单位 `percentunit` ↔ `percent` 切换时自动缩放阈值数值，降低人工改单位导致的误报/漏报
- 单位库注册已在 #5072；本 PR 不改 ops-analysis，不改专业仪表盘已有 `100 *` 查询

## Test plan
- [ ] `0.85` + `percentunit` 在实例概览/指标视图显示约 `85%`
- [ ] 策略编辑：阈值单位 `percentunit` → `percent` 时 `0.9` 变为 `90`；反向变为 `0.9`
- [ ] vLLM 等专业仪表盘 KV 占用仍正常（查询侧已有 `100 *`，无双重放大）

## Review notes
- 本地对照计划做过 Standards/Spec 双轴审查：无阻断性功能缺陷
- 提交范围已排除测试文件与无关图标/本地产物