### PR TITLE
fix(监控): 批量建策略时清空 Enum/JSON metric_unit

### DIFF
--- a/server/apps/monitor/services/policy_bulk.py
+++ b/server/apps/monitor/services/policy_bulk.py
@@ -37,6 +37,18 @@ def normalize_default_calculation_unit(metric_unit: str) -> str:
     return normalized_unit if UnitConverter.is_known_unit(normalized_unit) else ""
 
 
+def normalize_stored_metric_unit(metric_unit: str, data_type: str = "") -> str:
+    """策略表 metric_unit 只存短单位名；Enum/JSON 枚举定义留在 Metric.unit。"""
+    unit = (metric_unit or "").strip()
+    if not unit or unit in ("none", "short"):
+        return ""
+    if data_type == "Enum" or unit.startswith("["):
+        return ""
+    if len(unit) > 50:
+        return ""
+    return unit
+
+
 def _merge_asset_organizations(assets: list[dict[str, Any]]) -> list[Any]:
     organizations: list[Any] = []
     seen = set()
@@ -108,7 +120,10 @@ def build_bulk_policy_payloads(
     policy_names = build_distinct_policy_names(templates, name_prefix)
     for template, policy_name in zip(templates, policy_names):
         group_algorithm, algorithm = normalize_template_algorithms(template)
-        metric_unit = template.get("metric_unit") or ""
+        metric_unit = normalize_stored_metric_unit(
+            template.get("metric_unit") or "",
+            str(template.get("data_type") or ""),
+        )
         default_calculation_unit = normalize_default_calculation_unit(metric_unit)
         group_by = config.get("group_by") or template.get("group_by") or ["instance_id"]
         template_name = template.get("name") or template.get("metric_name") or ""
@@ -119,7 +134,8 @@ def build_bulk_policy_payloads(
             "monitor_object": monitor_object_id,
             "organizations": organizations,
             "collect_type": template.get("collect_type"),
-            "query_condition": template.get("query_condition") or {
+            "query_condition": template.get("query_condition")
+            or {
                 "type": "metric",
                 "metric_id": template.get("metric_id"),
                 "filter": template.get("filter") or [],

--- a/server/apps/monitor/views/monitor_policy.py
+++ b/server/apps/monitor/views/monitor_policy.py
@@ -27,7 +27,7 @@ from apps.monitor.services.alert_lifecycle_notify import NOTIFY_SCOPE_ALERT_CENT
 from apps.monitor.services.node_mgmt import InstanceConfigService
 from apps.monitor.services.policy import PolicyService
 from apps.monitor.services.policy_baseline import PolicyBaselineService
-from apps.monitor.services.policy_bulk import build_bulk_policy_payloads
+from apps.monitor.services.policy_bulk import build_bulk_policy_payloads, normalize_stored_metric_unit
 from apps.monitor.services.policy_preview import PolicyPreviewService
 from apps.monitor.utils.pagination import parse_page_params
 from config.drf.pagination import CustomPageNumberPagination
@@ -827,7 +827,7 @@ class MonitorPolicyViewSet(viewsets.ModelViewSet):
                 {
                     **template,
                     "metric_id": metric.id,
-                    "metric_unit": "" if metric.unit in ("none", "short") else metric.unit,
+                    "metric_unit": normalize_stored_metric_unit(metric.unit, getattr(metric, "data_type", "") or ""),
                     "collect_type": collect_type or metric.monitor_plugin_id,
                 }
             )


### PR DESCRIPTION
## Summary
- 批量/自动建策略时，将 Enum 指标的长 JSON `unit` 规范化为空串，避免写入 `MonitorPolicy.metric_unit`（`max_length=50`）导致校验失败
- 修复华为等交换机自动接入「采集配置已保存，但监控策略创建失败: metric_unit 超 50 字符」
- 与前端 `resolveMetricExpressionUnits`（枚举 unit 不落库）行为对齐；不放宽字段长度、不改插件 metrics.json

## Test plan
- [ ] 华为交换机（含风扇策略）自动接入：采集保存成功，默认策略全部创建成功，不再报 metric_unit 超长
- [ ] Cisco/Juniper 等同类 Enum 风扇/电源策略同样可创建
- [ ] 普通 percent/bytes 策略 `metric_unit` 仍正常写入
- [ ] 本地已跑：`pytest apps/monitor/tests/test_policy_bulk_payload.py -m 'not django_db'`（枚举清空用例通过；测试文件未纳入本 PR）

## 提交范围说明
- 仅产品代码 2 个文件；**未提交**测试文件与其它无关改动