### PR TITLE
fix(监控): 修复 vLLM/SGLang Telegraf histogram 分位数与亚秒显示

### DIFF
--- a/server/apps/monitor/support-files/plugins/Telegraf/bkpull/sglang/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/bkpull/sglang/metrics.json
@@ -181,7 +181,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟 TTFT P99。",
-      "query": "histogram_quantile(0.99, sum(rate((label_replace({__name__=~\"sglang:time_to_first_token_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"sglang:time_to_first_token_seconds_(.+)\"))[5m:]) or label_replace(rate(sglang:time_to_first_token_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.99, sum by (instance_id, le) (label_replace(rate({__name__=~\"sglang:time_to_first_token_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"sglang:time_to_first_token_seconds_(.+)\") or label_replace(rate({__name__=\"sglang:time_to_first_token_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -194,7 +194,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟端到端请求时延 P99。",
-      "query": "histogram_quantile(0.99, sum(rate((label_replace({__name__=~\"sglang:e2e_request_latency_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"sglang:e2e_request_latency_seconds_(.+)\"))[5m:]) or label_replace(rate(sglang:e2e_request_latency_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.99, sum by (instance_id, le) (label_replace(rate({__name__=~\"sglang:e2e_request_latency_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"sglang:e2e_request_latency_seconds_(.+)\") or label_replace(rate({__name__=\"sglang:e2e_request_latency_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -207,7 +207,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟 TTFT P50。",
-      "query": "histogram_quantile(0.50, sum(rate((label_replace({__name__=~\"sglang:time_to_first_token_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"sglang:time_to_first_token_seconds_(.+)\"))[5m:]) or label_replace(rate(sglang:time_to_first_token_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.50, sum by (instance_id, le) (label_replace(rate({__name__=~\"sglang:time_to_first_token_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"sglang:time_to_first_token_seconds_(.+)\") or label_replace(rate({__name__=\"sglang:time_to_first_token_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -220,7 +220,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟 TTFT P90。",
-      "query": "histogram_quantile(0.90, sum(rate((label_replace({__name__=~\"sglang:time_to_first_token_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"sglang:time_to_first_token_seconds_(.+)\"))[5m:]) or label_replace(rate(sglang:time_to_first_token_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.90, sum by (instance_id, le) (label_replace(rate({__name__=~\"sglang:time_to_first_token_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"sglang:time_to_first_token_seconds_(.+)\") or label_replace(rate({__name__=\"sglang:time_to_first_token_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -246,7 +246,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟端到端请求时延 P50。",
-      "query": "histogram_quantile(0.50, sum(rate((label_replace({__name__=~\"sglang:e2e_request_latency_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"sglang:e2e_request_latency_seconds_(.+)\"))[5m:]) or label_replace(rate(sglang:e2e_request_latency_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.50, sum by (instance_id, le) (label_replace(rate({__name__=~\"sglang:e2e_request_latency_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"sglang:e2e_request_latency_seconds_(.+)\") or label_replace(rate({__name__=\"sglang:e2e_request_latency_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -259,7 +259,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟端到端请求时延 P90。",
-      "query": "histogram_quantile(0.90, sum(rate((label_replace({__name__=~\"sglang:e2e_request_latency_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"sglang:e2e_request_latency_seconds_(.+)\"))[5m:]) or label_replace(rate(sglang:e2e_request_latency_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.90, sum by (instance_id, le) (label_replace(rate({__name__=~\"sglang:e2e_request_latency_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"sglang:e2e_request_latency_seconds_(.+)\") or label_replace(rate({__name__=\"sglang:e2e_request_latency_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",

--- a/server/apps/monitor/support-files/plugins/Telegraf/bkpull/vllm/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/bkpull/vllm/metrics.json
@@ -155,7 +155,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟 Time-to-First-Token（TTFT）P99。",
-      "query": "histogram_quantile(0.99, sum(rate((label_replace({__name__=~\"vllm:time_to_first_token_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:time_to_first_token_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:time_to_first_token_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.99, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:time_to_first_token_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:time_to_first_token_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:time_to_first_token_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -168,7 +168,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟端到端请求时延 P99。",
-      "query": "histogram_quantile(0.99, sum(rate((label_replace({__name__=~\"vllm:e2e_request_latency_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:e2e_request_latency_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:e2e_request_latency_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.99, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:e2e_request_latency_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:e2e_request_latency_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:e2e_request_latency_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "请求结果",
@@ -194,7 +194,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟 TTFT P50。",
-      "query": "histogram_quantile(0.50, sum(rate((label_replace({__name__=~\"vllm:time_to_first_token_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:time_to_first_token_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:time_to_first_token_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.50, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:time_to_first_token_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:time_to_first_token_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:time_to_first_token_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -207,7 +207,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟 TTFT P90。",
-      "query": "histogram_quantile(0.90, sum(rate((label_replace({__name__=~\"vllm:time_to_first_token_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:time_to_first_token_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:time_to_first_token_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.90, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:time_to_first_token_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:time_to_first_token_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:time_to_first_token_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -220,7 +220,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟 TTFT P95。",
-      "query": "histogram_quantile(0.95, sum(rate((label_replace({__name__=~\"vllm:time_to_first_token_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:time_to_first_token_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:time_to_first_token_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.95, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:time_to_first_token_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:time_to_first_token_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:time_to_first_token_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -246,7 +246,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟端到端请求时延 P50。",
-      "query": "histogram_quantile(0.50, sum(rate((label_replace({__name__=~\"vllm:e2e_request_latency_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:e2e_request_latency_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:e2e_request_latency_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.50, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:e2e_request_latency_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:e2e_request_latency_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:e2e_request_latency_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -259,7 +259,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟端到端请求时延 P90。",
-      "query": "histogram_quantile(0.90, sum(rate((label_replace({__name__=~\"vllm:e2e_request_latency_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:e2e_request_latency_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:e2e_request_latency_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.90, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:e2e_request_latency_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:e2e_request_latency_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:e2e_request_latency_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -272,7 +272,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟端到端请求时延 P95。",
-      "query": "histogram_quantile(0.95, sum(rate((label_replace({__name__=~\"vllm:e2e_request_latency_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:e2e_request_latency_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:e2e_request_latency_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.95, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:e2e_request_latency_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:e2e_request_latency_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:e2e_request_latency_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -298,7 +298,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟 Inter-Token Latency（ITL）P50。",
-      "query": "histogram_quantile(0.50, sum(rate((label_replace({__name__=~\"vllm:inter_token_latency_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:inter_token_latency_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:inter_token_latency_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.50, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:inter_token_latency_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:inter_token_latency_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:inter_token_latency_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -311,7 +311,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟 Inter-Token Latency（ITL）P90。",
-      "query": "histogram_quantile(0.90, sum(rate((label_replace({__name__=~\"vllm:inter_token_latency_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:inter_token_latency_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:inter_token_latency_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.90, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:inter_token_latency_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:inter_token_latency_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:inter_token_latency_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -324,7 +324,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟 Inter-Token Latency（ITL）P95。",
-      "query": "histogram_quantile(0.95, sum(rate((label_replace({__name__=~\"vllm:inter_token_latency_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:inter_token_latency_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:inter_token_latency_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.95, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:inter_token_latency_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:inter_token_latency_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:inter_token_latency_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -337,7 +337,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟 Inter-Token Latency（ITL）P99。",
-      "query": "histogram_quantile(0.99, sum(rate((label_replace({__name__=~\"vllm:inter_token_latency_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:inter_token_latency_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:inter_token_latency_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.99, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:inter_token_latency_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:inter_token_latency_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:inter_token_latency_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -363,7 +363,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟请求排队时延 P50。",
-      "query": "histogram_quantile(0.50, sum(rate((label_replace({__name__=~\"vllm:request_queue_time_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:request_queue_time_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:request_queue_time_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.50, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_queue_time_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_queue_time_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:request_queue_time_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -376,7 +376,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟请求排队时延 P90。",
-      "query": "histogram_quantile(0.90, sum(rate((label_replace({__name__=~\"vllm:request_queue_time_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:request_queue_time_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:request_queue_time_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.90, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_queue_time_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_queue_time_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:request_queue_time_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -389,7 +389,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟请求排队时延 P95。",
-      "query": "histogram_quantile(0.95, sum(rate((label_replace({__name__=~\"vllm:request_queue_time_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:request_queue_time_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:request_queue_time_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.95, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_queue_time_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_queue_time_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:request_queue_time_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -402,7 +402,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟请求排队时延 P99。",
-      "query": "histogram_quantile(0.99, sum(rate((label_replace({__name__=~\"vllm:request_queue_time_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:request_queue_time_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:request_queue_time_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.99, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_queue_time_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_queue_time_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:request_queue_time_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -428,7 +428,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟 Prefill 时延 P50。",
-      "query": "histogram_quantile(0.50, sum(rate((label_replace({__name__=~\"vllm:request_prefill_time_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:request_prefill_time_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:request_prefill_time_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.50, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_prefill_time_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_prefill_time_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:request_prefill_time_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -441,7 +441,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟 Prefill 时延 P90。",
-      "query": "histogram_quantile(0.90, sum(rate((label_replace({__name__=~\"vllm:request_prefill_time_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:request_prefill_time_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:request_prefill_time_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.90, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_prefill_time_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_prefill_time_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:request_prefill_time_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -454,7 +454,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟 Prefill 时延 P95。",
-      "query": "histogram_quantile(0.95, sum(rate((label_replace({__name__=~\"vllm:request_prefill_time_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:request_prefill_time_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:request_prefill_time_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.95, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_prefill_time_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_prefill_time_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:request_prefill_time_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -467,7 +467,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟 Prefill 时延 P99。",
-      "query": "histogram_quantile(0.99, sum(rate((label_replace({__name__=~\"vllm:request_prefill_time_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:request_prefill_time_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:request_prefill_time_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.99, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_prefill_time_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_prefill_time_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:request_prefill_time_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -493,7 +493,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟 Decode 时延 P50。",
-      "query": "histogram_quantile(0.50, sum(rate((label_replace({__name__=~\"vllm:request_decode_time_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:request_decode_time_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:request_decode_time_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.50, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_decode_time_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_decode_time_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:request_decode_time_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -506,7 +506,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟 Decode 时延 P90。",
-      "query": "histogram_quantile(0.90, sum(rate((label_replace({__name__=~\"vllm:request_decode_time_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:request_decode_time_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:request_decode_time_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.90, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_decode_time_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_decode_time_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:request_decode_time_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -519,7 +519,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟 Decode 时延 P95。",
-      "query": "histogram_quantile(0.95, sum(rate((label_replace({__name__=~\"vllm:request_decode_time_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:request_decode_time_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:request_decode_time_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.95, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_decode_time_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_decode_time_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:request_decode_time_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -532,7 +532,7 @@
       "unit": "s",
       "dimensions": [],
       "description": "最近 5 分钟 Decode 时延 P99。",
-      "query": "histogram_quantile(0.99, sum(rate((label_replace({__name__=~\"vllm:request_decode_time_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:request_decode_time_seconds_(.+)\"))[5m:]) or label_replace(rate(vllm:request_decode_time_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.99, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_decode_time_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_decode_time_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:request_decode_time_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "时延",
@@ -571,7 +571,7 @@
       "unit": "counts",
       "dimensions": [],
       "description": "最近 5 分钟请求 prompt token 数 P50。",
-      "query": "histogram_quantile(0.50, sum(rate((label_replace({__name__=~\"vllm:request_prompt_tokens_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:request_prompt_tokens_(.+)\"))[5m:]) or label_replace(rate(vllm:request_prompt_tokens_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.50, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_prompt_tokens_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_prompt_tokens_(.+)\") or label_replace(rate({__name__=\"vllm:request_prompt_tokens_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "Token分布",
@@ -584,7 +584,7 @@
       "unit": "counts",
       "dimensions": [],
       "description": "最近 5 分钟请求 prompt token 数 P90。",
-      "query": "histogram_quantile(0.90, sum(rate((label_replace({__name__=~\"vllm:request_prompt_tokens_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:request_prompt_tokens_(.+)\"))[5m:]) or label_replace(rate(vllm:request_prompt_tokens_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.90, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_prompt_tokens_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_prompt_tokens_(.+)\") or label_replace(rate({__name__=\"vllm:request_prompt_tokens_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "Token分布",
@@ -597,7 +597,7 @@
       "unit": "counts",
       "dimensions": [],
       "description": "最近 5 分钟请求 prompt token 数 P99。",
-      "query": "histogram_quantile(0.99, sum(rate((label_replace({__name__=~\"vllm:request_prompt_tokens_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:request_prompt_tokens_(.+)\"))[5m:]) or label_replace(rate(vllm:request_prompt_tokens_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.99, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_prompt_tokens_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_prompt_tokens_(.+)\") or label_replace(rate({__name__=\"vllm:request_prompt_tokens_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "Token分布",
@@ -623,7 +623,7 @@
       "unit": "counts",
       "dimensions": [],
       "description": "最近 5 分钟请求生成 token 数 P50。",
-      "query": "histogram_quantile(0.50, sum(rate((label_replace({__name__=~\"vllm:request_generation_tokens_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:request_generation_tokens_(.+)\"))[5m:]) or label_replace(rate(vllm:request_generation_tokens_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.50, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_generation_tokens_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_generation_tokens_(.+)\") or label_replace(rate({__name__=\"vllm:request_generation_tokens_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "Token分布",
@@ -636,7 +636,7 @@
       "unit": "counts",
       "dimensions": [],
       "description": "最近 5 分钟请求生成 token 数 P90。",
-      "query": "histogram_quantile(0.90, sum(rate((label_replace({__name__=~\"vllm:request_generation_tokens_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:request_generation_tokens_(.+)\"))[5m:]) or label_replace(rate(vllm:request_generation_tokens_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.90, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_generation_tokens_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_generation_tokens_(.+)\") or label_replace(rate({__name__=\"vllm:request_generation_tokens_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "Token分布",
@@ -649,7 +649,7 @@
       "unit": "counts",
       "dimensions": [],
       "description": "最近 5 分钟请求生成 token 数 P99。",
-      "query": "histogram_quantile(0.99, sum(rate((label_replace({__name__=~\"vllm:request_generation_tokens_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"vllm:request_generation_tokens_(.+)\"))[5m:]) or label_replace(rate(vllm:request_generation_tokens_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+      "query": "histogram_quantile(0.99, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_generation_tokens_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_generation_tokens_(.+)\") or label_replace(rate({__name__=\"vllm:request_generation_tokens_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
     },
     {
       "metric_group": "Token分布",

--- a/web/src/app/monitor/dashboards/objects/sglang/config.ts
+++ b/web/src/app/monitor/dashboards/objects/sglang/config.ts
@@ -1,4 +1,7 @@
 import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
+import { telegrafHistogramQuantile } from '../../shared/utils/telegrafHistogram';
+
+const histQuantile = (base: string, quantile: string) => telegrafHistogramQuantile(base, quantile);
 
 export const SGLANG_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   routeKey: 'sglang',
@@ -71,7 +74,7 @@ export const SGLANG_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '最近 5 分钟 TTFT P99。',
       unit: 's',
       query:
-        'histogram_quantile(0.99, sum(rate((label_replace({__name__=~"sglang:time_to_first_token_seconds_[0-9.]+", __$labels__}, "le", "$1", "__name__", "sglang:time_to_first_token_seconds_(.+)"))[5m:]) or label_replace(rate(sglang:time_to_first_token_seconds_count{__$labels__}[5m]), "le", "+Inf", "__name__", ".*")) by (le))',
+        histQuantile('sglang:time_to_first_token_seconds', '0.99'),
       color: '#597ef7'
     },
     {
@@ -80,7 +83,7 @@ export const SGLANG_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '最近 5 分钟端到端请求时延 P99。',
       unit: 's',
       query:
-        'histogram_quantile(0.99, sum(rate((label_replace({__name__=~"sglang:e2e_request_latency_seconds_[0-9.]+", __$labels__}, "le", "$1", "__name__", "sglang:e2e_request_latency_seconds_(.+)"))[5m:]) or label_replace(rate(sglang:e2e_request_latency_seconds_count{__$labels__}[5m]), "le", "+Inf", "__name__", ".*")) by (le))',
+        histQuantile('sglang:e2e_request_latency_seconds', '0.99'),
       color: '#ff4d4f'
     },
     {
@@ -89,7 +92,7 @@ export const SGLANG_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '最近 5 分钟 TTFT P50。',
       unit: 's',
       query:
-        'histogram_quantile(0.50, sum(rate((label_replace({__name__=~"sglang:time_to_first_token_seconds_[0-9.]+", __$labels__}, "le", "$1", "__name__", "sglang:time_to_first_token_seconds_(.+)"))[5m:]) or label_replace(rate(sglang:time_to_first_token_seconds_count{__$labels__}[5m]), "le", "+Inf", "__name__", ".*")) by (le))',
+        histQuantile('sglang:time_to_first_token_seconds', '0.50'),
       color: '#91caff'
     },
     {
@@ -98,7 +101,7 @@ export const SGLANG_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '最近 5 分钟 TTFT P90。',
       unit: 's',
       query:
-        'histogram_quantile(0.90, sum(rate((label_replace({__name__=~"sglang:time_to_first_token_seconds_[0-9.]+", __$labels__}, "le", "$1", "__name__", "sglang:time_to_first_token_seconds_(.+)"))[5m:]) or label_replace(rate(sglang:time_to_first_token_seconds_count{__$labels__}[5m]), "le", "+Inf", "__name__", ".*")) by (le))',
+        histQuantile('sglang:time_to_first_token_seconds', '0.90'),
       color: '#4096ff'
     },
     {
@@ -116,7 +119,7 @@ export const SGLANG_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '最近 5 分钟端到端请求时延 P50。',
       unit: 's',
       query:
-        'histogram_quantile(0.50, sum(rate((label_replace({__name__=~"sglang:e2e_request_latency_seconds_[0-9.]+", __$labels__}, "le", "$1", "__name__", "sglang:e2e_request_latency_seconds_(.+)"))[5m:]) or label_replace(rate(sglang:e2e_request_latency_seconds_count{__$labels__}[5m]), "le", "+Inf", "__name__", ".*")) by (le))',
+        histQuantile('sglang:e2e_request_latency_seconds', '0.50'),
       color: '#ffa39e'
     },
     {
@@ -125,7 +128,7 @@ export const SGLANG_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '最近 5 分钟端到端请求时延 P90。',
       unit: 's',
       query:
-        'histogram_quantile(0.90, sum(rate((label_replace({__name__=~"sglang:e2e_request_latency_seconds_[0-9.]+", __$labels__}, "le", "$1", "__name__", "sglang:e2e_request_latency_seconds_(.+)"))[5m:]) or label_replace(rate(sglang:e2e_request_latency_seconds_count{__$labels__}[5m]), "le", "+Inf", "__name__", ".*")) by (le))',
+        histQuantile('sglang:e2e_request_latency_seconds', '0.90'),
       color: '#ff7875'
     },
     {

--- a/web/src/app/monitor/dashboards/objects/vllm/config.ts
+++ b/web/src/app/monitor/dashboards/objects/vllm/config.ts
@@ -1,8 +1,8 @@
 import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
+import { telegrafHistogramQuantile } from '../../shared/utils/telegrafHistogram';
 
 /** Telegraf histogram bucket query; group by instance_id only (one scrape URL = one instance). */
-const histQuantile = (base: string, quantile: string) =>
-  `histogram_quantile(${quantile}, sum(rate((label_replace({__name__=~"${base}_[0-9.]+", __$labels__}, "le", "$1", "__name__", "${base}_(.+)"))[5m:]) or label_replace(rate(${base}_count{__$labels__}[5m]), "le", "+Inf", "__name__", ".*")) by (instance_id, le))`;
+const histQuantile = (base: string, quantile: string) => telegrafHistogramQuantile(base, quantile);
 
 export const VLLM_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   routeKey: 'vllm',

--- a/web/src/app/monitor/dashboards/shared/utils/format.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/format.ts
@@ -83,6 +83,22 @@ const formatTimeValue = (value: number, unit: MetricUnit) => {
     }
   }
 
+  // Scale down sub-unit values (e.g. 0.009s → 9ms) so small latencies are not rounded to 0s.
+  const downscaleFactor: Record<number, number> = {
+    1: 1000, // µs → ns
+    2: 1000, // ms → µs
+    3: 1000, // s → ms
+    4: 60, // m → s
+    5: 60, // h → m
+    6: 24, // d → h
+  };
+  while (index > 0 && Math.abs(next) > 0 && Math.abs(next) < 1) {
+    const factor = downscaleFactor[index];
+    if (!factor) break;
+    next *= factor;
+    index -= 1;
+  }
+
   return {
     value: formatScaledValue(next),
     unit: TIME_LABELS[TIME_UNITS[index]]

--- a/web/src/app/monitor/dashboards/shared/utils/telegrafHistogram.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/telegrafHistogram.ts
@@ -1,0 +1,16 @@
+/**
+ * Telegraf inputs.prometheus (metric_version=1) flattens Prometheus histogram
+ * buckets into separate series `{base}_<le>` and `{base}_+Inf`, plus `_count`/`_sum`.
+ *
+ * VictoriaMetrics drops `__name__` from `rate()` by default, which collapses all buckets
+ * into duplicate timeseries. Use `keep_metric_names`, then restore `le` via
+ * `label_replace`. Prefer the real `+Inf` series — do NOT synthesize +Inf from
+ * `_count` (that yields bogus quantiles near the largest finite bucket).
+ */
+export const telegrafHistogramQuantile = (base: string, quantile: string, groupBy = 'instance_id') =>
+  `histogram_quantile(${quantile}, sum by (${groupBy}, le) (` +
+  `label_replace(rate({__name__=~"${base}_[0-9.]+", __$labels__}[5m]) keep_metric_names, ` +
+  `"le", "$1", "__name__", "${base}_(.+)") ` +
+  `or label_replace(rate({__name__="${base}_+Inf", __$labels__}[5m]) keep_metric_names, ` +
+  `"le", "+Inf", "__name__", ".*")` +
+  `))`;


### PR DESCRIPTION
## Summary
- 修复 Telegraf `metric_version=1` 拉平后的 histogram 分位数查询：不再用 `_count` 伪造 `+Inf`（会把 P95 顶到最大有限桶，出现小时级假时延），改为 `rate(...) keep_metric_names` + 真实 `{base}_+Inf`。
- vLLM / SGLang 仪表盘配置与插件 `metrics.json` 同步；抽出共享 helper `telegrafHistogramQuantile`。
- 时间格式化对 `<1s` 自动降到 `ms`/`µs`，避免 TTFT/TPOT 显示成 `0s`。

## Test plan
- [ ] 打开 vLLM 仪表盘，确认无「系统错误」toast 刷屏
- [ ] 有流量时 TTFT / ITL(TPOT) / E2E 显示为毫秒～秒级合理值（非小时级、非长期 `--`）
- [ ] 亚秒时延显示为 `Xms` 而非 `0s`
- [ ] SGLang 同类分位数卡片行为一致
- [ ] 确认未纳入测试文件与无关分支改动

## Review notes
本地已对 VictoriaMetrics 验证：`keep_metric_names` 查询可算出约 9.5ms ITL P95；含 `default (avg)` 的旧加固写法会 422。

提交范围已检查：仅 6 个相关文件，无测试 / Storybook mock / 图标 / 设计文档。