### PR TITLE
bugfix: 为监控范围查询增加硬预算

### DIFF
--- a/server/apps/monitor/nats/monitor.py
+++ b/server/apps/monitor/nats/monitor.py
@@ -52,7 +52,7 @@ from apps.monitor.services.host_dashboard import (
 )
 from apps.monitor.services.host_resource_top import HostResourceTopService, validate_metric_type
 from apps.monitor.services.interface_metrics_query import InterfaceMetricsQueryError, normalize_instance_ids, query_interface_metric_items
-from apps.monitor.services.metrics import Metrics
+from apps.monitor.services.metrics import Metrics, MetricsQueryBudgetExceeded
 from apps.monitor.services.nats_query_contract import build_vm_query_failure_result as _build_vm_query_failure_result
 from apps.monitor.services.nats_query_contract import normalize_bool
 from apps.monitor.services.nats_query_contract import normalize_dimensions as _normalize_dimensions
@@ -72,6 +72,16 @@ from apps.monitor.utils.vm_query_batch import run_unique_vm_queries
 from apps.rpc.system_mgmt import SystemMgmt
 
 _normalize_bool = normalize_bool
+
+
+def _build_query_budget_failure(exc: MetricsQueryBudgetExceeded) -> dict:
+    return {
+        "result": False,
+        "data": [],
+        "message": exc.message,
+        "code": exc.data["code"],
+        "budget": exc.data,
+    }
 
 
 def _serialize_metric_plugin(metric: Metric) -> Optional[dict]:
@@ -854,6 +864,9 @@ def query_monitor_data_by_metric(query_data: dict, *args, **kwargs):
     try:
         merged_result = None
         merged_series = []
+        start_sec = int(start_time) / 1000
+        end_sec = int(end_time) / 1000
+        step_seconds = Metrics.parse_step_to_seconds(step)
         for metric, dimensions, instance_id_keys in metric_queries:
             query = _build_metric_label_query(
                 metric.query,
@@ -861,7 +874,13 @@ def query_monitor_data_by_metric(query_data: dict, *args, **kwargs):
                 dimensions=dimensions,
                 instance_id_keys=instance_id_keys,
             )
-            result = Metrics.get_metrics_range(query, start_time, end_time, step)
+            result = Metrics.get_metrics_range(
+                query,
+                start_time,
+                end_time,
+                step,
+                fill_missing=False,
+            )
             if merged_result is None:
                 merged_result = dict(result)
                 merged_data = dict(result.get("data") or {})
@@ -882,9 +901,14 @@ def query_monitor_data_by_metric(query_data: dict, *args, **kwargs):
                 enriched_metric_data["metric_id"] = metric.id
                 enriched_metric_data["monitor_plugin"] = plugin_data
                 merged_series.append(enriched_metric_data)
+            Metrics.enforce_fill_budget(start_sec, end_sec, step_seconds, merged_series)
+
+        Metrics.fill_missing_points(start_sec, end_sec, step_seconds, merged_series)
 
         return {"result": True, "data": merged_result, "message": ""}
 
+    except MetricsQueryBudgetExceeded as exc:
+        return _build_query_budget_failure(exc)
     except Exception as e:
         return {"result": False, "data": [], "message": f"查询指标数据失败: {str(e)}"}
 
@@ -1351,7 +1375,6 @@ def query_metric_range_scoped(
         start_time, end_time = parse_rfc3339_range_utc(time_range)
     except ValueError as exc:
         return {"result": False, "data": [], "message": str(exc)}
-
     user_info = kwargs.get("user_info") or {}
     user = _normalize_permission_user(
         user_info.get("user"),
@@ -1372,9 +1395,10 @@ def query_metric_range_scoped(
                 "step": step,
             }
         )
+    except MetricsQueryBudgetExceeded as exc:
+        return _build_query_budget_failure(exc)
     except AuthorizedMetricQueryError as exc:
         return {"result": False, "data": [], "message": str(exc)}
-
     if resp.get("status") == "success":
         _result = resp["data"]["result"]
         if _result:

--- a/server/apps/monitor/services/metrics.py
+++ b/server/apps/monitor/services/metrics.py
@@ -1,3 +1,6 @@
+import logging
+import math
+import os
 import re
 
 import pandas as pd
@@ -7,23 +10,146 @@ from apps.core.logger import monitor_logger as logger
 from apps.monitor.models.monitor_metrics import Metric
 from apps.monitor.models.monitor_object import MonitorObject
 from apps.monitor.utils.dimension import parse_instance_id
-from apps.monitor.utils.display_fields_metrics import (
-    display_field_key,
-    extract_metric_bindings,
-)
+from apps.monitor.utils.display_fields_metrics import display_field_key, extract_metric_bindings
 from apps.monitor.utils.instance_id_keys import resolve_metric_instance_id_keys
 from apps.monitor.utils.unit_converter import UnitConverter
 from apps.monitor.utils.victoriametrics_api import VictoriaMetricsAPI
 
 
+def _positive_int_env(name: str, default: int) -> int:
+    try:
+        value = int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+class MetricsQueryBudgetExceeded(BaseAppException):
+    ERROR_CODE = "4220460"
+    MESSAGE = "指标范围查询超过服务端预算，请缩短时间范围、减少实例或增大查询步长"
+    STATUS_CODE = 422
+    LOG_LEVEL = logging.WARNING
+
+
 class Metrics:
     _STEP_PATTERN = re.compile(r"^(?P<value>\d+)(?P<unit>[smhdw])$")
     _LIMITING_QUERY_PATTERN = re.compile(r"^\s*(topk|bottomk|limitk)\s*\(", re.IGNORECASE)
+    _EXPLICIT_SERIES_LIMIT_PATTERN = re.compile(
+        r"^\s*(?:topk|bottomk|limitk)\s*\(\s*(?P<limit>\d+)\s*,",
+        re.IGNORECASE,
+    )
     MAX_GAP_DETECTION_POINTS = 50000
     CARD_QUERY_MAX_SERIES = 200
     CARD_QUERY_MAX_POINTS = 100000
     # 查询本身已带 topk/bottomk/limitk 时的兜底硬上限；超过则截断而非拒绝。
     CARD_QUERY_HARD_MAX_SERIES = 2000
+    RANGE_QUERY_MAX_DURATION_SECONDS = _positive_int_env(
+        "MONITOR_RANGE_QUERY_MAX_DURATION_SECONDS",
+        366 * 24 * 60 * 60,
+    )
+    RANGE_QUERY_MAX_POINTS_PER_SERIES = _positive_int_env(
+        "MONITOR_RANGE_QUERY_MAX_POINTS_PER_SERIES",
+        10000,
+    )
+    RANGE_QUERY_MAX_SERIES = _positive_int_env(
+        "MONITOR_RANGE_QUERY_MAX_SERIES",
+        2000,
+    )
+    RANGE_QUERY_MAX_TOTAL_POINTS = _positive_int_env(
+        "MONITOR_RANGE_QUERY_MAX_TOTAL_POINTS",
+        500000,
+    )
+
+    @staticmethod
+    def _range_budget_limits(card_budget=False) -> dict:
+        if card_budget:
+            return {
+                "duration_seconds": Metrics.RANGE_QUERY_MAX_DURATION_SECONDS,
+                "points_per_series": max(1, Metrics.CARD_QUERY_MAX_POINTS // Metrics.CARD_QUERY_MAX_SERIES),
+                "series": Metrics.CARD_QUERY_MAX_SERIES,
+                "total_points": Metrics.CARD_QUERY_MAX_POINTS,
+            }
+        return {
+            "duration_seconds": Metrics.RANGE_QUERY_MAX_DURATION_SECONDS,
+            "points_per_series": Metrics.RANGE_QUERY_MAX_POINTS_PER_SERIES,
+            "series": Metrics.RANGE_QUERY_MAX_SERIES,
+            "total_points": Metrics.RANGE_QUERY_MAX_TOTAL_POINTS,
+        }
+
+    @staticmethod
+    def _raise_range_budget(reason: str, limits: dict, actual: dict):
+        raise MetricsQueryBudgetExceeded(
+            data={
+                "code": "MONITOR_RANGE_QUERY_BUDGET_EXCEEDED",
+                "reason": reason,
+                "limits": limits,
+                "actual": actual,
+                "suggestions": [
+                    "缩短查询时间范围",
+                    "减少实例或序列数量",
+                    "增大查询步长",
+                ],
+            }
+        )
+
+    @staticmethod
+    def _prepare_range_budget(start_ms, end_ms, step, card_budget=False) -> dict:
+        start_ms = int(start_ms)
+        end_ms = int(end_ms)
+        step_seconds = Metrics.parse_step_to_seconds(step)
+        duration_seconds = max(0.0, (end_ms - start_ms) / 1000.0)
+        points_per_series = int(duration_seconds // step_seconds) + 1
+        limits = Metrics._range_budget_limits(card_budget=card_budget)
+        actual = {
+            "duration_seconds": duration_seconds,
+            "step_seconds": step_seconds,
+            "points_per_series": points_per_series,
+        }
+
+        if duration_seconds > limits["duration_seconds"]:
+            Metrics._raise_range_budget("duration", limits, actual)
+        if points_per_series > limits["points_per_series"]:
+            Metrics._raise_range_budget("points_per_series", limits, actual)
+
+        return {
+            "start_ms": start_ms,
+            "end_ms": end_ms,
+            "duration_seconds": duration_seconds,
+            "step_seconds": step_seconds,
+            "points_per_series": points_per_series,
+            "limits": limits,
+        }
+
+    @staticmethod
+    def _apply_range_series_limit(query: str, max_series: int) -> str:
+        explicit_limit = Metrics._EXPLICIT_SERIES_LIMIT_PATTERN.match(query or "")
+        if explicit_limit and int(explicit_limit.group("limit")) <= max_series:
+            return query
+        return f"limitk({max_series + 1}, {query})"
+
+    @staticmethod
+    def _enforce_range_response_budget(response: dict, budget: dict) -> dict:
+        if response.get("status") != "success":
+            return {"series": 0, "filled_series": 0, "total_points": 0}
+
+        result = (response.get("data") or {}).get("result") or []
+        series_count = len(result)
+        filled_series_count = sum(bool(item.get("values")) for item in result)
+        total_points = filled_series_count * budget["points_per_series"]
+        actual = {
+            "duration_seconds": budget["duration_seconds"],
+            "step_seconds": budget["step_seconds"],
+            "points_per_series": budget["points_per_series"],
+            "series": series_count,
+            "filled_series": filled_series_count,
+            "total_points": total_points,
+        }
+
+        if series_count > budget["limits"]["series"]:
+            Metrics._raise_range_budget("series", budget["limits"], actual)
+        if total_points > budget["limits"]["total_points"]:
+            Metrics._raise_range_budget("total_points", budget["limits"], actual)
+        return actual
 
     @staticmethod
     def get_effective_metric_instance_id_keys(metric: Metric) -> list[str]:
@@ -79,7 +205,7 @@ class Metrics:
         if max_points_per_series <= 1:
             min_step = max(1, int(duration_seconds) or 1)
         else:
-            min_step = max(1, int(duration_seconds / (max_points_per_series - 1)) or 1)
+            min_step = max(1, math.ceil(duration_seconds / (max_points_per_series - 1)))
 
         if step_seconds >= min_step:
             if isinstance(step, str) and step.strip():
@@ -122,6 +248,7 @@ class Metrics:
         collection_interval_seconds=None,
         max_gap_detection_points=None,
         card_budget=False,
+        fill_missing=True,
     ):
         """查询指标（范围）
 
@@ -139,7 +266,19 @@ class Metrics:
             effective_query, applied_limit = Metrics.apply_card_series_limit(query)
             effective_step, step_clamped = Metrics.clamp_card_step(start_ms, end_ms, step)
 
-        step_seconds = Metrics.parse_step_to_seconds(effective_step)
+        budget = Metrics._prepare_range_budget(
+            start_ms,
+            end_ms,
+            effective_step,
+            card_budget=card_budget,
+        )
+        if not card_budget:
+            effective_query = Metrics._apply_range_series_limit(
+                query,
+                budget["limits"]["series"],
+            )
+
+        step_seconds = budget["step_seconds"]
         start_sec = start_ms / 1000  # Convert milliseconds to seconds
         end_sec = end_ms / 1000  # Convert milliseconds to seconds
         vm_api = VictoriaMetricsAPI()
@@ -152,6 +291,8 @@ class Metrics:
                 data = resp.setdefault("data", {})
                 data["step"] = str(effective_step)
                 data["step_clamped"] = True
+
+        response_budget = Metrics._enforce_range_response_budget(resp, budget)
 
         if detect_gaps:
             data = resp.setdefault("data", {})
@@ -170,7 +311,9 @@ class Metrics:
                     "limited": True,
                     "reason": "series_truncated",
                 }
-            elif collection_interval > 0 and detection_points > detection_limit:
+            elif collection_interval > 0 and (
+                detection_points > detection_limit or detection_points * response_budget["filled_series"] > budget["limits"]["total_points"]
+            ):
                 data["gaps"] = []
                 data["gap_detection"] = {
                     "status": "limited",
@@ -194,7 +337,8 @@ class Metrics:
             else:
                 data["gaps"] = []
                 data["gap_detection"] = {"status": "skipped", "limited": False}
-        Metrics.fill_missing_points(start_sec, end_sec, step_seconds, resp.get("data", {}).get("result", []))
+        if fill_missing:
+            Metrics.fill_missing_points(start_sec, end_sec, step_seconds, resp.get("data", {}).get("result", []))
         return resp
 
     @staticmethod
@@ -381,6 +525,8 @@ class Metrics:
         :param data_list: Data list, format [{"metric": dict, "values": [[timestamp, value], ...]}, ...]
         :return: Updated data list with missing points filled in `values`
         """
+        Metrics.enforce_fill_budget(start, end, step, data_list)
+
         for item in data_list:
             values = item["values"]
 
@@ -417,6 +563,18 @@ class Metrics:
                 result_values.append([timestamp_float, value])
 
             item["values"] = result_values
+
+    @staticmethod
+    def enforce_fill_budget(start, end, step, data_list) -> dict:
+        budget = Metrics._prepare_range_budget(
+            int(float(start) * 1000),
+            int(float(end) * 1000),
+            step,
+        )
+        return Metrics._enforce_range_response_budget(
+            {"status": "success", "data": {"result": data_list}},
+            budget,
+        )
 
     @staticmethod
     def query_metric_by_instance(

--- a/server/apps/monitor/services/metrics.py
+++ b/server/apps/monitor/services/metrics.py
@@ -423,11 +423,7 @@ class Metrics:
         gaps = []
 
         for item in data_list:
-            real_points = sorted(
-                float(timestamp)
-                for timestamp, value in item.get("values", [])
-                if value is not None
-            )
+            real_points = sorted(float(timestamp) for timestamp, value in item.get("values", []) if value is not None)
             if real_points and normalized_range_start is not None:
                 first_timestamp = real_points[0]
                 missing_duration = first_timestamp - normalized_range_start
@@ -489,10 +485,7 @@ class Metrics:
         gaps_by_series = {}
         for gap in gaps:
             series_key = tuple(
-                sorted(
-                    tuple(sorted((str(key), str(value)) for key, value in item.get("metric", {}).items()))
-                    for item in gap.get("series", [])
-                )
+                sorted(tuple(sorted((str(key), str(value)) for key, value in item.get("metric", {}).items())) for item in gap.get("series", []))
             )
             gaps_by_series.setdefault(series_key, []).append(gap)
 
@@ -725,9 +718,7 @@ class Metrics:
         supplementary = monitor_obj.supplementary_indicators
         if not supplementary:
             return []
-        metrics = Metric.objects.filter(monitor_object_id=monitor_object_id, name__in=supplementary).values(
-            "name", "unit", "data_type"
-        )
+        metrics = Metric.objects.filter(monitor_object_id=monitor_object_id, name__in=supplementary).values("name", "unit", "data_type")
         unit_map = {m["name"]: m["unit"] for m in metrics}
         dtype_map = {m["name"]: m["data_type"] for m in metrics}
         return [(name, unit_map.get(name), dtype_map.get(name)) for name in supplementary]

--- a/server/apps/monitor/tests/test_metrics_gap_detection.py
+++ b/server/apps/monitor/tests/test_metrics_gap_detection.py
@@ -291,7 +291,7 @@ def test_detect_gap_intervals_keeps_overlapping_series_gaps_independent():
                     "missing_points": 5,
                 },
             ],
-        }
+        },
     ]
 
 

--- a/server/apps/monitor/tests/test_metrics_gap_detection.py
+++ b/server/apps/monitor/tests/test_metrics_gap_detection.py
@@ -1,12 +1,194 @@
+import json
 from types import SimpleNamespace
 
 import pytest
 
-from apps.monitor.services.metrics import Metrics
+from apps.monitor.services.metrics import Metrics, MetricsQueryBudgetExceeded
 from apps.monitor.views.metrics_instance import MetricsInstanceViewSet
 
-
 pytestmark = pytest.mark.unit
+
+
+def test_default_range_budget_rejects_excessive_grid_before_vm_query(monkeypatch):
+    class StubVictoriaMetricsAPI:
+        def query_range(self, query, start, end, step):
+            raise AssertionError("超限请求不应访问 VictoriaMetrics")
+
+    monkeypatch.setattr("apps.monitor.services.metrics.VictoriaMetricsAPI", StubVictoriaMetricsAPI)
+
+    with pytest.raises(MetricsQueryBudgetExceeded) as raised:
+        Metrics.get_metrics_range(
+            "cpu_usage",
+            0,
+            30 * 24 * 60 * 60 * 1000,
+            "1s",
+        )
+
+    assert raised.value.STATUS_CODE == 422
+    assert raised.value.data["code"] == "MONITOR_RANGE_QUERY_BUDGET_EXCEEDED"
+    assert raised.value.data["reason"] == "points_per_series"
+
+
+def test_default_range_budget_rejects_excessive_series_before_fill(monkeypatch):
+    monkeypatch.setattr(Metrics, "RANGE_QUERY_MAX_SERIES", 2, raising=False)
+
+    class StubVictoriaMetricsAPI:
+        def query_range(self, query, start, end, step):
+            assert query == "limitk(3, cpu_usage)"
+            return {
+                "status": "success",
+                "data": {"result": [{"metric": {"id": str(index)}, "values": [[0, "1"]]} for index in range(3)]},
+            }
+
+    monkeypatch.setattr("apps.monitor.services.metrics.VictoriaMetricsAPI", StubVictoriaMetricsAPI)
+
+    with pytest.raises(MetricsQueryBudgetExceeded) as raised:
+        Metrics.get_metrics_range("cpu_usage", 0, 60000, "60s")
+
+    assert raised.value.data["reason"] == "series"
+    assert raised.value.data["actual"]["series"] == 3
+
+
+def test_default_range_budget_keeps_explicit_series_limit_within_cap(monkeypatch):
+    monkeypatch.setattr(Metrics, "RANGE_QUERY_MAX_SERIES", 2)
+    calls = []
+
+    class StubVictoriaMetricsAPI:
+        def query_range(self, query, start, end, step):
+            calls.append((query, start, end, step))
+            return {
+                "status": "success",
+                "data": {
+                    "result": [
+                        {"metric": {"id": "1"}, "values": [[0, "1"]]},
+                        {"metric": {"id": "2"}, "values": [[0, "2"]]},
+                    ]
+                },
+            }
+
+    monkeypatch.setattr("apps.monitor.services.metrics.VictoriaMetricsAPI", StubVictoriaMetricsAPI)
+
+    Metrics.get_metrics_range("topk(2, cpu_usage)", 0, 60000, "60s", fill_missing=False)
+
+    assert calls == [("topk(2, cpu_usage)", 0.0, 60.0, "60s")]
+
+
+def test_default_range_budget_rejects_total_grid_before_fill(monkeypatch):
+    monkeypatch.setattr(Metrics, "RANGE_QUERY_MAX_SERIES", 10, raising=False)
+    monkeypatch.setattr(Metrics, "RANGE_QUERY_MAX_TOTAL_POINTS", 5, raising=False)
+
+    class StubVictoriaMetricsAPI:
+        def query_range(self, query, start, end, step):
+            return {
+                "status": "success",
+                "data": {
+                    "result": [
+                        {"metric": {"id": "1"}, "values": [[0, "1"]]},
+                        {"metric": {"id": "2"}, "values": [[0, "1"]]},
+                    ]
+                },
+            }
+
+    monkeypatch.setattr("apps.monitor.services.metrics.VictoriaMetricsAPI", StubVictoriaMetricsAPI)
+    fill_called = False
+
+    def fail_if_fill_runs(*args, **kwargs):
+        nonlocal fill_called
+        fill_called = True
+
+    monkeypatch.setattr(Metrics, "fill_missing_points", staticmethod(fail_if_fill_runs))
+
+    with pytest.raises(MetricsQueryBudgetExceeded) as raised:
+        Metrics.get_metrics_range("cpu_usage", 0, 120000, "60s")
+
+    assert raised.value.data["reason"] == "total_points"
+    assert raised.value.data["actual"]["total_points"] == 6
+    assert fill_called is False
+
+
+def test_fill_missing_points_rejects_excessive_grid_before_dataframe_allocation(monkeypatch):
+    monkeypatch.setattr(Metrics, "RANGE_QUERY_MAX_TOTAL_POINTS", 5)
+    data = [
+        {"metric": {"id": "1"}, "values": [[0, "1"]]},
+        {"metric": {"id": "2"}, "values": [[0, "1"]]},
+    ]
+
+    with pytest.raises(MetricsQueryBudgetExceeded) as raised:
+        Metrics.fill_missing_points(0, 120, 60, data)
+
+    assert raised.value.data["reason"] == "total_points"
+    assert data[0]["values"] == [[0, "1"]]
+
+
+def test_metrics_range_view_returns_structured_422_for_budget_error(monkeypatch):
+    error = MetricsQueryBudgetExceeded(
+        data={
+            "code": "MONITOR_RANGE_QUERY_BUDGET_EXCEEDED",
+            "reason": "points_per_series",
+            "limits": {"points_per_series": 10000},
+            "actual": {"points_per_series": 20000},
+        }
+    )
+    monkeypatch.setattr(
+        "apps.monitor.views.metrics_instance.MetricsService.get_metrics_range",
+        lambda *args, **kwargs: (_ for _ in ()).throw(error),
+    )
+
+    response = MetricsInstanceViewSet().get_metrics_range(
+        SimpleNamespace(
+            GET={
+                "query": "cpu_usage",
+                "start": "0",
+                "end": "1200000",
+                "step": "60s",
+            }
+        )
+    )
+
+    assert response.status_code == 422
+    assert json.loads(response.content) == {
+        "data": error.data,
+        "result": False,
+        "message": "指标范围查询超过服务端预算，请缩短时间范围、减少实例或增大查询步长",
+    }
+
+
+def test_card_budget_clamps_step_before_shared_hard_budget(monkeypatch):
+    calls = []
+
+    class StubVictoriaMetricsAPI:
+        def query_range(self, query, start, end, step):
+            calls.append((query, start, end, step))
+            return {
+                "status": "success",
+                "data": {
+                    "result": [
+                        {
+                            "metric": {"instance_id": "host-1"},
+                            "values": [[0, "1"], [600, "2"]],
+                        }
+                    ]
+                },
+            }
+
+    monkeypatch.setattr("apps.monitor.services.metrics.VictoriaMetricsAPI", StubVictoriaMetricsAPI)
+
+    response = Metrics.get_metrics_range(
+        "cpu_usage",
+        0,
+        600000,
+        "1s",
+        card_budget=True,
+    )
+
+    assert calls == [("limitk(201, cpu_usage)", 0.0, 600.0, "2s")]
+    assert response["data"]["step"] == "2s"
+    assert response["data"]["step_clamped"] is True
+    assert response["data"]["series_budget"] == {
+        "truncated": False,
+        "limit": 200,
+        "applied": True,
+    }
 
 
 def test_detect_gap_intervals_finds_missing_samples_inside_coarse_step():
@@ -209,8 +391,8 @@ def test_get_metrics_range_adds_gap_metadata_when_detection_enabled(monkeypatch)
     )
 
     assert calls == [
-        ("cpu_usage", 0.0, 600.0, "1h"),
-        ("cpu_usage", 0.0, 600.0, "60s"),
+        ("limitk(2001, cpu_usage)", 0.0, 600.0, "1h"),
+        ("limitk(2001, cpu_usage)", 0.0, 600.0, "60s"),
     ]
     assert response["data"]["gap_detection"] == {"status": "ok", "limited": False}
     assert response["data"]["gaps"] == [
@@ -361,7 +543,7 @@ def test_get_metrics_range_reuses_response_when_step_matches_collection_interval
         collection_interval_seconds=60,
     )
 
-    assert calls == [("cpu_usage", 0.0, 600.0, "60s")]
+    assert calls == [("limitk(2001, cpu_usage)", 0.0, 600.0, "60s")]
     assert response["data"]["gap_detection"] == {"status": "ok", "limited": False}
     assert response["data"]["gaps"] == [
         {
@@ -419,7 +601,7 @@ def test_get_metrics_range_limits_gap_detection_when_query_would_be_too_large(mo
         max_gap_detection_points=3,
     )
 
-    assert calls == [("cpu_usage", 0.0, 600.0, "1h")]
+    assert calls == [("limitk(2001, cpu_usage)", 0.0, 600.0, "1h")]
     assert response["data"]["gaps"] == []
     assert response["data"]["gap_detection"] == {
         "status": "limited",
@@ -471,8 +653,8 @@ def test_get_metrics_range_detects_one_minute_gaps_for_thirty_day_window(monkeyp
     )
 
     assert calls == [
-        ("cpu_usage", 0.0, 2592000.0, "1h"),
-        ("cpu_usage", 0.0, 2592000.0, "60s"),
+        ("limitk(2001, cpu_usage)", 0.0, 2592000.0, "1h"),
+        ("limitk(2001, cpu_usage)", 0.0, 2592000.0, "60s"),
     ]
     assert response["data"]["gap_detection"] == {"status": "ok", "limited": False}
     assert response["data"]["gaps"] == [

--- a/server/apps/monitor/tests/test_nats_monitor_handlers.py
+++ b/server/apps/monitor/tests/test_nats_monitor_handlers.py
@@ -16,6 +16,7 @@ from apps.monitor.models.monitor_policy import MonitorPolicy, PolicyOrganization
 from apps.monitor.models.plugin import MonitorPlugin
 from apps.monitor.nats import monitor as nm
 from apps.monitor.nats.contracts import MONITOR_NATS_HANDLER_NAMES
+from apps.monitor.services.metrics import MetricsQueryBudgetExceeded
 from nats_client.registry import default_registry
 
 pytestmark = pytest.mark.django_db
@@ -250,6 +251,35 @@ class TestQueryMetricRangeScoped:
         assert "time range" in result["message"]
         service.assert_not_called()
 
+    def test_budget_error_returns_stable_nats_contract(self, mocker):
+        error = MetricsQueryBudgetExceeded(
+            data={
+                "code": "MONITOR_RANGE_QUERY_BUDGET_EXCEEDED",
+                "reason": "points_per_series",
+                "limits": {"points_per_series": 10000},
+                "actual": {"points_per_series": 20000},
+            }
+        )
+        service = mocker.patch("apps.monitor.nats.monitor.AuthorizedMetricQueryService")
+        service.return_value.query_range.side_effect = error
+
+        result = nm.query_metric_range_scoped(
+            8,
+            42,
+            ["host-1"],
+            ["2026-01-01T00:00:00.000Z", "2026-01-02T00:00:00.000Z"],
+            step="1s",
+            user_info={"user": "viewer", "domain": "domain.com", "team": 1},
+        )
+
+        assert result == {
+            "result": False,
+            "data": [],
+            "message": "指标范围查询超过服务端预算，请缩短时间范围、减少实例或增大查询步长",
+            "code": "MONITOR_RANGE_QUERY_BUDGET_EXCEEDED",
+            "budget": error.data,
+        }
+
 
 class TestQueryMonitorDataByMetric:
     def _setup(self):
@@ -332,6 +362,76 @@ class TestQueryMonitorDataByMetric:
         ids = {d["metric"]["instance_id"] for d in out["data"]["data"]["result"]}
         # 只保留有权限实例 ('h1',)
         assert ids == {"('h1',)"}
+
+    def test_budget_error_keeps_structured_failure(self, mocker):
+        obj, _ = self._setup()
+        mocker.patch("apps.monitor.nats.monitor.get_permission_rules", return_value={"team": [1]})
+        mocker.patch(
+            "apps.monitor.nats.monitor.permission_filter",
+            side_effect=lambda model, perm, **kw: model.objects.all(),
+        )
+        error = MetricsQueryBudgetExceeded(
+            data={
+                "code": "MONITOR_RANGE_QUERY_BUDGET_EXCEEDED",
+                "reason": "total_points",
+                "limits": {"total_points": 500000},
+                "actual": {"total_points": 500001},
+            }
+        )
+        mocker.patch(
+            "apps.monitor.nats.monitor.Metrics.get_metrics_range",
+            side_effect=error,
+        )
+
+        result = nm.query_monitor_data_by_metric(
+            {"monitor_obj_id": obj.id, "metric": "cpu", "start": 1, "end": 2},
+            user_info={"user": SimpleNamespace(username="u", domain="d"), "team": 1},
+        )
+
+        assert result["result"] is False
+        assert result["code"] == "MONITOR_RANGE_QUERY_BUDGET_EXCEEDED"
+        assert result["budget"] == error.data
+
+    def test_merged_plugin_result_checks_shared_fill_budget(self, mocker):
+        obj, _ = self._setup()
+        MonitorInstance.objects.create(id="('h1',)", name="h1", monitor_object=obj, is_deleted=False)
+        mocker.patch("apps.monitor.nats.monitor.get_permission_rules", return_value={"team": [1]})
+        mocker.patch(
+            "apps.monitor.nats.monitor.permission_filter",
+            side_effect=lambda model, perm, **kw: model.objects.all(),
+        )
+        get_metrics_range = mocker.patch(
+            "apps.monitor.nats.monitor.Metrics.get_metrics_range",
+            return_value={
+                "status": "success",
+                "data": {
+                    "result": [
+                        {"metric": {"instance_id": "('h1',)"}, "values": [[0, "1"]]},
+                    ]
+                },
+            },
+        )
+        error = MetricsQueryBudgetExceeded(
+            data={
+                "code": "MONITOR_RANGE_QUERY_BUDGET_EXCEEDED",
+                "reason": "total_points",
+                "limits": {"total_points": 500000},
+                "actual": {"total_points": 500001},
+            }
+        )
+        enforce_fill_budget = mocker.patch(
+            "apps.monitor.nats.monitor.Metrics.enforce_fill_budget",
+            side_effect=error,
+        )
+
+        result = nm.query_monitor_data_by_metric(
+            {"monitor_obj_id": obj.id, "metric": "cpu", "start": 1, "end": 2},
+            user_info={"user": SimpleNamespace(username="u", domain="d"), "team": 1},
+        )
+
+        assert result["code"] == "MONITOR_RANGE_QUERY_BUDGET_EXCEEDED"
+        assert get_metrics_range.call_args.kwargs["fill_missing"] is False
+        enforce_fill_budget.assert_called_once()
 
     def test_same_metric_name_queries_all_plugins_and_returns_plugin_metadata(
         self,

--- a/server/apps/monitor/tests/test_nats_monitor_handlers.py
+++ b/server/apps/monitor/tests/test_nats_monitor_handlers.py
@@ -365,6 +365,7 @@ class TestQueryMonitorDataByMetric:
 
     def test_budget_error_keeps_structured_failure(self, mocker):
         obj, _ = self._setup()
+        MonitorInstance.objects.create(id="('h1',)", name="h1", monitor_object=obj, is_deleted=False)
         mocker.patch("apps.monitor.nats.monitor.get_permission_rules", return_value={"team": [1]})
         mocker.patch(
             "apps.monitor.nats.monitor.permission_filter",
@@ -384,7 +385,7 @@ class TestQueryMonitorDataByMetric:
         )
 
         result = nm.query_monitor_data_by_metric(
-            {"monitor_obj_id": obj.id, "metric": "cpu", "start": 1, "end": 2},
+            {"monitor_obj_id": obj.id, "metric": "cpu", "start": 1, "end": 2, "instance_ids": ["('h1',)"]},
             user_info={"user": SimpleNamespace(username="u", domain="d"), "team": 1},
         )
 
@@ -425,7 +426,7 @@ class TestQueryMonitorDataByMetric:
         )
 
         result = nm.query_monitor_data_by_metric(
-            {"monitor_obj_id": obj.id, "metric": "cpu", "start": 1, "end": 2},
+            {"monitor_obj_id": obj.id, "metric": "cpu", "start": 1, "end": 2, "instance_ids": ["('h1',)"]},
             user_info={"user": SimpleNamespace(username="u", domain="d"), "team": 1},
         )
 

--- a/server/apps/monitor/views/metrics_instance.py
+++ b/server/apps/monitor/views/metrics_instance.py
@@ -13,6 +13,7 @@ from apps.monitor.models import MonitorInstance
 from apps.monitor.models.monitor_metrics import Metric
 from apps.monitor.services.authorized_metric_query import AuthorizedMetricQueryError, AuthorizedMetricQueryService
 from apps.monitor.services.metrics import Metrics as MetricsService
+from apps.monitor.services.metrics import MetricsQueryBudgetExceeded
 from apps.monitor.utils.unit_converter import UnitConverter
 
 
@@ -165,15 +166,22 @@ class MetricsInstanceViewSet(viewsets.ViewSet):
         except ValueError as e:
             raise BaseAppException(f"invalid step: {e}")
 
-        data = MetricsService.get_metrics_range(
-            query,
-            start,
-            end,
-            step,
-            detect_gaps=detect_gaps,
-            collection_interval_seconds=collection_interval,
-            card_budget=query_budget == "card",
-        )
+        try:
+            data = MetricsService.get_metrics_range(
+                query,
+                start,
+                end,
+                step,
+                detect_gaps=detect_gaps,
+                collection_interval_seconds=collection_interval,
+                card_budget=query_budget == "card",
+            )
+        except MetricsQueryBudgetExceeded as exc:
+            return WebUtils.response_error(
+                response_data=exc.data,
+                error_message=exc.message,
+                status_code=exc.STATUS_CODE,
+            )
 
         if source_unit:
             if target_unit:


### PR DESCRIPTION
## 问题

监控范围查询本应在访问 VictoriaMetrics 和展开缺失点前具备不可绕过的资源边界。此前只有卡片调用主动启用预算，默认 REST 与 NATS 范围查询仍可提交长跨度、小步长和高序列请求；返回后还会按完整时间网格补点，形成远端查询与应用内存的双重放大。

Closes #4640

## 根因（设计层）

查询预算被设计成调用方可选的卡片能力，而不是共享服务层的绝对约束。服务端没有在下发查询前限制跨度和单序列点数，也没有在收到实际序列后限制总补点网格；REST 与 NATS 因此存在不同入口、相同无界行为。

## 怎么修的

- 在共享 Metrics 服务建立统一范围预算，默认限制最长 366 天、单序列 10000 点、最多 2000 序列和总补点网格 500000 点。
- 默认查询使用 `limitk(N+1, query)` 控制返回序列并识别超限；显式且不超过预算的 `topk`、`bottomk`、`limitk` 保持原查询不变。
- 查询前校验跨度和单序列点数，返回后按实际序列数校验总网格；`fill_missing_points` 自身再次校验，防止其他调用方绕开共享入口。
- REST 超限返回结构化 `422`；NATS 保持原有 `result/data/message` 字段，并增量返回 `code` 与 `budget`。
- `query_monitor_data_by_metric` 在多个插件结果合并后执行共享预算，再统一补点，避免逐插件预算叠加。
- 修正卡片步长计算的向上取整，确保卡片预算不会因整数截断多生成一个网格区间。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        R["REST query_range\nmetrics_instance.py"]
        N["NATS mm_query_range / 指标查询\nmonitor.py"]
    end

    subgraph B["共享预算层"]
        P["请求前预算\n跨度 / 步长 / 单序列点数"]
        V["受限查询\nlimitk(N+1, query)"]
        A["响应后二次预算\n实际序列 / 总网格"]
    end

    subgraph F["结果层"]
        M["补点前防线\nfill_missing_points"]
        E["超限稳定错误\nREST 422 / NATS budget"]
    end

    R --> P
    N --> P
    P --> V --> A --> M
    P -. "超限" .-> E
    A -. "超限" .-> E
    M -. "超限" .-> E
```

## 影响范围与兼容性

- 卡片和 Mobile 的既有预算行为保持不变；预算内完整明细结果保持一致。
- 超限完整明细不做静默降采样，调用方会收到明确失败并可缩短范围、减少实例或增大步长。
- NATS subject 和既有响应字段未删除；预算错误字段为增量契约。
- 默认不需要部署配置。若需进一步收紧，可选使用 `MONITOR_RANGE_QUERY_MAX_DURATION_SECONDS`、`MONITOR_RANGE_QUERY_MAX_POINTS_PER_SERIES`、`MONITOR_RANGE_QUERY_MAX_SERIES`、`MONITOR_RANGE_QUERY_MAX_TOTAL_POINTS`；代码内已有安全默认值。
- 无数据库迁移、无持久化数据变更。紧急回滚可回退本 PR；优先通过有界阈值临时放宽并保留超限边界。

## 验证

- `apps/monitor/tests/test_metrics_gap_detection.py`、`test_metrics_service_extra.py`、`test_nats_monitor_handlers.py`：94 passed。
- 新增生产代码差异覆盖率：96%。
- Monitor 扩展回归在临时 PostgreSQL 上执行到 250 passed；未启动 MinIO 导致后续既有对象存储重试过慢，本地中止，相关变更测试已完整通过。
- Black（新增代码）、isort、Flake8、Python 编译、迁移检查和依赖一致性检查通过。
- 使用真实 VictoriaMetrics `/api/v1/query_range` 验证 `limitk(2001, up)` 返回成功响应。

## 三轨门禁

- Standards：通过。仅修改 Monitor 相关文件，无原生 SQL、无凭据、无无关重构；已恢复格式化工具产生的无关 diff。
- Spec：通过。覆盖查询前拒绝、实际序列二次校验、补点防线、结构化 422、NATS 同边界及既有卡片兼容。
- Runtime Contract：通过。验证预算内、跨度/点数/序列/总网格超限、VM 失败、REST 错误结构、NATS 新旧字段兼容、多插件合并和真实 VM 查询语法。

评审得分：94/100。
