### PR TITLE
fix(webhookd): 云区域部署 NATS 重试超时前输出真实报错

### DIFF
--- a/agents/webhookd/infra/proxy/bootstrap.sh
+++ b/agents/webhookd/infra/proxy/bootstrap.sh
@@ -18,7 +18,10 @@ retry() {
     local elapsed=0
     while ! "$@" 2>/dev/null; do
         elapsed=$((elapsed + interval))
-        [ $elapsed -ge $max ] && return 1
+        if [ $elapsed -ge $max ]; then
+            "$@" || true
+            return 1
+        fi
         info "$desc... (${elapsed}s/${max}s)"
         sleep $interval
     done


### PR DESCRIPTION
bootstrap.sh 的 retry 此前把 stderr 全部吞掉，镜像拉取失败、鉴权失败与
TLS 错误在屏幕上都只剩 "Cannot connect to NATS"，无法定位。超时前将命令 不重定向地再执行一次，把最后一次真实错误打印出来，重试节奏与返回值不变。