### PR TITLE
test(server): 补齐公开接口覆盖率

### DIFF
--- a/server/apps/alerts/tests/test_init_alert_commands.py
+++ b/server/apps/alerts/tests/test_init_alert_commands.py
@@ -1,0 +1,60 @@
+"""告警初始化命令：级别幂等写入、系统设置、内置聚合规则。"""
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+
+from apps.alerts.constants.init_data import DEFAULT_LEVEL, SYSTEM_SETTINGS
+from apps.alerts.models.alert_operator import AlarmStrategy
+from apps.alerts.models.alert_source import AlertSource
+from apps.alerts.models.models import Level
+from apps.alerts.models.sys_setting import SystemSetting
+
+pytestmark = pytest.mark.django_db
+
+
+def test_init_alert_levels_creates_then_is_idempotent():
+    Level.objects.all().delete()
+    out = StringIO()
+    call_command("init_alert_levels", stdout=out)
+    assert f"成功初始化 {len(DEFAULT_LEVEL)} 个告警级别" in out.getvalue()
+    assert Level.objects.filter(built_in=True).count() == len(DEFAULT_LEVEL)
+
+    out = StringIO()
+    call_command("init_alert_levels", stdout=out)
+    assert "成功初始化 0 个告警级别" in out.getvalue()
+    assert Level.objects.filter(built_in=True).count() == len(DEFAULT_LEVEL)
+
+
+def test_init_alert_levels_reraises_after_logging():
+    with (
+        patch("apps.alerts.models.models.Level.objects.get_or_create", side_effect=RuntimeError("db down")),
+        pytest.raises(RuntimeError, match="db down"),
+    ):
+        call_command("init_alert_levels")
+
+
+def test_init_system_settings_creates_and_runs_enrichment():
+    SystemSetting.objects.all().delete()
+    with patch("apps.alerts.constants.init_data.init_enrichment_rules") as enrich:
+        out = StringIO()
+        call_command("init_system_settings", stdout=out)
+    enrich.assert_called_once()
+    assert f"成功初始化 {len(SYSTEM_SETTINGS)} 个系统设置" in out.getvalue()
+    assert SystemSetting.objects.count() == len(SYSTEM_SETTINGS)
+
+
+def test_init_alert_rules_creates_when_empty_and_skips_when_present():
+    AlertSource.objects.filter(source_id="nats").delete()
+    AlarmStrategy.objects.all().delete()
+    AlertSource.objects.create(name="NATS", source_id="nats", source_type="nats", secret="x")
+    call_command("init_alert_rules")
+    strategy = AlarmStrategy.objects.get(name="内置检测规则")
+    assert strategy.strategy_type == "smart_denoise"
+    assert strategy.params["window_size"] == 2
+    assert strategy.auto_close is True
+    assert strategy.close_minutes == 120
+
+    call_command("init_alert_rules")
+    assert AlarmStrategy.objects.filter(name="内置检测规则").count() == 1

--- a/server/apps/alerts/tests/test_init_alert_sources_command.py
+++ b/server/apps/alerts/tests/test_init_alert_sources_command.py
@@ -1,0 +1,27 @@
+"""init_alert_sources：内置告警源新建与字段变更更新。"""
+import pytest
+from django.core.management import call_command
+
+from apps.alerts.constants.init_data import BUILTIN_ALERT_SOURCES
+from apps.alerts.models.alert_source import AlertSource
+
+pytestmark = pytest.mark.django_db
+
+
+def test_init_alert_sources_creates_then_updates_changed_fields():
+    builtin_ids = [src["source_id"] for src in BUILTIN_ALERT_SOURCES]
+    assert "restful" in builtin_ids
+
+    call_command("init_alert_sources")
+    created = {src.source_id: src for src in AlertSource.all_objects.filter(source_id__in=builtin_ids)}
+    assert set(created) == set(builtin_ids)
+    restful = created["restful"]
+    assert restful.name == "RESTful"
+    assert restful.is_active is True
+
+    restful.name = "RESTful-old"
+    restful.save(update_fields=["name"])
+    call_command("init_alert_sources")
+    restful.refresh_from_db()
+    assert restful.name == "RESTful"
+    assert AlertSource.all_objects.filter(source_id="restful").count() == 1

--- a/server/apps/alerts/tests/test_snmp_trap_bridge_command.py
+++ b/server/apps/alerts/tests/test_snmp_trap_bridge_command.py
@@ -1,0 +1,151 @@
+"""SNMP Trap bridge 管理命令：NATS 连接、JSON 解析与投递契约。
+
+对照 spec/prd/告警中心·集成：常驻订阅 vector subject，只处理合法 JSON SNMP 消息。
+"""
+
+import asyncio
+import json
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from nats.aio.errors import ErrNoServers, ErrTimeout
+
+from apps.alerts.management.commands import snmp_trap_bridge as cmd_mod
+
+
+def _make_command(config=None):
+    with patch.object(cmd_mod, "load_bridge_config", return_value=config or {"subject": "vector"}):
+        command = cmd_mod.Command()
+    command.stdout = StringIO()
+    command.style = SimpleNamespace(SUCCESS=lambda text: text)
+    command.nats = AsyncMock()
+    return command
+
+
+# --------------------------------------------------------------------------
+# add_arguments / handle
+# --------------------------------------------------------------------------
+
+
+def test_add_arguments_registers_reload_flag():
+    command = _make_command()
+    parser = MagicMock()
+    command.add_arguments(parser)
+    parser.add_argument.assert_called_once()
+    kwargs = parser.add_argument.call_args.kwargs
+    assert kwargs["dest"] == "reload"
+    assert kwargs["action"] == "store_true"
+
+
+def test_handle_without_reload_calls_inner_run():
+    command = _make_command()
+    with patch.object(command, "inner_run") as inner:
+        command.handle(reload=False)
+    inner.assert_called_once()
+    output = command.stdout.getvalue()
+    assert "Starting SNMP trap bridge" in output
+    assert "with reload enabled" not in output
+
+
+def test_handle_with_reload_uses_autoreload():
+    command = _make_command()
+    with patch.object(cmd_mod.autoreload, "run_with_reloader") as reloader:
+        command.handle(reload=True)
+    reloader.assert_called_once()
+    assert reloader.call_args.args[0] == command.inner_run
+    assert "with reload enabled" in command.stdout.getvalue()
+
+
+# --------------------------------------------------------------------------
+# inner_run：事件循环生命周期
+# --------------------------------------------------------------------------
+
+
+def test_inner_run_runs_forever_then_closes_loop():
+    command = _make_command()
+    fake_loop = MagicMock()
+    fake_loop.run_forever.side_effect = KeyboardInterrupt()
+    close_coro = object()
+    command.nats.close = MagicMock(return_value=close_coro)
+
+    with (
+        patch.object(cmd_mod.asyncio, "new_event_loop", return_value=fake_loop),
+        patch.object(cmd_mod.asyncio, "set_event_loop"),
+        patch.object(cmd_mod.asyncio, "ensure_future"),
+        patch.object(command, "bridge_coroutine", return_value=object()),
+    ):
+        command.inner_run()
+
+    fake_loop.run_forever.assert_called_once()
+    fake_loop.run_until_complete.assert_called_once_with(close_coro)
+    fake_loop.close.assert_called_once()
+
+
+def test_inner_run_closes_loop_without_interrupt():
+    command = _make_command()
+    fake_loop = MagicMock()
+    with (
+        patch.object(cmd_mod.asyncio, "new_event_loop", return_value=fake_loop),
+        patch.object(cmd_mod.asyncio, "set_event_loop"),
+        patch.object(cmd_mod.asyncio, "ensure_future"),
+        patch.object(command, "bridge_coroutine", return_value=object()),
+    ):
+        command.inner_run()
+    fake_loop.run_until_complete.assert_not_called()
+    fake_loop.close.assert_called_once()
+
+
+# --------------------------------------------------------------------------
+# bridge_coroutine：连接失败 / 订阅 / 回调契约
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("exc_cls", [ErrNoServers, ErrTimeout])
+def test_bridge_coroutine_connect_failure_reraises(exc_cls):
+    command = _make_command()
+
+    async def _run():
+        with patch.object(cmd_mod, "get_nc_client", AsyncMock(side_effect=exc_cls("nats down"))):
+            with pytest.raises(exc_cls):
+                await command.bridge_coroutine()
+
+    asyncio.run(_run())
+    command.nats.subscribe.assert_not_called()
+
+
+def test_bridge_callback_ignores_non_json_and_dispatches_valid():
+    """非 JSON 必须忽略；合法 payload 交给 handle_vector_message；处理失败不得打断订阅。"""
+    command = _make_command({"subject": "vector"})
+    captured = {}
+
+    async def fake_subscribe(subject, cb=None):
+        captured["subject"] = subject
+        captured["cb"] = cb
+
+    command.nats.subscribe = fake_subscribe
+
+    async def _run():
+        with patch.object(cmd_mod, "get_nc_client", AsyncMock()):
+            await command.bridge_coroutine()
+
+        assert captured["subject"] == "vector"
+        assert "** Listening on subject: vector" in command.stdout.getvalue()
+        callback = captured["cb"]
+
+        await callback(SimpleNamespace(data=b"not-json{", subject="vector"))
+
+        with patch.object(cmd_mod, "handle_vector_message", return_value=True) as handled:
+            payload = {"collect_type": "snmp_trap", "trap_message": "linkDown"}
+            await callback(SimpleNamespace(data=json.dumps(payload).encode(), subject="vector"))
+        handled.assert_called_once_with(payload, command.config)
+
+        with patch.object(cmd_mod, "handle_vector_message", return_value=False) as skipped:
+            await callback(SimpleNamespace(data=b'{"collect_type":"log"}', subject="vector"))
+        skipped.assert_called_once()
+
+        with patch.object(cmd_mod, "handle_vector_message", side_effect=RuntimeError("dispatch boom")):
+            await callback(SimpleNamespace(data=b'{"collect_type":"snmp_trap"}', subject="vector"))
+
+    asyncio.run(_run())

--- a/server/apps/cmdb/tests/test_collect_service_permission_and_node_params.py
+++ b/server/apps/cmdb/tests/test_collect_service_permission_and_node_params.py
@@ -1,0 +1,50 @@
+"""采集服务：权限守卫、组织规则删除、节点参数推送/删除。"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.cmdb.services.collect_service import CollectModelService
+from apps.core.exceptions.base_app_exception import BaseAppException
+
+pytestmark = pytest.mark.unit
+
+
+def test_has_permission_raises_when_view_denies():
+    request = SimpleNamespace(user=SimpleNamespace(username="u"), COOKIES={})
+    instance = SimpleNamespace(id=1)
+    view = MagicMock()
+    view.get_has_permission.return_value = False
+    with patch("apps.cmdb.services.collect_service.get_current_team_from_request", return_value=1):
+        with pytest.raises(BaseAppException, match="权限"):
+            CollectModelService.has_permission(request, instance, view)
+    view.get_has_permission.assert_called_once()
+
+    view.get_has_permission.return_value = True
+    with patch("apps.cmdb.services.collect_service.get_current_team_from_request", return_value=1):
+        CollectModelService.has_permission(request, instance, view)
+
+
+def test_delete_team_only_removes_dropped_orgs():
+    view = MagicMock()
+    CollectModelService.delete_team(9, [1, 2, 3], [1], view)
+    view.delete_rules.assert_called_once_with(9, [2, 3])
+
+
+def test_push_and_delete_node_params_call_node_mgmt():
+    instance = SimpleNamespace(id=5, is_k8s=False)
+    factory = MagicMock()
+    factory.get_node_params.return_value.main.return_value = [{"node_id": "n1"}]
+    node_mgmt = MagicMock()
+    node_mgmt.batch_add_node_child_config.return_value = {"ok": True}
+    node_mgmt.delete_child_configs.return_value = {"ok": True}
+    with (
+        patch("apps.cmdb.services.collect_service.NodeParamsFactory", factory),
+        patch("apps.cmdb.services.collect_service.NodeMgmt", return_value=node_mgmt),
+    ):
+        CollectModelService.push_butch_node_params(instance)
+        CollectModelService.delete_butch_node_params(instance)
+    factory.get_node_params.assert_called()
+    node_mgmt.batch_add_node_child_config.assert_called_once_with([{"node_id": "n1"}])
+    node_mgmt.delete_child_configs.assert_called_once()
+    factory.get_node_params.return_value.main.assert_any_call(operator="delete")

--- a/server/apps/cmdb/tests/test_collect_tool_system_task_isolation.py
+++ b/server/apps/cmdb/tests/test_collect_tool_system_task_isolation.py
@@ -3,12 +3,12 @@ import json
 import pytest
 from rest_framework.test import APIRequestFactory, force_authenticate
 
-from apps.cmdb.constants.constants import CollectPluginTypes, CollectRunStatusType, PERMISSION_TASK
+from apps.cmdb.constants.constants import PERMISSION_TASK, CollectPluginTypes, CollectRunStatusType
 from apps.cmdb.models.collect_model import CollectModels
-from apps.cmdb.nats.nats import _get_collect_task_queryset, get_cmdb_module_data
+from apps.cmdb.nats.nats import _get_collect_task_queryset, get_cmdb_collect_statistics, get_cmdb_module_data
 from apps.cmdb.services.collect_tool_service import MASKED_PASSWORD
-from apps.cmdb.views.config_file import ConfigFileVersionViewSet
 from apps.cmdb.views.collect_tool import CollectToolViewSet
+from apps.cmdb.views.config_file import ConfigFileVersionViewSet
 from apps.core.exceptions.base_app_exception import BaseAppException
 
 
@@ -66,9 +66,7 @@ def test_collect_tool_prefill_rejects_node_mgmt_system_task(superuser, system_ta
 
 
 @pytest.mark.django_db
-def test_collect_tool_masked_execute_cannot_restore_node_mgmt_system_task_credentials(
-    superuser, system_task, monkeypatch, mocker
-):
+def test_collect_tool_masked_execute_cannot_restore_node_mgmt_system_task_credentials(superuser, system_task, monkeypatch, mocker):
     monkeypatch.setattr(
         "apps.cmdb.permissions.inst_task_permission.InstanceTaskPermission.has_object_permission",
         lambda *args, **kwargs: True,
@@ -150,3 +148,58 @@ def test_collect_statistics_queryset_excludes_node_mgmt_system_tasks(system_task
     queryset = _get_collect_task_queryset({"team": 1})
 
     assert "is_system" in str(queryset.query.where)
+
+
+@pytest.mark.django_db
+def test_collect_statistics_counts_each_team_exactly():
+    team_a = 881001
+    team_b = 881002
+    CollectModels.objects.create(
+        name="team-a-success",
+        task_type=CollectPluginTypes.HOST,
+        model_id="host-a-success",
+        cycle_value_type="cycle",
+        team=[team_a],
+        is_interval=True,
+        exec_status=CollectRunStatusType.SUCCESS,
+    )
+    CollectModels.objects.create(
+        name="team-a-error",
+        task_type=CollectPluginTypes.HOST,
+        model_id="host-a-error",
+        cycle_value_type="cycle",
+        team=[team_a],
+        exec_status=CollectRunStatusType.ERROR,
+    )
+    CollectModels.objects.create(
+        name="team-b-success",
+        task_type=CollectPluginTypes.HOST,
+        model_id="host-b-success",
+        cycle_value_type="cycle",
+        team=[team_b],
+        exec_status=CollectRunStatusType.SUCCESS,
+    )
+
+    team_a_data = get_cmdb_collect_statistics(user_info={"team": team_a})["data"]
+    team_b_data = get_cmdb_collect_statistics(user_info={"team": team_b})["data"]
+
+    assert team_a_data == {
+        "task_count": 2,
+        "interval_task_count": 1,
+        "success_count": 1,
+        "error_count": 1,
+        "running_count": 0,
+        "timeout_count": 0,
+        "never_run_count": 0,
+        "partial_success_count": 0,
+    }
+    assert team_b_data == {
+        "task_count": 1,
+        "interval_task_count": 0,
+        "success_count": 1,
+        "error_count": 0,
+        "running_count": 0,
+        "timeout_count": 0,
+        "never_run_count": 0,
+        "partial_success_count": 0,
+    }

--- a/server/apps/cmdb/tests/test_custom_reporting_views.py
+++ b/server/apps/cmdb/tests/test_custom_reporting_views.py
@@ -1,0 +1,93 @@
+"""自定义上报 ViewSet：列表/写操作委托、缺 credential_id 400、Bearer 与裸 token 解析。"""
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.cmdb.views.custom_reporting import CustomReportingIngestViewSet, CustomReportingTaskViewSet
+
+pytestmark = pytest.mark.unit
+VIEWS = "apps.cmdb.views.custom_reporting"
+
+
+def _body(resp):
+    return json.loads(resp.content.decode("utf-8"))
+
+
+def _qp(**kwargs):
+    return SimpleNamespace(dict=lambda: dict(kwargs))
+
+
+def test_task_viewset_delegates_list_stats_crud_and_reviews():
+    ext = MagicMock()
+    ext.list_tasks.return_value = {"count": 0, "results": []}
+    ext.get_stats.return_value = {"tasks": 2}
+    ext.create_task.return_value = {"id": 11}
+    ext.get_task.return_value = {"id": 11, "name": "t"}
+    ext.update_task.return_value = {"id": 11, "name": "t2"}
+    ext.get_field_registrations.return_value = [{"field": "cpu"}]
+    ext.get_batch_activity.return_value = {"batches": []}
+    ext.get_onboarding_document.return_value = {"md": "# doc"}
+    ext.issue_credential.return_value = {"token": "cred"}
+    ext.rotate_credential.return_value = {"token": "rotated"}
+    ext.revoke_credential.return_value = {"ok": True}
+    ext.approve_cleanup_review.return_value = {"approved": True}
+    ext.reject_cleanup_review.return_value = {"rejected": True}
+
+    vs = CustomReportingTaskViewSet()
+    req = SimpleNamespace(query_params=_qp(q="x"), data={"name": "t", "team": [1], "config": {"a": 1}}, user=None)
+    with patch(f"{VIEWS}.get_custom_reporting_extension", return_value=ext):
+        assert _body(vs.list(req))["data"] == {"count": 0, "results": []}
+        ext.list_tasks.assert_called_once_with(req, {"q": "x"})
+        assert _body(vs.stats(req))["data"] == {"tasks": 2}
+        created = _body(vs.create(req))["data"]
+        assert created == {"id": 11}
+        ext.create_task.assert_called_once()
+        assert ext.create_task.call_args.args[1] == {"name": "t", "team": [1], "config": {"a": 1}, "is_enabled": True}
+        assert _body(vs.retrieve(req, pk=11))["data"]["name"] == "t"
+        upd = SimpleNamespace(data={"name": "t2"})
+        assert _body(vs.update(upd, pk=11))["data"]["name"] == "t2"
+        assert _body(vs.destroy(req, pk=11))["data"] == {}
+        ext.delete_task.assert_called_once_with(req, 11)
+        assert _body(vs.field_registrations(req, pk=11))["data"] == [{"field": "cpu"}]
+        assert _body(vs.batch_activity(req, pk=11))["data"] == {"batches": []}
+        assert _body(vs.onboarding_document(req, pk=11))["data"] == {"md": "# doc"}
+        cred_req = SimpleNamespace(data={"name": "bot"})
+        assert _body(vs.issue_credential(cred_req, pk=11))["data"]["token"] == "cred"
+        rot_req = SimpleNamespace(data={"credential_id": "c1"})
+        assert _body(vs.rotate_credential(rot_req, pk=11))["data"]["token"] == "rotated"
+        ext.rotate_credential.assert_called_once_with(rot_req, 11, "c1")
+        rev_req = SimpleNamespace(data={"credential_id": "c1"})
+        assert _body(vs.revoke_credential(rev_req, pk=11))["data"] == {"ok": True}
+        assert _body(vs.approve_review(req, pk=11, review_id="r1"))["data"] == {"approved": True}
+        assert _body(vs.reject_review(req, pk=11, review_id="r1"))["data"] == {"rejected": True}
+
+
+def test_rotate_and_revoke_require_credential_id():
+    vs = CustomReportingTaskViewSet()
+    req = SimpleNamespace(data={})
+    rot = vs.rotate_credential(req, pk=1)
+    assert rot.status_code == 400
+    assert _body(rot) == {"data": {}, "result": False, "message": "credential_id is required"}
+    rev = vs.revoke_credential(req, pk=1)
+    assert rev.status_code == 400
+    assert _body(rev)["message"] == "credential_id is required"
+
+
+def test_ingest_strips_bearer_prefix_or_uses_raw_authorization():
+    ext = MagicMock()
+    ext.ingest.return_value = {"accepted": 1}
+    vs = CustomReportingIngestViewSet()
+    with patch(f"{VIEWS}.get_custom_reporting_extension", return_value=ext):
+        bearer = SimpleNamespace(META={"HTTP_AUTHORIZATION": "Bearer secret-token"}, data={"rows": [1]})
+        assert _body(vs.create(bearer))["data"] == {"accepted": 1}
+        ext.ingest.assert_called_with(bearer, "secret-token", {"rows": [1]})
+
+        raw = SimpleNamespace(META={"HTTP_AUTHORIZATION": "plain-token"}, data={"rows": []})
+        vs.create(raw)
+        ext.ingest.assert_called_with(raw, "plain-token", {"rows": []})
+
+        empty = SimpleNamespace(META={}, data={})
+        vs.create(empty)
+        ext.ingest.assert_called_with(empty, None, {})

--- a/server/apps/cmdb/tests/test_init_display_fields_command.py
+++ b/server/apps/cmdb/tests/test_init_display_fields_command.py
@@ -1,0 +1,45 @@
+"""init_display_fields：dry-run 提示；成功/失败结果输出。"""
+from unittest.mock import MagicMock
+
+import pytest
+from django.core.management import call_command
+
+pytestmark = pytest.mark.django_db
+
+
+def test_init_display_fields_dry_run_success(monkeypatch, capsys):
+    init = MagicMock()
+    init.initialize_all.return_value = {
+        "success": True,
+        "models_processed": 2,
+        "instances_processed": 5,
+        "errors": [],
+    }
+    monkeypatch.setattr(
+        "apps.cmdb.management.commands.init_display_fields.DisplayFieldInitializer",
+        lambda: init,
+    )
+    call_command("init_display_fields", dry_run=True)
+    out = capsys.readouterr().out
+    assert "试运行" in out
+    assert "初始化完成" in out
+    assert "模型数: 2" in out
+    init.initialize_all.assert_called_once()
+
+
+def test_init_display_fields_prints_errors(monkeypatch, capsys):
+    init = MagicMock()
+    init.initialize_all.return_value = {
+        "success": False,
+        "models_processed": 1,
+        "instances_processed": 0,
+        "errors": ["graph down"],
+    }
+    monkeypatch.setattr(
+        "apps.cmdb.management.commands.init_display_fields.DisplayFieldInitializer",
+        lambda: init,
+    )
+    call_command("init_display_fields")
+    out = capsys.readouterr().out
+    assert "初始化失败" in out
+    assert "graph down" in out

--- a/server/apps/cmdb/tests/test_model_attr_graph_ops.py
+++ b/server/apps/cmdb/tests/test_model_attr_graph_ops.py
@@ -1,0 +1,207 @@
+"""ModelManage 属性创建/更新/查询：GraphClient 边界 mock，钉死校验与回写。"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.cmdb.services.model import ModelManage
+from apps.core.exceptions.base_app_exception import BaseAppException
+
+pytestmark = pytest.mark.unit
+
+
+class _Graph:
+    def __init__(self, models=None, attrs="[]"):
+        self.models = models if models is not None else [{"_id": 11, "model_id": "host", "model_name": "主机", "attrs": attrs}]
+        self.last_attrs = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def query_entity(self, *a, **k):
+        return self.models, len(self.models)
+
+    def set_entity_properties(self, *args, **kwargs):
+        payload = args[2] if len(args) > 2 else kwargs.get("data") or {}
+        self.last_attrs = payload.get("attrs")
+        return [{"attrs": self.last_attrs or "[]"}]
+
+    def batch_delete_entity(self, *a, **k):
+        return None
+
+
+def test_create_model_attr_missing_model_and_duplicate():
+    with patch("apps.cmdb.services.model.GraphClient", return_value=_Graph(models=[])):
+        with pytest.raises(BaseAppException, match="model not present"):
+            ModelManage.create_model_attr("host", {"attr_id": "cpu", "attr_type": "str", "attr_name": "CPU"})
+
+    existing = '[{"attr_id":"cpu","attr_type":"str"}]'
+    with patch("apps.cmdb.services.model.GraphClient", return_value=_Graph(attrs=existing)):
+        with pytest.raises(BaseAppException, match="model attr repetition"):
+            ModelManage.create_model_attr("host", {"attr_id": "cpu", "attr_type": "str", "attr_name": "CPU"})
+
+
+def test_create_model_attr_writes_attr_and_change_record(monkeypatch):
+    graph = _Graph()
+    records = []
+    monkeypatch.setattr(
+        "apps.cmdb.services.model.create_change_record",
+        lambda **kw: records.append(kw),
+    )
+    monkeypatch.setattr(
+        "apps.cmdb.display_field.ExcludeFieldsCache.update_on_model_change",
+        lambda model_id: None,
+    )
+    with patch("apps.cmdb.services.model.GraphClient", return_value=graph):
+        attr = ModelManage.create_model_attr(
+            "host",
+            {
+                "attr_id": "cpu",
+                "attr_type": "str",
+                "attr_name": "CPU",
+                "attr_group": "default",
+                "is_required": False,
+                "editable": True,
+                "option": [],
+                "user_prompt": "",
+            },
+            username="alice",
+        )
+    assert attr["attr_id"] == "cpu"
+    assert '"cpu"' in (graph.last_attrs or "")
+    assert records[0]["operator"] == "alice"
+    assert records[0]["_type"]
+    assert "创建模型属性" in records[0]["message"]
+
+
+def test_create_model_attr_tag_and_enum_public_library(monkeypatch):
+    graph = _Graph()
+    monkeypatch.setattr("apps.cmdb.services.model.create_change_record", lambda **kw: None)
+    monkeypatch.setattr(
+        "apps.cmdb.display_field.ExcludeFieldsCache.update_on_model_change",
+        lambda model_id: None,
+    )
+    monkeypatch.setattr(
+        "apps.cmdb.services.public_enum_library.get_library_or_raise",
+        lambda lid: type("Lib", (), {"options": [{"id": "on", "name": "开"}]})(),
+    )
+    with patch("apps.cmdb.services.model.GraphClient", return_value=graph):
+        tag = ModelManage.create_model_attr(
+            "host",
+            {"attr_id": "tag", "attr_type": "tag", "attr_name": "标签", "attr_group": "g", "option": {}},
+        )
+    assert tag["attr_id"] == "tag"
+    assert tag["editable"] is True
+
+    graph2 = _Graph()
+    with patch("apps.cmdb.services.model.GraphClient", return_value=graph2):
+        enum_attr = ModelManage.create_model_attr(
+            "host",
+            {
+                "attr_id": "status",
+                "attr_type": "enum",
+                "attr_name": "状态",
+                "attr_group": "g",
+                "option": {
+                    "enum_rule_type": "public_library",
+                    "public_library_id": 3,
+                    "option": [],
+                },
+            },
+        )
+    assert enum_attr["option"] == [{"id": "on", "name": "开"}]
+    assert enum_attr["enum_rule_type"] == "public_library"
+
+
+def test_update_model_attr_missing_and_protected():
+    with pytest.raises(BaseAppException):
+        ModelManage.update_model_attr("host", {"attr_id": "organization", "attr_type": "str"})
+    with patch("apps.cmdb.services.model.GraphClient", return_value=_Graph(models=[])):
+        with pytest.raises(BaseAppException, match="model not present"):
+            ModelManage.update_model_attr("host", {"attr_id": "cpu", "attr_type": "str"})
+    with patch("apps.cmdb.services.model.GraphClient", return_value=_Graph(attrs="[]")):
+        with pytest.raises(BaseAppException, match="model attr not present"):
+            ModelManage.update_model_attr("host", {"attr_id": "cpu", "attr_type": "str"})
+
+
+def test_update_model_attr_writes_fields(monkeypatch):
+    attrs = (
+        '[{"attr_id":"cpu","attr_type":"str","attr_group":"old","attr_name":"旧",' '"is_required":false,"editable":true,"option":[],"user_prompt":""}]'
+    )
+    graph = _Graph(attrs=attrs)
+    monkeypatch.setattr("apps.cmdb.services.model.create_change_record", lambda **kw: None)
+    monkeypatch.setattr(
+        "apps.cmdb.display_field.ExcludeFieldsCache.update_on_model_change",
+        lambda model_id: None,
+    )
+    with patch("apps.cmdb.services.model.GraphClient", return_value=graph):
+        out = ModelManage.update_model_attr(
+            "host",
+            {
+                "attr_id": "cpu",
+                "attr_type": "str",
+                "attr_group": "new",
+                "attr_name": "CPU核数",
+                "is_required": True,
+                "editable": False,
+                "option": [],
+                "user_prompt": "hint",
+            },
+        )
+    assert out["attr_name"] == "CPU核数"
+    assert out["attr_group"] == "new"
+    assert out["is_required"] is True
+
+
+def test_search_model_filters_hidden_and_permissions(monkeypatch):
+    models = [
+        {"model_id": "host", "model_name": "Host", "is_visible": True, "order_id": 1},
+        {"model_id": "hidden", "model_name": "Hidden", "is_visible": False},
+        {"model_id": "bare", "model_name": "Bare"},
+    ]
+
+    class _SearchGraph(_Graph):
+        def query_entity(self, **query):
+            perm = query["format_permission_dict"]
+            org_key = next(iter(perm))
+            assert perm[org_key][0]["field"] == "classification_id"
+            assert perm[org_key][1]["value"] == ["host"]
+            return models, 3
+
+    monkeypatch.setattr(
+        "apps.cmdb.services.model.SettingLanguage",
+        lambda language: type("L", (), {"get_val": staticmethod(lambda *a, **k: None)})(),
+    )
+    with patch("apps.cmdb.services.model.GraphClient", return_value=_SearchGraph()):
+        visible = ModelManage.search_model(
+            language="zh-CN",
+            classification_ids=["host_class"],
+            permissions_map={"1": {"inst_names": ["host"]}},
+            creator="alice",
+        )
+    ids = {m["model_id"] for m in visible}
+    assert "hidden" not in ids
+    assert "host" in ids
+    assert "bare" in ids
+    bare = next(m for m in visible if m["model_id"] == "bare")
+    assert bare["is_visible"] is True
+    assert bare["order_id"] == 0
+
+    with patch("apps.cmdb.services.model.GraphClient", return_value=_SearchGraph()):
+        all_models = ModelManage.search_model(
+            include_hidden=True,
+            classification_ids=["host_class"],
+            permissions_map={"1": {"inst_names": ["host"]}},
+            creator="alice",
+        )
+    assert {m["model_id"] for m in all_models} == {"host", "hidden", "bare"}
+
+
+def test_delete_model_calls_batch_delete():
+    graph = _Graph()
+    graph.batch_delete_entity = MagicMock()
+    with patch("apps.cmdb.services.model.GraphClient", return_value=graph):
+        ModelManage.delete_model(99)
+    graph.batch_delete_entity.assert_called_once_with("model", [99])

--- a/server/apps/cmdb/tests/test_model_views_save_layout.py
+++ b/server/apps/cmdb/tests/test_model_views_save_layout.py
@@ -1,0 +1,78 @@
+"""ModelViewSet.save_layout：超管鉴权、入参校验、模型写失败回滚分类布局。"""
+import json
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.cmdb.views.model import ModelViewSet
+
+VIEWS = "apps.cmdb.views.model"
+
+
+@pytest.fixture
+def superuser(authenticated_user):
+    u = authenticated_user
+    u.is_superuser = True
+    u.group_list = [{"id": 1}]
+    return u
+
+
+def _req(user, data=None):
+    factory = APIRequestFactory()
+    request = factory.post("/x/", data=data or {}, format="json")
+    request.COOKIES["current_team"] = "1"
+    force_authenticate(request, user=user)
+    return request
+
+
+def _body(response):
+    if hasattr(response, "render"):
+        response.render()
+        return json.loads(response.rendered_content)
+    return json.loads(response.content)
+
+
+@pytest.mark.django_db
+def test_save_layout_ok(superuser, monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        f"{VIEWS}.ClassificationManage.snapshot_classification_layout",
+        lambda ids: calls.append(("snapshot", ids)) or [{"classification_id": "biz"}],
+    )
+    monkeypatch.setattr(
+        f"{VIEWS}.ClassificationManage.update_classification_layout",
+        lambda items: calls.append(("update_cls", items)),
+    )
+    monkeypatch.setattr(
+        f"{VIEWS}.ModelManage.update_model_orders",
+        lambda items: calls.append(("update_models", items)),
+    )
+    payload = {"classifications": [{"classification_id": "biz"}], "models": [{"model_id": "host"}]}
+    response = ModelViewSet.as_view({"post": "save_layout"})(_req(superuser, payload))
+    assert response.status_code == status.HTTP_200_OK
+    assert ("snapshot", ["biz"]) in calls
+    assert ("update_models", payload["models"]) in calls
+
+
+@pytest.mark.django_db
+def test_save_layout_reverts_classification_when_model_write_fails(superuser, monkeypatch):
+    reverted = []
+    monkeypatch.setattr(
+        f"{VIEWS}.ClassificationManage.snapshot_classification_layout",
+        lambda ids: [{"classification_id": "biz", "order": 1}],
+    )
+    monkeypatch.setattr(
+        f"{VIEWS}.ClassificationManage.update_classification_layout",
+        lambda items: reverted.append(items),
+    )
+
+    def boom(items):
+        raise RuntimeError("graph write failed")
+
+    monkeypatch.setattr(f"{VIEWS}.ModelManage.update_model_orders", boom)
+    with pytest.raises(RuntimeError, match="graph write failed"):
+        ModelViewSet.as_view({"post": "save_layout"})(
+            _req(superuser, {"classifications": [{"classification_id": "biz"}], "models": [{"model_id": "host"}]})
+        )
+    assert reverted == [[{"classification_id": "biz"}], [{"classification_id": "biz", "order": 1}]]

--- a/server/apps/log/tests/test_get_log_module_data_type_guard_3655.py
+++ b/server/apps/log/tests/test_get_log_module_data_type_guard_3655.py
@@ -11,79 +11,56 @@ Issue #3655: get_log_module_data 参数无类型校验导致 NATS worker 崩溃
 import importlib.util
 import sys
 import types
-from types import SimpleNamespace
-
-_MISSING = object()
-
 
 # ---------------------------------------------------------------------------
 # 注入伪依赖（nats_client + apps.log.models.*）
 # ---------------------------------------------------------------------------
 
-def _install(name, **attrs):
-    """往 sys.modules 注入一个伪模块（支持属性设置）。"""
+
+def _install(monkeypatch, name, **attrs):
+    """往 sys.modules 注入一个伪模块，并在用例结束后自动恢复。"""
     mod = types.ModuleType(name)
     for k, v in attrs.items():
         setattr(mod, k, v)
-    sys.modules[name] = mod
+    monkeypatch.setitem(sys.modules, name, mod)
     return mod
 
 
-def _load_permission_module():
+def _load_permission_module(monkeypatch):
     """
     每次调用都重新加载 nats/permission.py，避免测试间模块缓存相互污染。
     返回加载后的模块对象。
     """
     import os
 
-    injected_modules = (
-        "nats_client",
-        "apps",
-        "apps.log",
-        "apps.log.models",
-        "apps.log.models.policy",
+    def _register(fn):
+        return fn
+
+    _install(monkeypatch, "nats_client", register=_register)
+    _install(monkeypatch, "apps")
+    _install(monkeypatch, "apps.log")
+    _install(monkeypatch, "apps.log.models")
+    _install(monkeypatch, "apps.log.models.policy", Policy=object)
+
+    for sym in ("LogGroup", "CollectType", "CollectInstance"):
+        setattr(sys.modules["apps.log.models"], sym, object)
+
+    permission_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "nats",
+        "permission.py",
     )
-    original_modules = {name: sys.modules.get(name, _MISSING) for name in injected_modules}
-
-    try:
-        # ── nats_client ──────────────────────────────────────────────────────
-        def _register(fn):
-            return fn
-
-        _install("nats_client", register=_register)
-
-        # ── apps.log.models（顶层包 + 子模块）─────────────────────────────────
-        _install("apps")
-        _install("apps.log")
-        _install("apps.log.models")
-        _install("apps.log.models.policy", Policy=object)
-
-        # LogGroup / CollectType / CollectInstance 用于 from ... import 语句
-        for sym in ("LogGroup", "CollectType", "CollectInstance"):
-            setattr(sys.modules["apps.log.models"], sym, object)
-
-        # ── 加载被测文件 ───────────────────────────────────────────────────────
-        permission_path = os.path.join(
-            os.path.dirname(__file__),
-            "..", "nats", "permission.py",
-        )
-        spec = importlib.util.spec_from_file_location(
-            "apps.log.nats.permission", permission_path
-        )
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        return mod
-    finally:
-        for name, original in original_modules.items():
-            if original is _MISSING:
-                sys.modules.pop(name, None)
-            else:
-                sys.modules[name] = original
+    spec = importlib.util.spec_from_file_location("apps.log.nats.permission", permission_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
 
 
 # ---------------------------------------------------------------------------
 # 辅助：构造能被正常执行的伪 queryset
 # ---------------------------------------------------------------------------
+
 
 class _FakeQS:
     """模拟 Django QuerySet 的最小接口。"""
@@ -107,12 +84,12 @@ class _FakeQS:
         return self._items[sl]
 
 
-def _make_handler_with_queryset(qs: _FakeQS):
+def _make_handler_with_queryset(monkeypatch, qs: _FakeQS):
     """
     返回一个已注入 ORM 的 get_log_module_data 函数。
     通过 monkeypatch LogGroup.objects / Policy.objects / CollectInstance.objects。
     """
-    mod = _load_permission_module()
+    mod = _load_permission_module(monkeypatch)
 
     # patch model managers
     class _Manager:
@@ -134,68 +111,69 @@ def _make_handler_with_queryset(qs: _FakeQS):
 # 测试用例
 # ---------------------------------------------------------------------------
 
+
 class TestGetLogModuleDataTypeGuard:
     """修复验证：参数类型错误时返回错误响应，而非崩溃。"""
 
-    def test_string_page_returns_error_not_typeerror(self):
+    def test_string_page_returns_error_not_typeerror(self, monkeypatch):
         """page='2'（字符串）在修复前触发 TypeError。修复后返回 result=False 的错误响应。"""
-        handler = _make_handler_with_queryset(_FakeQS())
+        handler = _make_handler_with_queryset(monkeypatch, _FakeQS())
         result = handler("log_group", None, "not-a-number", 10, 1)
-        assert result.get("result") is False
-        assert "参数类型错误" in result.get("message", "")
+        assert result["result"] is False
+        assert result["data"] == []
+        assert result["message"].startswith("参数类型错误:")
 
-    def test_string_page_size_returns_error_not_typeerror(self):
+    def test_string_page_size_returns_error_not_typeerror(self, monkeypatch):
         """page_size='abc'（字符串）在修复前触发 TypeError。修复后返回错误响应。"""
-        handler = _make_handler_with_queryset(_FakeQS())
+        handler = _make_handler_with_queryset(monkeypatch, _FakeQS())
         result = handler("log_group", None, 1, "abc", 1)
-        assert result.get("result") is False
-        assert "参数类型错误" in result.get("message", "")
+        assert result["result"] is False
+        assert result["data"] == []
+        assert result["message"].startswith("参数类型错误:")
 
-    def test_string_group_id_returns_error_not_orm_crash(self):
+    def test_string_group_id_returns_error_not_orm_crash(self, monkeypatch):
         """group_id='xyz'（字符串）在修复前导致 ORM TypeError。修复后返回错误响应。"""
-        handler = _make_handler_with_queryset(_FakeQS())
+        handler = _make_handler_with_queryset(monkeypatch, _FakeQS())
         result = handler("log_group", None, 1, 10, "xyz")
-        assert result.get("result") is False
-        assert "参数类型错误" in result.get("message", "")
+        assert result["result"] is False
+        assert result["data"] == []
+        assert result["message"].startswith("参数类型错误:")
 
-    def test_negative_page_size_clamped_to_one(self):
-        """page_size=-1 在修复前导致负数切片，返回静默错误数据。修复后 clamp 为 1。"""
+    def test_negative_page_size_clamped_to_one(self, monkeypatch):
+        """page_size=-1 在修复前导致负数切片，修复后 clamp 为 1。"""
         qs = _FakeQS([{"id": i, "name": str(i)} for i in range(1, 6)])
-        handler = _make_handler_with_queryset(qs)
+        handler = _make_handler_with_queryset(monkeypatch, qs)
         result = handler("log_group", None, 1, -1, 1)
-        # 修复后正常返回，page_size 被 clamp 为 1，start=0 end=1
-        assert "result" not in result or result.get("result") is not False
-        assert result.get("count") == 5
-        # 取第一条（切片 [0:1]），不应该从末尾反向取
-        assert result["items"] == [{"id": 1, "name": "1"}]
+        assert result == {"count": 5, "items": [{"id": 1, "name": "1"}]}
 
-    def test_zero_page_size_clamped_to_one(self):
-        """page_size=0 在修复前导致 ZeroDivisionError 或空结果，修复后 clamp 为 1。"""
+    def test_zero_page_size_clamped_to_one(self, monkeypatch):
+        """page_size=0 在修复前导致空结果，修复后 clamp 为 1。"""
         qs = _FakeQS([{"id": 1, "name": "a"}])
-        handler = _make_handler_with_queryset(qs)
+        handler = _make_handler_with_queryset(monkeypatch, qs)
         result = handler("log_group", None, 1, 0, 1)
-        assert "result" not in result or result.get("result") is not False
-        assert result.get("count") == 1
+        assert result == {"count": 1, "items": [{"id": 1, "name": "a"}]}
 
-    def test_page_size_exceeds_max_clamped(self):
+    def test_page_size_exceeds_max_clamped(self, monkeypatch):
         """page_size 超过 _PAGE_SIZE_MAX 时被 clamp 到上限，不崩溃。"""
         qs = _FakeQS([{"id": i, "name": str(i)} for i in range(1, 3)])
-        handler = _make_handler_with_queryset(qs)
+        handler = _make_handler_with_queryset(monkeypatch, qs)
         result = handler("log_group", None, 1, 99999, 1)
-        assert "result" not in result or result.get("result") is not False
-        assert result.get("count") == 2
+        assert result == {
+            "count": 2,
+            "items": [{"id": 1, "name": "1"}, {"id": 2, "name": "2"}],
+        }
 
-    def test_numeric_strings_are_accepted(self):
-        """'1'、'10'、'42' 这类数字字符串（NATS 反序列化常见）应被正常转换为 int。"""
-        qs = _FakeQS([{"id": i, "name": str(i)} for i in range(1, 11)])
-        handler = _make_handler_with_queryset(qs)
+    def test_numeric_strings_are_accepted(self, monkeypatch):
+        """'1'、'5'、'42' 这类 NATS 反序列化数字字符串应被正常转换。"""
+        items = [{"id": i, "name": str(i)} for i in range(1, 11)]
+        handler = _make_handler_with_queryset(monkeypatch, _FakeQS(items))
         result = handler("policy", "ctype-1", "1", "5", "42")
-        assert result.get("count") == 10
-        assert len(result.get("items", [])) == 5
+        assert result == {"count": 10, "items": items[:5]}
 
-    def test_none_page_returns_error(self):
+    def test_none_page_returns_error(self, monkeypatch):
         """page=None 时返回错误响应，不崩溃。"""
-        handler = _make_handler_with_queryset(_FakeQS())
+        handler = _make_handler_with_queryset(monkeypatch, _FakeQS())
         result = handler("log_group", None, None, 10, 1)
-        assert result.get("result") is False
-        assert "参数类型错误" in result.get("message", "")
+        assert result["result"] is False
+        assert result["data"] == []
+        assert result["message"].startswith("参数类型错误:")

--- a/server/apps/log/tests/test_search_service_remaining.py
+++ b/server/apps/log/tests/test_search_service_remaining.py
@@ -1,0 +1,55 @@
+"""SearchService 剩余查询编排：hits 无分组、top_stats 空总数、tail 响应头。"""
+from unittest.mock import MagicMock
+
+from django.http import StreamingHttpResponse
+
+from apps.log.services.search import SearchService
+
+
+def test_search_hits_without_group_info_returns_raw(mocker):
+    mocker.patch(
+        "apps.log.services.search.LogGroupQueryBuilder.build_query_with_groups",
+        return_value=("FQ", []),
+    )
+    vm = mocker.patch("apps.log.services.search.VictoriaMetricsAPI").return_value
+    vm.hits.return_value = {"hits": [{"count": 1}]}
+    out = SearchService.search_hits("q", "s", "e", "host")
+    assert out == {"hits": [{"count": 1}]}
+    assert "_log_group_info" not in out
+
+
+def test_search_logs_applies_default_window(mocker):
+    mocker.patch(
+        "apps.log.services.search.LogGroupQueryBuilder.build_query_with_groups",
+        return_value=("FQ", []),
+    )
+    vm = mocker.patch("apps.log.services.search.VictoriaMetricsAPI").return_value
+    vm.query.return_value = {"data": []}
+    SearchService.search_logs("", "", "", limit=4)
+    start, end = vm.query.call_args.args[1], vm.query.call_args.args[2]
+    assert start.endswith("Z") and end.endswith("Z")
+    assert start < end
+
+
+def test_top_stats_empty_total_response(mocker):
+    mocker.patch(
+        "apps.log.services.search.LogGroupQueryBuilder.build_query_with_groups",
+        return_value=("FQ", []),
+    )
+    vm = mocker.patch("apps.log.services.search.VictoriaMetricsAPI").return_value
+    vm.query.side_effect = [None, []]
+    out = SearchService.top_stats("q", "s", "e", "host")
+    assert out == {"attr": "host", "top_num": 5, "total": 0, "items": []}
+
+
+def test_tail_sets_sse_headers(mocker):
+    mocker.patch(
+        "apps.log.services.search.LogGroupQueryBuilder.build_query_with_groups",
+        return_value=("error", []),
+    )
+    mocker.patch("apps.log.services.search.VictoriaMetricsAPI", return_value=MagicMock())
+    response = SearchService.tail("error")
+    assert isinstance(response, StreamingHttpResponse)
+    assert response["Content-Type"] == "text/event-stream"
+    assert response["Cache-Control"] == "no-cache, no-store, must-revalidate"
+    assert response["X-Accel-Buffering"] == "no"

--- a/server/apps/mlops/tests/test_algo_config_per_view.py
+++ b/server/apps/mlops/tests/test_algo_config_per_view.py
@@ -1,0 +1,165 @@
+"""六套算法视图内嵌 AlgorithmConfigViewSet：列表序列化、禁用/删除护栏、by_type 与 get_image。"""
+import importlib
+
+import pydantic.root_model  # noqa
+import pytest
+from rest_framework import status
+from rest_framework.test import APIRequestFactory
+
+from apps.base.tests.factories import UserFactory
+from apps.mlops.models import AlgorithmConfig
+from apps.mlops.tests.test_views_actions_param import ALGO_IDS, ALGOS, _call, _make_train_job
+
+pytestmark = [pytest.mark.django_db, pytest.mark.integration]
+
+factory = APIRequestFactory()
+
+
+@pytest.fixture
+def superuser():
+    return UserFactory(username="algo-per-view-su", domain="domain.com", roles=[], is_superuser=True)
+
+
+def _view_module(suffix):
+    return importlib.import_module(f"apps.mlops.views.{suffix}")
+
+
+def _mk(algorithm_type, name, *, is_active=True, image="repo/algo:1", form_config=None):
+    return AlgorithmConfig.objects.create(
+        algorithm_type=algorithm_type,
+        name=name,
+        display_name=name,
+        image=image,
+        is_active=is_active,
+        form_config=form_config or {"k": 1},
+    )
+
+
+@pytest.mark.parametrize("suffix,prefix,model_module,basename", ALGOS, ids=ALGO_IDS)
+def test_algo_config_list_omits_form_config_unless_requested(superuser, suffix, prefix, model_module, basename):
+    _mk(suffix, f"List-{suffix}")
+    mod = _view_module(suffix)
+    vs = getattr(mod, f"{basename}AlgorithmConfigViewSet")
+    view = vs.as_view({"get": "list"})
+    resp = _call(view, factory.get(f"/{suffix}_algo_configs/"), superuser)
+    assert resp.status_code == status.HTTP_200_OK
+    items = resp.data["items"] if isinstance(resp.data, dict) and "items" in resp.data else resp.data
+    assert items
+    assert "form_config" not in items[0]
+
+    resp_full = _call(
+        view,
+        factory.get(f"/{suffix}_algo_configs/?include_form_config=true"),
+        superuser,
+    )
+    items_full = resp_full.data["items"] if isinstance(resp_full.data, dict) and "items" in resp_full.data else resp_full.data
+    assert "form_config" in items_full[0]
+
+
+@pytest.mark.parametrize("suffix,prefix,model_module,basename", ALGOS, ids=ALGO_IDS)
+def test_algo_config_create_forces_algorithm_type(superuser, suffix, prefix, model_module, basename):
+    mod = _view_module(suffix)
+    vs = getattr(mod, f"{basename}AlgorithmConfigViewSet")
+    view = vs.as_view({"post": "create"})
+    payload = {
+        "algorithm_type": "classification",
+        "name": f"Forced-{suffix}",
+        "display_name": "Forced",
+        "image": "repo/forced:1",
+        "form_config": {},
+    }
+    resp = _call(view, factory.post(f"/{suffix}_algo_configs/", payload, format="json"), superuser)
+    assert resp.status_code == status.HTTP_201_CREATED
+    cfg = AlgorithmConfig.objects.get(name=f"Forced-{suffix}")
+    assert cfg.algorithm_type == suffix
+
+
+@pytest.mark.parametrize("suffix,prefix,model_module,basename", ALGOS, ids=ALGO_IDS)
+def test_algo_config_disable_and_destroy_blocked_when_jobs_exist(superuser, suffix, prefix, model_module, basename):
+    cfg = _mk(suffix, f"InUse-{suffix}", is_active=True)
+    _make_train_job(model_module, basename)
+    job_model = importlib.import_module(f"apps.mlops.models.{model_module}")
+    TrainJob = getattr(job_model, f"{basename}TrainJob")
+    TrainJob.objects.filter(name="job").update(algorithm=cfg.name)
+
+    mod = _view_module(suffix)
+    vs = getattr(mod, f"{basename}AlgorithmConfigViewSet")
+    disable = _call(
+        vs.as_view({"patch": "partial_update"}),
+        factory.patch(f"/{suffix}_algo_configs/x/", {"is_active": False}, format="json"),
+        superuser,
+        pk=cfg.id,
+    )
+    assert disable.status_code == status.HTTP_400_BAD_REQUEST
+    assert disable.data["task_count"] == 1
+    cfg.refresh_from_db()
+    assert cfg.is_active is True
+
+    destroy = _call(
+        vs.as_view({"delete": "destroy"}),
+        factory.delete(f"/{suffix}_algo_configs/x/"),
+        superuser,
+        pk=cfg.id,
+    )
+    assert destroy.status_code == status.HTTP_400_BAD_REQUEST
+    assert AlgorithmConfig.objects.filter(id=cfg.id).exists()
+
+
+@pytest.mark.parametrize("suffix,prefix,model_module,basename", ALGOS, ids=ALGO_IDS)
+def test_algo_config_disable_destroy_and_get_image_when_unused(superuser, suffix, prefix, model_module, basename):
+    cfg = _mk(suffix, f"Free-{suffix}", is_active=True, image="repo/free:9")
+    _mk(suffix, f"Inactive-{suffix}", is_active=False, image="repo/off:1")
+    mod = _view_module(suffix)
+    vs = getattr(mod, f"{basename}AlgorithmConfigViewSet")
+
+    disable = _call(
+        vs.as_view({"patch": "partial_update"}),
+        factory.patch(f"/{suffix}_algo_configs/x/", {"is_active": False}, format="json"),
+        superuser,
+        pk=cfg.id,
+    )
+    assert disable.status_code == status.HTTP_200_OK
+    cfg.refresh_from_db()
+    assert cfg.is_active is False
+
+    cfg.is_active = True
+    cfg.save(update_fields=["is_active"])
+
+    by_type = _call(vs.as_view({"get": "by_type"}), factory.get(f"/{suffix}_algo_configs/by_type/"), superuser)
+    assert by_type.status_code == status.HTTP_200_OK
+    names = {item["name"] for item in by_type.data}
+    assert f"Free-{suffix}" in names
+    assert f"Inactive-{suffix}" not in names
+
+    missing_name = _call(
+        vs.as_view({"get": "get_image"}),
+        factory.get(f"/{suffix}_algo_configs/get_image/"),
+        superuser,
+    )
+    assert missing_name.status_code == 400
+    assert missing_name.data["error"] == "name is required"
+
+    not_found = _call(
+        vs.as_view({"get": "get_image"}),
+        factory.get(f"/{suffix}_algo_configs/get_image/?name=no-such"),
+        superuser,
+    )
+    assert not_found.status_code == 404
+    assert f"{suffix}/no-such" in not_found.data["error"]
+
+    ok = _call(
+        vs.as_view({"get": "get_image"}),
+        factory.get(f"/{suffix}_algo_configs/get_image/?name=Free-{suffix}"),
+        superuser,
+    )
+    assert ok.status_code == status.HTTP_200_OK
+    assert ok.data["image"] == "repo/free:9"
+
+    destroy = _call(
+        vs.as_view({"delete": "destroy"}),
+        factory.delete(f"/{suffix}_algo_configs/x/"),
+        superuser,
+        pk=cfg.id,
+    )
+    assert destroy.status_code in (status.HTTP_200_OK, status.HTTP_204_NO_CONTENT)
+    assert not AlgorithmConfig.objects.filter(id=cfg.id).exists()

--- a/server/apps/mlops/tests/test_train_remaining_branches.py
+++ b/server/apps/mlops/tests/test_train_remaining_branches.py
@@ -1,0 +1,137 @@
+"""六套算法 TrainJob.train 剩余分支：MLflow 计数降级、抢占冲突、stop 忽略、连接失败回滚、数据集范围。"""
+import types
+from unittest.mock import Mock
+
+import pandas as pd
+import pydantic.root_model  # noqa
+import pytest
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.test import APIRequestFactory
+
+from apps.base.tests.factories import UserFactory
+from apps.mlops.constants import DatasetReleaseStatus, TrainJobStatus
+from apps.mlops.tests.test_views_actions_param import ALGO_IDS, ALGOS, _call, _model, _patch_mlflow, _view_module
+from apps.mlops.utils.webhook_client import WebhookError
+
+pytestmark = [pytest.mark.django_db, pytest.mark.integration]
+factory = APIRequestFactory()
+
+
+@pytest.fixture
+def superuser():
+    return UserFactory(username="mlops-train-su", domain="domain.com", roles=[], is_superuser=True)
+
+
+def _ready_job(model_module, basename):
+    TrainJob = _model(model_module, basename, "TrainJob")
+    Dataset = _model(model_module, basename, "Dataset")
+    Release = _model(model_module, basename, "DatasetRelease")
+    ds = Dataset.objects.create(name="ds-ready", description="", team=[1])
+    dv = Release.objects.create(
+        name="r",
+        description="",
+        dataset=ds,
+        version="v1",
+        dataset_file="path/data.zip",
+        status=DatasetReleaseStatus.PUBLISHED,
+        metadata={},
+        file_size=10,
+    )
+    tj = TrainJob.objects.create(
+        name="job-ready",
+        description="",
+        team=[1],
+        status=TrainJobStatus.PENDING,
+        algorithm="demo-algo",
+        dataset_version=dv,
+        hyperopt_config={},
+    )
+    TrainJob.objects.filter(pk=tj.pk).update(config_url="path/config.json")
+    tj.refresh_from_db()
+    return tj
+
+
+def _prep_train(monkeypatch, suffix):
+    mod = _view_module(suffix)
+    monkeypatch.setattr(
+        mod,
+        "get_mlflow_train_config",
+        lambda: types.SimpleNamespace(
+            bucket="b",
+            minio_endpoint="e",
+            mlflow_tracking_uri="u",
+            minio_access_key="ak",
+            minio_secret_key="sk",
+        ),
+    )
+    monkeypatch.setattr(mod, "get_image_by_prefix", lambda p, algo: "repo/train:1")
+    return mod
+
+
+@pytest.mark.parametrize("suffix,prefix,model_module,basename", ALGOS, ids=ALGO_IDS)
+def test_train_mlflow_count_and_stop_ignored(monkeypatch, superuser, suffix, prefix, model_module, basename):
+    tj = _ready_job(model_module, basename)
+    mod = _prep_train(monkeypatch, suffix)
+    _patch_mlflow(
+        monkeypatch,
+        suffix,
+        get_experiment_by_name=lambda name: types.SimpleNamespace(experiment_id="1"),
+        get_experiment_runs=lambda eid, **kw: pd.DataFrame({"run_id": ["a", "b"]}),
+    )
+    monkeypatch.setattr(mod.WebhookClient, "stop", staticmethod(Mock(side_effect=WebhookError("gone"))))
+    train_mock = Mock(return_value={"ok": True})
+    monkeypatch.setattr(mod.WebhookClient, "train", staticmethod(train_mock))
+    delay = Mock()
+    from apps.mlops.tasks.poll_train_job_status import poll_train_job_status as poll_task
+
+    monkeypatch.setattr(poll_task, "delay", delay)
+    view = getattr(mod, f"{basename}TrainJobViewSet").as_view({"post": "train"})
+    resp = _call(view, factory.post("/train/"), superuser, pk=tj.id)
+    assert resp.status_code == status.HTTP_200_OK
+    train_mock.assert_called_once()
+    assert delay.call_args.args[2] == 3
+    tj.refresh_from_db()
+    assert tj.status == TrainJobStatus.RUNNING
+
+
+@pytest.mark.parametrize("suffix,prefix,model_module,basename", ALGOS, ids=ALGO_IDS)
+def test_train_mlflow_count_exception_falls_back_to_zero(monkeypatch, superuser, suffix, prefix, model_module, basename):
+    tj = _ready_job(model_module, basename)
+    mod = _prep_train(monkeypatch, suffix)
+    _patch_mlflow(
+        monkeypatch,
+        suffix,
+        get_experiment_by_name=Mock(side_effect=RuntimeError("mlflow down")),
+    )
+    monkeypatch.setattr(mod.WebhookClient, "stop", staticmethod(Mock()))
+    monkeypatch.setattr(mod.WebhookClient, "train", staticmethod(Mock(return_value={"ok": True})))
+    delay = Mock()
+    from apps.mlops.tasks.poll_train_job_status import poll_train_job_status as poll_task
+
+    monkeypatch.setattr(poll_task, "delay", delay)
+    view = getattr(mod, f"{basename}TrainJobViewSet").as_view({"post": "train"})
+    resp = _call(view, factory.post("/train/"), superuser, pk=tj.id)
+    assert resp.status_code == status.HTTP_200_OK
+    assert delay.call_args.args[2] == 0
+
+
+@pytest.mark.parametrize("suffix,prefix,model_module,basename", ALGOS, ids=ALGO_IDS)
+def test_train_dataset_scope_error(monkeypatch, superuser, suffix, prefix, model_module, basename):
+    tj = _ready_job(model_module, basename)
+    mod = _prep_train(monkeypatch, suffix)
+    vs_cls = getattr(mod, f"{basename}TrainJobViewSet")
+    monkeypatch.setattr(
+        vs_cls,
+        "ensure_train_job_dataset_scope",
+        lambda self, request, job: Response(
+            {"error": "训练任务关联的数据集版本无权访问"},
+            status=status.HTTP_400_BAD_REQUEST,
+        ),
+    )
+    view = vs_cls.as_view({"post": "train"})
+    resp = _call(view, factory.post("/train/"), superuser, pk=tj.id)
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert "无权访问" in resp.data["error"]
+    tj.refresh_from_db()
+    assert tj.status == TrainJobStatus.PENDING

--- a/server/apps/mlops/tests/test_views_crud_download.py
+++ b/server/apps/mlops/tests/test_views_crud_download.py
@@ -1,0 +1,149 @@
+"""MLOps 六算法 Dataset CRUD 与训练数据下载：无文件 404，有 metadata 返回 JSON。"""
+import importlib
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.base.tests.factories import UserFactory
+from apps.mlops.constants import DatasetReleaseStatus
+
+pytestmark = [pytest.mark.django_db, pytest.mark.integration]
+
+factory = APIRequestFactory()
+
+ALGOS = [
+    ("anomaly_detection", "AnomalyDetection", "anomaly_detection", "AnomalyDetection"),
+    ("classification", "Classification", "classification", "Classification"),
+    ("log_clustering", "LogClustering", "log_clustering", "LogClustering"),
+    ("timeseries_predict", "TimeseriesPredict", "timeseries_predict", "TimeSeriesPredict"),
+    ("image_classification", "ImageClassification", "image_classification", "ImageClassification"),
+    ("object_detection", "ObjectDetection", "object_detection", "ObjectDetection"),
+]
+ALGO_IDS = [a[0] for a in ALGOS]
+
+
+def _view_module(suffix):
+    return importlib.import_module(f"apps.mlops.views.{suffix}")
+
+
+def _model(model_module, basename, kind):
+    mod = importlib.import_module(f"apps.mlops.models.{model_module}")
+    return getattr(mod, f"{basename}{kind}")
+
+
+@pytest.fixture
+def superuser():
+    return UserFactory(username="mlops-crud", domain="domain.com", roles=[], is_superuser=True)
+
+
+def _call(view, request, superuser, **kwargs):
+    force_authenticate(request, user=superuser)
+    request.COOKIES["current_team"] = "1"
+    return view(request, **kwargs)
+
+
+@pytest.mark.parametrize("suffix,prefix,model_module,basename", ALGOS, ids=ALGO_IDS)
+def test_dataset_list_create_retrieve_destroy(superuser, suffix, prefix, model_module, basename):
+    Dataset = _model(model_module, basename, "Dataset")
+    ds = Dataset.objects.create(name="ds-list", description="", team=[1])
+    mod = _view_module(suffix)
+    vs = getattr(mod, f"{basename}DatasetViewSet")
+
+    listed = _call(vs.as_view({"get": "list"}), factory.get("/"), superuser)
+    assert listed.status_code == status.HTTP_200_OK
+
+    retrieved = _call(vs.as_view({"get": "retrieve"}), factory.get("/x/"), superuser, pk=ds.id)
+    assert retrieved.status_code == status.HTTP_200_OK
+    assert retrieved.data["id"] == ds.id
+    assert retrieved.data["name"] == "ds-list"
+
+    created = _call(
+        vs.as_view({"post": "create"}),
+        factory.post("/", {"name": f"ds-new-{suffix}", "description": "", "team": [1]}, format="json"),
+        superuser,
+    )
+    assert created.status_code == status.HTTP_201_CREATED
+    assert Dataset.objects.filter(name=f"ds-new-{suffix}").exists()
+
+    updated = _call(
+        vs.as_view({"put": "update"}),
+        factory.put("/x/", {"name": "ds-renamed", "description": "d", "team": [1]}, format="json"),
+        superuser,
+        pk=ds.id,
+    )
+    assert updated.status_code == status.HTTP_200_OK
+    ds.refresh_from_db()
+    assert ds.name == "ds-renamed"
+
+    deleted = _call(vs.as_view({"delete": "destroy"}), factory.delete("/x/"), superuser, pk=ds.id)
+    # as_view 直调不经 CustomRenderer，DRF destroy 成功仍是 204
+    assert deleted.status_code == status.HTTP_204_NO_CONTENT
+    assert not Dataset.objects.filter(id=ds.id).exists()
+
+
+@pytest.mark.parametrize(
+    "suffix,model_module,basename",
+    [
+        ("image_classification", "image_classification", "ImageClassification"),
+    ],
+    ids=["image_classification"],
+)
+def test_train_data_download_missing_file_and_metadata(superuser, suffix, model_module, basename):
+    Dataset = _model(model_module, basename, "Dataset")
+    TrainData = _model(model_module, basename, "TrainData")
+    ds = Dataset.objects.create(name="ds-dl", description="", team=[1])
+    td = TrainData.objects.create(name="td", dataset=ds, metadata={})
+    mod = _view_module(suffix)
+    vs = getattr(mod, f"{basename}TrainDataViewSet")
+    missing = _call(vs.as_view({"get": "download"}), factory.get("/x/download/"), superuser, pk=td.id)
+    assert missing.status_code == status.HTTP_404_NOT_FOUND
+    assert missing.data == {"error": "Training data file was not found"}
+    meta_missing = _call(vs.as_view({"get": "download_metadata"}), factory.get("/x/meta/"), superuser, pk=td.id)
+    assert meta_missing.status_code == status.HTTP_404_NOT_FOUND
+
+    td.metadata = {"labels": ["cat"]}
+    td.save()
+    meta_ok = _call(vs.as_view({"get": "download_metadata"}), factory.get("/x/meta/"), superuser, pk=td.id)
+    assert meta_ok.status_code == status.HTTP_200_OK
+    assert meta_ok.data["labels"] == ["cat"]
+
+
+def test_object_detection_train_data_download_missing_file(superuser):
+    Dataset = _model("object_detection", "ObjectDetection", "Dataset")
+    TrainData = _model("object_detection", "ObjectDetection", "TrainData")
+    ds = Dataset.objects.create(name="ds-od-dl", description="", team=[1])
+    td = TrainData.objects.create(name="td", dataset=ds, metadata={})
+    mod = _view_module("object_detection")
+    vs = getattr(mod, "ObjectDetectionTrainDataViewSet")
+    missing = _call(vs.as_view({"get": "download"}), factory.get("/x/download/"), superuser, pk=td.id)
+    assert missing.status_code == status.HTTP_404_NOT_FOUND
+    assert missing.data == {"error": "Training data file was not found"}
+
+
+@pytest.mark.parametrize(
+    "suffix,model_module,basename",
+    [
+        ("image_classification", "image_classification", "ImageClassification"),
+        ("object_detection", "object_detection", "ObjectDetection"),
+    ],
+    ids=["image_classification", "object_detection"],
+)
+def test_release_download_missing_file(superuser, suffix, model_module, basename):
+    Dataset = _model(model_module, basename, "Dataset")
+    Release = _model(model_module, basename, "DatasetRelease")
+    ds = Dataset.objects.create(name="ds-rel", description="", team=[1])
+    rel = Release.objects.create(
+        name="r",
+        description="",
+        dataset=ds,
+        version="v1",
+        dataset_file="",
+        status=DatasetReleaseStatus.PUBLISHED,
+        metadata={},
+        file_size=0,
+    )
+    mod = _view_module(suffix)
+    vs = getattr(mod, f"{basename}DatasetReleaseViewSet")
+    resp = _call(vs.as_view({"get": "download"}), factory.get("/x/download/"), superuser, pk=rel.id)
+    assert resp.status_code == status.HTTP_404_NOT_FOUND

--- a/server/apps/mlops/tests/test_views_remaining_errors.py
+++ b/server/apps/mlops/tests/test_views_remaining_errors.py
@@ -1,0 +1,235 @@
+"""六套算法视图剩余错误分支：run 指标/删除 500、serving remove 超时/连接失败。"""
+import types
+from unittest.mock import Mock
+
+import pydantic.root_model  # noqa
+import pytest
+from rest_framework import status
+from rest_framework.test import APIRequestFactory
+
+from apps.base.tests.factories import UserFactory
+from apps.mlops.constants import TrainJobStatus
+from apps.mlops.tests.test_views_actions_param import (
+    ALGO_IDS,
+    ALGOS,
+    _call,
+    _make_serving,
+    _make_train_job,
+    _model,
+    _patch_mlflow,
+    _runs_frame,
+    _view_module,
+)
+from apps.mlops.utils.webhook_client import WebhookConnectionError, WebhookError, WebhookTimeoutError
+
+pytestmark = [pytest.mark.django_db, pytest.mark.integration]
+
+factory = APIRequestFactory()
+
+
+@pytest.fixture
+def superuser():
+    return UserFactory(username="mlops-err-su", domain="domain.com", roles=[], is_superuser=True)
+
+
+@pytest.mark.parametrize("suffix,prefix,model_module,basename", ALGOS, ids=ALGO_IDS)
+def test_metrics_list_generic_exception_returns_500(monkeypatch, superuser, suffix, prefix, model_module, basename):
+    tj = _make_train_job(model_module, basename)
+    mod = _view_module(suffix)
+    _patch_mlflow(
+        monkeypatch,
+        suffix,
+        get_experiment_by_name=lambda name: types.SimpleNamespace(experiment_id="1"),
+        get_experiment_runs=lambda eid, **kw: _runs_frame([{"run_id": "run-1"}]),
+        get_run_metrics=Mock(side_effect=RuntimeError("mlflow down")),
+    )
+    vs = getattr(mod, f"{basename}TrainJobViewSet")
+    view = vs.as_view({"get": "get_runs_metrics_list"})
+    request = factory.get(f"/{suffix}_train_jobs/x/runs/run-1/metrics_list/")
+    resp = _call(view, request, superuser, pk=tj.id, run_id="run-1")
+    assert resp.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert resp.data["error"] == "Failed to get metric list: mlflow down"
+
+
+@pytest.mark.parametrize("suffix,prefix,model_module,basename", ALGOS, ids=ALGO_IDS)
+def test_delete_run_generic_exception_returns_500(monkeypatch, superuser, suffix, prefix, model_module, basename):
+    tj = _make_train_job(model_module, basename, status_value=TrainJobStatus.COMPLETED)
+    mod = _view_module(suffix)
+    _patch_mlflow(
+        monkeypatch,
+        suffix,
+        get_experiment_by_name=lambda name: types.SimpleNamespace(experiment_id="1"),
+        get_experiment_runs=lambda eid, **kw: _runs_frame([{"run_id": "run-1", "status": "FINISHED"}]),
+        delete_run=Mock(side_effect=RuntimeError("cannot delete")),
+    )
+    vs = getattr(mod, f"{basename}TrainJobViewSet")
+    view = vs.as_view({"delete": "delete_run"})
+    request = factory.delete(f"/{suffix}_train_jobs/x/runs/run-1/")
+    resp = _call(view, request, superuser, pk=tj.id, run_id="run-1")
+    assert resp.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert resp.data["message"] == "Failed to delete training run: cannot delete"
+
+
+@pytest.mark.parametrize("suffix,prefix,model_module,basename", ALGOS, ids=ALGO_IDS)
+def test_serving_remove_timeout_and_connection_errors(monkeypatch, superuser, suffix, prefix, model_module, basename):
+    serving = _make_serving(model_module, basename, container_info={"state": "running"})
+    mod = _view_module(suffix)
+    vs = getattr(mod, f"{basename}ServingViewSet")
+    if not hasattr(vs, "remove"):
+        pytest.skip(f"{suffix} serving has no remove action")
+    view = vs.as_view({"post": "remove"})
+
+    monkeypatch.setattr(mod.WebhookClient, "remove", staticmethod(Mock(side_effect=WebhookTimeoutError("timed out"))))
+    resp = _call(view, factory.post(f"/{suffix}_servings/x/remove/"), superuser, pk=serving.id)
+    assert resp.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert resp.data["error"] == "Request to the webhookd service timed out. Please check whether the service is running"
+
+    monkeypatch.setattr(
+        mod.WebhookClient,
+        "remove",
+        staticmethod(Mock(side_effect=WebhookConnectionError("conn refused"))),
+    )
+    resp = _call(view, factory.post(f"/{suffix}_servings/x/remove/"), superuser, pk=serving.id)
+    assert resp.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert resp.data["error"] == "Unable to connect to the webhookd service"
+
+    monkeypatch.setattr(mod.WebhookClient, "remove", staticmethod(Mock(side_effect=WebhookError("other", code="X"))))
+    resp = _call(view, factory.post(f"/{suffix}_servings/x/remove/"), superuser, pk=serving.id)
+    assert resp.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert resp.data["error"] == "Request to the webhookd service failed"
+
+
+@pytest.mark.parametrize("suffix,prefix,model_module,basename", ALGOS, ids=ALGO_IDS)
+def test_runs_data_list_generic_exception_returns_500(monkeypatch, superuser, suffix, prefix, model_module, basename):
+    tj = _make_train_job(model_module, basename)
+    mod = _view_module(suffix)
+    _patch_mlflow(
+        monkeypatch,
+        suffix,
+        get_experiment_by_name=Mock(side_effect=RuntimeError("mlflow down")),
+    )
+    view = getattr(mod, f"{basename}TrainJobViewSet").as_view({"get": "get_run_data_list"})
+    resp = _call(view, factory.get(f"/{suffix}_train_jobs/x/runs_data_list/"), superuser, pk=tj.id)
+    assert resp.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert resp.data["error"] == "Failed to get training records: mlflow down"
+
+
+@pytest.mark.parametrize("suffix,prefix,model_module,basename", ALGOS, ids=ALGO_IDS)
+def test_run_params_generic_exception_returns_500(monkeypatch, superuser, suffix, prefix, model_module, basename):
+    tj = _make_train_job(model_module, basename)
+    mod = _view_module(suffix)
+    _patch_mlflow(
+        monkeypatch,
+        suffix,
+        get_experiment_by_name=lambda name: types.SimpleNamespace(experiment_id="1"),
+        get_experiment_runs=lambda eid, **kw: _runs_frame([{"run_id": "run-1"}]),
+        get_run_info=Mock(side_effect=RuntimeError("params down")),
+    )
+    view = getattr(mod, f"{basename}TrainJobViewSet").as_view({"get": "get_run_params"})
+    resp = _call(view, factory.get(f"/{suffix}_train_jobs/x/runs/run-1/run_params/"), superuser, pk=tj.id, run_id="run-1")
+    assert resp.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert resp.data["error"] == "Failed to get run parameters: params down"
+
+
+@pytest.mark.parametrize("suffix,prefix,model_module,basename", ALGOS, ids=ALGO_IDS)
+def test_model_versions_generic_exception_returns_500(monkeypatch, superuser, suffix, prefix, model_module, basename):
+    tj = _make_train_job(model_module, basename)
+    mod = _view_module(suffix)
+    _patch_mlflow(monkeypatch, suffix, get_model_versions=Mock(side_effect=RuntimeError("registry down")))
+    view = getattr(mod, f"{basename}TrainJobViewSet").as_view({"get": "get_model_versions"})
+    resp = _call(view, factory.get(f"/{suffix}_train_jobs/x/model_versions/"), superuser, pk=tj.id)
+    assert resp.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert resp.data["error"] == "Failed to get model versions: registry down"
+
+
+@pytest.mark.parametrize("suffix,prefix,model_module,basename", ALGOS, ids=ALGO_IDS)
+def test_download_model_generic_exception_returns_500(monkeypatch, superuser, suffix, prefix, model_module, basename):
+    tj = _make_train_job(model_module, basename)
+    mod = _view_module(suffix)
+    _patch_mlflow(
+        monkeypatch,
+        suffix,
+        get_experiment_by_name=lambda name: types.SimpleNamespace(experiment_id="1"),
+        get_experiment_runs=lambda eid, **kw: _runs_frame([{"run_id": "run-1"}]),
+        get_run_info=Mock(side_effect=RuntimeError("artifact down")),
+        download_model_artifact=Mock(side_effect=RuntimeError("artifact down")),
+    )
+    view = getattr(mod, f"{basename}TrainJobViewSet").as_view({"get": "download_model"})
+    resp = _call(view, factory.get(f"/{suffix}_train_jobs/x/runs/run-1/download_model/"), superuser, pk=tj.id, run_id="run-1")
+    assert resp.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert resp.data["error"] == "Failed to download model: artifact down"
+
+
+@pytest.mark.parametrize("suffix,prefix,model_module,basename", ALGOS, ids=ALGO_IDS)
+def test_serving_retrieve_missing_status_and_webhook_error(monkeypatch, superuser, suffix, prefix, model_module, basename):
+    if suffix in {"object_detection", "image_classification"}:
+        pytest.skip(f"{suffix} serving retrieve does not sync container status")
+    serving = _make_serving(model_module, basename, container_info={"state": "cached"})
+    mod = _view_module(suffix)
+    vs = getattr(mod, f"{basename}ServingViewSet")
+    view = vs.as_view({"get": "retrieve"})
+
+    monkeypatch.setattr(mod.WebhookClient, "get_status", staticmethod(lambda ids: []))
+    missing = _call(view, factory.get(f"/{suffix}_servings/x/"), superuser, pk=serving.id)
+    assert missing.status_code == status.HTTP_200_OK
+    assert missing.data["container_info"]["state"] == "unknown"
+    assert missing.data["container_info"]["message"] == "webhookd did not return container status"
+
+    monkeypatch.setattr(
+        mod.WebhookClient,
+        "get_status",
+        staticmethod(Mock(side_effect=WebhookError("status down"))),
+    )
+    degraded = _call(view, factory.get(f"/{suffix}_servings/x/"), superuser, pk=serving.id)
+    assert degraded.status_code == status.HTTP_200_OK
+    assert degraded.data["container_info"]["status"] == "error"
+    assert degraded.data["container_info"]["_query_failed"] is True
+    assert degraded.data["container_info"]["_error"] == "Request to the webhookd service failed"
+
+
+@pytest.mark.parametrize("suffix,prefix,model_module,basename", ALGOS, ids=ALGO_IDS)
+def test_serving_list_missing_container_marks_unknown(monkeypatch, superuser, suffix, prefix, model_module, basename):
+    from apps.mlops.tests.test_views_actions_param import _allow_team_one
+
+    _allow_team_one(monkeypatch)
+    serving = _make_serving(model_module, basename, container_info={"state": "cached"})
+    mod = _view_module(suffix)
+    monkeypatch.setattr(mod.WebhookClient, "get_status", staticmethod(lambda ids: []))
+    view = getattr(mod, f"{basename}ServingViewSet").as_view({"get": "list"})
+    resp = _call(view, factory.get(f"/{suffix}_servings/"), superuser)
+    assert resp.status_code == status.HTTP_200_OK
+    items = resp.data["items"] if isinstance(resp.data, dict) and "items" in resp.data else resp.data
+    target = next(s for s in items if s["id"] == serving.id)
+    assert target["container_info"]["state"] == "unknown"
+    assert target["container_info"]["message"] == "webhookd did not return status for this container"
+
+
+@pytest.mark.parametrize("suffix,prefix,model_module,basename", ALGOS, ids=ALGO_IDS)
+def test_train_data_and_release_crud(superuser, suffix, prefix, model_module, basename):
+    from apps.mlops.constants import DatasetReleaseStatus
+
+    Dataset = _model(model_module, basename, "Dataset")
+    Release = _model(model_module, basename, "DatasetRelease")
+    ds = Dataset.objects.create(name=f"ds-{suffix}", description="", team=[1])
+    rel = Release.objects.create(
+        name="r",
+        description="",
+        dataset=ds,
+        version="v1",
+        dataset_file="",
+        status=DatasetReleaseStatus.PUBLISHED,
+        metadata={},
+        file_size=0,
+    )
+    mod = _view_module(suffix)
+    rel_vs = getattr(mod, f"{basename}DatasetReleaseViewSet")
+
+    rel_list = _call(rel_vs.as_view({"get": "list"}), factory.get("/"), superuser)
+    assert rel_list.status_code == status.HTTP_200_OK
+    rel_get = _call(rel_vs.as_view({"get": "retrieve"}), factory.get("/x/"), superuser, pk=rel.id)
+    assert rel_get.status_code == status.HTTP_200_OK
+    assert rel_get.data["version"] == "v1"
+
+    missing = _call(rel_vs.as_view({"get": "download"}), factory.get("/x/download/"), superuser, pk=rel.id)
+    assert missing.status_code == status.HTTP_404_NOT_FOUND
+    assert missing.data == {"error": "Dataset file was not found"}

--- a/server/apps/monitor/tests/test_custom_pull_plugin_service.py
+++ b/server/apps/monitor/tests/test_custom_pull_plugin_service.py
@@ -1,0 +1,49 @@
+"""CustomPullPluginService：自定义 PULL 插件必须绑定监控对象并写入 child/UI 模板。"""
+import pytest
+
+from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.monitor.models import MonitorObject, MonitorPlugin, MonitorPluginConfigTemplate, MonitorPluginUITemplate
+from apps.monitor.services.custom_pull_plugin import DEFAULT_PULL_CHILD_TEMPLATE, CustomPullPluginService
+
+pytestmark = pytest.mark.django_db
+
+
+def test_initialize_templates_requires_bound_monitor_object():
+    plugin = MonitorPlugin.objects.create(name="pull-unbound")
+    with pytest.raises(BaseAppException, match="必须绑定一个监控对象"):
+        CustomPullPluginService.initialize_templates(plugin)
+
+
+def test_initialize_templates_writes_child_toml_and_ui_for_object():
+    obj = MonitorObject.objects.create(name="HostPull", level="base")
+    plugin = MonitorPlugin.objects.create(name="pull-bound")
+    plugin.monitor_object.add(obj)
+
+    CustomPullPluginService.initialize_templates(plugin)
+
+    child = MonitorPluginConfigTemplate.objects.get(plugin=plugin, type="custom_pull", config_type="child")
+    assert child.file_type == "toml"
+    assert child.content == DEFAULT_PULL_CHILD_TEMPLATE
+    assert "{{ server_url }}" in child.content
+
+    ui = MonitorPluginUITemplate.objects.get(plugin=plugin)
+    assert ui.content["object_name"] == "HostPull"
+    assert ui.content["instance_type"] == "HostPull"
+    assert ui.content["collect_type"] == "bkpull"
+    assert ui.content["config_type"] == ["custom_pull"]
+
+
+def test_initialize_templates_is_idempotent_and_refreshes_object_name():
+    obj = MonitorObject.objects.create(name="OldName", level="base")
+    plugin = MonitorPlugin.objects.create(name="pull-refresh")
+    plugin.monitor_object.add(obj)
+    CustomPullPluginService.initialize_templates(plugin)
+
+    obj.name = "NewName"
+    obj.save()
+    CustomPullPluginService.initialize_templates(plugin)
+
+    assert MonitorPluginConfigTemplate.objects.filter(plugin=plugin).count() == 1
+    assert MonitorPluginUITemplate.objects.filter(plugin=plugin).count() == 1
+    ui = MonitorPluginUITemplate.objects.get(plugin=plugin)
+    assert ui.content["object_name"] == "NewName"

--- a/server/apps/monitor/tests/test_instance_status_infra_and_init.py
+++ b/server/apps/monitor/tests/test_instance_status_infra_and_init.py
@@ -1,0 +1,139 @@
+"""监控：实例状态、分页、Infra 渲染、分组任务与初始化命令。"""
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from django.core.management import call_command
+
+from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.monitor.services.infra import InfraService
+from apps.monitor.views.infra import InfraViewSet
+from apps.monitor.views.system_mgmt import SystemMgmtView
+
+pytestmark = pytest.mark.django_db
+
+
+def test_infra_view_requires_token_and_sets_remaining_header():
+    vs = InfraViewSet()
+    with pytest.raises(BaseAppException, match="Missing required parameter: token"):
+        vs.render(SimpleNamespace(data={}))
+    with (
+        patch(
+            "apps.monitor.views.infra.InfraService.validate_and_get_token_data",
+            return_value={"cluster_name": "c1", "cloud_region_id": 2, "remaining_usage": 4},
+        ),
+        patch(
+            "apps.monitor.views.infra.InfraService.render_config_from_cloud_region",
+            return_value="kind: DaemonSet\n",
+        ) as render,
+    ):
+        resp = vs.render(SimpleNamespace(data={"token": "abc"}))
+    render.assert_called_once_with(
+        cluster_name="c1",
+        cloud_region_id=2,
+        config_type="metric",
+        image_registry_prefix=None,
+    )
+    assert resp.content == b"kind: DaemonSet\n"
+    assert resp["X-Token-Remaining-Usage"] == "4"
+    assert "yaml" in resp["Content-Type"]
+
+
+def test_infra_render_from_cloud_region_requires_env_and_posts_yaml():
+    env = {
+        "NATS_USERNAME": "u",
+        "NATS_PASSWORD": "p",
+        "NATS_SERVERS": "nats://n:4222",
+        "NATS_TLS_CA": "ca",
+        "WEBHOOK_SERVER_URL": "https://wh",
+    }
+    with patch("apps.monitor.services.infra.NodeMgmt") as rpc:
+        rpc.return_value.get_cloud_region_envconfig.return_value = {"NATS_USERNAME": "u"}
+        with pytest.raises(BaseAppException, match="Missing required environment variables"):
+            InfraService.render_config_from_cloud_region("c1", "9")
+
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {"yaml": "kind: Pod"}
+    with (
+        patch("apps.monitor.services.infra.NodeMgmt") as rpc,
+        patch("apps.monitor.services.infra.requests.post", return_value=resp) as post,
+        patch("apps.monitor.services.infra.get_webhook_tls_verify", return_value=True),
+    ):
+        rpc.return_value.get_cloud_region_envconfig.return_value = env
+        yaml = InfraService.render_config_from_cloud_region("c1", "9", config_type="metric")
+    assert yaml == "kind: Pod"
+    post.assert_called_once()
+    assert post.call_args.args[0] == "https://wh/infra/kubernetes"
+    assert post.call_args.kwargs["json"]["cluster_name"] == "c1"
+
+
+def test_infra_render_from_api_error_paths(monkeypatch):
+    with pytest.raises(BaseAppException, match="Webhook API URL is required"):
+        InfraService.render_config_from_api({}, None)
+
+    bad = MagicMock(status_code=500, text="oops")
+    monkeypatch.setattr("apps.monitor.services.infra.requests.post", lambda *a, **k: bad)
+    with pytest.raises(BaseAppException, match="Infra API returned status 500"):
+        InfraService.render_config_from_api({"a": 1}, "https://wh")
+
+    empty = MagicMock(status_code=200)
+    empty.json.return_value = {}
+    monkeypatch.setattr("apps.monitor.services.infra.requests.post", lambda *a, **k: empty)
+    with pytest.raises(BaseAppException, match="missing 'yaml' field"):
+        InfraService.render_config_from_api({"a": 1}, "https://wh")
+
+    def timeout(*a, **k):
+        raise requests.Timeout("slow")
+
+    monkeypatch.setattr("apps.monitor.services.infra.requests.post", timeout)
+    with pytest.raises(BaseAppException, match="Infra API request timeout"):
+        InfraService.render_config_from_api({"a": 1}, "https://wh")
+
+    def conn(*a, **k):
+        raise requests.ConnectionError("down")
+
+    monkeypatch.setattr("apps.monitor.services.infra.requests.post", conn)
+    with pytest.raises(BaseAppException, match="Infra API request failed"):
+        InfraService.render_config_from_api({"a": 1}, "https://wh")
+
+    boom = MagicMock(status_code=200)
+    boom.json.side_effect = ValueError("bad json")
+    monkeypatch.setattr("apps.monitor.services.infra.requests.post", lambda *a, **k: boom)
+    with pytest.raises(BaseAppException, match="Failed to parse response"):
+        InfraService.render_config_from_api({"a": 1}, "https://wh")
+
+
+def test_monitor_init_commands(monkeypatch):
+    calls = []
+    monkeypatch.setattr("apps.monitor.management.commands.plugin_init.migrate_plugin", lambda: calls.append("plugin"))
+    monkeypatch.setattr("apps.monitor.management.commands.plugin_init.migrate_policy", lambda: calls.append("policy"))
+    monkeypatch.setattr(
+        "apps.monitor.management.commands.plugin_init.migrate_default_order",
+        lambda: calls.append("order"),
+    )
+    call_command("plugin_init")
+    assert calls[-3:] == ["plugin", "policy", "order"]
+
+    monkeypatch.setattr(
+        "apps.monitor.management.commands.autodiscover.sync_instance_and_group",
+        lambda: calls.append("autodiscover"),
+    )
+    call_command("autodiscover")
+    assert calls[-1] == "autodiscover"
+
+
+def test_system_mgmt_actor_context_and_channel_list(monkeypatch):
+    user = SimpleNamespace(username="alice", domain="d.com", is_superuser=True, group_list=[{"id": 3}])
+    captured = {}
+    monkeypatch.setattr(
+        "apps.monitor.views.system_mgmt.SystemMgmtUtils.search_channel_list",
+        staticmethod(lambda actor, teams, include_children: captured.update(teams=teams, include_children=include_children) or [{"id": 1}]),
+    )
+    req = SimpleNamespace(user=user, COOKIES={"current_team": "8", "include_children": "0"})
+    resp = SystemMgmtView().search_channel_list(req)
+    body = json.loads(resp.content.decode("utf-8"))
+    assert body["data"] == [{"id": 1}]
+    assert captured["teams"] == [8]
+    assert captured["include_children"] is False

--- a/server/apps/monitor/tests/test_manual_collect_views.py
+++ b/server/apps/monitor/tests/test_manual_collect_views.py
@@ -1,0 +1,219 @@
+"""手动采集视图：校验剩余分支与动作成功/失败契约。"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.base.tests.factories import UserFactory
+from apps.core.exceptions.base_app_exception import ValidationAppException
+from apps.monitor.views import manual_collect as mc
+from apps.monitor.views.manual_collect import ManualCollect
+
+pytestmark = pytest.mark.django_db
+factory = APIRequestFactory()
+
+
+def _user():
+    return UserFactory(domain="domain.com", is_superuser=True)
+
+
+def _json(resp):
+    return json.loads(resp.content)
+
+
+# --------------------------------------------------------------------------
+# 校验剩余分支
+# --------------------------------------------------------------------------
+
+
+def test_cloud_area_list_wraps_node_mgmt_result():
+    user = _user()
+    request = factory.get("/cloud_region_list")
+    force_authenticate(request, user=user)
+    with patch.object(mc, "NodeMgmt", return_value=SimpleNamespace(cloud_region_list=lambda: [{"id": 1}])):
+        resp = ManualCollect.as_view({"get": "cloud_area_list"})(request)
+    body = _json(resp)
+    assert resp.status_code == 200
+    assert body["result"] is True
+    assert body["data"] == [{"id": 1}]
+
+
+def test_create_manual_instance_checks_orgs_and_returns_data():
+    user = _user()
+    request = factory.post(
+        "/create_manual_instance",
+        {"organizations": [1], "name": "x"},
+        format="json",
+    )
+    force_authenticate(request, user=user)
+    with (
+        patch.object(mc, "_build_actor_context", return_value={"is_superuser": True, "current_team": 1}),
+        patch.object(mc, "_ensure_target_organizations") as ensure_orgs,
+        patch.object(
+            mc.ManualCollectService,
+            "create_manual_collect_instance",
+            return_value={"id": "m1"},
+        ) as created,
+    ):
+        resp = ManualCollect.as_view({"post": "create_manual_instance"})(request)
+    ensure_orgs.assert_called_once()
+    created.assert_called_once()
+    body = _json(resp)
+    assert resp.status_code == 200
+    assert body["data"] == {"id": "m1"}
+
+
+def test_flow_asset_binds_existing_instance_id():
+    user = _user()
+    payload = {
+        "monitor_object_id": 3,
+        "protocol": "netflow",
+        "cloud_region_id": 2,
+        "ip": "10.0.0.1",
+        "name": "sw1",
+        "instance_id": "inst-1",
+        "organizations": [1],
+    }
+    request = factory.post("/flow_asset", payload, format="json")
+    force_authenticate(request, user=user)
+    with (
+        patch.object(mc, "_build_actor_context", return_value={"is_superuser": True, "current_team": 1}),
+        patch.object(mc.FlowOnboardingService, "lock_monitor_object"),
+        patch.object(mc, "_validate_existing_flow_instance", return_value="inst-1") as validate,
+        patch.object(mc, "_ensure_operate_instances") as ensure_ops,
+        patch.object(mc, "_ensure_target_organizations"),
+        patch.object(
+            mc.FlowOnboardingService,
+            "create_or_bind_asset",
+            return_value={"instance_id": "inst-1"},
+        ) as bind,
+    ):
+        resp = ManualCollect.as_view({"post": "flow_asset"})(request)
+    validate.assert_called_once_with("inst-1")
+    ensure_ops.assert_called()
+    bind.assert_called_once()
+    body = _json(resp)
+    assert resp.status_code == 200
+    assert body["data"]["instance_id"] == "inst-1"
+
+
+def test_flow_asset_reuses_soft_deleted_asset():
+    user = _user()
+    payload = {
+        "monitor_object_id": 3,
+        "protocol": "sflow",
+        "cloud_region_id": 2,
+        "ip": "10.0.0.2",
+        "name": "sw2",
+    }
+    request = factory.post("/flow_asset", payload, format="json")
+    force_authenticate(request, user=user)
+    existing = SimpleNamespace(id="reuse-1", is_deleted=True)
+    with (
+        patch.object(mc, "_build_actor_context", return_value={"is_superuser": True, "current_team": 1}),
+        patch.object(mc.FlowOnboardingService, "lock_monitor_object"),
+        patch.object(mc.FlowOnboardingService, "find_reusable_asset", return_value=existing),
+        patch.object(mc, "_ensure_operate_instances") as ensure_ops,
+        patch.object(mc, "_ensure_target_organizations"),
+        patch.object(
+            mc.FlowOnboardingService,
+            "create_or_bind_asset",
+            return_value={"instance_id": "reuse-1"},
+        ) as bind,
+    ):
+        resp = ManualCollect.as_view({"post": "flow_asset"})(request)
+    ensure_ops.assert_called()
+    kwargs = bind.call_args.kwargs
+    assert kwargs["instance_id"] == "reuse-1"
+    assert kwargs["allow_deleted_instance_reuse"] is True
+    assert _json(resp)["result"] is True
+
+
+def test_update_flow_asset_and_access_guide_and_detect():
+    user = _user()
+    update_req = factory.post(
+        "/flow_asset/update",
+        {"instance_id": "inst-u", "name": "new"},
+        format="json",
+    )
+    force_authenticate(update_req, user=user)
+    with (
+        patch.object(mc, "_build_actor_context", return_value={"is_superuser": True, "current_team": 1}),
+        patch.object(mc, "_validate_existing_flow_instance", return_value="inst-u"),
+        patch.object(mc, "_ensure_operate_instances"),
+        patch.object(mc, "_ensure_target_organizations"),
+        patch.object(mc.FlowOnboardingService, "update_asset", return_value={"ok": True}),
+    ):
+        resp = ManualCollect.as_view({"post": "update_flow_asset"})(update_req)
+    assert resp.status_code == 200
+    assert _json(resp)["data"] == {"ok": True}
+
+    guide_req = factory.post(
+        "/flow_access_guide",
+        {"monitor_object_id": 1, "protocol": "netflow", "cloud_region_id": 2},
+        format="json",
+    )
+    force_authenticate(guide_req, user=user)
+    with patch.object(mc.FlowAccessGuideService, "build_document", return_value={"doc": "x"}) as built:
+        resp = ManualCollect.as_view({"post": "flow_access_guide"})(guide_req)
+    built.assert_called_once()
+    assert _json(resp)["data"] == {"doc": "x"}
+
+    detect_req = factory.post(
+        "/flow_detect_status",
+        {"instance_id": "inst-d", "monitor_object_id": 1, "protocol": "netflow", "time_window": "5m"},
+        format="json",
+    )
+    force_authenticate(detect_req, user=user)
+    with (
+        patch.object(mc, "_build_actor_context", return_value={"is_superuser": True, "current_team": 1}),
+        patch.object(mc, "_ensure_operate_instances") as ensure_ops,
+        patch.object(mc.FlowOnboardingService, "detect_status", return_value={"status": "ok"}),
+    ):
+        resp = ManualCollect.as_view({"post": "flow_detect_status"})(detect_req)
+    ensure_ops.assert_called()
+    assert _json(resp)["data"] == {"status": "ok"}
+
+
+def test_generate_install_command_and_check_collect_status():
+    user = _user()
+    cmd_req = factory.post(
+        "/generate_install_command",
+        {"instance_id": "inst-c", "cloud_region_id": 4},
+        format="json",
+    )
+    force_authenticate(cmd_req, user=user)
+    with (
+        patch.object(mc, "_build_actor_context", return_value={"is_superuser": True, "current_team": 1}),
+        patch.object(mc, "_ensure_operate_instances"),
+        patch.object(mc.ManualCollectService, "generate_install_command", return_value={"cmd": "echo"}),
+    ):
+        resp = ManualCollect.as_view({"post": "generate_install_command"})(cmd_req)
+    assert _json(resp)["data"] == {"cmd": "echo"}
+
+    check_req = factory.post(
+        "/check_collect_status",
+        {"instance_id": "inst-c", "monitor_object_id": 9},
+        format="json",
+    )
+    force_authenticate(check_req, user=user)
+    with (
+        patch.object(mc, "_build_actor_context", return_value={"is_superuser": True, "current_team": 1}),
+        patch.object(mc, "_ensure_operate_instances"),
+        patch.object(mc.ManualCollectService, "check_collect_status", return_value=True),
+    ):
+        resp = ManualCollect.as_view({"post": "check_collect_status"})(check_req)
+    body = _json(resp)
+    assert body["result"] is True
+    assert body["data"] == {"success": True}
+
+
+def test_flow_asset_unknown_field_raises():
+    user = _user()
+    request = factory.post("/flow_asset", {"foo": 1}, format="json")
+    force_authenticate(request, user=user)
+    with pytest.raises(ValidationAppException, match="Unknown request fields"):
+        ManualCollect.as_view({"post": "flow_asset"})(request)

--- a/server/apps/monitor/tests/test_monitor_plugin_view_remaining.py
+++ b/server/apps/monitor/tests/test_monitor_plugin_view_remaining.py
@@ -1,0 +1,126 @@
+"""MonitorPluginViewSet 剩余：内置只读销毁、SNMP 删除、UI 模板、collect_template、导入导出。"""
+import pytest
+from django.db import ProgrammingError
+
+from apps.monitor.models import MonitorPlugin, MonitorPluginUITemplate
+
+pytestmark = pytest.mark.django_db
+BASE = "/api/v1/monitor"
+
+
+@pytest.fixture
+def su_client(api_client, authenticated_user):
+    authenticated_user.is_superuser = True
+    authenticated_user.save(update_fields=["is_superuser"])
+    return api_client
+
+
+def test_destroy_builtin_plugin_rejected(su_client):
+    plugin = MonitorPlugin.objects.create(name="pre-plugin", template_type="builtin", is_pre=True)
+    resp = su_client.delete(f"{BASE}/api/monitor_plugin/{plugin.id}/")
+    assert resp.status_code == 500
+    assert resp.json()["result"] is False
+    assert "只读" in resp.json()["message"]
+    assert MonitorPlugin.objects.filter(id=plugin.id).exists()
+
+
+def test_destroy_snmp_plugin_success_and_missing_column(su_client, mocker):
+    plugin = MonitorPlugin.objects.create(name="snmp-del", template_type="snmp", is_pre=False)
+    resp = su_client.delete(f"{BASE}/api/monitor_plugin/{plugin.id}/")
+    assert resp.status_code == 200
+    assert resp.json()["result"] is True
+    assert not MonitorPlugin.objects.filter(id=plugin.id).exists()
+
+    plugin2 = MonitorPlugin.objects.create(name="snmp-err", template_type="snmp", is_pre=False)
+    mocker.patch.object(
+        MonitorPlugin,
+        "delete",
+        side_effect=ProgrammingError('column "monitor_plugin_id" does not exist'),
+    )
+    resp = su_client.delete(f"{BASE}/api/monitor_plugin/{plugin2.id}/")
+    assert resp.status_code == 500
+    assert "monitor_collectconfig.monitor_plugin_id" in resp.json()["message"]
+
+
+def test_get_ui_template_found_and_empty(su_client):
+    plugin = MonitorPlugin.objects.create(
+        name="ui-p",
+        template_type="api",
+        is_pre=False,
+        node_selector={"os": "linux"},
+        support_collect_detect=True,
+    )
+    empty = su_client.get(f"{BASE}/api/monitor_plugin/{plugin.id}/ui_template/")
+    assert empty.status_code == 200
+    assert empty.json()["data"] == {
+        "ui_template": {},
+        "node_selector": {"os": "linux"},
+        "support_collect_detect": True,
+    }
+    MonitorPluginUITemplate.objects.create(plugin=plugin, content={"fields": [1]})
+    found = su_client.get(f"{BASE}/api/monitor_plugin/{plugin.id}/ui_template/")
+    assert found.json()["data"]["ui_template"] == {"fields": [1]}
+
+
+def test_collect_template_requires_snmp_and_dispatches(su_client, mocker):
+    api_plugin = MonitorPlugin.objects.create(name="api-ct", template_type="api", is_pre=False)
+    bad = su_client.get(f"{BASE}/api/monitor_plugin/{api_plugin.id}/collect_template/")
+    assert bad.status_code == 400
+    assert bad.json()["message"] == "当前模板不是自建 SNMP 模板"
+
+    snmp = MonitorPlugin.objects.create(name="snmp-ct", template_type="snmp", is_pre=False)
+    mocker.patch(
+        "apps.monitor.views.plugin.CustomSnmpPluginService.get_collect_template",
+        return_value={"content": "oid"},
+    )
+    got = su_client.get(f"{BASE}/api/monitor_plugin/{snmp.id}/collect_template/")
+    assert got.json()["data"] == {"content": "oid"}
+    mocker.patch(
+        "apps.monitor.views.plugin.CustomSnmpPluginService.update_collect_template",
+        return_value={"content": "updated"},
+    )
+    put = su_client.put(
+        f"{BASE}/api/monitor_plugin/{snmp.id}/collect_template/",
+        {"content": "updated"},
+        format="json",
+    )
+    assert put.json()["data"] == {"content": "updated"}
+
+
+def test_import_and_export_delegate_to_service(su_client, mocker):
+    importer = mocker.patch("apps.monitor.views.plugin.MonitorPluginService.import_monitor_plugin")
+    exporter = mocker.patch(
+        "apps.monitor.views.plugin.MonitorPluginService.export_monitor_plugin",
+        return_value={"name": "p"},
+    )
+    plugin = MonitorPlugin.objects.create(name="exp", template_type="api", is_pre=False)
+    imp = su_client.post(f"{BASE}/api/monitor_plugin/import/", {"name": "p"}, format="json")
+    assert imp.status_code == 200
+    importer.assert_called_once()
+    exp = su_client.get(f"{BASE}/api/monitor_plugin/export/{plugin.id}/")
+    assert exp.json()["data"] == {"name": "p"}
+    exporter.assert_called_once_with(str(plugin.id))
+
+
+def test_ensure_modifiable_used_on_update(su_client):
+    plugin = MonitorPlugin.objects.create(name="upd-pre", template_type="builtin", is_pre=True)
+    resp = su_client.put(
+        f"{BASE}/api/monitor_plugin/{plugin.id}/",
+        {"name": "upd-pre", "template_type": "builtin"},
+        format="json",
+    )
+    assert resp.status_code == 500
+    assert "只读" in resp.json()["message"]
+
+
+def test_ui_template_by_params_delegates(su_client, mocker):
+    mocker.patch(
+        "apps.monitor.views.plugin.MonitorPluginService.get_ui_template_by_params",
+        return_value={"ui": 1},
+    )
+    resp = su_client.get(f"{BASE}/api/monitor_plugin/ui_template_by_params/?collector=telegraf&collect_type=host&monitor_object_id=1")
+    assert resp.json()["data"] == {
+        "ui": 1,
+        "ui_template": None,
+        "support_collect_detect": False,
+    }

--- a/server/apps/monitor/tests/test_nats_monitor_permission_module.py
+++ b/server/apps/monitor/tests/test_nats_monitor_permission_module.py
@@ -1,0 +1,50 @@
+"""监控 NATS 权限模块：按组织分页实例/策略/条件，以及模块列表分组。"""
+import pytest
+
+from apps.monitor.models.monitor_condition import MonitorCondition, MonitorConditionOrganization
+from apps.monitor.models.monitor_object import MonitorInstance, MonitorInstanceOrganization, MonitorObject, MonitorObjectType
+from apps.monitor.models.monitor_policy import MonitorPolicy, PolicyOrganization
+from apps.monitor.nats import permission as nats_perm
+
+pytestmark = pytest.mark.django_db
+
+
+def test_get_monitor_module_data_filters_by_org_and_rejects_unknown():
+    obj = MonitorObject.objects.create(name="NatsPermObj", level="base")
+    inst = MonitorInstance.objects.create(id="nats-inst-1", name="i1", monitor_object=obj)
+    MonitorInstanceOrganization.objects.create(monitor_instance=inst, organization=7)
+    other = MonitorInstance.objects.create(id="nats-inst-2", name="i2", monitor_object=obj)
+    MonitorInstanceOrganization.objects.create(monitor_instance=other, organization=8)
+
+    out = nats_perm.get_monitor_module_data("instance", obj.id, 1, 10, 7)
+    assert out["count"] == 1
+    assert out["items"] == [{"id": "nats-inst-1", "name": "i1"}]
+
+    policy = MonitorPolicy.objects.create(monitor_object=obj, name="p-nats", algorithm="avg")
+    PolicyOrganization.objects.create(policy=policy, organization=7)
+    out = nats_perm.get_monitor_module_data("policy", obj.id, 1, 10, 7)
+    assert out["count"] == 1
+    assert out["items"] == [{"id": policy.id, "name": "p-nats"}]
+
+    cond = MonitorCondition.objects.create(name="c-nats", condition={})
+    MonitorConditionOrganization.objects.create(monitor_condition=cond, organization=7)
+    out = nats_perm.get_monitor_module_data("condition", obj.id, 1, 10, 7)
+    assert out["count"] == 1
+    assert out["items"] == [{"id": cond.id, "name": "c-nats"}]
+
+    with pytest.raises(ValueError, match="Invalid module type"):
+        nats_perm.get_monitor_module_data("unknown", obj.id, 1, 10, 7)
+
+
+def test_get_monitor_module_list_groups_objects_by_type():
+    otype = MonitorObjectType.objects.create(id="host-nats-perm", name="Host")
+    obj = MonitorObject.objects.create(name="NatsListObj", level="base", type=otype)
+    out = nats_perm.get_monitor_module_list()
+    assert out[0]["name"] == "instance"
+    assert out[0]["display_name"] == "Instance"
+    assert out[1]["name"] == "policy"
+    assert out[2] == {"name": "condition", "display_name": "Condition", "children": []}
+    host_group = next(item for item in out[0]["children"] if item["name"] == "host-nats-perm")
+    assert host_group["display_name"] == "host-nats-perm"
+    assert {"name": obj.id, "display_name": "NatsListObj"} in host_group["children"]
+    assert out[1]["children"] == out[0]["children"]

--- a/server/apps/node_mgmt/tests/test_cloud_service_check_health_service.py
+++ b/server/apps/node_mgmt/tests/test_cloud_service_check_health_service.py
@@ -1,0 +1,68 @@
+"""云区域 Stargazer / NATS Executor 健康检查：只 mock RPC 客户端。"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from apps.node_mgmt.constants.cloudregion_service import CloudRegionServiceConstants
+from apps.node_mgmt.tasks.services import cloud_service_check_health as health
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def region():
+    return SimpleNamespace(name="zone-a")
+
+
+def test_check_stargazer_health_ok(monkeypatch, region):
+    monkeypatch.setattr(health.RegionService, "get_region_service_instance_id", staticmethod(lambda *a: "inst-1"))
+    client = MagicMock()
+    client.health_check.return_value = {"status": "ok"}
+    monkeypatch.setattr(health, "Stargazer", lambda instance_id: client)
+    status, message = health.check_stargazer_health(region)
+    assert status == CloudRegionServiceConstants.NORMAL
+    assert message == "服务正常"
+    client.health_check.assert_called_once_with(timeout=health.HEALTH_CHECK_TIMEOUT)
+
+
+def test_check_stargazer_health_abnormal_payload(monkeypatch, region):
+    monkeypatch.setattr(health.RegionService, "get_region_service_instance_id", staticmethod(lambda *a: "inst-1"))
+    client = MagicMock()
+    client.health_check.return_value = {"status": "down"}
+    monkeypatch.setattr(health, "Stargazer", lambda instance_id: client)
+    status, message = health.check_stargazer_health(region)
+    assert status == CloudRegionServiceConstants.N_ERROR
+    assert "异常" in message
+
+
+def test_check_stargazer_health_exception(monkeypatch, region):
+    monkeypatch.setattr(health.RegionService, "get_region_service_instance_id", staticmethod(lambda *a: "inst-1"))
+    monkeypatch.setattr(health, "Stargazer", lambda instance_id: (_ for _ in ()).throw(RuntimeError("rpc down")))
+    status, message = health.check_stargazer_health(region)
+    assert status == CloudRegionServiceConstants.N_ERROR
+    assert "rpc down" in message
+
+
+def test_check_nats_executor_health_ok_and_failure(monkeypatch, region):
+    monkeypatch.setattr(health.RegionService, "get_region_service_instance_id", staticmethod(lambda *a: "exec-1"))
+    client = MagicMock()
+    client.health_check.return_value = {"status": "ok"}
+    monkeypatch.setattr(health, "Executor", lambda instance_id: client)
+    status, message = health.check_nats_executor_health(region)
+    assert status == CloudRegionServiceConstants.NORMAL
+    assert message == "服务正常"
+
+    client.health_check.return_value = None
+    status, message = health.check_nats_executor_health(region)
+    assert status == CloudRegionServiceConstants.N_ERROR
+
+    monkeypatch.setattr(health, "Executor", lambda instance_id: (_ for _ in ()).throw(TimeoutError("timeout")))
+    status, message = health.check_nats_executor_health(region)
+    assert status == CloudRegionServiceConstants.N_ERROR
+    assert "timeout" in message
+
+
+def test_services_func_maps_known_service_names():
+    assert health.SERVICES_FUNC[CloudRegionServiceConstants.STARGAZER_SERVICE_NAME] is health.check_stargazer_health
+    assert health.SERVICES_FUNC[CloudRegionServiceConstants.NATS_EXECUTOR_SERVICE_NAME] is health.check_nats_executor_health

--- a/server/apps/node_mgmt/tests/test_collector_configuration_service.py
+++ b/server/apps/node_mgmt/tests/test_collector_configuration_service.py
@@ -1,0 +1,87 @@
+"""采集器配置应用到节点：覆盖旧配置、缺失实体、节点计数。"""
+import uuid
+
+import pytest
+
+from apps.node_mgmt.models import Collector, Node
+from apps.node_mgmt.models.cloud_region import CloudRegion
+from apps.node_mgmt.models.sidecar import CollectorConfiguration
+from apps.node_mgmt.services.collector_configuration import CollectorConfigurationService
+
+pytestmark = pytest.mark.django_db
+
+
+def _region():
+    return CloudRegion.objects.create(name=f"cr-ccs-{uuid.uuid4().hex[:8]}")
+
+
+def _node(region, **over):
+    data = dict(
+        id=f"n-{uuid.uuid4().hex[:8]}",
+        name="n",
+        ip="10.0.0.2",
+        operating_system="linux",
+        collector_configuration_directory="/etc/sidecar",
+        cloud_region=region,
+        cpu_architecture="x86_64",
+    )
+    data.update(over)
+    return Node.objects.create(**data)
+
+
+def _collector(suffix):
+    return Collector.objects.create(
+        id=f"c-{suffix}-{uuid.uuid4().hex[:8]}",
+        name=f"Telegraf-{suffix}",
+        service_type="svc",
+        node_operating_system="linux",
+        executable_path="/bin",
+        execute_parameters="-c",
+    )
+
+
+def _cfg(collector, region, name):
+    return CollectorConfiguration.objects.create(
+        name=name,
+        collector=collector,
+        config_template="x",
+        cloud_region=region,
+    )
+
+
+def test_apply_to_node_missing_node_and_config():
+    ok, msg = CollectorConfigurationService.apply_to_node("missing-node", "missing-cfg")
+    assert ok is False
+    assert msg == "节点missing-node不存在"
+
+    region = _region()
+    node = _node(region)
+    ok, msg = CollectorConfigurationService.apply_to_node(node.id, "missing-cfg")
+    assert ok is False
+    assert msg == "采集器配置missing-cfg不存在"
+
+
+def test_apply_to_node_replaces_same_collector_config():
+    region = _region()
+    node = _node(region)
+    collector = _collector("one")
+    old = _cfg(collector, region, f"old-{uuid.uuid4().hex[:6]}")
+    new = _cfg(collector, region, f"new-{uuid.uuid4().hex[:6]}")
+    old.nodes.add(node)
+
+    ok, msg = CollectorConfigurationService.apply_to_node(node.id, new.id)
+    assert ok is True
+    assert msg == ""
+    assert node not in old.nodes.all()
+    assert node in new.nodes.all()
+
+
+def test_calculate_node_count_splits_applied_and_pending():
+    region = _region()
+    applied = _node(region, status={"collectors": [{"configuration_id": ["cfg-1"]}]})
+    pending = _node(region, status={"collectors": [{"configuration_id": ["other"]}]})
+    configurations = [{"id": "cfg-1", "nodes": [applied.id, pending.id, "ghost"]}]
+    out = CollectorConfigurationService.calculate_node_count(configurations)
+    assert out[0]["node_count"] == 1
+    assert out[0]["nodes"] == [applied.id]
+    assert set(out[0]["not_applied_nodes"]) == {pending.id, "ghost"}

--- a/server/apps/node_mgmt/tests/test_installer_failure_enrichment.py
+++ b/server/apps/node_mgmt/tests/test_installer_failure_enrichment.py
@@ -3,6 +3,8 @@ from types import SimpleNamespace
 import pytest
 
 from apps.node_mgmt.constants.installer import InstallerConstants
+from apps.node_mgmt.models.cloud_region import CloudRegion
+from apps.node_mgmt.models.installer import ControllerTask, ControllerTaskNode
 from apps.node_mgmt.tasks import installer as installer_tasks
 from apps.node_mgmt.tasks.installer import _handle_step_exception
 from apps.node_mgmt.utils.installer_schema import build_installer_event_record, normalize_failure
@@ -20,9 +22,7 @@ class _DummyNode:
 
 class _InstallNode(_DummyNode):
     def __init__(self, password="", private_key="", passphrase=""):
-        super().__init__(
-            result={InstallerConstants.EXECUTION_PHASE_KEY: InstallerConstants.EXECUTION_PHASE_BOOTSTRAP_RUNNING}
-        )
+        super().__init__(result={InstallerConstants.EXECUTION_PHASE_KEY: InstallerConstants.EXECUTION_PHASE_BOOTSTRAP_RUNNING})
         self.password = password
         self.private_key = private_key
         self.passphrase = passphrase
@@ -37,6 +37,41 @@ class _FailingCryptor:
         return "decoded-value"
 
 
+@pytest.mark.django_db
+def test_uninstall_controller_without_credentials_records_exact_failure(monkeypatch):
+    region = CloudRegion.objects.create(name="uninstall-no-credentials")
+    task = ControllerTask.objects.create(cloud_region=region, type="uninstall", status="pending")
+    node = ControllerTaskNode.objects.create(
+        task=task,
+        ip="10.1.1.1",
+        os="linux",
+        port=22,
+        username="root",
+        password="",
+        private_key="",
+        status="waiting",
+        result={},
+    )
+    monkeypatch.setattr(installer_tasks, "AESCryptor", lambda: SimpleNamespace())
+    monkeypatch.setattr(
+        installer_tasks,
+        "exec_command_to_remote",
+        lambda *args, **kwargs: pytest.fail("无凭据时不应执行远程命令"),
+    )
+
+    installer_tasks.uninstall_controller(task.id)
+
+    task.refresh_from_db()
+    node.refresh_from_db()
+    assert task.status == "finished"
+    assert node.status == "error"
+    assert node.result["steps"][0]["action"] == "credential_check"
+    assert node.result["steps"][0]["status"] == "error"
+    assert node.result["steps"][0]["message"] == ("Windows requires a password; Linux requires a password or private key.")
+    assert node.result["final_message"] == "Credential validation failed"
+    assert node.result["overall_status"] == "error"
+
+
 @pytest.mark.parametrize(
     ("password", "private_key", "passphrase"),
     [
@@ -45,9 +80,7 @@ class _FailingCryptor:
         ("", "valid-ciphertext", "invalid-ciphertext"),
     ],
 )
-def test_install_controller_on_nodes_converges_credential_decryption_failure(
-    monkeypatch, password, private_key, passphrase
-):
+def test_install_controller_on_nodes_converges_credential_decryption_failure(monkeypatch, password, private_key, passphrase):
     node = _InstallNode(password=password, private_key=private_key, passphrase=passphrase)
     dispatch_calls = []
     monkeypatch.setattr(installer_tasks, "AESCryptor", _FailingCryptor)

--- a/server/apps/node_mgmt/tests/test_nats_node_env_and_delegates.py
+++ b/server/apps/node_mgmt/tests/test_nats_node_env_and_delegates.py
@@ -1,0 +1,145 @@
+"""节点 NATS：TLS 环境、云区域列表/环境变量，以及委托入口。"""
+from unittest.mock import patch
+
+import pytest
+
+from apps.node_mgmt.constants.database import EnvVariableConstants
+from apps.node_mgmt.constants.node import NodeConstants
+from apps.node_mgmt.models import CloudRegion, Node, SidecarEnv
+from apps.node_mgmt.nats import node as n
+
+pytestmark = pytest.mark.django_db
+
+
+def _region(name):
+    return CloudRegion.objects.create(name=name, introduction="", created_by="tester", updated_by="tester")
+
+
+def test_cloudregion_tls_env_defaults_when_node_missing():
+    assert n.cloudregion_tls_env_by_node_id("missing-node-881") == {
+        "NATS_PROTOCOL": "nats",
+        "NATS_TLS_CA_FILE": "",
+        "NATS_TLS_CA_WIN_FILE": "",
+    }
+
+
+def test_cloudregion_tls_env_overlays_sidecar_values():
+    region = _region("tls-env-881")
+    node = Node.objects.create(
+        id="tls-node-881",
+        name="tls-node-881",
+        ip="10.8.8.1",
+        operating_system=NodeConstants.LINUX_OS,
+        collector_configuration_directory="/etc/collector",
+        cloud_region=region,
+        created_by="tester",
+        updated_by="tester",
+    )
+    SidecarEnv.objects.create(cloud_region=region, key="NATS_PROTOCOL", value="tls", type=EnvVariableConstants.TYPE_NORMAL)
+    SidecarEnv.objects.create(cloud_region=region, key="NATS_TLS_CA_FILE", value="/ca.pem", type=EnvVariableConstants.TYPE_NORMAL)
+    out = n.cloudregion_tls_env_by_node_id(node.id)
+    assert out["NATS_PROTOCOL"] == "tls"
+    assert out["NATS_TLS_CA_FILE"] == "/ca.pem"
+    assert out["NATS_TLS_CA_WIN_FILE"] == ""
+
+
+def test_cloud_region_list_includes_created_region():
+    region = _region("list-region-881")
+    rows = n.cloud_region_list()
+    assert {"id": region.id, "name": "list-region-881"} in rows
+
+
+def test_get_cloud_region_envconfig_plain_and_secret_decode_fallback():
+    region = _region("env-region-881")
+    SidecarEnv.objects.create(cloud_region=region, key="PLAIN", value="visible", type=EnvVariableConstants.TYPE_NORMAL)
+    SidecarEnv.objects.create(cloud_region=region, key="SECRET", value="cipher", type=EnvVariableConstants.TYPE_SECRET)
+    with patch("apps.node_mgmt.nats.node.AESCryptor") as aes_cls:
+        aes_cls.return_value.decode.side_effect = ValueError("bad-cipher")
+        out = n.get_cloud_region_envconfig(str(region.id))
+    assert out["PLAIN"] == "visible"
+    assert out["SECRET"] == "cipher"
+
+
+def test_collector_list_always_empty():
+    assert n.collector_list({"page": 1}) == []
+
+
+def test_nats_delegates_to_services():
+    with patch.object(n.NodeService, "get_node_list", return_value={"count": 0, "nodes": []}) as listed:
+        assert n.node_list({"name": "x", "page": 2, "page_size": 5}) == {"count": 0, "nodes": []}
+        listed.assert_called_once()
+        args = listed.call_args.args
+        assert args[2] == "x"
+        assert args[5] == 2
+        assert args[6] == 5
+
+    with patch.object(n.NodeService, "get_node_names_by_ids", return_value={"a": "n1"}) as names:
+        assert n.get_node_names_by_ids(["a"]) == {"a": "n1"}
+        names.assert_called_once_with(["a"])
+
+    with patch.object(n.NodeService, "get_nodes_by_ids", return_value=[{"id": "a"}]) as nodes:
+        assert n.get_nodes_by_ids(["a"]) == [{"id": "a"}]
+        nodes.assert_called_once_with(["a"])
+
+    with patch.object(n.NodeService, "get_authorized_nodes_by_ids", return_value=["n1"]) as auth:
+        assert n.get_authorized_nodes_by_ids(["n1"], {"team": 1}) == ["n1"]
+        auth.assert_called_once_with(["n1"], {"team": 1})
+
+    with patch.object(n, "import_collector", return_value={"ok": True}) as imported:
+        assert n.import_collectors([{"id": 1}]) == {"ok": True}
+        imported.assert_called_once_with([{"id": 1}])
+
+    svc = n.NatsService
+    with patch.object(svc, "batch_create_configs_and_child_configs") as batch:
+        n.batch_create_configs_and_child_configs([{"id": "c"}], [{"id": "ch"}])
+        batch.assert_called_once_with([{"id": "c"}], [{"id": "ch"}])
+    with patch.object(svc, "batch_create_child_configs") as child:
+        n.batch_add_node_child_config([{"id": "ch"}])
+        child.assert_called_once_with([{"id": "ch"}])
+    with patch.object(svc, "batch_create_configs") as cfg:
+        n.batch_add_node_config([{"id": "c"}])
+        cfg.assert_called_once_with([{"id": "c"}])
+    with patch.object(svc, "get_child_configs_by_ids", return_value=[{"id": 1}]) as gch:
+        assert n.get_child_configs_by_ids([1]) == [{"id": 1}]
+        gch.assert_called_once_with([1])
+    with patch.object(svc, "get_configs_by_ids", return_value=[{"id": 2}]) as gcfg:
+        assert n.get_configs_by_ids([2]) == [{"id": 2}]
+        gcfg.assert_called_once_with([2])
+    with patch.object(svc, "update_child_config_content") as uch:
+        n.update_child_config_content({"id": 3, "content": "x", "env_config": {"a": 1}})
+        uch.assert_called_once_with(3, "x", {"a": 1})
+    with patch.object(svc, "update_config_content") as ucfg:
+        n.update_config_content({"id": 4, "content": "y", "env_config": None})
+        ucfg.assert_called_once_with(4, "y", None)
+    with patch.object(svc, "delete_child_configs") as dch:
+        n.delete_child_configs([5])
+        dch.assert_called_once_with([5])
+    with patch.object(svc, "delete_configs") as dcfg:
+        n.delete_configs([6])
+        dcfg.assert_called_once_with([6])
+
+
+def test_install_collector_and_managed_component_return_task_id():
+    with (
+        patch.object(n.InstallerService, "install_collector", return_value="tid-881") as install,
+        patch.object(n.install_collector_task, "delay") as delay,
+    ):
+        payload = {"collector_package": "pkg", "nodes": ["n1"]}
+        assert n.install_collector(payload) == {"task_id": "tid-881"}
+        assert n.install_managed_component(payload) == {"task_id": "tid-881"}
+    assert install.call_count == 2
+    assert delay.call_count == 2
+    delay.assert_called_with("tid-881")
+
+
+def test_update_config_content_requires_payload_and_existing_row():
+    from apps.core.exceptions.base_app_exception import BaseAppException
+
+    with pytest.raises(BaseAppException, match="must be provided"):
+        n.NatsService().update_child_config_content(1, None, None)
+    with pytest.raises(BaseAppException, match="not found"):
+        n.NatsService().update_child_config_content(999881001, "x", None)
+    with pytest.raises(BaseAppException, match="must be provided"):
+        n.NatsService().update_config_content(1, None, None)
+    with pytest.raises(BaseAppException, match="not found"):
+        n.NatsService().update_config_content("missing-cfg-881", "x", None)

--- a/server/apps/node_mgmt/tests/test_nats_permission_module.py
+++ b/server/apps/node_mgmt/tests/test_nats_permission_module.py
@@ -1,0 +1,44 @@
+"""节点 NATS 权限模块：按云区域/组织分页节点，以及模块列表。"""
+import pytest
+
+from apps.node_mgmt.models import CloudRegion, Node, NodeOrganization
+from apps.node_mgmt.nats import permission as nats_perm
+
+pytestmark = pytest.mark.django_db
+
+
+def test_get_node_module_data_filters_by_org_and_rejects_unknown():
+    region = CloudRegion.objects.create(name="nats-perm-region")
+    node = Node.objects.create(
+        id="nats-node-1",
+        name="nn1",
+        ip="10.9.9.1",
+        operating_system="linux",
+        collector_configuration_directory="/etc/sidecar",
+        cloud_region=region,
+    )
+    NodeOrganization.objects.create(node=node, organization=4)
+    other = Node.objects.create(
+        id="nats-node-2",
+        name="nn2",
+        ip="10.9.9.2",
+        operating_system="linux",
+        collector_configuration_directory="/etc/sidecar",
+        cloud_region=region,
+    )
+    NodeOrganization.objects.create(node=other, organization=9)
+
+    out = nats_perm.get_node_module_data("instance", region.id, 1, 10, 4)
+    assert out["count"] == 1
+    assert out["items"] == [{"id": "nats-node-1", "name": "nn1"}]
+
+    with pytest.raises(ValueError, match="Invalid module type"):
+        nats_perm.get_node_module_data("policy", region.id, 1, 10, 4)
+
+
+def test_get_node_module_list_includes_cloud_regions():
+    region = CloudRegion.objects.create(name="nats-list-region")
+    out = nats_perm.get_node_module_list()
+    assert out[0]["name"] == "instance"
+    assert out[0]["display_name"] == "Instance"
+    assert {"name": region.id, "display_name": "nats-list-region", "children": []} in out[0]["children"]

--- a/server/apps/node_mgmt/tests/test_node_viewset_search_update_enum.py
+++ b/server/apps/node_mgmt/tests/test_node_viewset_search_update_enum.py
@@ -1,0 +1,281 @@
+"""NodeViewSet.search / update / enum / 批量绑定与采集动作节点。"""
+import json
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.base.tests.factories import UserFactory
+from apps.node_mgmt.constants.collector import CollectorConstants
+from apps.node_mgmt.constants.controller import ControllerConstants
+from apps.node_mgmt.constants.node import NodeConstants
+from apps.node_mgmt.models import CloudRegion, Collector, Node
+from apps.node_mgmt.models.action import CollectorActionTask, CollectorActionTaskNode
+from apps.node_mgmt.models.sidecar import NodeOrganization
+from apps.node_mgmt.views import node as node_view
+
+pytestmark = pytest.mark.django_db
+factory = APIRequestFactory()
+
+
+def _user():
+    user = UserFactory(username=f"node-vs-{uuid.uuid4().hex[:8]}", domain="domain.com", is_superuser=True)
+    user.permission = {
+        "node": {
+            "cloud_region_node-View",
+            "cloud_region_node-Edit",
+            "cloud_region_node-EditMainConfiguration",
+            "cloud_region_node-OperateCollector",
+        }
+    }
+    user.locale = "en"
+    return user
+
+
+def _auth(request, user=None):
+    user = user or _user()
+    force_authenticate(request, user=user)
+    request.COOKIES["current_team"] = "1"
+    return user
+
+
+def _region_and_nodes():
+    region = CloudRegion.objects.create(name=f"nv-{uuid.uuid4().hex[:8]}")
+    keep = Node.objects.create(
+        id=f"keep-{uuid.uuid4().hex[:8]}",
+        name="keep-node",
+        ip="10.0.0.1",
+        operating_system=NodeConstants.LINUX_OS,
+        collector_configuration_directory="/tmp",
+        cloud_region=region,
+        status={},
+    )
+    other = Node.objects.create(
+        id=f"other-{uuid.uuid4().hex[:8]}",
+        name="other-node",
+        ip="10.0.0.2",
+        operating_system=NodeConstants.LINUX_OS,
+        collector_configuration_directory="/tmp",
+        cloud_region=region,
+        status={},
+    )
+    NodeOrganization.objects.create(node=keep, organization=7)
+    NodeOrganization.objects.create(node=other, organization=8)
+    return region, keep, other
+
+
+def test_search_filters_by_name_org_and_cloud_region(monkeypatch):
+    region, keep, other = _region_and_nodes()
+    monkeypatch.setattr(node_view, "get_node_permission", lambda request: {"team": [1], "instance": []})
+    monkeypatch.setattr(
+        node_view,
+        "get_authorized_node_queryset",
+        lambda request, permission=None: Node.objects.filter(id__in=[keep.id, other.id]),
+    )
+    monkeypatch.setattr(node_view.NodeService, "process_node_data", staticmethod(lambda data: data))
+
+    request = factory.post(
+        "/node/search/",
+        {
+            "filters": {"name": [{"lookup_expr": "icontains", "value": "keep"}]},
+            "organization_ids": "7",
+            "cloud_region_id": region.id,
+        },
+        format="json",
+    )
+    _auth(request)
+    resp = node_view.NodeViewSet.as_view({"post": "search"})(request)
+    body = json.loads(resp.content)
+    assert body["result"] is True
+    ids = [item["id"] for item in body["data"]]
+    assert ids == [keep.id]
+    assert body["data"][0]["organization"] == [7]
+
+
+def test_search_paginates_when_page_size_set(monkeypatch):
+    _, keep, other = _region_and_nodes()
+    monkeypatch.setattr(node_view, "get_node_permission", lambda request: {})
+    monkeypatch.setattr(
+        node_view,
+        "get_authorized_node_queryset",
+        lambda request, permission=None: Node.objects.filter(id__in=[keep.id, other.id]),
+    )
+    monkeypatch.setattr(node_view.NodeService, "process_node_data", staticmethod(lambda data: data))
+    request = factory.post("/node/search/?page=1&page_size=1", {}, format="json")
+    _auth(request)
+    resp = node_view.NodeViewSet.as_view({"post": "search"})(request)
+    resp.render()
+    body = json.loads(resp.content)
+    assert body["result"] is True
+    assert body["code"] == "20000"
+    assert body["data"]["count"] == 2
+    assert len(body["data"]["items"]) == 1
+    assert body["data"]["items"][0]["id"] in {keep.id, other.id}
+
+
+def test_update_node_renames_replaces_orgs_and_syncs(monkeypatch):
+    _, node, _ = _region_and_nodes()
+    delay = MagicMock()
+    monkeypatch.setattr(node_view, "authorize_node_ids", lambda request, node_ids: ([node], None))
+    monkeypatch.setattr(node_view, "authorize_target_organizations", lambda request, node, orgs: None)
+    monkeypatch.setattr(node_view.sync_node_properties_to_sidecar, "delay", delay)
+    request = factory.patch(f"/node/{node.id}/update/", {"name": "renamed", "organizations": [11, 12]}, format="json")
+    _auth(request)
+    resp = node_view.NodeViewSet.as_view({"patch": "update_node"})(request, pk=node.id)
+    body = json.loads(resp.content)
+    assert body["result"] is True
+    node.refresh_from_db()
+    assert node.name == "renamed"
+    assert set(NodeOrganization.objects.filter(node=node).values_list("organization", flat=True)) == {11, 12}
+    delay.assert_called_once_with(node_id=node.id, name="renamed", organizations=[11, 12])
+
+
+def test_enum_falls_back_to_constant_labels(monkeypatch):
+    monkeypatch.setattr(node_view.LanguageLoader, "get", lambda self, key, default=None: "")
+    request = factory.get("/node/enum/")
+    _auth(request)
+    resp = node_view.NodeViewSet.as_view({"get": "enum"})(request)
+    body = json.loads(resp.content)
+    data = body["data"]
+    assert data["sidecar_status"][ControllerConstants.NORMAL] == ControllerConstants.SIDECAR_STATUS_ENUM[ControllerConstants.NORMAL]
+    assert data["install_method"][ControllerConstants.AUTO] == ControllerConstants.INSTALL_METHOD_ENUM[ControllerConstants.AUTO]
+    assert data["os"][NodeConstants.LINUX_OS] == NodeConstants.LINUX_OS_DISPLAY
+    assert data["tag"]["monitor"]["is_app"] is True
+    assert data["tag"]["monitor"]["name"] == CollectorConstants.TAG_ENUM["monitor"]["name"]
+    assert data["node_type"] == ControllerConstants.NODE_TYPE_ENUM
+
+
+def test_batch_binding_success_and_error(monkeypatch):
+    monkeypatch.setattr(node_view, "authorize_node_ids", lambda request, node_ids: (node_ids, None))
+    monkeypatch.setattr(node_view, "authorize_mutable_collector_configuration_ids", lambda request, ids: (ids, None))
+    monkeypatch.setattr(
+        node_view.NodeService,
+        "batch_binding_node_configuration",
+        staticmethod(lambda node_ids, cfg_id: (True, "bound")),
+    )
+    request = factory.post(
+        "/node/batch_binding_configuration/",
+        {"node_ids": ["n1"], "collector_configuration_id": "cfg-1"},
+        format="json",
+    )
+    _auth(request)
+    ok = node_view.NodeViewSet.as_view({"post": "batch_binding_node_configuration"})(request)
+    body = json.loads(ok.content)
+    assert body["result"] is True
+    assert body["data"] == "bound"
+
+    monkeypatch.setattr(
+        node_view.NodeService,
+        "batch_binding_node_configuration",
+        staticmethod(lambda node_ids, cfg_id: (False, "conflict")),
+    )
+    request = factory.post(
+        "/node/batch_binding_configuration/",
+        {"node_ids": ["n1"], "collector_configuration_id": "cfg-1"},
+        format="json",
+    )
+    _auth(request)
+    err = node_view.NodeViewSet.as_view({"post": "batch_binding_node_configuration"})(request)
+    body = json.loads(err.content)
+    assert body["result"] is False
+    assert body["message"] == "conflict"
+
+
+def test_batch_operate_returns_task_id(monkeypatch):
+    called = {}
+
+    def _operate(node_ids, collector_id, operation, created_by="", domain="domain.com", updated_by_domain="domain.com"):
+        called["node_ids"] = node_ids
+        called["collector_id"] = collector_id
+        called["operation"] = operation
+        called["created_by"] = created_by
+        return "task-88"
+
+    monkeypatch.setattr(node_view, "authorize_node_ids", lambda request, node_ids: (node_ids, None))
+    monkeypatch.setattr(node_view.NodeService, "batch_operate_node_collector", staticmethod(_operate))
+    request = factory.post(
+        "/node/batch_operate_collector/",
+        {"node_ids": ["n1"], "collector_id": "c1", "operation": "restart"},
+        format="json",
+    )
+    user = _auth(request)
+    resp = node_view.NodeViewSet.as_view({"post": "batch_operate_node_collector"})(request)
+    body = json.loads(resp.content)
+    assert body["result"] is True
+    assert body["data"] == {"task_id": "task-88"}
+    assert called == {
+        "node_ids": ["n1"],
+        "collector_id": "c1",
+        "operation": "restart",
+        "created_by": user.username,
+    }
+
+
+def test_collector_action_nodes_filters_status_and_summarizes(monkeypatch):
+    region, node, _ = _region_and_nodes()
+    collector = Collector.objects.create(
+        id=f"col-{uuid.uuid4().hex[:8]}",
+        name="Telegraf",
+        service_type="exec",
+        node_operating_system=NodeConstants.LINUX_OS,
+        executable_path="/opt/telegraf",
+        execute_parameters="--config %s",
+    )
+    task = CollectorActionTask.objects.create(
+        collector=collector,
+        cloud_region=region,
+        action="restart",
+        status="running",
+        total_count=1,
+    )
+    CollectorActionTaskNode.objects.create(
+        task=task,
+        node=node,
+        status="success",
+        result={"overall_status": "success"},
+    )
+    waiting_node = Node.objects.create(
+        id=f"wait-{uuid.uuid4().hex[:8]}",
+        name="wait-node",
+        ip="10.0.0.9",
+        operating_system=NodeConstants.LINUX_OS,
+        collector_configuration_directory="/tmp",
+        cloud_region=region,
+        status={},
+    )
+    CollectorActionTaskNode.objects.create(task=task, node=waiting_node, status="waiting", result={})
+    monkeypatch.setattr(
+        node_view,
+        "get_authorized_node_queryset",
+        lambda request: Node.objects.filter(id__in=[node.id, waiting_node.id]),
+    )
+    request = factory.post(
+        f"/node/collector/action/{task.id}/nodes/",
+        {"status": ["success"], "page": 1, "page_size": 10},
+        format="json",
+    )
+    _auth(request)
+    resp = node_view.NodeViewSet.as_view({"post": "collector_action_nodes"})(request, task_id=task.id)
+    body = json.loads(resp.content)
+    data = body["data"]
+    assert data["task_id"] == task.id
+    assert data["status"] == "running"
+    assert data["count"] == 1
+    assert data["items"][0]["node_id"] == node.id
+    assert data["items"][0]["status"] == "success"
+    assert data["items"][0]["ip"] == node.ip
+    assert data["summary"]["total"] == 2
+    assert data["summary"]["success"] == 1
+    assert data["summary"]["waiting"] == 1
+
+
+def test_destroy_deletes_authorized_node(monkeypatch):
+    _, node, _ = _region_and_nodes()
+    monkeypatch.setattr(node_view, "authorize_node_ids", lambda request, node_ids: ([node], None))
+    request = factory.delete(f"/node/{node.id}/")
+    _auth(request)
+    resp = node_view.NodeViewSet.as_view({"delete": "destroy"})(request, pk=node.id)
+    body = json.loads(resp.content)
+    assert body["result"] is True
+    assert not Node.objects.filter(id=node.id).exists()

--- a/server/apps/node_mgmt/tests/test_package_stream_and_resolve.py
+++ b/server/apps/node_mgmt/tests/test_package_stream_and_resolve.py
@@ -1,0 +1,233 @@
+"""PackageService 路径解析 / 流式下载契约。
+
+仅 mock JetStream / S3 异步边界。钉死候选路径去重、404 回退与流式分块。
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from nats.js.errors import ObjectNotFoundError
+
+from apps.node_mgmt.services.package import PackageService
+
+pytestmark = pytest.mark.django_db
+
+
+def _pkg(**over):
+    data = dict(cpu_architecture="x86_64", os="linux", object="telegraf", version="1.0.0", name="t.tar.gz")
+    data.update(over)
+    return SimpleNamespace(**data)
+
+
+# --------------------------------------------------------------------------
+# build_candidate_file_paths 去重
+# --------------------------------------------------------------------------
+
+
+def test_candidate_paths_dedup_when_primary_equals_legacy():
+    obj = _pkg()
+    with (
+        patch.object(PackageService, "build_file_path", return_value="linux/telegraf/1.0.0/t.tar.gz"),
+        patch.object(PackageService, "build_legacy_file_path", return_value="linux/telegraf/1.0.0/t.tar.gz"),
+    ):
+        assert PackageService.build_candidate_file_paths(obj) == ["linux/telegraf/1.0.0/t.tar.gz"]
+
+
+# --------------------------------------------------------------------------
+# resolve_existing_file_path
+# --------------------------------------------------------------------------
+
+
+class _FakeJetStream:
+    def __init__(self, existing=None, raise_on=None):
+        self.existing = set(existing or [])
+        self.raise_on = raise_on
+        self.closed = False
+        self.object_store = self
+
+    async def connect(self):
+        return None
+
+    async def close(self):
+        self.closed = True
+
+    async def get_info(self, path):
+        if self.raise_on and path == self.raise_on:
+            raise RuntimeError("js down")
+        if path in self.existing:
+            return SimpleNamespace(description="ok")
+        raise ObjectNotFoundError()
+
+
+def test_resolve_existing_file_path_returns_first_hit():
+    obj = _pkg()
+    js = _FakeJetStream(existing={PackageService.build_file_path(obj)})
+    with patch("apps.rpc.jetstream.JetStreamService", return_value=js):
+        assert PackageService.resolve_existing_file_path(obj) == PackageService.build_file_path(obj)
+    assert js.closed is True
+
+
+def test_resolve_existing_file_path_falls_back_to_legacy():
+    obj = _pkg()
+    js = _FakeJetStream(existing={PackageService.build_legacy_file_path(obj)})
+    with patch("apps.rpc.jetstream.JetStreamService", return_value=js):
+        assert PackageService.resolve_existing_file_path(obj) == PackageService.build_legacy_file_path(obj)
+
+
+def test_resolve_existing_file_path_all_missing_raises():
+    obj = _pkg()
+    js = _FakeJetStream(existing=set())
+    with patch("apps.rpc.jetstream.JetStreamService", return_value=js):
+        with pytest.raises(ObjectNotFoundError):
+            PackageService.resolve_existing_file_path(obj)
+
+
+def test_resolve_existing_file_path_empty_candidates_raises():
+    obj = _pkg()
+    js = _FakeJetStream(existing=set())
+    with (
+        patch.object(PackageService, "build_candidate_file_paths", return_value=[]),
+        patch("apps.rpc.jetstream.JetStreamService", return_value=js),
+    ):
+        with pytest.raises(ObjectNotFoundError):
+            PackageService.resolve_existing_file_path(obj)
+
+
+# --------------------------------------------------------------------------
+# _download_file_async 空候选
+# --------------------------------------------------------------------------
+
+
+def test_download_file_empty_candidates_raises():
+    obj = _pkg()
+    with patch.object(PackageService, "build_candidate_file_paths", return_value=[]):
+        with pytest.raises(ObjectNotFoundError):
+            PackageService.download_file(obj)
+
+
+# --------------------------------------------------------------------------
+# stream_download_file
+# --------------------------------------------------------------------------
+
+
+def test_stream_download_file_yields_chunks_from_first_hit():
+    obj = _pkg()
+
+    async def fake_stream(path):
+        assert path == PackageService.build_file_path(obj)
+        yield b"abc", "t.tar.gz", 3
+        yield b"def", "t.tar.gz", 3
+
+    async def collect():
+        items = []
+        async for item in PackageService.stream_download_file(obj):
+            items.append(item)
+        return items
+
+    with patch("apps.node_mgmt.services.package.stream_download_file_by_s3", fake_stream):
+        items = asyncio.run(collect())
+    assert items == [(b"abc", "t.tar.gz", 3), (b"def", "t.tar.gz", 3)]
+
+
+def test_stream_download_file_falls_back_then_raises():
+    obj = _pkg()
+    seen = []
+
+    async def fake_stream(path):
+        seen.append(path)
+        raise ObjectNotFoundError()
+        yield  # make it an async generator  # noqa: B901
+
+    async def collect():
+        async for _ in PackageService.stream_download_file(obj):
+            pass
+
+    with patch("apps.node_mgmt.services.package.stream_download_file_by_s3", fake_stream):
+        with pytest.raises(ObjectNotFoundError):
+            asyncio.run(collect())
+    assert seen == PackageService.build_candidate_file_paths(obj)
+
+
+def test_stream_download_file_empty_candidates_raises():
+    async def collect():
+        async for _ in PackageService.stream_download_file(_pkg()):
+            pass
+
+    with patch.object(PackageService, "build_candidate_file_paths", return_value=[]):
+        with pytest.raises(ObjectNotFoundError):
+            asyncio.run(collect())
+
+
+# --------------------------------------------------------------------------
+# download_file_streaming
+# --------------------------------------------------------------------------
+
+
+def test_download_file_streaming_reads_tempfile_and_unlinks(tmp_path):
+    obj = _pkg()
+    primary = PackageService.build_file_path(obj)
+    tmp = tmp_path / "pkg.bin"
+    tmp.write_bytes(b"hello-world")
+
+    class Store:
+        async def get_info(self, path):
+            if path != primary:
+                raise ObjectNotFoundError()
+            return SimpleNamespace(description="display-name.bin")
+
+        async def get(self, path, writeinto=None):
+            writeinto.write(b"hello-world")
+
+    js = SimpleNamespace(object_store=Store(), closed=False)
+
+    async def connect():
+        return None
+
+    async def close():
+        js.closed = True
+
+    js.connect = connect
+    js.close = close
+
+    with (
+        patch("apps.rpc.jetstream.JetStreamService", return_value=js),
+        patch("tempfile.NamedTemporaryFile", return_value=open(tmp, "w+b")),
+    ):
+        gen, filename = PackageService.download_file_streaming(obj)
+
+    assert filename == "display-name.bin"
+    assert b"".join(gen) == b"hello-world"
+    assert not tmp.exists()
+    assert js.closed is True
+
+
+def test_download_file_streaming_all_missing_raises():
+    obj = _pkg()
+
+    class Store:
+        async def get_info(self, path):
+            raise ObjectNotFoundError()
+
+        async def get(self, path, writeinto=None):
+            raise ObjectNotFoundError()
+
+    js = SimpleNamespace(object_store=Store())
+    js.connect = AsyncMock()
+    js.close = AsyncMock()
+    with patch("apps.rpc.jetstream.JetStreamService", return_value=js):
+        with pytest.raises(ObjectNotFoundError):
+            PackageService.download_file_streaming(obj)
+
+
+def test_download_file_streaming_empty_candidates_raises():
+    js = SimpleNamespace(object_store=MagicMock())
+    js.connect = AsyncMock()
+    js.close = AsyncMock()
+    with (
+        patch.object(PackageService, "build_candidate_file_paths", return_value=[]),
+        patch("apps.rpc.jetstream.JetStreamService", return_value=js),
+    ):
+        with pytest.raises(ObjectNotFoundError):
+            PackageService.download_file_streaming(_pkg())

--- a/server/apps/node_mgmt/tests/test_sidecar_action_ack_and_default_config.py
+++ b/server/apps/node_mgmt/tests/test_sidecar_action_ack_and_default_config.py
@@ -1,0 +1,352 @@
+"""Sidecar 剩余契约：动作 ack、304 无 IP 回退、标签补全、默认配置跳过/更新。"""
+
+import json
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.node_mgmt.constants.collector import CollectorConstants
+from apps.node_mgmt.constants.controller import ControllerConstants
+from apps.node_mgmt.models import Collector, Node
+from apps.node_mgmt.models.action import CollectorActionTask, CollectorActionTaskNode
+from apps.node_mgmt.models.cloud_region import CloudRegion
+from apps.node_mgmt.models.sidecar import Action, CollectorConfiguration
+from apps.node_mgmt.services.sidecar import Sidecar
+
+pytestmark = pytest.mark.django_db
+
+
+def _region(suffix=None):
+    suffix = suffix or uuid.uuid4().hex[:8]
+    return CloudRegion.objects.create(name=f"cr-r13-{suffix}")
+
+
+def _node(region, **over):
+    suffix = uuid.uuid4().hex[:8]
+    data = dict(
+        id=f"node-r13-{suffix}",
+        name="n",
+        ip="10.13.13.13",
+        operating_system="linux",
+        collector_configuration_directory="/etc/sidecar",
+        cloud_region=region,
+        cpu_architecture="x86_64",
+    )
+    data.update(over)
+    return Node.objects.create(**data)
+
+
+def _request(headers=None, data=None, meta=None):
+    req = MagicMock()
+    req.headers = headers or {}
+    req.META = meta or {}
+    req.data = data or {}
+    return req
+
+
+# --------------------------------------------------------------------------
+# _collector_status_signature / trigger_converge
+# --------------------------------------------------------------------------
+
+
+def test_trigger_converge_schedules_action_on_signature_change():
+    region = _region()
+    node = _node(region)
+    collector = Collector.objects.create(
+        id=f"c-act-{uuid.uuid4().hex[:8]}",
+        name="Telegraf",
+        service_type="svc",
+        node_operating_system="linux",
+        executable_path="/bin",
+        execute_parameters="-c",
+    )
+    task = CollectorActionTask.objects.create(collector=collector, action="restart", status="running")
+    CollectorActionTaskNode.objects.create(task=task, node=node, status="running", result={})
+
+    with (
+        patch("apps.node_mgmt.services.sidecar.cache.get", return_value=None),
+        patch("apps.node_mgmt.services.sidecar.cache.set"),
+        patch("apps.node_mgmt.services.sidecar.converge_collector_action_task_for_node") as conv,
+    ):
+        Sidecar.trigger_converge_tasks_if_needed(
+            node.id,
+            node.ip,
+            {"collectors": [{"collector_id": collector.id, "status": "ok"}]},
+        )
+    conv.delay.assert_called_once_with(node.id)
+
+
+# --------------------------------------------------------------------------
+# update_node_client：304 无 IP、标签补全、动作 ack
+# --------------------------------------------------------------------------
+
+
+def test_update_node_client_etag_hit_looks_up_ip_from_db():
+    region = _region()
+    node = _node(region, ip="10.9.8.7")
+    req = SimpleNamespace(
+        headers={"If-None-Match": '"etag-r13"'},
+        data={"node_details": {"status": {"cpu": 2}}},
+    )
+    with (
+        patch("apps.node_mgmt.services.sidecar.cache.get", return_value="etag-r13"),
+        patch.object(Sidecar, "trigger_converge_tasks_if_needed") as converge,
+    ):
+        resp = Sidecar.update_node_client(req, node.id)
+    assert resp.status_code == 304
+    converge.assert_called_once_with(node.id, "10.9.8.7", {"cpu": 2})
+
+
+def test_update_node_client_applies_install_method_and_node_type_tags():
+    region = _region()
+    node = _node(region)
+    req = SimpleNamespace(
+        headers={},
+        META={},
+        data={
+            "node_name": "edge",
+            "node_details": {
+                "ip": node.ip,
+                "operating_system": "Linux",
+                "collector_configuration_directory": "/etc/sidecar",
+                "metrics": {},
+                "status": {},
+                "log_file_list": [],
+                "tags": [
+                    f"{ControllerConstants.INSTALL_METHOD_TAG}:{ControllerConstants.MANUAL}",
+                    f"{ControllerConstants.NODE_TYPE_TAG}:{ControllerConstants.NODE_TYPE_CONTAINER}",
+                    f"{ControllerConstants.CLOUD_TAG}:{region.id}",
+                ],
+            },
+        },
+    )
+    with (
+        patch("apps.node_mgmt.services.sidecar.cache.get", return_value=None),
+        patch("apps.node_mgmt.services.sidecar.cache.set"),
+        patch.object(Sidecar, "trigger_converge_tasks_if_needed"),
+    ):
+        resp = Sidecar.update_node_client(req, node.id)
+    assert resp.status_code == 202
+    node.refresh_from_db()
+    assert node.install_method == ControllerConstants.MANUAL
+    assert node.node_type == ControllerConstants.NODE_TYPE_CONTAINER
+    assert node.cloud_region_id == region.id
+
+
+def test_update_node_client_acks_waiting_action_task():
+    region = _region()
+    node = _node(region)
+    collector = Collector.objects.create(
+        id=f"c-wait-{uuid.uuid4().hex[:8]}",
+        name="Telegraf",
+        service_type="svc",
+        node_operating_system="linux",
+        executable_path="/bin",
+        execute_parameters="-c",
+    )
+    task = CollectorActionTask.objects.create(collector=collector, action="restart", status="waiting")
+    task_node = CollectorActionTaskNode.objects.create(task=task, node=node, status="waiting", result={})
+    Action.objects.create(node=node, action=[{"task_id": task.id, "collector_id": collector.id}])
+
+    req = SimpleNamespace(
+        headers={},
+        META={},
+        data={
+            "node_name": node.name,
+            "node_details": {
+                "ip": node.ip,
+                "operating_system": "linux",
+                "collector_configuration_directory": "/etc/sidecar",
+                "metrics": {},
+                "status": {},
+                "log_file_list": [],
+                "tags": [],
+            },
+        },
+    )
+    with (
+        patch("apps.node_mgmt.services.sidecar.cache.get", return_value=None),
+        patch("apps.node_mgmt.services.sidecar.cache.set"),
+        patch.object(Sidecar, "trigger_converge_tasks_if_needed"),
+    ):
+        resp = Sidecar.update_node_client(req, node.id)
+    assert resp.status_code == 202
+    task_node.refresh_from_db()
+    assert task_node.status == "running"
+    assert task_node.result["overall_status"] == "running"
+    assert not Action.objects.filter(node=node).exists()
+
+
+def test_update_node_client_updates_running_action_consume_ack():
+    region = _region()
+    node = _node(region)
+    collector = Collector.objects.create(
+        id=f"c-run-{uuid.uuid4().hex[:8]}",
+        name="Telegraf",
+        service_type="svc",
+        node_operating_system="linux",
+        executable_path="/bin",
+        execute_parameters="-c",
+    )
+    task = CollectorActionTask.objects.create(collector=collector, action="restart", status="waiting")
+    task_node = CollectorActionTaskNode.objects.create(
+        task=task,
+        node=node,
+        status="running",
+        result={"steps": [{"action": "consume_ack", "status": "running"}]},
+    )
+    Action.objects.create(node=node, action=[{"task_id": task.id, "collector_id": collector.id}])
+
+    req = SimpleNamespace(
+        headers={},
+        META={},
+        data={
+            "node_name": node.name,
+            "node_details": {
+                "ip": node.ip,
+                "operating_system": "linux",
+                "collector_configuration_directory": "/etc/sidecar",
+                "metrics": {},
+                "status": {},
+                "log_file_list": [],
+                "tags": [],
+            },
+        },
+    )
+    with (
+        patch("apps.node_mgmt.services.sidecar.cache.get", return_value=None),
+        patch("apps.node_mgmt.services.sidecar.cache.set"),
+        patch.object(Sidecar, "trigger_converge_tasks_if_needed"),
+    ):
+        resp = Sidecar.update_node_client(req, node.id)
+    assert resp.status_code == 202
+    task_node.refresh_from_db()
+    steps = {step["action"]: step for step in task_node.result["steps"]}
+    assert steps["consume_ack"]["status"] == "success"
+    assert "execute_command" in steps
+    task.refresh_from_db()
+    assert task.status == "running"
+
+
+# --------------------------------------------------------------------------
+# get_node_config：ETag 命中但节点不存在
+# --------------------------------------------------------------------------
+
+
+def test_get_node_config_etag_hit_missing_node_returns_404():
+    req = _request(headers={"If-None-Match": "stale"})
+    with patch("apps.node_mgmt.services.sidecar.cache.get", return_value="stale"):
+        resp = Sidecar.get_node_config(req, "missing-node-r13", "cfg-x")
+    assert resp.status_code == 404
+    assert json.loads(resp.content)["error"] == "Node not found"
+
+
+# --------------------------------------------------------------------------
+# create_default_config
+# --------------------------------------------------------------------------
+
+
+def _collector(region, name, default_config):
+    return Collector.objects.create(
+        id=f"c-{name}-{uuid.uuid4().hex[:8]}",
+        name=name,
+        service_type="svc",
+        node_operating_system="linux",
+        executable_path="/bin",
+        execute_parameters="-c",
+        default_config=default_config,
+    )
+
+
+def test_create_default_config_skips_container_collector_on_host():
+    region = _region()
+    node = _node(region)
+    collector = _collector(region, "Snmptrapd", {"nats": "x"})
+    assert collector.name in CollectorConstants.DEFAULT_CONTAINER_COLLECTOR_CONFIGS
+    with (
+        patch.object(Sidecar, "_get_default_collectors_for_node", return_value={collector.name: collector}),
+        patch.object(Sidecar, "get_cloud_region_envconfig", return_value={"SIDECAR_INPUT_MODE": "nats"}),
+    ):
+        Sidecar.create_default_config(node, [])
+    assert not CollectorConfiguration.objects.filter(collector=collector).exists()
+
+
+def test_create_default_config_skips_when_template_missing():
+    region = _region()
+    node = _node(region)
+    collector = _collector(region, "Telegraf", {"other": "x"})
+    with (
+        patch.object(Sidecar, "_get_default_collectors_for_node", return_value={collector.name: collector}),
+        patch.object(Sidecar, "get_cloud_region_envconfig", return_value={"SIDECAR_INPUT_MODE": "nats"}),
+    ):
+        Sidecar.create_default_config(node, [])
+    assert not CollectorConfiguration.objects.filter(collector=collector).exists()
+
+
+def test_create_default_config_updates_existing_pre_and_skips_identical():
+    region = _region()
+    node = _node(region)
+    collector = _collector(region, "Telegraf", {"nats": "url={{ HOST }}"})
+    cfg = CollectorConfiguration.objects.create(
+        name=f"pre-{collector.id}",
+        collector=collector,
+        config_template="old",
+        is_pre=True,
+        cloud_region=region,
+    )
+    cfg.nodes.add(node)
+    with (
+        patch.object(Sidecar, "_get_default_collectors_for_node", return_value={collector.name: collector}),
+        patch.object(Sidecar, "get_cloud_region_envconfig", return_value={"SIDECAR_INPUT_MODE": "nats", "HOST": "10.1.1.1"}),
+    ):
+        Sidecar.create_default_config(node, [])
+    cfg.refresh_from_db()
+    assert "10.1.1.1" in cfg.config_template
+
+    with (
+        patch.object(Sidecar, "_get_default_collectors_for_node", return_value={collector.name: collector}),
+        patch.object(Sidecar, "get_cloud_region_envconfig", return_value={"SIDECAR_INPUT_MODE": "nats", "HOST": "10.1.1.1"}),
+    ):
+        Sidecar.create_default_config(node, [])
+    assert CollectorConfiguration.objects.filter(collector=collector, nodes=node).count() == 1
+
+
+def test_create_default_config_skips_custom_and_swallows_render_error():
+    region = _region()
+    node = _node(region)
+    custom = _collector(region, "Vector", {"nats": "ok"})
+    cfg = CollectorConfiguration.objects.create(
+        name="custom",
+        collector=custom,
+        config_template="user",
+        is_pre=False,
+        cloud_region=region,
+    )
+    cfg.nodes.add(node)
+    boom = _collector(region, "Broken", {"nats": "{% invalid jinja %}"})
+    with (
+        patch.object(
+            Sidecar,
+            "_get_default_collectors_for_node",
+            return_value={custom.name: custom, boom.name: boom},
+        ),
+        patch.object(Sidecar, "get_cloud_region_envconfig", return_value={"SIDECAR_INPUT_MODE": "nats"}),
+    ):
+        Sidecar.create_default_config(node, [])
+    assert not CollectorConfiguration.objects.filter(collector=boom).exists()
+    assert CollectorConfiguration.objects.get(pk=cfg.pk).config_template == "user"
+
+
+def test_create_default_config_appends_add_config_for_container():
+    region = _region()
+    node = _node(region, node_type=ControllerConstants.NODE_TYPE_CONTAINER)
+    collector = _collector(region, "Telegraf", {"nats": "base", "add_config": "extra-line"})
+    with (
+        patch.object(Sidecar, "_get_default_collectors_for_node", return_value={collector.name: collector}),
+        patch.object(Sidecar, "get_cloud_region_envconfig", return_value={"SIDECAR_INPUT_MODE": "nats"}),
+    ):
+        Sidecar.create_default_config(node, [ControllerConstants.NODE_TYPE_CONTAINER])
+    cfg = CollectorConfiguration.objects.get(collector=collector, nodes=node, is_pre=True)
+    assert "extra-line" in cfg.config_template

--- a/server/apps/node_mgmt/tests/test_token_auth_service.py
+++ b/server/apps/node_mgmt/tests/test_token_auth_service.py
@@ -1,0 +1,65 @@
+"""Sidecar Token 认证：解析 Authorization、节点不匹配、签名错误。"""
+import base64
+from types import SimpleNamespace
+
+import pytest
+
+from apps.core.exceptions.base_app_exception import BaseAppException, UnauthorizedException
+from apps.node_mgmt.utils import token_auth
+from config.components.drf import AUTH_TOKEN_HEADER_NAME
+
+pytestmark = pytest.mark.unit
+
+
+def test_get_client_token_parses_basic_and_rejects_bad_header():
+    assert token_auth.get_client_token(SimpleNamespace(META={})) is None
+
+    raw = base64.b64encode(b"node-token:ignored-password").decode()
+    request = SimpleNamespace(META={AUTH_TOKEN_HEADER_NAME: f"Basic {raw}"})
+    assert token_auth.get_client_token(request) == "node-token"
+
+    bad = SimpleNamespace(META={AUTH_TOKEN_HEADER_NAME: "Basic not-base64!!!"})
+    assert token_auth.get_client_token(bad) is None
+
+
+def test_check_token_auth_rejects_missing_node_token_and_mismatch(monkeypatch):
+    request = SimpleNamespace(META={})
+    with pytest.raises(UnauthorizedException, match="节点ID为空"):
+        token_auth.check_token_auth("", request)
+
+    monkeypatch.setattr(token_auth, "get_client_token", lambda req: None)
+    with pytest.raises(UnauthorizedException, match="未获取到有效的认证Token"):
+        token_auth.check_token_auth("n1", request)
+
+    monkeypatch.setattr(token_auth, "get_client_token", lambda req: "tok")
+    monkeypatch.setattr(token_auth, "decode_token", lambda token, node_id="": {"node_id": "other"})
+    with pytest.raises(UnauthorizedException, match="节点ID与Token不匹配"):
+        token_auth.check_token_auth("n1", request)
+
+    monkeypatch.setattr(token_auth, "decode_token", lambda token, node_id="": {"node_id": "n1"})
+    monkeypatch.setattr(token_auth, "get_node_cache_token", lambda node_id: None)
+    with pytest.raises(UnauthorizedException, match="服务端无此节点"):
+        token_auth.check_token_auth("n1", request)
+
+    monkeypatch.setattr(token_auth, "get_node_cache_token", lambda node_id: "different")
+    with pytest.raises(UnauthorizedException, match="与服务端记录不一致"):
+        token_auth.check_token_auth("n1", request)
+
+
+def test_check_token_auth_accepts_matching_token(monkeypatch):
+    monkeypatch.setattr(token_auth, "get_client_token", lambda req: "tok")
+    monkeypatch.setattr(token_auth, "decode_token", lambda token, node_id="": {"node_id": "n1"})
+    monkeypatch.setattr(token_auth, "get_node_cache_token", lambda node_id: "tok")
+    token_auth.check_token_auth("n1", SimpleNamespace(META={}))
+
+
+def test_decode_token_rejects_tampered_signature_and_short_payload():
+    with pytest.raises(BaseAppException, match="格式错误"):
+        token_auth.decode_token(base64.urlsafe_b64encode(b"short").decode())
+
+    good = token_auth.hmac.new(token_auth.SECRET_KEY.encode(), b'{"node_id":"n"}', token_auth.hashlib.sha256).digest()
+    tampered = base64.urlsafe_b64encode(b"\x00" * 32 + b"." + b'{"node_id":"n"}').decode()
+    with pytest.raises(BaseAppException, match="无效的 token"):
+        token_auth.decode_token(tampered)
+    valid = base64.urlsafe_b64encode(good + b"." + b'{"node_id":"n"}').decode()
+    assert token_auth.decode_token(valid) == {"node_id": "n"}

--- a/server/apps/operation_analysis/tests/test_namespace_datasource_crud.py
+++ b/server/apps/operation_analysis/tests/test_namespace_datasource_crud.py
@@ -1,0 +1,168 @@
+"""NameSpace / DataSource CRUD：ids 过滤、审计、组织删除闸与 brief 列表。"""
+import json
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.operation_analysis.models.datasource_models import DataSourceAPIModel, NameSpace
+from apps.operation_analysis.views import datasource_view
+from apps.system_mgmt.models import OperationLog
+
+pytestmark = pytest.mark.django_db
+
+factory = APIRequestFactory()
+
+
+def _superuser(user):
+    user.is_superuser = True
+    return user
+
+
+def _req(method, path, user, data=None, query=""):
+    fn = getattr(factory, method)
+    url = f"{path}{query}"
+    request = fn(url, data=data or {}, format="json") if data is not None else fn(url)
+    request.COOKIES["current_team"] = "1"
+    request.COOKIES["include_children"] = "0"
+    force_authenticate(request, user=user)
+    return request
+
+
+def _render(resp):
+    resp.render()
+    if not resp.content:
+        return None
+    return json.loads(resp.content.decode("utf-8"))
+
+
+def test_namespace_list_filters_ids_and_crud_writes_audit(authenticated_user):
+    user = _superuser(authenticated_user)
+    ns1 = NameSpace.objects.create(name="ns-keep", account="a", password="p1", domain="127.0.0.1:4222")
+    ns2 = NameSpace.objects.create(name="ns-drop", account="a", password="p2", domain="127.0.0.1:4222")
+
+    listed = datasource_view.NameSpaceModelViewSet.as_view({"get": "list"})(_req("get", "/namespace/", user, query=f"?ids={ns1.id},"))
+    payload = _render(listed)
+    assert listed.status_code == status.HTTP_200_OK
+    items = payload["data"]["items"] if isinstance(payload.get("data"), dict) else payload.get("data") or payload
+    names = {item["name"] for item in items}
+    assert "ns-keep" in names
+    assert "ns-drop" not in names
+
+    created = datasource_view.NameSpaceModelViewSet.as_view({"post": "create"})(
+        _req(
+            "post",
+            "/namespace/",
+            user,
+            data={"name": "ns-new", "account": "acct", "password": "secret", "domain": "nats.local:4222"},
+        )
+    )
+    payload = _render(created)
+    assert created.status_code == status.HTTP_201_CREATED
+    assert payload["data"]["name"] == "ns-new"
+    ns = NameSpace.objects.get(name="ns-new")
+    log = OperationLog.objects.get(app="ops-analysis", action_type="create", summary="新增命名空间: ns-new")
+    assert log.username == "testuser"
+
+    updated = datasource_view.NameSpaceModelViewSet.as_view({"put": "update"})(
+        _req(
+            "put",
+            f"/namespace/{ns.id}/",
+            user,
+            data={"name": "ns-renamed", "account": "acct", "password": "secret", "domain": "nats.local:4222"},
+        ),
+        pk=str(ns.id),
+    )
+    payload = _render(updated)
+    assert updated.status_code == status.HTTP_200_OK
+    ns.refresh_from_db()
+    assert ns.name == "ns-renamed"
+    assert OperationLog.objects.filter(summary="编辑命名空间: ns-renamed").exists()
+
+    retrieved = datasource_view.NameSpaceModelViewSet.as_view({"get": "retrieve"})(
+        _req("get", f"/namespace/{ns.id}/", user),
+        pk=str(ns.id),
+    )
+    payload = _render(retrieved)
+    assert retrieved.status_code == status.HTTP_200_OK
+    assert payload["data"]["name"] == "ns-renamed"
+
+    deleted = datasource_view.NameSpaceModelViewSet.as_view({"delete": "destroy"})(
+        _req("delete", f"/namespace/{ns.id}/", user),
+        pk=str(ns.id),
+    )
+    _render(deleted)
+    assert not NameSpace.objects.filter(id=ns.id).exists()
+    assert OperationLog.objects.filter(summary="删除命名空间: ns-renamed").exists()
+    assert NameSpace.objects.filter(id=ns2.id).exists()
+
+
+def test_datasource_create_update_destroy_and_foreign_team_forbidden(authenticated_user, monkeypatch):
+    user = _superuser(authenticated_user)
+    monkeypatch.setattr(
+        "apps.core.utils.serializers.get_permission_rules",
+        lambda *a, **k: {"team": [1], "instance": []},
+    )
+    monkeypatch.setattr(
+        "apps.core.utils.viewset_utils.get_permission_rules",
+        lambda *a, **k: {"team": [1], "instance": []},
+    )
+
+    created = datasource_view.DataSourceAPIModelViewSet.as_view({"post": "create"})(
+        _req(
+            "post",
+            "/data_source/",
+            user,
+            data={"name": "ds-a", "groups": [1], "rest_api": "monitor/query", "source_type": "nats"},
+        )
+    )
+    payload = _render(created)
+    assert created.status_code == status.HTTP_201_CREATED
+    assert payload["data"]["name"] == "ds-a"
+    ds = DataSourceAPIModel.objects.get(name="ds-a")
+    assert OperationLog.objects.filter(summary="新增数据源: ds-a").exists()
+
+    updated = datasource_view.DataSourceAPIModelViewSet.as_view({"put": "update"})(
+        _req(
+            "put",
+            f"/data_source/{ds.id}/",
+            user,
+            data={"name": "ds-b", "groups": [1], "rest_api": "monitor/query", "source_type": "nats"},
+        ),
+        pk=str(ds.id),
+    )
+    payload = _render(updated)
+    assert updated.status_code == status.HTTP_200_OK
+    ds.refresh_from_db()
+    assert ds.name == "ds-b"
+    assert OperationLog.objects.filter(summary="编辑数据源: ds-b").exists()
+
+    listed = datasource_view.DataSourceAPIModelViewSet.as_view({"get": "list"})(_req("get", "/data_source/", user, query=f"?ids={ds.id}&mode=brief"))
+    payload = _render(listed)
+    assert listed.status_code == status.HTTP_200_OK
+
+    retrieved = datasource_view.DataSourceAPIModelViewSet.as_view({"get": "retrieve"})(
+        _req("get", f"/data_source/{ds.id}/", user),
+        pk=str(ds.id),
+    )
+    payload = _render(retrieved)
+    assert retrieved.status_code == status.HTTP_200_OK
+    assert payload["data"]["name"] == "ds-b"
+
+    foreign = DataSourceAPIModel.objects.create(name="ds-other", groups=[9], rest_api="x/y")
+    forbidden = datasource_view.DataSourceAPIModelViewSet.as_view({"delete": "destroy"})(
+        _req("delete", f"/data_source/{foreign.id}/", user),
+        pk=str(foreign.id),
+    )
+    payload = _render(forbidden)
+    assert forbidden.status_code == status.HTTP_403_FORBIDDEN
+    assert "无权删除该数据源" in json.dumps(payload, ensure_ascii=False)
+    assert DataSourceAPIModel.objects.filter(id=foreign.id).exists()
+
+    deleted = datasource_view.DataSourceAPIModelViewSet.as_view({"delete": "destroy"})(
+        _req("delete", f"/data_source/{ds.id}/", user),
+        pk=str(ds.id),
+    )
+    _render(deleted)
+    assert not DataSourceAPIModel.objects.filter(id=ds.id).exists()
+    assert OperationLog.objects.filter(summary="删除数据源: ds-b").exists()

--- a/server/apps/opspilot/tests/test_bot_view_channels_logs_and_destroy.py
+++ b/server/apps/opspilot/tests/test_bot_view_channels_logs_and_destroy.py
@@ -1,0 +1,219 @@
+"""BotViewSet：retrieve 回填测试 execution_id、渠道读写、destroy 清理、日志守卫。"""
+import json
+import uuid
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.base.tests.factories import UserFactory
+from apps.opspilot.enum import WorkFlowTaskStatus
+from apps.opspilot.models import Bot, BotChannel, BotWorkFlow, WorkFlowConversationHistory, WorkFlowTaskResult
+from apps.opspilot.viewsets.bot_view import BotViewSet
+
+pytestmark = pytest.mark.django_db
+factory = APIRequestFactory()
+MOD = "apps.opspilot.viewsets.bot_view"
+
+
+def _su(name="bot-ch-admin"):
+    return UserFactory(
+        username=f"{name}-{uuid.uuid4().hex[:8]}", domain="domain.com", roles=[], is_superuser=True, group_list=[{"id": 1, "name": "T1"}]
+    )
+
+
+def _body(resp):
+    if hasattr(resp, "content"):
+        try:
+            return json.loads(resp.content.decode("utf-8"))
+        except Exception:
+            pass
+    return getattr(resp, "data", None)
+
+
+def test_retrieve_fills_running_test_execution_id_only():
+    user = _su("bot-ret")
+    bot = Bot.objects.create(name="ret-bot", team=[1])
+    flow = BotWorkFlow.objects.create(bot=bot, flow_json={}, web_json={})
+    WorkFlowTaskResult.objects.create(
+        bot_work_flow=flow,
+        execution_id="prod-run",
+        status=WorkFlowTaskStatus.RUNNING,
+        input_data="{}",
+        is_test=False,
+    )
+    WorkFlowTaskResult.objects.create(
+        bot_work_flow=flow,
+        execution_id="test-run",
+        status=WorkFlowTaskStatus.RUNNING,
+        input_data="{}",
+        is_test=True,
+    )
+    req = factory.get(f"/{bot.id}/")
+    force_authenticate(req, user=user)
+    req.COOKIES["current_team"] = "1"
+    resp = BotViewSet.as_view({"get": "retrieve"})(req, pk=bot.id)
+    assert resp.data["execution_id"] == "test-run"
+
+
+def test_get_bot_channels_validates_bot_and_masks_secrets():
+    user = _su("bot-ch")
+    missing = BotViewSet.as_view({"get": "get_bot_channels"})(factory.get("/"))
+    # unauthenticated would 403; authenticate
+    req = factory.get("/")
+    force_authenticate(req, user=user)
+    req.COOKIES["current_team"] = "1"
+    missing = BotViewSet.as_view({"get": "get_bot_channels"})(req)
+    assert missing.status_code == 400
+
+    req404 = factory.get("/?bot_id=999999")
+    force_authenticate(req404, user=user)
+    req404.COOKIES["current_team"] = "1"
+    not_found = BotViewSet.as_view({"get": "get_bot_channels"})(req404)
+    assert not_found.status_code == 404
+
+    bot = Bot.objects.create(name="ch-bot", team=[1])
+    BotChannel.objects.create(
+        bot=bot,
+        name="web",
+        channel_type="web",
+        channel_config={"channels.web": {"token": "secret", "url": "http://x"}},
+        enabled=True,
+    )
+    req_ok = factory.get(f"/?bot_id={bot.id}")
+    force_authenticate(req_ok, user=user)
+    req_ok.COOKIES["current_team"] = "1"
+    ok = BotViewSet.as_view({"get": "get_bot_channels"})(req_ok)
+    body = _body(ok)
+    assert body["result"] is True
+    channel = body["data"][0]
+    assert channel["enabled"] is True
+    assert channel["channel_config"]["channels.web"]["token"] == "******"
+    assert channel["channel_config"]["channels.web"]["url"] == "http://x"
+
+
+def test_update_bot_channel_toggles_enabled_and_config():
+    user = _su("bot-upd-ch")
+    bot = Bot.objects.create(name="upd-ch", team=[1])
+    ch = BotChannel.objects.create(bot=bot, name="web", channel_type="web", channel_config={}, enabled=False)
+    req = factory.post("/", {"id": ch.id, "enabled": True, "channel_config": {"k": {"v": 1}}}, format="json")
+    force_authenticate(req, user=user)
+    req.COOKIES["current_team"] = "1"
+    resp = BotViewSet.as_view({"post": "update_bot_channel"})(req)
+    assert _body(resp)["result"] is True
+    ch.refresh_from_db()
+    assert ch.enabled is True
+    assert ch.channel_config["k"]["v"] == 1
+
+
+def test_destroy_deletes_celery_and_nats_channels():
+    user = _su("bot-del")
+    bot = Bot.objects.create(name="del-bot", team=[1])
+    BotWorkFlow.objects.create(bot=bot, flow_json={}, web_json={})
+    req = factory.delete(f"/{bot.id}/")
+    force_authenticate(req, user=user)
+    req.COOKIES["current_team"] = "1"
+    with (
+        patch(f"{MOD}.delete_celery_task") as del_task,
+        patch(f"{MOD}.cleanup_opspilot_nats_channels_for_bot") as cleanup,
+        patch(f"{MOD}.log_operation"),
+    ):
+        resp = BotViewSet.as_view({"delete": "destroy"})(req, pk=bot.id)
+    assert resp.status_code == 204
+    del_task.assert_called_once_with(bot.id)
+    cleanup.assert_called_once_with(bot.id)
+    assert not Bot.objects.filter(id=bot.id).exists()
+
+
+def test_search_workflow_log_requires_bot_and_aggregates_rows():
+    user = _su("bot-log")
+    req = factory.get("/")
+    force_authenticate(req, user=user)
+    req.COOKIES["current_team"] = "1"
+    missing = BotViewSet.as_view({"get": "search_workflow_log"})(req)
+    assert missing.status_code == 400
+
+    req404 = factory.get("/?bot_id=999999")
+    force_authenticate(req404, user=user)
+    req404.COOKIES["current_team"] = "1"
+    assert BotViewSet.as_view({"get": "search_workflow_log"})(req404).status_code == 404
+
+    bot = Bot.objects.create(name="log-bot", team=[1])
+    now = timezone.now()
+    WorkFlowConversationHistory.objects.create(
+        bot_id=bot.id,
+        node_id="n1",
+        user_id="alice",
+        conversation_role="user",
+        conversation_content="hello title",
+        conversation_time=now,
+        entry_type="web_chat",
+        session_id="s1",
+    )
+    req_ok = factory.get(f"/?bot_id={bot.id}")
+    force_authenticate(req_ok, user=user)
+    req_ok.COOKIES["current_team"] = "1"
+    resp = BotViewSet.as_view({"get": "search_workflow_log"})(req_ok)
+    body = _body(resp)
+    assert body["result"] is True
+    assert body["data"]["count"] >= 1
+    item = body["data"]["items"][0]
+    assert item["user_id"] == "alice"
+    assert "hello title" in item["title"]
+    assert item["count"] == 1
+
+
+def test_get_workflow_log_detail_paginates_and_maps_entry_type():
+    user = _su("bot-log-d")
+    bot = Bot.objects.create(name="logd-bot", team=[1])
+    now = timezone.now()
+    h = WorkFlowConversationHistory.objects.create(
+        bot_id=bot.id,
+        node_id="n1",
+        user_id="bob",
+        conversation_role="user",
+        conversation_content="detail",
+        conversation_time=now,
+        entry_type="web_chat",
+        session_id="s1",
+    )
+    req = factory.post("/", {"ids": [h.id], "bot_id": bot.id, "page": 1, "page_size": 10}, format="json")
+    force_authenticate(req, user=user)
+    req.COOKIES["current_team"] = "1"
+    resp = BotViewSet.as_view({"post": "get_workflow_log_detail"})(req)
+    body = _body(resp)
+    assert body["result"] is True
+    assert body["data"][0]["content"] == "detail"
+    assert body["data"][0]["role"] == "user"
+
+    bad_page = factory.post("/", {"ids": [h.id], "bot_id": bot.id, "page": 99, "page_size": 10}, format="json")
+    force_authenticate(bad_page, user=user)
+    bad_page.COOKIES["current_team"] = "1"
+    empty = BotViewSet.as_view({"post": "get_workflow_log_detail"})(bad_page)
+    assert _body(empty)["data"] == []
+
+
+def test_non_superuser_denied_for_channels_and_authorize():
+    user = UserFactory(
+        username=f"bot-guest-{uuid.uuid4().hex[:8]}",
+        domain="domain.com",
+        roles=[],
+        is_superuser=False,
+        group_list=[{"id": 1, "name": "T1"}],
+    )
+    user.permission = {"opspilot": {"bot_channel-View", "bot_settings-Edit"}}
+    bot = Bot.objects.create(name="deny-bot", team=[1])
+    req = factory.get(f"/?bot_id={bot.id}")
+    force_authenticate(req, user=user)
+    req.COOKIES["current_team"] = "1"
+    with patch.object(BotViewSet, "get_has_permission", return_value=False):
+        resp = BotViewSet.as_view({"get": "get_bot_channels"})(req)
+    assert _body(resp)["result"] is False
+
+    auth_req = factory.post(f"/{bot.id}/authorize_usage_team/", {"usage_team": [2]}, format="json")
+    force_authenticate(auth_req, user=user)
+    auth_req.COOKIES["current_team"] = "1"
+    with patch.object(BotViewSet, "get_has_permission", return_value=False):
+        denied = BotViewSet.as_view({"post": "authorize_usage_team"})(auth_req, pk=bot.id)
+    assert _body(denied)["result"] is False

--- a/server/apps/opspilot/tests/test_bot_view_pilot_and_crontab.py
+++ b/server/apps/opspilot/tests/test_bot_view_pilot_and_crontab.py
@@ -1,0 +1,116 @@
+"""BotViewSet：usage_team 合并、crontab 预览、启停工作台。"""
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.base.tests.factories import UserFactory
+from apps.opspilot.models import Bot, BotWorkFlow
+from apps.opspilot.viewsets.bot_view import BotFilter, BotViewSet, _merge_usage_team, _schedule_memory_write_cache_flush
+
+pytestmark = pytest.mark.django_db
+factory = APIRequestFactory()
+
+
+def _unwrap(fn):
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+def test_merge_usage_team_keeps_management_first_and_unique():
+    assert _merge_usage_team([1], [1, 2, 1]) == [1, 2]
+    assert _merge_usage_team([3, 1], [2]) == [3, 1, 2]
+    assert _merge_usage_team([], [4]) == [4]
+    assert _merge_usage_team(None, None) == []
+
+
+def test_filter_bot_type_splits_and_ignores_empty():
+    qs = SimpleNamespace(filter=lambda **kwargs: kwargs)
+    assert BotFilter.filter_bot_type(qs, "bot_type", "") is qs
+    out = BotFilter.filter_bot_type(qs, "bot_type", "1, 2,")
+    assert out["bot_type__in"] == [1, 2]
+
+
+def test_preview_crontab_requires_expression_and_caps_count():
+    view = BotViewSet()
+    view.loader = None
+    fn = _unwrap(BotViewSet.preview_crontab)
+    request_user = SimpleNamespace(timezone=None)
+    empty = fn(view, SimpleNamespace(data={"crontab_expression": ""}, user=request_user))
+    body = json.loads(empty.content)
+    assert body["result"] is False
+    with patch("apps.opspilot.viewsets.bot_view.get_crontab_next_runs", return_value=["2026-01-01 00:00:00"]) as preview:
+        ok = fn(
+            view,
+            SimpleNamespace(
+                data={"crontab_expression": "0 * * * *", "count": 99},
+                user=request_user,
+            ),
+        )
+    assert json.loads(ok.content)["result"] is True
+    preview.assert_called_once()
+    assert preview.call_args.kwargs["count"] == 20
+    with patch("apps.opspilot.viewsets.bot_view.get_crontab_next_runs", side_effect=ValueError("bad")):
+        bad = fn(
+            view,
+            SimpleNamespace(
+                data={"crontab_expression": "not a cron"},
+                user=request_user,
+            ),
+        )
+    assert json.loads(bad.content)["result"] is False
+
+
+def test_start_and_stop_pilot_superuser_toggles_online():
+    user = UserFactory(username="bot-admin", domain="domain.com", roles=[], is_superuser=True)
+    bot = Bot.objects.create(name="pilot-bot", team=[1], online=False, api_token="")
+    BotWorkFlow.objects.create(bot=bot, flow_json={"nodes": []}, web_json={"nodes": []})
+    view = BotViewSet.as_view({"post": "start_pilot"})
+    req = factory.post("/start_pilot/", {"bot_ids": [bot.id]}, format="json")
+    force_authenticate(req, user=user)
+    req.COOKIES["current_team"] = "1"
+    with (
+        patch("apps.opspilot.viewsets.bot_view.create_celery_task"),
+        patch("apps.opspilot.viewsets.bot_view.sync_opspilot_nats_channels_for_bot"),
+        patch("apps.opspilot.viewsets.bot_view.log_operation"),
+    ):
+        resp = view(req)
+    assert json.loads(resp.content)["result"] is True
+    bot.refresh_from_db()
+    assert bot.online is True
+    assert bot.api_token
+
+    stop = BotViewSet.as_view({"post": "stop_pilot"})
+    req2 = factory.post("/stop_pilot/", {"bot_ids": [bot.id]}, format="json")
+    force_authenticate(req2, user=user)
+    req2.COOKIES["current_team"] = "1"
+    with (
+        patch("apps.opspilot.viewsets.bot_view.delete_celery_task"),
+        patch("apps.opspilot.viewsets.bot_view.cleanup_opspilot_nats_channels_for_bot"),
+        patch("apps.opspilot.viewsets.bot_view.log_operation"),
+    ):
+        resp2 = stop(req2)
+    assert json.loads(resp2.content)["result"] is True
+    bot.refresh_from_db()
+    assert bot.online is False
+    assert bot.api_token == ""
+
+
+def test_schedule_memory_flush_uses_both_field_names():
+    workflow = SimpleNamespace(id=9)
+    old = {"nodes": [{"id": "n1", "data": {"config": {"memorySpace": 11, "title": "旧"}}}]}
+    new = {"nodes": []}
+    with patch(
+        "apps.opspilot.viewsets.bot_view.find_memory_write_nodes_to_flush", return_value={"n1": {"memorySpace": 11, "title": "旧", "llmModel": 3}}
+    ):
+        with patch("apps.opspilot.viewsets.bot_view.flush_memory_write_cache_for_node") as task:
+            _schedule_memory_write_cache_flush(workflow, old, new)
+    task.delay.assert_called_once()
+    assert task.delay.call_args.kwargs["memory_space_id"] == 11
+    with patch("apps.opspilot.viewsets.bot_view.find_memory_write_nodes_to_flush", return_value={"n2": {"title": "无空间"}}):
+        with patch("apps.opspilot.viewsets.bot_view.flush_memory_write_cache_for_node") as task2:
+            _schedule_memory_write_cache_flush(workflow, old, new)
+    task2.delay.assert_not_called()

--- a/server/apps/opspilot/tests/test_bot_view_remaining_actions.py
+++ b/server/apps/opspilot/tests/test_bot_view_remaining_actions.py
@@ -1,0 +1,187 @@
+"""BotViewSet 剩余动作：授权成功、destroy 审计、启停拒绝、日志/crontab 契约。
+
+对照契约：authorize_usage_team 超管成功并入管理组织并记「授权使用组织」；
+destroy 成功记「删除工作台」；非超管无编辑权拒绝更新/启停/看日志；
+preview_crontab 缺表达式与非法表达式返回固定英文文案。
+"""
+import json
+import uuid
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.base.tests.factories import UserFactory
+from apps.opspilot.models import Bot, BotWorkFlow, WorkFlowConversationHistory
+from apps.opspilot.viewsets.bot_view import BotViewSet
+
+pytestmark = pytest.mark.django_db
+factory = APIRequestFactory()
+MOD = "apps.opspilot.viewsets.bot_view"
+
+
+def _su(name="bot-rem"):
+    return UserFactory(
+        username=f"{name}-{uuid.uuid4().hex[:8]}",
+        domain="domain.com",
+        roles=[],
+        is_superuser=True,
+        group_list=[{"id": 1, "name": "T1"}, {"id": 2, "name": "T2"}],
+    )
+
+
+def _guest(perm):
+    user = UserFactory(
+        username=f"bot-guest-{uuid.uuid4().hex[:8]}",
+        domain="domain.com",
+        roles=[],
+        is_superuser=False,
+        group_list=[{"id": 1, "name": "T1"}],
+    )
+    user.permission = {"opspilot": perm}
+    return user
+
+
+def _body(resp):
+    if hasattr(resp, "content"):
+        try:
+            return json.loads(resp.content.decode("utf-8"))
+        except Exception:
+            pass
+    return getattr(resp, "data", None)
+
+
+def _unwrap(fn):
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+def test_authorize_usage_team_success_merges_and_logs():
+    user = _su("bot-auth-ok")
+    bot = Bot.objects.create(name="授权台", team=[1], usage_team=[1])
+    req = factory.post(f"/{bot.id}/authorize_usage_team/", {"usage_team": [2]}, format="json")
+    force_authenticate(req, user=user)
+    req.COOKIES["current_team"] = "1"
+    with patch(f"{MOD}.log_operation") as log:
+        resp = BotViewSet.as_view({"post": "authorize_usage_team"})(req, pk=bot.id)
+    assert resp.status_code == 200
+    assert _body(resp) == {"result": True, "data": {"usage_team": [1, 2]}}
+    bot.refresh_from_db()
+    assert bot.usage_team == [1, 2]
+    assert bot.updated_by == user.username
+    log.assert_called_once()
+    assert log.call_args.args[-1] == "授权使用组织: 授权台"
+
+
+def test_destroy_logs_bot_name():
+    user = _su("bot-del-log")
+    bot = Bot.objects.create(name="待删台", team=[1])
+    BotWorkFlow.objects.create(bot=bot, flow_json={}, web_json={})
+    req = factory.delete(f"/{bot.id}/")
+    force_authenticate(req, user=user)
+    req.COOKIES["current_team"] = "1"
+    with (
+        patch(f"{MOD}.delete_celery_task"),
+        patch(f"{MOD}.cleanup_opspilot_nats_channels_for_bot"),
+        patch(f"{MOD}.log_operation") as log,
+    ):
+        resp = BotViewSet.as_view({"delete": "destroy"})(req, pk=bot.id)
+    assert resp.status_code == 204
+    assert not Bot.objects.filter(id=bot.id).exists()
+    assert any(c.args[-1] == "删除工作台: 待删台" for c in log.call_args_list)
+
+
+def test_update_and_start_stop_denied_for_non_owner():
+    user = _guest({"bot_settings-Edit", "bot_settings-Save&Publish"})
+    bot = Bot.objects.create(name="锁台", team=[1], online=False)
+    BotWorkFlow.objects.create(bot=bot, flow_json={}, web_json={})
+
+    upd = factory.put(f"/{bot.id}/", {"name": "改名"}, format="json")
+    force_authenticate(upd, user=user)
+    upd.COOKIES["current_team"] = "1"
+    with patch.object(BotViewSet, "get_has_permission", return_value=False):
+        denied_upd = BotViewSet.as_view({"put": "update"})(upd, pk=bot.id)
+    assert _body(denied_upd) == {"result": False, "message": "You do not have permission to update this bot."}
+
+    start = factory.post("/start_pilot/", {"bot_ids": [bot.id]}, format="json")
+    force_authenticate(start, user=user)
+    start.COOKIES["current_team"] = "1"
+    with patch.object(BotViewSet, "get_has_permission", return_value=False):
+        denied_start = BotViewSet.as_view({"post": "start_pilot"})(start)
+    assert _body(denied_start) == {"result": False, "message": "You do not have permission to start this bot."}
+
+    stop = factory.post("/stop_pilot/", {"bot_ids": [bot.id]}, format="json")
+    force_authenticate(stop, user=user)
+    stop.COOKIES["current_team"] = "1"
+    with patch.object(BotViewSet, "get_has_permission", return_value=False):
+        denied_stop = BotViewSet.as_view({"post": "stop_pilot"})(stop)
+    assert _body(denied_stop) == {"result": False, "message": "You do not have permission to stop this bot"}
+
+
+def test_search_and_detail_log_denied_without_bot_id_uses_history():
+    user = _guest({"bot_conversation_log-View"})
+    bot = Bot.objects.create(name="日志台", team=[1])
+    now = timezone.now()
+    h = WorkFlowConversationHistory.objects.create(
+        bot_id=bot.id,
+        node_id="n1",
+        user_id="alice",
+        conversation_role="user",
+        conversation_content="hello",
+        conversation_time=now,
+        entry_type="web_chat",
+        session_id="s1",
+    )
+
+    view = BotViewSet()
+    view.loader = None
+    search = SimpleNamespace(
+        GET={"bot_id": str(bot.id)},
+        user=user,
+        COOKIES={"current_team": "1"},
+    )
+    with (
+        patch.object(BotViewSet, "_validate_current_team_permission", return_value=1),
+        patch.object(BotViewSet, "get_has_permission", return_value=False),
+    ):
+        denied_search = _unwrap(BotViewSet.search_workflow_log)(view, search)
+    assert _body(denied_search) == {"result": False, "message": "You do not have permission to view this bot."}
+
+    detail = SimpleNamespace(
+        data={"ids": [h.id], "page": 1, "page_size": 10},
+        user=user,
+        COOKIES={"current_team": "1"},
+    )
+    with (
+        patch.object(BotViewSet, "_validate_current_team_permission", return_value=1),
+        patch.object(BotViewSet, "get_has_permission", return_value=False),
+    ):
+        denied_detail = _unwrap(BotViewSet.get_workflow_log_detail)(view, detail)
+    assert _body(denied_detail) == {"result": False, "message": "You do not have permission to view this bot."}
+
+
+def test_preview_crontab_locks_required_and_invalid_messages():
+    view = BotViewSet()
+    view.loader = None
+    fn = _unwrap(BotViewSet.preview_crontab)
+    request_user = SimpleNamespace(timezone=None)
+    empty = fn(view, SimpleNamespace(data={"crontab_expression": ""}, user=request_user))
+    assert json.loads(empty.content.decode("utf-8")) == {
+        "result": False,
+        "message": "crontab_expression is required",
+    }
+    with patch(f"{MOD}.get_crontab_next_runs", side_effect=ValueError("bad")):
+        bad = fn(
+            view,
+            SimpleNamespace(
+                data={"crontab_expression": "not a cron"},
+                user=request_user,
+            ),
+        )
+    assert json.loads(bad.content.decode("utf-8")) == {
+        "result": False,
+        "message": "Invalid crontab expression: not a cron",
+    }

--- a/server/apps/opspilot/tests/test_branch_node_service.py
+++ b/server/apps/opspilot/tests/test_branch_node_service.py
@@ -1,0 +1,97 @@
+"""分支节点：内置操作符、triggerType、变量回退、安全求值失败返回 False。"""
+import pytest
+
+from apps.opspilot.utils.chat_flow_utils.nodes.condition.branch import BranchNode, ConditionNode
+
+pytestmark = pytest.mark.unit
+
+
+class _VM:
+    def __init__(self, variables):
+        self._variables = variables
+
+    def get_all_variables(self):
+        return self._variables
+
+
+def _cfg(**overrides):
+    config = {
+        "inputParams": "last_message",
+        "outputParams": "last_message",
+        "conditionField": "status",
+        "conditionOperator": "equals",
+        "conditionValue": "ok",
+    }
+    config.update(overrides)
+    return {"data": {"config": config}}
+
+
+def test_equals_uses_variable_and_returns_condition_result():
+    node = BranchNode(_VM({"status": "ok"}))
+    out = node.execute("n1", _cfg(), {"last_message": "ignored"})
+    assert out == {"last_message": True, "condition_result": True}
+
+
+def test_operators_not_equals_contains_starts_and_ends():
+    node = BranchNode(_VM({}))
+    assert (
+        node.execute("n", _cfg(conditionField="missing", conditionOperator="!=", conditionValue="x"), {"last_message": "y"})["condition_result"]
+        is True
+    )
+    assert (
+        node.execute(
+            "n",
+            _cfg(conditionField="missing", conditionOperator="contains", conditionValue="ab"),
+            {"last_message": "xxabxx"},
+        )["condition_result"]
+        is True
+    )
+    assert (
+        node.execute(
+            "n",
+            _cfg(conditionField="missing", conditionOperator="not_contains", conditionValue="z"),
+            {"last_message": "abc"},
+        )["condition_result"]
+        is True
+    )
+    assert (
+        node.execute(
+            "n",
+            _cfg(conditionField="missing", conditionOperator="starts_with", conditionValue="he"),
+            {"last_message": "hello"},
+        )["condition_result"]
+        is True
+    )
+    assert (
+        node.execute(
+            "n",
+            _cfg(conditionField="missing", conditionOperator="ends_with", conditionValue="lo"),
+            {"last_message": "hello"},
+        )["condition_result"]
+        is True
+    )
+
+
+def test_trigger_type_prefers_start_node_id_then_variable():
+    node = BranchNode(_VM({"start_node": "from-var"}), start_node_id="from-init")
+    out = node.execute("n", _cfg(conditionField="triggerType", conditionValue="from-init"), {"last_message": ""})
+    assert out["condition_result"] is True
+
+    fallback = BranchNode(_VM({"start_node": "from-var"}))
+    out = fallback.execute("n", _cfg(conditionField="triggerType", conditionValue="from-var"), {"last_message": ""})
+    assert out["condition_result"] is True
+
+
+def test_unknown_operator_falls_back_to_safe_eval_and_swallows_error():
+    node = BranchNode(_VM({}))
+    false_out = node.execute(
+        "n",
+        _cfg(conditionField="missing", conditionOperator="not a valid op", conditionValue="x"),
+        {"last_message": "y"},
+    )
+    assert false_out == {"last_message": False, "condition_result": False}
+
+
+def test_condition_node_alias_is_branch_node():
+    assert ConditionNode is BranchNode
+    assert isinstance(ConditionNode(_VM({})), BranchNode)

--- a/server/apps/opspilot/tests/test_chat_application_viewset.py
+++ b/server/apps/opspilot/tests/test_chat_application_viewset.py
@@ -1,0 +1,199 @@
+"""ChatApplicationViewSet：会话列表/消息解析、技能引导 BFS、删除仅当前用户历史。"""
+import json
+import uuid
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.base.tests.factories import UserFactory
+from apps.opspilot.models import Bot, BotWorkFlow, ChatApplication, LLMSkill, WorkFlowConversationHistory
+from apps.opspilot.viewsets.chat_application_view import ChatApplicationFilter, ChatApplicationViewSet
+
+pytestmark = pytest.mark.django_db
+factory = APIRequestFactory()
+
+
+def _su(name="chat-app-admin"):
+    return UserFactory(
+        username=f"{name}-{uuid.uuid4().hex[:8]}",
+        domain="domain.com",
+        roles=[],
+        is_superuser=True,
+        group_list=[{"id": 1, "name": "T1"}],
+    )
+
+
+def _dispatch(action_name, method, *, data=None, query="", user=None):
+    path = f"/{query}"
+    if method == "post":
+        request = factory.post(path, data=data or {}, format="json")
+    else:
+        request = factory.get(path)
+    force_authenticate(request, user=user or _su())
+    request.COOKIES["current_team"] = "1"
+    view = ChatApplicationViewSet.as_view({method: action_name})
+    return view(request)
+
+
+def test_filter_app_tags_contains_value_or_passthrough():
+    qs_calls = {}
+
+    class Dummy:
+        def filter(self, **kwargs):
+            qs_calls.update(kwargs)
+            return "filtered"
+
+    flt = ChatApplicationFilter()
+    dummy = Dummy()
+    assert flt.filter_app_tags(dummy, "app_tags", "") is dummy
+    assert flt.filter_app_tags(dummy, "app_tags", "ops") == "filtered"
+    assert qs_calls["app_tags__contains"] == ["ops"]
+
+
+def test_web_chat_sessions_titles_and_truncation():
+    user = _su("sess-user")
+    bot = Bot.objects.create(name="sess-bot", team=[1])
+    now = timezone.now()
+    long_text = "问" * 60
+    WorkFlowConversationHistory.objects.create(
+        bot_id=bot.id,
+        node_id="n1",
+        user_id=f"{user.username}@{user.domain}",
+        conversation_role="user",
+        conversation_content=long_text,
+        conversation_time=now,
+        entry_type="web_chat",
+        session_id="s-long",
+    )
+    WorkFlowConversationHistory.objects.create(
+        bot_id=bot.id,
+        node_id="n1",
+        user_id=f"{user.username}@{user.domain}",
+        conversation_role="user",
+        conversation_content="短问",
+        conversation_time=now - timedelta(minutes=1),
+        entry_type="web_chat",
+        session_id="s-short",
+    )
+    resp = _dispatch("web_chat_sessions", "get", query="?node_id=n1&bot_id=" + str(bot.id), user=user)
+    items = resp.data
+    by_sid = {i["session_id"]: i for i in items}
+    assert by_sid["s-long"]["title"].endswith("...")
+    assert by_sid["s-short"]["title"] == "短问"
+    assert by_sid["s-long"]["bot_id"] == bot.id
+
+
+def test_session_messages_requires_id_and_parses_json_content():
+    missing = _dispatch("session_messages", "get")
+    assert missing.status_code == 400
+    user = _su("msg-user")
+    bot = Bot.objects.create(name="msg-bot", team=[1])
+    WorkFlowConversationHistory.objects.create(
+        bot_id=bot.id,
+        node_id="n1",
+        user_id=f"{user.username}@{user.domain}",
+        conversation_role="user",
+        conversation_content=json.dumps({"text": "hi"}),
+        conversation_time=timezone.now(),
+        entry_type="web_chat",
+        session_id="s1",
+    )
+    WorkFlowConversationHistory.objects.create(
+        bot_id=bot.id,
+        node_id="n1",
+        user_id=f"{user.username}@{user.domain}",
+        conversation_role="bot",
+        conversation_content="plain",
+        conversation_time=timezone.now(),
+        entry_type="web_chat",
+        session_id="s1",
+    )
+    resp = _dispatch("session_messages", "get", query="?session_id=s1", user=user)
+    contents = [i["conversation_content"] for i in resp.data]
+    assert {"text": "hi"} in contents
+    assert "plain" in contents
+
+
+def test_skill_guide_bfs_finds_first_agent_and_handles_missing():
+    missing_bot = _dispatch("skill_guide", "get", query="?node_id=n1")
+    assert missing_bot.status_code == 400
+    missing_node = _dispatch("skill_guide", "get", query="?bot_id=1")
+    assert missing_node.status_code == 400
+
+    bot = Bot.objects.create(name="guide-bot", team=[1])
+    no_flow = _dispatch("skill_guide", "get", query=f"?bot_id={bot.id}&node_id=n1")
+    assert no_flow.status_code == 404
+
+    skill = LLMSkill.objects.create(name="guide-skill", team=[1], guide="欢迎使用")
+    BotWorkFlow.objects.create(
+        bot=bot,
+        flow_json={
+            "nodes": [
+                {"id": "entry", "data": {"config": {}}},
+                {"id": "llm", "data": {"config": {"agent": skill.id}}},
+            ],
+            "edges": [{"source": "entry", "target": "llm"}],
+        },
+    )
+    ok = _dispatch("skill_guide", "get", query=f"?bot_id={bot.id}&node_id=entry")
+    assert ok.data["guide"] == "欢迎使用"
+
+    empty = _dispatch("skill_guide", "get", query=f"?bot_id={bot.id}&node_id=unknown")
+    assert empty.data["guide"] == ""
+
+
+def test_delete_session_history_only_current_user():
+    user = _su("del-hist")
+    other = _su("other-hist")
+    bot = Bot.objects.create(name="del-bot", team=[1])
+    now = timezone.now()
+    mine = WorkFlowConversationHistory.objects.create(
+        bot_id=bot.id,
+        node_id="n1",
+        user_id=f"{user.username}@{user.domain}",
+        conversation_role="user",
+        conversation_content="mine",
+        conversation_time=now,
+        entry_type="web_chat",
+        session_id="s-del",
+    )
+    theirs = WorkFlowConversationHistory.objects.create(
+        bot_id=bot.id,
+        node_id="n1",
+        user_id=f"{other.username}@{other.domain}",
+        conversation_role="user",
+        conversation_content="theirs",
+        conversation_time=now,
+        entry_type="web_chat",
+        session_id="s-del",
+    )
+    missing = _dispatch("delete_session_history", "post", data={"session_id": "s-del"}, user=user)
+    assert missing.status_code == 400
+    ok = _dispatch("delete_session_history", "post", data={"node_id": "n1", "session_id": "s-del"}, user=user)
+    assert ok.data["result"] is True
+    assert not WorkFlowConversationHistory.objects.filter(id=mine.id).exists()
+    assert WorkFlowConversationHistory.objects.filter(id=theirs.id).exists()
+
+
+def test_get_queryset_guest_group_includes_guest_bots():
+    guest = UserFactory(
+        username=f"guest-app-{uuid.uuid4().hex[:8]}",
+        domain="domain.com",
+        roles=[],
+        is_superuser=False,
+        group_list=[{"id": 1, "name": "T1"}, {"id": 9, "name": "OpsPilotGuest"}],
+    )
+    bot_team = Bot.objects.create(name="team-bot", team=[1])
+    bot_guest = Bot.objects.create(name="guest-bot", team=[9])
+    ChatApplication.objects.create(bot=bot_team, node_id="n1", app_type="web_chat", app_name="a")
+    ChatApplication.objects.create(bot=bot_guest, node_id="n2", app_type="web_chat", app_name="b")
+    request = factory.get("/")
+    request.user = guest
+    request.COOKIES["current_team"] = "1"
+    view = ChatApplicationViewSet()
+    view.request = request
+    view.format_kwarg = None
+    names = set(view.get_queryset().values_list("app_name", flat=True))
+    assert names == {"a", "b"}

--- a/server/apps/opspilot/tests/test_dingtalk_chatflow_service.py
+++ b/server/apps/opspilot/tests/test_dingtalk_chatflow_service.py
@@ -1,0 +1,120 @@
+"""钉钉 ChatFlow：Bot/节点校验、签名、发信 SSRF、引擎执行与 token。"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.http import JsonResponse
+
+from apps.opspilot.models import Bot, BotWorkFlow
+from apps.opspilot.services.dingtalk_chat_flow_utils import DingTalkChatFlowUtils
+
+pytestmark = pytest.mark.django_db
+
+
+def _utils(bot_id=1):
+    u = DingTalkChatFlowUtils.__new__(DingTalkChatFlowUtils)
+    u.bot_id = bot_id
+    return u
+
+
+def test_validate_bot_and_workflow_offline_missing_empty():
+    utils = _utils(1)
+    flow, err = utils.validate_bot_and_workflow()
+    assert flow is None
+    assert isinstance(err, JsonResponse)
+
+    bot = Bot.objects.create(name="dt-bot", team=[1], online=False)
+    utils.bot_id = bot.id
+    flow, err = utils.validate_bot_and_workflow()
+    assert err is not None
+
+    bot.online = True
+    bot.save()
+    flow, err = utils.validate_bot_and_workflow()
+    assert err is not None
+    assert b"Workflow not configured" in err.content
+
+    wf = BotWorkFlow.objects.create(bot=bot, flow_json={})
+    flow, err = utils.validate_bot_and_workflow()
+    assert err is not None
+    assert b"empty" in err.content.lower()
+
+    wf.flow_json = {"nodes": []}
+    wf.save()
+    flow, err = utils.validate_bot_and_workflow()
+    assert err is None
+    assert flow.id == wf.id
+
+
+def test_get_dingtalk_node_config_missing_and_required_params():
+    utils = _utils()
+    empty = SimpleNamespace(flow_json={"nodes": [{"type": "wechat", "id": "n1", "data": {}}]})
+    cfg, err = utils.get_dingtalk_node_config(empty)
+    assert cfg is None and err is not None
+
+    missing = SimpleNamespace(flow_json={"nodes": [{"type": "dingtalk", "id": "n-dt", "data": {"config": {"client_id": "a"}}}]})
+    cfg, err = utils.get_dingtalk_node_config(missing)
+    assert cfg is None
+    assert b"client_secret" in err.content
+
+    ok = SimpleNamespace(
+        flow_json={
+            "nodes": [
+                {
+                    "type": "dingtalk",
+                    "id": "n-dt",
+                    "data": {"config": {"client_id": "a", "client_secret": "b"}},
+                }
+            ]
+        }
+    )
+    cfg, err = utils.get_dingtalk_node_config(ok)
+    assert err is None
+    assert cfg["node_id"] == "n-dt"
+    assert cfg["client_id"] == "a"
+
+
+def test_send_message_rejects_empty_and_ssrf_and_posts():
+    utils = _utils()
+    assert utils.send_message("", "text", {"content": "hi"}) is False
+    assert utils.send_message("https://evil.example/hook", "text", {"content": "hi"}) is False
+    with patch("apps.opspilot.services.dingtalk_chat_flow_utils.requests.post") as post:
+        post.return_value.json.return_value = {"errcode": 1, "errmsg": "fail"}
+        assert utils.send_message("https://oapi.dingtalk.com/robot/send", "text", {"content": "hi"}) is False
+        post.return_value.json.return_value = {"errcode": 0}
+        assert utils.send_message("https://oapi.dingtalk.com/robot/send", "text", {"content": "hi"}) is True
+        post.side_effect = RuntimeError("timeout")
+        assert utils.send_message("https://oapi.dingtalk.com/robot/send", "text", {"content": "hi"}) is False
+
+
+def test_get_access_token_success_and_error():
+    utils = _utils()
+    with patch("apps.opspilot.services.dingtalk_chat_flow_utils.requests.get") as get:
+        get.return_value.json.return_value = {"errcode": 0, "access_token": "tok"}
+        assert utils.get_access_token("k", "s") == "tok"
+        get.return_value.json.return_value = {"errcode": 88, "errmsg": "bad"}
+        with pytest.raises(Exception, match="获取access_token失败"):
+            utils.get_access_token("k", "s")
+
+
+def test_execute_chatflow_uses_engine_and_prefers_content():
+    utils = _utils(9)
+    engine = MagicMock()
+    engine.execute.return_value = {"content": "回复A"}
+    flow = SimpleNamespace()
+    with patch("apps.opspilot.services.dingtalk_chat_flow_utils.create_chat_flow_engine", return_value=engine):
+        assert utils.execute_chatflow_with_message(flow, "n1", "你好", "u1") == "回复A"
+        engine.execute.return_value = {"data": "回复B"}
+        assert utils.execute_chatflow_with_message(flow, "n1", "你好", "u1") == "回复B"
+        engine.execute.return_value = None
+        assert utils.execute_chatflow_with_message(flow, "n1", "你好", "u1") == "处理完成"
+
+
+def test_send_reply_skips_empty_and_delegates():
+    utils = _utils()
+    with patch.object(utils, "send_message", return_value=True) as send:
+        utils.send_reply("", "sid", {"webhook_url": "https://oapi.dingtalk.com/x"})
+        send.assert_not_called()
+        utils.send_reply("hello", "sid", {"webhook_url": "https://oapi.dingtalk.com/x"})
+        send.assert_called_once()
+        assert send.call_args.args[1] == "text"

--- a/server/apps/opspilot/tests/test_dingtalk_stream_and_reply.py
+++ b/server/apps/opspilot/tests/test_dingtalk_stream_and_reply.py
@@ -1,0 +1,212 @@
+"""钉钉 Stream 处理器、启动客户端与剩余发信/去重契约。
+
+仅 mock dingtalk_stream / requests / Celery / ChatFlow 引擎边界。
+锁定：
+- is_valid_dingtalk_url：空 hostname、非法字符、urlparse 异常；
+- verify_signature 异常返回 False；
+- send_reply 缺 webhook 不发信；
+- handle_dingtalk_message 已处理消息跳过投递；
+- Stream Event/Callback：非文本、空文本、成功回复、异常状态码；
+- start_dingtalk_stream_client：缺凭证、启动成功、启动异常。
+"""
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import dingtalk_stream
+import pytest
+from django.http import JsonResponse
+
+from apps.opspilot.services.dingtalk_chat_flow_utils import (
+    DingTalkChatFlowUtils,
+    DingTalkStreamCallbackHandler,
+    DingTalkStreamEventHandler,
+    is_valid_dingtalk_url,
+    start_dingtalk_stream_client,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _utils(bot_id=3):
+    u = DingTalkChatFlowUtils.__new__(DingTalkChatFlowUtils)
+    u.bot_id = bot_id
+    return u
+
+
+def _req(body, headers=None):
+    return SimpleNamespace(
+        body=body if isinstance(body, (bytes, str)) else json.dumps(body).encode(),
+        headers=headers or {},
+    )
+
+
+class TestUrlAndSignatureRemaining:
+    def test_空hostname与非法字符拒绝(self):
+        assert is_valid_dingtalk_url("https://") is False
+        assert is_valid_dingtalk_url("https://oapi_dingtalk.com") is False
+
+    def test_urlparse异常返回False(self, mocker):
+        mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.urlparse",
+            side_effect=ValueError("bad url"),
+        )
+        assert is_valid_dingtalk_url("https://oapi.dingtalk.com") is False
+
+    def test_验签异常返回False(self):
+        utils = _utils()
+        assert utils.verify_signature("ts", "sign", None) is False
+
+
+class TestSendReplyAndHandleSkip:
+    def test_缺webhook不发信(self):
+        utils = _utils()
+        with patch.object(utils, "send_message") as send:
+            utils.send_reply("hello", "u1", {})
+        send.assert_not_called()
+
+    def test_已处理消息跳过投递(self):
+        utils = _utils(8)
+        with patch.object(utils, "is_message_processed", return_value=True), patch("apps.opspilot.tasks.process_dingtalk_message.delay") as delay:
+            resp = utils.handle_dingtalk_message(
+                _req(
+                    {
+                        "msgtype": "text",
+                        "text": {"content": "hi"},
+                        "senderStaffId": "u",
+                        "msgId": "dup-1",
+                    }
+                ),
+                None,
+                {},
+            )
+        assert isinstance(resp, JsonResponse)
+        assert json.loads(resp.content)["success"] is True
+        delay.assert_not_called()
+
+
+class TestStreamHandlers:
+    def test_event_handler_ack(self):
+        handler = DingTalkStreamEventHandler(9)
+        status, msg = asyncio.run(handler.process(SimpleNamespace()))
+        assert status == dingtalk_stream.AckMessage.STATUS_OK
+        assert msg == "OK"
+
+    def test_callback_非文本与空文本ack(self):
+        handler = DingTalkStreamCallbackHandler(1, SimpleNamespace(), {"node_id": "n1"})
+        status, msg = asyncio.run(handler.process(SimpleNamespace(data={"msgtype": "image"})))
+        assert status == dingtalk_stream.AckMessage.STATUS_OK
+        assert msg == "OK"
+
+        status, msg = asyncio.run(handler.process(SimpleNamespace(data={"msgtype": "text", "text": {"content": ""}})))
+        assert status == dingtalk_stream.AckMessage.STATUS_OK
+        assert msg == "OK"
+
+    def test_callback_成功返回文本回复(self):
+        handler = DingTalkStreamCallbackHandler(2, SimpleNamespace(), {"node_id": "n-dt"})
+        with patch.object(handler.utils, "execute_chatflow_with_message", return_value="回复内容") as exec_cf:
+            status, body = asyncio.run(
+                handler.process(
+                    SimpleNamespace(
+                        data={
+                            "msgtype": "text",
+                            "text": {"content": "你好"},
+                            "senderStaffId": "staff-1",
+                        }
+                    )
+                )
+            )
+        exec_cf.assert_called_once()
+        assert exec_cf.call_args.args[2] == "你好"
+        assert exec_cf.call_args.kwargs["is_third_party"] is True
+        assert status == dingtalk_stream.AckMessage.STATUS_OK
+        assert body == {"msgtype": "text", "text": {"content": "回复内容"}}
+
+    def test_callback_异常返回系统异常码(self):
+        handler = DingTalkStreamCallbackHandler(2, SimpleNamespace(), {"node_id": "n-dt"})
+        with patch.object(
+            handler.utils,
+            "execute_chatflow_with_message",
+            side_effect=RuntimeError("engine down"),
+        ):
+            status, msg = asyncio.run(
+                handler.process(
+                    SimpleNamespace(
+                        data={
+                            "msgtype": "text",
+                            "text": {"content": "hi"},
+                            "senderId": "sid",
+                        }
+                    )
+                )
+            )
+        assert status == dingtalk_stream.AckMessage.STATUS_SYSTEM_EXCEPTION
+        assert msg == "engine down"
+
+
+class TestStartStreamClient:
+    def test_缺凭证返回False(self):
+        assert start_dingtalk_stream_client(1, None, {}) is False
+        assert start_dingtalk_stream_client(1, None, {"client_id": "a"}) is False
+
+    def test_启动成功注册处理器并开线程(self, mocker):
+        credential = MagicMock()
+        client = MagicMock()
+        mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.Credential",
+            return_value=credential,
+        )
+        mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.DingTalkStreamClient",
+            return_value=client,
+        )
+        thread = MagicMock()
+        thread_cls = mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.threading.Thread",
+            return_value=thread,
+        )
+        ok = start_dingtalk_stream_client(
+            7,
+            SimpleNamespace(),
+            {"client_id": "cid", "client_secret": "sec", "node_id": "n1"},
+        )
+        assert ok is True
+        client.register_all_event_handler.assert_called_once()
+        client.register_callback_handler.assert_called_once()
+        thread_cls.assert_called_once()
+        assert thread_cls.call_args.kwargs["daemon"] is True
+        thread.start.assert_called_once()
+
+    def test_启动异常返回False(self, mocker):
+        mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.Credential",
+            side_effect=RuntimeError("auth fail"),
+        )
+        assert start_dingtalk_stream_client(1, None, {"client_id": "a", "client_secret": "b"}) is False
+
+    def test_线程内start_forever异常被吞(self, mocker):
+        client = MagicMock()
+        client.start_forever.side_effect = RuntimeError("stream down")
+        mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.Credential",
+            return_value=MagicMock(),
+        )
+        mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.DingTalkStreamClient",
+            return_value=client,
+        )
+
+        class _ImmediateThread:
+            def __init__(self, target=None, daemon=None):
+                self.target = target
+
+            def start(self):
+                self.target()
+
+        mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.threading.Thread",
+            side_effect=lambda target=None, daemon=None: _ImmediateThread(target, daemon),
+        )
+        assert start_dingtalk_stream_client(4, SimpleNamespace(), {"client_id": "a", "client_secret": "b"}) is True
+        client.start_forever.assert_called_once()

--- a/server/apps/opspilot/tests/test_init_commands_and_shims.py
+++ b/server/apps/opspilot/tests/test_init_commands_and_shims.py
@@ -1,0 +1,50 @@
+"""OpsPilot 兼容 shim、初始化命令与用户创建信号。"""
+from io import StringIO
+from unittest.mock import MagicMock
+
+import pytest
+from django.core.management import call_command
+
+from apps.base.models import User
+from apps.opspilot.signals.user_create_signal import user_create_signal
+from apps.opspilot.utils import approval, dingtalk_chat_flow_utils, mcp_client, wechat_official_chat_flow_utils
+
+pytestmark = pytest.mark.django_db
+
+
+def test_compat_shims_reexport_services():
+    assert callable(approval.submit_approval_decision)
+    assert callable(approval.wait_for_approval)
+    assert mcp_client.MCPClient is not None
+    assert dingtalk_chat_flow_utils.DingTalkChatFlowUtils is not None
+    assert callable(dingtalk_chat_flow_utils.is_valid_dingtalk_url)
+    assert wechat_official_chat_flow_utils.WechatOfficialChatFlowUtils is not None
+
+
+def test_init_bot_llm_chatflow_commands(monkeypatch):
+    bot = MagicMock()
+    llm = MagicMock()
+    flow = MagicMock()
+    monkeypatch.setattr("apps.opspilot.management.commands.init_bot.BotInitService", lambda owner: bot)
+    monkeypatch.setattr("apps.opspilot.management.commands.init_llm.ModelProviderInitService", lambda owner="admin": llm)
+    monkeypatch.setattr("apps.opspilot.management.commands.init_chatflow.ChatFlowInitService", lambda: flow)
+    call_command("init_bot")
+    bot.init.assert_called_once_with()
+    call_command("init_llm")
+    llm.init.assert_called_once_with()
+    stdout = StringIO()
+    call_command("init_chatflow", stdout=stdout)
+    flow.init.assert_called_once_with()
+    assert "ChatFlow 初始化完成" in stdout.getvalue()
+
+
+def test_user_create_signal_inits_bot_and_channel(monkeypatch):
+    bot = MagicMock()
+    channel = MagicMock()
+    monkeypatch.setattr("apps.opspilot.signals.user_create_signal.BotInitService", lambda owner: bot)
+    monkeypatch.setattr("apps.opspilot.signals.user_create_signal.ChannelInitService", lambda owner: channel)
+    user_create_signal()
+    admin = User.objects.get(username="admin")
+    assert admin.is_superuser is True
+    bot.init.assert_called_once_with()
+    channel.init.assert_called_once_with()

--- a/server/apps/opspilot/tests/test_llm_client_factory_routing.py
+++ b/server/apps/opspilot/tests/test_llm_client_factory_routing.py
@@ -1,0 +1,189 @@
+"""LLMClientFactory：协议路由、thinking 参数、隔离客户端。"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+from apps.opspilot.metis.llm.chain.entity import BasicLLMRequest
+from apps.opspilot.metis.llm.common.llm_client_factory import LLMClientFactory
+
+pytestmark = pytest.mark.unit
+
+
+def _request(**kwargs):
+    data = dict(
+        openai_api_base="http://llm.local",
+        openai_api_key="k",
+        model="gpt-4o",
+        protocol_type="openai",
+        temperature=0.2,
+        extra_config={"show_think": True},
+    )
+    data.update(kwargs)
+    return BasicLLMRequest(**data)
+
+
+def test_create_client_openai_qwen_deepseek_and_isolated(monkeypatch):
+    monkeypatch.setattr(
+        "apps.opspilot.metis.llm.common.llm_client_factory.SSRFValidator.validate_llm_endpoint",
+        lambda *a, **k: None,
+    )
+
+    created = {}
+
+    class FakeChat:
+        def __init__(self, **kwargs):
+            created["kwargs"] = kwargs
+            self.extra_body = None
+            self.callbacks = "keep"
+
+    monkeypatch.setattr("apps.opspilot.metis.llm.common.llm_client_factory.ChatOpenAI", FakeChat)
+    qwen = LLMClientFactory.create_client(_request(model="Qwen2.5-72B"), isolated=True)
+    assert qwen.callbacks is None
+    assert qwen.extra_body["enable_thinking"] is True
+
+    deepseek = LLMClientFactory.create_client(_request(model="deepseek-chat", extra_config={"show_think": False}))
+    assert deepseek.extra_body["thinking"] == {"type": "disabled"}
+
+
+def test_create_client_anthropic_and_compatible(monkeypatch):
+    monkeypatch.setattr(
+        "apps.opspilot.metis.llm.common.llm_client_factory.SSRFValidator.validate_llm_endpoint",
+        lambda *a, **k: None,
+    )
+    anthro = MagicMock(name="ChatAnthropic")
+    monkeypatch.setattr("apps.opspilot.metis.llm.common.llm_client_factory.ChatAnthropic", anthro)
+    LLMClientFactory.create_client(_request(protocol_type="anthropic", model="claude-3", openai_api_base="https://api.openai.com"))
+    anthro.assert_called_once()
+    kwargs = anthro.call_args.kwargs
+    assert kwargs["anthropic_api_url"] == "https://api.anthropic.com"
+    assert kwargs["model"] == "claude-3"
+
+    compat = MagicMock(name="Compat")
+    monkeypatch.setattr(
+        "apps.opspilot.metis.llm.common.llm_client_factory.AnthropicCompatibleChatClient",
+        compat,
+    )
+    LLMClientFactory.create_client(_request(protocol_type="anthropic", vendor_type="deepseek", model="deepseek-v3"))
+    compat.assert_called_once()
+    assert compat.call_args.kwargs["vendor_type"] == "deepseek"
+
+
+def test_create_isolated_clients_and_invoke(monkeypatch):
+    monkeypatch.setattr(
+        "apps.opspilot.metis.llm.common.llm_client_factory.SSRFValidator.validate_llm_endpoint",
+        lambda *a, **k: None,
+    )
+    openai_cls = MagicMock(name="OpenAI")
+    anthro_cls = MagicMock(name="Anthropic")
+    monkeypatch.setattr("apps.opspilot.metis.llm.common.llm_client_factory.OpenAI", openai_cls)
+    monkeypatch.setattr("apps.opspilot.metis.llm.common.llm_client_factory.anthropic.Anthropic", anthro_cls)
+
+    openai_client = LLMClientFactory.create_isolated_client(_request())
+    assert openai_client is openai_cls.return_value
+    openai_cls.assert_called_once()
+    assert openai_cls.call_args.kwargs["base_url"] == "http://llm.local"
+
+    anthro_client = LLMClientFactory.create_isolated_client(_request(protocol_type="anthropic", openai_api_base=""))
+    assert anthro_client is anthro_cls.return_value
+    assert anthro_cls.call_args.kwargs["base_url"] == "https://api.anthropic.com"
+
+    openai_cls.return_value.chat.completions.create.return_value = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="rewritten"))]
+    )
+    text = LLMClientFactory.invoke_isolated(_request(), [HumanMessage(content="hi")])
+    assert text == "rewritten"
+    payload = openai_cls.return_value.chat.completions.create.call_args.kwargs
+    assert payload["messages"][0] == {"role": "user", "content": "hi"}
+
+
+def test_create_client_gemma_and_openai_without_extra_body(monkeypatch):
+    monkeypatch.setattr(
+        "apps.opspilot.metis.llm.common.llm_client_factory.SSRFValidator.validate_llm_endpoint",
+        lambda *a, **k: None,
+    )
+
+    class FakeChat:
+        def __init__(self, **kwargs):
+            self.extra_body = None
+            self.callbacks = "keep"
+
+    monkeypatch.setattr("apps.opspilot.metis.llm.common.llm_client_factory.ChatOpenAI", FakeChat)
+    gemma = LLMClientFactory.create_client(_request(model="gemma-4-27b", extra_config={"show_think": False}))
+    assert gemma.extra_body["chat_template_kwargs"] == {"enable_thinking": False}
+    assert gemma.callbacks == "keep"
+
+
+def test_create_client_anthropic_deepseek_thinking(monkeypatch):
+    monkeypatch.setattr(
+        "apps.opspilot.metis.llm.common.llm_client_factory.SSRFValidator.validate_llm_endpoint",
+        lambda *a, **k: None,
+    )
+    anthro = MagicMock(name="ChatAnthropic")
+    monkeypatch.setattr("apps.opspilot.metis.llm.common.llm_client_factory.ChatAnthropic", anthro)
+    LLMClientFactory.create_client(_request(protocol_type="anthropic", model="deepseek-chat", extra_config={"show_think": False}))
+    kwargs = anthro.call_args.kwargs
+    assert kwargs["model_kwargs"] == {"thinking": {"type": "disabled"}}
+    assert kwargs["anthropic_api_url"] == "http://llm.local"
+
+
+def test_invoke_isolated_openai_roles_and_model_extras(monkeypatch):
+    monkeypatch.setattr(
+        "apps.opspilot.metis.llm.common.llm_client_factory.SSRFValidator.validate_llm_endpoint",
+        lambda *a, **k: None,
+    )
+    openai_cls = MagicMock(name="OpenAI")
+    openai_cls.return_value.chat.completions.create.return_value = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))])
+    monkeypatch.setattr("apps.opspilot.metis.llm.common.llm_client_factory.OpenAI", openai_cls)
+
+    other = SimpleNamespace(type="assistant", content="prev")
+    text = LLMClientFactory.invoke_isolated(
+        _request(model="Qwen2.5"),
+        [HumanMessage(content="q"), {"role": "user", "content": "dict"}, other],
+    )
+    assert text == "ok"
+    kwargs = openai_cls.return_value.chat.completions.create.call_args.kwargs
+    assert kwargs["messages"] == [
+        {"role": "user", "content": "q"},
+        {"role": "user", "content": "dict"},
+        {"role": "assistant", "content": "prev"},
+    ]
+    assert kwargs["extra_body"] == {
+        "enable_thinking": False,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+
+    LLMClientFactory.invoke_isolated(_request(model="deepseek-v3"), [HumanMessage(content="x")])
+    assert openai_cls.return_value.chat.completions.create.call_args.kwargs["extra_body"] == {
+        "enable_thinking": False,
+        "thinking": {"type": "disabled"},
+    }
+    LLMClientFactory.invoke_isolated(_request(model="gemma-3"), [HumanMessage(content="x")])
+    assert openai_cls.return_value.chat.completions.create.call_args.kwargs["extra_body"]["chat_template_kwargs"] == {"enable_thinking": False}
+
+
+def test_invoke_isolated_anthropic_system_and_plain_messages(monkeypatch):
+    monkeypatch.setattr(
+        "apps.opspilot.metis.llm.common.llm_client_factory.SSRFValidator.validate_llm_endpoint",
+        lambda *a, **k: None,
+    )
+    anthro_cls = MagicMock(name="Anthropic")
+    anthro_cls.return_value.messages.create.return_value = SimpleNamespace(content=[SimpleNamespace(text="ans")])
+    monkeypatch.setattr("apps.opspilot.metis.llm.common.llm_client_factory.anthropic.Anthropic", anthro_cls)
+    text = LLMClientFactory.invoke_isolated(
+        _request(protocol_type="anthropic", openai_api_base="https://api.openai.com"),
+        [
+            {"role": "system", "content": "sys"},
+            HumanMessage(content="hi"),
+            SimpleNamespace(type="system", content="sys2"),
+            SimpleNamespace(type="assistant", content="prev"),
+            {"role": "user", "content": "again"},
+        ],
+    )
+    assert text == "ans"
+    kwargs = anthro_cls.return_value.messages.create.call_args.kwargs
+    assert kwargs["system"] == "sys2"
+    assert kwargs["max_tokens"] == 4096
+    assert kwargs["messages"][0] == {"role": "user", "content": "hi"}
+    assert anthro_cls.call_args.kwargs["base_url"] == "https://api.anthropic.com"

--- a/server/apps/opspilot/tests/test_mcp_cache_and_view_filter.py
+++ b/server/apps/opspilot/tests/test_mcp_cache_and_view_filter.py
@@ -1,0 +1,65 @@
+"""MCP 工具缓存命中/清除与 EnabledFilter 布尔过滤契约。"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from apps.opspilot.utils import mcp_cache
+from apps.opspilot.viewsets.view_filter import EnabledFilter
+
+
+class _MemCache:
+    def __init__(self):
+        self.store = {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def set(self, key, value, timeout=None):
+        self.store[key] = value
+
+    def delete(self, key):
+        self.store.pop(key, None)
+
+
+def test_mcp_tools_cache_roundtrip_and_clear_by_url():
+    mem = _MemCache()
+    url = "http://mcp.example/sse"
+    tools = [{"name": "search"}]
+    with patch("apps.opspilot.utils.mcp_cache.cache", mem):
+        assert mcp_cache.get_cached_mcp_tools(url, auth_token="tok", transport="sse") is None
+        mcp_cache.set_cached_mcp_tools(url, tools, auth_token="tok", transport="sse")
+        assert mcp_cache.get_cached_mcp_tools(url, auth_token="tok", transport="sse") == tools
+        assert mcp_cache.get_cached_mcp_tools(url, auth_token="other", transport="sse") is None
+        mcp_cache.clear_mcp_tools_cache(url, auth_token="tok", transport="sse")
+        assert mcp_cache.get_cached_mcp_tools(url, auth_token="tok", transport="sse") is None
+
+
+def test_clear_all_mcp_tools_cache_uses_pattern_or_warns():
+    backend = SimpleNamespace()
+    backend.delete_pattern = MagicMock()
+    with patch("apps.opspilot.utils.mcp_cache.cache", backend):
+        mcp_cache.clear_mcp_tools_cache()
+    backend.delete_pattern.assert_called_once_with("mcp_tools:*")
+
+    with patch("apps.opspilot.utils.mcp_cache.cache", SimpleNamespace()):
+        mcp_cache.clear_mcp_tools_cache()
+
+    exploding = SimpleNamespace()
+    exploding.delete_pattern = MagicMock(side_effect=RuntimeError("redis down"))
+    with patch("apps.opspilot.utils.mcp_cache.cache", exploding):
+        mcp_cache.clear_mcp_tools_cache()
+
+
+def test_enabled_filter_treats_empty_as_noop_and_maps_1_0():
+    qs = MagicMock()
+    filtered = MagicMock()
+    qs.filter.return_value = filtered
+
+    assert EnabledFilter.filter_is_enabled(qs, "is_enabled", "") is qs
+    assert EnabledFilter.filter_is_enabled(qs, "is_enabled", None) is qs
+    qs.filter.assert_not_called()
+
+    assert EnabledFilter.filter_is_enabled(qs, "is_enabled", "1") is filtered
+    qs.filter.assert_called_with(enabled=True)
+
+    assert EnabledFilter.filter_is_enabled(qs, "is_enabled", "0") is filtered
+    qs.filter.assert_called_with(enabled=False)

--- a/server/apps/opspilot/tests/test_memory_viewset_crud.py
+++ b/server/apps/opspilot/tests/test_memory_viewset_crud.py
@@ -1,0 +1,239 @@
+"""MemorySpace / Memory CRUD 与 test_write 契约：鉴权通过后写库、审计与 LLM 校验。"""
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pydantic.root_model  # noqa
+import pytest
+from rest_framework import status
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.base.tests.factories import UserFactory
+from apps.opspilot.models import LLMModel
+from apps.opspilot.models.memory_mgmt import Memory, MemorySpace
+from apps.opspilot.viewsets.memory_view import MemorySpaceViewSet, MemoryViewSet
+
+pytestmark = pytest.mark.django_db
+
+factory = APIRequestFactory()
+
+
+def _superuser():
+    return UserFactory(username="mem-su", domain="domain.com", roles=[], is_superuser=True)
+
+
+def _call(view, request, user, **kwargs):
+    force_authenticate(request, user=user)
+    request.COOKIES["current_team"] = "1"
+    return view(request, **kwargs)
+
+
+def _body(resp):
+    if hasattr(resp, "content"):
+        return json.loads(resp.content.decode("utf-8"))
+    return resp.data
+
+
+def _allow_team(monkeypatch):
+    monkeypatch.setattr(
+        "apps.core.utils.serializers.get_permission_rules",
+        lambda *a, **k: {"team": [1], "instance": []},
+    )
+    monkeypatch.setattr(
+        "apps.core.utils.viewset_utils.get_permission_rules",
+        lambda *a, **k: {"team": [1], "instance": []},
+    )
+
+
+def test_memory_space_create_update_destroy_writes_audit(monkeypatch):
+    _allow_team(monkeypatch)
+    logs = []
+    monkeypatch.setattr(
+        "apps.opspilot.viewsets.memory_view.log_operation",
+        lambda request, action, app, summary: logs.append((action, app, summary)),
+    )
+    user = _superuser()
+    created = _call(
+        MemorySpaceViewSet.as_view({"post": "create"}),
+        factory.post("/", {"name": "空间A", "introduction": "i", "scope": "team"}, format="json"),
+        user,
+    )
+    assert created.status_code == status.HTTP_201_CREATED
+    space = MemorySpace.objects.get(name="空间A")
+    assert space.team == [1]
+    assert ("create", "opspilot", "新增记忆空间: 空间A") in logs
+
+    updated = _call(
+        MemorySpaceViewSet.as_view({"put": "update"}),
+        factory.put(
+            "/x/",
+            {"name": "空间B", "introduction": "j", "scope": "team", "team": [1]},
+            format="json",
+        ),
+        user,
+        pk=space.id,
+    )
+    assert updated.status_code == status.HTTP_200_OK
+    space.refresh_from_db()
+    assert space.name == "空间B"
+    assert ("update", "opspilot", "编辑记忆空间: 空间B") in logs
+
+    patched = _call(
+        MemorySpaceViewSet.as_view({"patch": "partial_update"}),
+        factory.patch("/x/", {"name": "空间B", "introduction": "k", "team": [1]}, format="json"),
+        user,
+        pk=space.id,
+    )
+    assert patched.status_code == status.HTTP_200_OK
+    space.refresh_from_db()
+    assert space.introduction == "k"
+
+    deleted = _call(
+        MemorySpaceViewSet.as_view({"delete": "destroy"}),
+        factory.delete("/x/"),
+        user,
+        pk=space.id,
+    )
+    assert deleted.status_code in (status.HTTP_200_OK, status.HTTP_204_NO_CONTENT)
+    assert not MemorySpace.objects.filter(id=space.id).exists()
+    assert ("delete", "opspilot", "删除记忆空间: 空间B") in logs
+
+
+def test_memory_space_retrieve_returns_detail():
+    user = _superuser()
+    space = MemorySpace.objects.create(name="详情空间", team=[1], scope=MemorySpace.SCOPE_TEAM)
+    resp = _call(
+        MemorySpaceViewSet.as_view({"get": "retrieve"}),
+        factory.get("/x/"),
+        user,
+        pk=space.id,
+    )
+    body = _body(resp)
+    assert body["result"] is True
+    assert body["data"]["name"] == "详情空间"
+
+
+def test_memory_create_sets_owner_and_audit(monkeypatch):
+    _allow_team(monkeypatch)
+    logs = []
+    monkeypatch.setattr(
+        "apps.opspilot.viewsets.memory_view.log_operation",
+        lambda request, action, app, summary: logs.append((action, summary)),
+    )
+    user = _superuser()
+    space = MemorySpace.objects.create(name="团队空间", team=[1], scope=MemorySpace.SCOPE_TEAM)
+    created = _call(
+        MemoryViewSet.as_view({"post": "create"}),
+        factory.post(
+            "/",
+            {"memory_space": space.id, "title": "第一条", "content": "hello"},
+            format="json",
+        ),
+        user,
+    )
+    assert created.status_code == status.HTTP_201_CREATED
+    mem = Memory.objects.get(title="第一条")
+    # owner_* 在序列化器上是 read_only，create 写入不会落到库；只钉死标题与审计。
+    assert mem.content == "hello"
+    assert ("create", "新增记忆: 第一条") in logs
+
+    updated = _call(
+        MemoryViewSet.as_view({"put": "update"}),
+        factory.put(
+            "/x/",
+            {"memory_space": space.id, "title": "改名", "content": "world"},
+            format="json",
+        ),
+        user,
+        pk=mem.id,
+    )
+    assert updated.status_code == status.HTTP_200_OK
+    mem.refresh_from_db()
+    assert mem.title == "改名"
+    assert ("update", "编辑记忆: 改名") in logs
+
+    patched = _call(
+        MemoryViewSet.as_view({"patch": "partial_update"}),
+        factory.patch(
+            "/x/",
+            {"memory_space": space.id, "title": "改名", "content": "patched"},
+            format="json",
+        ),
+        user,
+        pk=mem.id,
+    )
+    assert patched.status_code == status.HTTP_200_OK
+    mem.refresh_from_db()
+    assert mem.content == "patched"
+
+    retrieved = _call(MemoryViewSet.as_view({"get": "retrieve"}), factory.get("/x/"), user, pk=mem.id)
+    body = _body(retrieved)
+    assert body["result"] is True
+    assert body["data"]["title"] == "改名"
+
+    deleted = _call(MemoryViewSet.as_view({"delete": "destroy"}), factory.delete("/x/"), user, pk=mem.id)
+    assert deleted.status_code in (status.HTTP_200_OK, status.HTTP_204_NO_CONTENT)
+    assert not Memory.objects.filter(id=mem.id).exists()
+    assert ("delete", "删除记忆: 改名") in logs
+
+
+def test_test_write_validates_input_rule_and_model(monkeypatch):
+    user = _superuser()
+    view = MemorySpaceViewSet.as_view({"post": "test_write"})
+
+    missing_input = _call(view, factory.post("/", {"write_rule": "r"}, format="json"), user)
+    body = _body(missing_input)
+    assert missing_input.status_code == 400
+    assert body["result"] is False
+    assert body["message"] == "input 为必填项"
+
+    passthrough = _call(view, factory.post("/", {"input": "原文"}, format="json"), user)
+    body = _body(passthrough)
+    assert passthrough.status_code == 200
+    assert body == {"result": True, "data": {"result": "原文"}}
+
+    missing_model = _call(
+        view,
+        factory.post("/", {"input": "原文", "write_rule": "整理"}, format="json"),
+        user,
+    )
+    body = _body(missing_model)
+    assert missing_model.status_code == 400
+    assert body["message"] == "model_id 为必填项"
+
+    not_found = _call(
+        view,
+        factory.post("/", {"input": "原文", "write_rule": "整理", "model_id": 999999}, format="json"),
+        user,
+    )
+    body = _body(not_found)
+    assert not_found.status_code == 404
+    assert body["message"] == "配置的模型不存在"
+
+    llm = LLMModel.objects.create(name="mem-llm", model="gpt", team=[1])
+    monkeypatch.setattr(
+        "apps.opspilot.viewsets.memory_view.LLMClientFactory.create_client",
+        lambda *a, **k: SimpleNamespace(invoke=lambda messages: SimpleNamespace(content="规范化结果")),
+    )
+    ok = _call(
+        view,
+        factory.post("/", {"input": "原文", "write_rule": "整理成要点", "model_id": llm.id}, format="json"),
+        user,
+    )
+    body = _body(ok)
+    assert ok.status_code == 200
+    assert body == {"result": True, "data": {"result": "规范化结果"}}
+
+    monkeypatch.setattr(
+        "apps.opspilot.viewsets.memory_view.LLMClientFactory.create_client",
+        Mock(side_effect=RuntimeError("llm down")),
+    )
+    failed = _call(
+        view,
+        factory.post("/", {"input": "原文", "write_rule": "整理", "model_id": llm.id}, format="json"),
+        user,
+    )
+    body = _body(failed)
+    assert failed.status_code == 500
+    assert body["result"] is False
+    assert body["message"] == "LLM 调用失败: llm down"

--- a/server/apps/opspilot/tests/test_nats_api_normalize_and_module.py
+++ b/server/apps/opspilot/tests/test_nats_api_normalize_and_module.py
@@ -1,0 +1,67 @@
+"""OpsPilot NATS：模块列表/分页与工作流触发行为。"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from apps.opspilot.models import Bot, BotWorkFlow, LLMSkill
+from apps.opspilot.nats_api import get_opspilot_module_data, get_opspilot_module_list, trigger_workflow_by_nats
+
+pytestmark = pytest.mark.django_db
+
+
+def test_get_opspilot_module_list_and_unknown_module():
+    modules = get_opspilot_module_list()
+    assert modules[0] == {"name": "bot", "display_name": "Studio"}
+    provider = [m for m in modules if m["name"] == "provider"][0]
+    assert [c["name"] for c in provider["children"]] == [
+        "llm_model",
+        "ocr_model",
+        "embed_model",
+        "rerank_model",
+    ]
+    assert get_opspilot_module_data("unknown", None, 1, 10, 1) == {
+        "result": False,
+        "message": "Unknown module: unknown",
+    }
+    assert get_opspilot_module_data("provider", "bad", 1, 10, 1) == {
+        "result": False,
+        "message": "Unknown child_module: bad",
+    }
+
+
+def test_get_opspilot_module_data_pages_team_scoped_items():
+    Bot.objects.create(name="in-team", team=[3])
+    Bot.objects.create(name="other-team", team=[9])
+    LLMSkill.objects.create(name="skill-in", team=[3])
+    out = get_opspilot_module_data("bot", None, 1, 10, 3)
+    assert out["count"] == 1
+    assert out["items"] == [{"id": Bot.objects.get(name="in-team").id, "name": "in-team"}]
+    skill_out = get_opspilot_module_data("skill", None, 1, 10, 3)
+    assert skill_out["count"] == 1
+    assert skill_out["items"][0]["name"] == "skill-in"
+
+
+def test_trigger_workflow_by_nats_missing_workflow_and_engine_success():
+    assert trigger_workflow_by_nats("", 1, ["u"], 1, "n1") == {
+        "result": False,
+        "message": "message is required",
+    }
+    bot = Bot.objects.create(name="nats-bot", team=[1])
+    assert trigger_workflow_by_nats("hello", 1, ["u1"], bot.id, "start") == {
+        "result": False,
+        "message": "Bot workflow not found",
+    }
+    BotWorkFlow.objects.create(bot=bot, flow_json={}, web_json={})
+    engine = SimpleNamespace(execution_id="exec-1", execute=lambda data: {"success": True, "echo": data["message"]})
+    with patch("apps.opspilot.nats_api.create_chat_flow_engine", return_value=engine) as create:
+        out = trigger_workflow_by_nats("hello", 1, ["u1", None], bot.id, "start")
+    create.assert_called_once()
+    assert create.call_args.args[1] == "start"
+    assert create.call_args.kwargs["entry_type"] == "nats"
+    assert out == {
+        "result": True,
+        "data": {"success": True, "echo": "hello"},
+        "entry_type": "nats",
+        "execution_id": "exec-1",
+    }

--- a/server/apps/opspilot/tests/test_parse_tools_yml_command.py
+++ b/server/apps/opspilot/tests/test_parse_tools_yml_command.py
@@ -1,0 +1,83 @@
+"""parse_tools_yml：元数据转换、密码字段映射、内置工具落库。"""
+import uuid
+from unittest.mock import patch
+
+import pytest
+from django.core.management import CommandError, call_command
+
+from apps.opspilot.management.commands.parse_tools_yml import Command
+from apps.opspilot.models import SkillTools
+
+pytestmark = pytest.mark.django_db
+
+
+def test_convert_to_target_format_maps_password_and_types():
+    cmd = Command()
+    result = cmd.convert_to_target_format(
+        [
+            {
+                "name": "mysql",
+                "description": "MySQL 工具",
+                "constructor": "apps.tools.mysql",
+                "tools": ["query"],
+                "constructor_parameters": [
+                    {"name": "host", "type": "string", "required": True, "description": "地址"},
+                    {"name": "password", "type": "string", "required": True, "description": "密码"},
+                    {"name": "port", "type": "integer", "required": False, "description": "端口"},
+                    {"name": "", "type": "string"},
+                ],
+            }
+        ]
+    )
+    assert result[0]["id"] == "mysql"
+    params = result[0]["params"]
+    assert params["password"]["type"] == "password"
+    assert params["host"]["type"] == "string"
+    assert params["port"]["type"] == "integer"
+    assert "" not in params
+
+
+def test_save_to_database_creates_and_updates_builtin_tools():
+    cmd = Command()
+    toolkit_id = f"redis-kit-{uuid.uuid4().hex[:8]}"
+    toolkits = [
+        {
+            "id": toolkit_id,
+            "name": toolkit_id,
+            "description": "Redis",
+            "tools": ["get", "set"],
+            "params": {
+                "host": {"type": "string", "required": True, "description": "h"},
+                "pwd": {"type": "password", "required": True, "description": "p"},
+                "enabled": {"type": "boolean", "required": False, "description": "e"},
+            },
+        }
+    ]
+    cmd.save_to_database(toolkits)
+    obj = SkillTools.objects.get(name=toolkit_id, is_build_in=True)
+    assert obj.team == [1]
+    keys = {i["key"]: i for i in obj.params["kwargs"]}
+    assert keys["pwd"]["type"] == "password"
+    assert keys["host"]["type"] == "text"
+    assert keys["enabled"]["type"] == "checkbox"
+    assert obj.params["url"] == f"langchain:{toolkit_id}"
+
+    toolkits[0]["description"] = "Redis 更新"
+    cmd.save_to_database(toolkits)
+    obj.refresh_from_db()
+    assert obj.description == "Redis 更新"
+
+
+def test_handle_writes_tools_and_raises_on_loader_failure():
+    toolkit_id = f"k8s-{uuid.uuid4().hex[:8]}"
+    metadata = [{"name": toolkit_id, "description": "k", "tools": [], "constructor_parameters": []}]
+    with patch("apps.opspilot.management.commands.parse_tools_yml.ToolsLoader.get_all_tools_metadata", return_value=metadata):
+        call_command("parse_tools_yml")
+    assert SkillTools.objects.filter(name=toolkit_id, is_build_in=True).exists()
+
+    with patch(
+        "apps.opspilot.management.commands.parse_tools_yml.ToolsLoader.get_all_tools_metadata",
+        side_effect=RuntimeError("discover failed"),
+    ):
+        with pytest.raises(CommandError, match="同步失败"):
+            call_command("parse_tools_yml")

--- a/server/apps/opspilot/tests/test_text_to_pdf_node_service.py
+++ b/server/apps/opspilot/tests/test_text_to_pdf_node_service.py
@@ -1,0 +1,51 @@
+"""TextToPdfNode：空输入拒绝；有文本时生成 PDF 字节流并写入变量管理器。"""
+from io import BytesIO
+
+import pytest
+
+from apps.opspilot.utils.chat_flow_utils.nodes.converter.text_to_pdf import TextToPdfNode
+
+pytestmark = pytest.mark.unit
+
+
+class _Vars:
+    def __init__(self):
+        self.store = {}
+
+    def set_variable(self, key, value):
+        self.store[key] = value
+
+
+def test_execute_rejects_empty_input():
+    node = TextToPdfNode(_Vars())
+    result = node.execute(
+        "n1",
+        {"data": {"config": {"inputParams": "last_message", "outputParams": "last_message"}}},
+        {"last_message": ""},
+    )
+    assert "输入文本为空" in result["last_message"]
+
+
+def test_execute_builds_pdf_stream_and_metadata():
+    vars_ = _Vars()
+    node = TextToPdfNode(vars_)
+    node.chinese_font_name = "Helvetica"
+    result = node.execute(
+        "pdf-1",
+        {
+            "data": {
+                "config": {
+                    "inputParams": "last_message",
+                    "outputParams": "pdf_file",
+                    "pdfConfig": {"title": "报告", "fontSize": 11, "fontName": "Helvetica"},
+                }
+            }
+        },
+        {"last_message": "第一行\n\n第二行 <tag> & amp"},
+    )
+    assert isinstance(result["pdf_file"], BytesIO)
+    assert result["pdf_file"].getvalue()[:4] == b"%PDF"
+    assert result["pdf_metadata"]["title"] == "报告"
+    assert result["pdf_metadata"]["variable_name"] == "pdf_file"
+    assert result["pdf_metadata"]["content_length"] == len("第一行\n\n第二行 <tag> & amp")
+    assert vars_.store["pdf_file"] is result["pdf_file"]

--- a/server/apps/opspilot/tests/test_tools_es_indices_remaining.py
+++ b/server/apps/opspilot/tests/test_tools_es_indices_remaining.py
@@ -1,0 +1,50 @@
+"""Elasticsearch 索引工具剩余：refresh/stats/forcemerge 成功，以及客户端异常走 es_error。"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.opspilot.metis.llm.tools.elasticsearch import indices as idx
+
+pytestmark = pytest.mark.unit
+
+
+def test_refresh_stats_and_forcemerge_success():
+    client = MagicMock()
+    client.indices.refresh.return_value = {"_shards": {"successful": 1}}
+    client.indices.stats.return_value = {"indices": {"logs": {}}}
+    client.indices.forcemerge.return_value = {"_shards": {"successful": 1}}
+    with patch.object(idx, "get_es_client", return_value=client):
+        refreshed = idx.es_refresh_index.invoke({"index": "logs"})
+        stats = idx.es_index_stats.invoke({"index": "logs"})
+        merged = idx.es_forcemerge_index.invoke({"index": "logs", "max_num_segments": 1, "confirm": True})
+    assert refreshed == {"success": True, "data": {"_shards": {"successful": 1}}, "index": "logs"}
+    assert stats["success"] is True
+    assert stats["index"] == "logs"
+    assert merged["success"] is True
+    client.indices.forcemerge.assert_called_once_with(index="logs", max_num_segments=1)
+
+
+def test_forcemerge_and_close_require_confirm():
+    denied_merge = idx.es_forcemerge_index.invoke({"index": "logs", "confirm": False})
+    assert denied_merge == {
+        "success": False,
+        "error": "Operation 'forcemerge_index' requires confirm=True",
+        "error_type": "confirmation_required",
+    }
+    denied_close = idx.es_close_index.invoke({"index": "logs", "confirm": False})
+    assert denied_close["error_type"] == "confirmation_required"
+
+
+def test_list_exists_create_open_close_delete_wrap_client_errors():
+    with patch.object(idx, "get_es_client", side_effect=RuntimeError("cluster down")):
+        listed = idx.es_list_indices.invoke({})
+        exists = idx.es_index_exists.invoke({"index": "logs"})
+        created = idx.es_create_index.invoke({"index": "new"})
+        opened = idx.es_open_index.invoke({"index": "logs"})
+        refreshed = idx.es_refresh_index.invoke({"index": "logs"})
+        stats = idx.es_index_stats.invoke({"index": "logs"})
+        deleted = idx.es_delete_index.invoke({"index": "logs", "confirm": True})
+        closed = idx.es_close_index.invoke({"index": "logs", "confirm": True})
+        merged = idx.es_forcemerge_index.invoke({"index": "logs", "confirm": True})
+    for err in (listed, exists, created, opened, refreshed, stats, deleted, closed, merged):
+        assert err == {"success": False, "error": "cluster down", "error_type": "es_error"}

--- a/server/apps/opspilot/tests/test_tools_es_indices_service.py
+++ b/server/apps/opspilot/tests/test_tools_es_indices_service.py
@@ -1,0 +1,53 @@
+"""Elasticsearch 索引工具：列出/存在性、删除必须 confirm。"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.opspilot.metis.llm.tools.elasticsearch import indices as idx
+
+pytestmark = pytest.mark.unit
+
+
+def _client():
+    client = MagicMock()
+    client.indices.get_alias.return_value = {"logs": {}}
+    client.indices.get.return_value = {"logs": {"settings": {}}}
+    client.indices.exists.return_value = True
+    client.indices.create.return_value = {"acknowledged": True}
+    client.indices.delete.return_value = {"acknowledged": True}
+    client.indices.open.return_value = {"acknowledged": True}
+    client.indices.close.return_value = {"acknowledged": True}
+    return client
+
+
+def test_list_get_exists_and_create_index():
+    client = _client()
+    with patch.object(idx, "get_es_client", return_value=client):
+        listed = idx.es_list_indices.invoke({})
+        assert listed["success"] is True
+        assert "logs" in listed["data"]
+        got = idx.es_get_index.invoke({"index": "logs"})
+        assert got["success"] is True
+        exists = idx.es_index_exists.invoke({"index": "logs"})
+        assert exists["data"]["exists"] is True
+        created = idx.es_create_index.invoke({"index": "new"})
+        assert created["success"] is True
+        client.indices.create.assert_called_once()
+    with patch.object(idx, "get_es_client", side_effect=RuntimeError("down")):
+        err = idx.es_get_index.invoke({"index": "x"})
+    assert err == {"success": False, "error": "down", "error_type": "not_found"}
+
+
+def test_delete_and_close_require_confirm():
+    denied = idx.es_delete_index.invoke({"index": "logs", "confirm": False})
+    assert denied["success"] is False
+    client = _client()
+    with patch.object(idx, "get_es_client", return_value=client):
+        ok = idx.es_delete_index.invoke({"index": "logs", "confirm": True})
+    assert ok["success"] is True
+    client.indices.delete.assert_called_once()
+    denied_close = idx.es_close_index.invoke({"index": "logs", "confirm": False})
+    assert denied_close["success"] is False
+    with patch.object(idx, "get_es_client", return_value=client):
+        opened = idx.es_open_index.invoke({"index": "logs"})
+    assert opened["success"] is True

--- a/server/apps/opspilot/tests/test_tools_es_remaining_service.py
+++ b/server/apps/opspilot/tests/test_tools_es_remaining_service.py
@@ -1,0 +1,218 @@
+"""Elasticsearch 剩余工具：cat/cluster/文档/搜索/快照/mapping/ingest/alias。
+
+删除/restore/bulk/pipeline 必须 confirm=True；失败走 error_type。
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.opspilot.metis.llm.tools.elasticsearch import aliases as als
+from apps.opspilot.metis.llm.tools.elasticsearch import cat as cat_mod
+from apps.opspilot.metis.llm.tools.elasticsearch import cluster as clu
+from apps.opspilot.metis.llm.tools.elasticsearch import documents as docs
+from apps.opspilot.metis.llm.tools.elasticsearch import ingest as ing
+from apps.opspilot.metis.llm.tools.elasticsearch import mappings as maps
+from apps.opspilot.metis.llm.tools.elasticsearch import search as sch
+from apps.opspilot.metis.llm.tools.elasticsearch import snapshots as snap
+
+pytestmark = pytest.mark.unit
+
+
+def _client():
+    client = MagicMock()
+    client.ping.return_value = True
+    client.info.return_value = {"cluster_name": "es"}
+    client.cluster.health.return_value = {"status": "green"}
+    client.cluster.stats.return_value = {"nodes": {"count": 1}}
+    client.nodes.info.return_value = {"nodes": {}}
+    client.nodes.stats.return_value = {"nodes": {}}
+    client.cat.indices.return_value = [{"index": "logs"}]
+    client.cat.shards.return_value = [{"index": "logs", "shard": "0"}]
+    client.cat.nodes.return_value = [{"name": "n1"}]
+    client.cat.aliases.return_value = [{"alias": "logs-write"}]
+    client.cat.allocation.return_value = [{"node": "n1"}]
+    client.cat.recovery.return_value = []
+    client.get.return_value = {"_id": "1", "_source": {"a": 1}}
+    client.index.return_value = {"result": "created"}
+    client.delete.return_value = {"result": "deleted"}
+    client.update.return_value = {"result": "updated"}
+    client.mget.return_value = {"docs": [{"_id": "1"}]}
+    client.bulk.return_value = {"errors": False}
+    client.search.return_value = {"took": 3, "timed_out": False, "hits": {"total": {"value": 1}, "hits": [{"_id": "1"}]}}
+    client.count.return_value = {"count": 2}
+    client.indices.validate_query.return_value = {"valid": True}
+    client.msearch.return_value = {"responses": []}
+    client.explain.return_value = {"matched": True}
+    client.search_template.return_value = {"hits": {"hits": []}}
+    client.snapshot.get_repository.return_value = {"fs": {}}
+    client.snapshot.create_repository.return_value = {"acknowledged": True}
+    client.snapshot.get.return_value = {"snapshots": []}
+    client.snapshot.create.return_value = {"accepted": True}
+    client.snapshot.restore.return_value = {"accepted": True}
+    client.indices.get_mapping.return_value = {"logs": {"mappings": {}}}
+    client.indices.get_settings.return_value = {"logs": {"settings": {}}}
+    client.indices.put_mapping.return_value = {"acknowledged": True}
+    client.indices.put_settings.return_value = {"acknowledged": True}
+    client.field_caps.return_value = {"fields": {}}
+    client.indices.get_alias.return_value = {"logs": {"aliases": {"logs-write": {}}}}
+    client.indices.exists_alias.return_value = True
+    client.indices.update_aliases.return_value = {"acknowledged": True}
+    client.ingest.get_pipeline.return_value = {"p1": {}}
+    client.ingest.put_pipeline.return_value = {"acknowledged": True}
+    client.ingest.delete_pipeline.return_value = {"acknowledged": True}
+    client.ingest.simulate.return_value = {"docs": []}
+    return client
+
+
+def test_cluster_ping_info_and_health():
+    client = _client()
+    with patch.object(clu, "get_es_client", return_value=client):
+        ping = clu.es_ping.invoke({})
+        assert ping["success"] is True
+        assert ping["data"]["pong"] is True
+        info = clu.es_info.invoke({})
+        assert info["data"]["cluster_name"] == "es"
+        health = clu.es_cluster_health.invoke({})
+        assert health["data"]["status"] == "green"
+        named = clu.es_cluster_health.invoke({"index": "logs"})
+        assert named["index"] == "logs"
+        client.cluster.health.assert_any_call(index="logs")
+        stats = clu.es_cluster_stats.invoke({})
+        assert stats["success"] is True
+        nodes = clu.es_nodes_info.invoke({})
+        assert nodes["success"] is True
+        node_stats = clu.es_nodes_stats.invoke({})
+        assert node_stats["success"] is True
+    with patch.object(clu, "get_es_client", side_effect=RuntimeError("refused")):
+        err = clu.es_ping.invoke({})
+    assert err["success"] is False
+    assert err["error_type"] == "connection_error"
+
+
+def test_cat_indices_shards_nodes_and_aliases():
+    client = _client()
+    with patch.object(cat_mod, "get_es_client", return_value=client):
+        indices = cat_mod.es_cat_indices.invoke({"index": "logs*"})
+        assert indices["success"] is True
+        assert indices["data"][0]["index"] == "logs"
+        shards = cat_mod.es_cat_shards.invoke({"index": "logs"})
+        assert shards["data"][0]["shard"] == "0"
+        nodes = cat_mod.es_cat_nodes.invoke({})
+        assert nodes["data"][0]["name"] == "n1"
+        aliases = cat_mod.es_cat_aliases.invoke({})
+        assert aliases["data"][0]["alias"] == "logs-write"
+        alloc = cat_mod.es_cat_allocation.invoke({})
+        assert alloc["success"] is True
+        recovery = cat_mod.es_cat_recovery.invoke({})
+        assert recovery["data"] == []
+    with patch.object(cat_mod, "get_es_client", side_effect=RuntimeError("down")):
+        err = cat_mod.es_cat_nodes.invoke({})
+    assert err["success"] is False
+
+
+def test_documents_crud_and_confirm_guards():
+    denied = docs.es_delete_document.invoke({"index": "logs", "doc_id": "1", "confirm": False})
+    assert denied["error_type"] == "confirmation_required"
+    denied_bulk = docs.es_bulk.invoke({"operations": [], "confirm": False})
+    assert denied_bulk["error_type"] == "confirmation_required"
+    client = _client()
+    with patch.object(docs, "get_es_client", return_value=client):
+        got = docs.es_get_document.invoke({"index": "logs", "doc_id": "1"})
+        assert got["data"]["_id"] == "1"
+        indexed = docs.es_index_document.invoke({"index": "logs", "document": {"a": 1}, "doc_id": "1"})
+        assert indexed["success"] is True
+        deleted = docs.es_delete_document.invoke({"index": "logs", "doc_id": "1", "confirm": True})
+        assert deleted["success"] is True
+        updated = docs.es_update_document.invoke({"index": "logs", "doc_id": "1", "doc": {"a": 2}})
+        assert updated["success"] is True
+        mget = docs.es_multi_get.invoke({"index": "logs", "ids": ["1"]})
+        assert mget["data"]["docs"][0]["_id"] == "1"
+        bulk = docs.es_bulk.invoke({"operations": [{"index": {}}], "confirm": True})
+        assert bulk["success"] is True
+    with patch.object(docs, "get_es_client", side_effect=RuntimeError("missing")):
+        err = docs.es_get_document.invoke({"index": "logs", "doc_id": "x"})
+    assert err["error_type"] == "not_found"
+
+
+def test_search_count_validate_and_knn():
+    client = _client()
+    with patch.object(sch, "get_es_client", return_value=client):
+        searched = sch.es_search.invoke({"index": "logs", "query": {"match_all": {}}})
+        assert searched["data"]["total"] == 1
+        assert searched["data"]["hits"][0]["_id"] == "1"
+        counted = sch.es_count.invoke({"index": "logs"})
+        assert counted["data"]["count"] == 2
+        valid = sch.es_validate_query.invoke({"index": "logs", "query": {"match_all": {}}})
+        assert valid["data"]["valid"] is True
+        msearch = sch.es_multi_search.invoke({"searches": [{}, {}]})
+        assert msearch["success"] is True
+        explained = sch.es_explain.invoke({"index": "logs", "doc_id": "1", "query": {"match_all": {}}})
+        assert explained["data"]["matched"] is True
+        templated = sch.es_search_template.invoke({"index": "logs", "source": {"query": {"match_all": {}}}})
+        assert templated["success"] is True
+        knn = sch.es_knn_search.invoke({"index": "logs", "knn": {"field": "vec", "query_vector": [0.1], "k": 1}})
+        assert knn["success"] is True
+    with patch.object(sch, "get_es_client", side_effect=RuntimeError("bad query")):
+        err = sch.es_search.invoke({"index": "logs", "query": {}})
+    assert err["success"] is False
+
+
+def test_snapshots_restore_requires_confirm():
+    denied = snap.es_restore_snapshot.invoke({"repository": "fs", "snapshot": "s1", "confirm": False})
+    assert denied["error_type"] == "confirmation_required"
+    client = _client()
+    with patch.object(snap, "get_es_client", return_value=client):
+        repos = snap.es_get_snapshot_repositories.invoke({})
+        assert "fs" in repos["data"]
+        created_repo = snap.es_create_snapshot_repository.invoke({"repository": "fs", "body": {"type": "fs"}})
+        assert created_repo["success"] is True
+        listed = snap.es_get_snapshots.invoke({"repository": "fs"})
+        assert listed["success"] is True
+        created = snap.es_create_snapshot.invoke({"repository": "fs", "snapshot": "s1"})
+        assert created["success"] is True
+        restored = snap.es_restore_snapshot.invoke({"repository": "fs", "snapshot": "s1", "confirm": True})
+        assert restored["success"] is True
+        client.snapshot.restore.assert_called_once()
+    with patch.object(snap, "get_es_client", side_effect=RuntimeError("no repo")):
+        err = snap.es_get_snapshots.invoke({"repository": "missing"})
+    assert err["success"] is False
+
+
+def test_mappings_settings_and_aliases():
+    client = _client()
+    with patch.object(maps, "get_es_client", return_value=client):
+        mapping = maps.es_get_mapping.invoke({"index": "logs"})
+        assert mapping["success"] is True
+        settings = maps.es_get_settings.invoke({"index": "logs"})
+        assert settings["success"] is True
+        put_map = maps.es_put_mapping.invoke({"index": "logs", "body": {"properties": {"a": {"type": "keyword"}}}})
+        assert put_map["success"] is True
+        put_set = maps.es_put_settings.invoke({"index": "logs", "body": {"index": {"number_of_replicas": 0}}})
+        assert put_set["success"] is True
+        caps = maps.es_field_caps.invoke({"index": "logs", "fields": ["a"]})
+        assert caps["success"] is True
+    with patch.object(als, "get_es_client", return_value=client):
+        alias = als.es_get_alias.invoke({"name": "logs-write"})
+        assert alias["success"] is True
+        exists = als.es_alias_exists.invoke({"name": "logs-write"})
+        assert exists["data"]["exists"] is True
+        updated = als.es_update_aliases.invoke({"actions": [{"add": {"index": "logs", "alias": "logs-write"}}]})
+        assert updated["success"] is True
+
+
+def test_ingest_pipeline_delete_requires_confirm():
+    denied = ing.es_delete_pipeline.invoke({"pipeline_id": "p1", "confirm": False})
+    assert denied["error_type"] == "confirmation_required"
+    client = _client()
+    with patch.object(ing, "get_es_client", return_value=client):
+        got = ing.es_get_pipeline.invoke({"pipeline_id": "p1"})
+        assert got["success"] is True
+        put = ing.es_put_pipeline.invoke({"pipeline_id": "p1", "body": {"processors": []}})
+        assert put["success"] is True
+        deleted = ing.es_delete_pipeline.invoke({"pipeline_id": "p1", "confirm": True})
+        assert deleted["success"] is True
+        simulated = ing.es_simulate_pipeline.invoke({"body": {"docs": []}, "pipeline_id": "p1"})
+        assert simulated["success"] is True
+    with patch.object(ing, "get_es_client", side_effect=RuntimeError("gone")):
+        err = ing.es_get_pipeline.invoke({"pipeline_id": "missing"})
+    assert err["success"] is False

--- a/server/apps/opspilot/tests/test_tools_fetch_service.py
+++ b/server/apps/opspilot/tests/test_tools_fetch_service.py
@@ -1,0 +1,78 @@
+"""Fetch 工具：HTTP 失败透传、HTML/文本/JSON/批量抓取。"""
+from unittest.mock import patch
+
+import pytest
+
+from apps.opspilot.metis.llm.tools.fetch import fetch as f
+
+pytestmark = pytest.mark.unit
+
+
+def _ok(content, url="https://example.com", content_type="text/html"):
+    return {"success": True, "content": content, "url": url, "content_type": content_type}
+
+
+def test_fetch_html_extracts_main_and_truncates():
+    html = "<html><body><nav>nav</nav><article><p>hello world from the main article body</p></article></body></html>"
+    with patch.object(f, "_http_get_impl", return_value=_ok(html)):
+        out = f.fetch_html.invoke({"url": "https://example.com", "extract_main": True, "max_length": 20})
+    assert out["success"] is True
+    assert out["truncated"] is True
+    assert len(out["content"]) <= 20
+    assert len(out["content"]) == 20
+    assert out["content"].startswith("<article>")
+    assert "nav" not in out["content"]
+    assert out["url"] == "https://example.com"
+
+
+def test_fetch_html_propagates_http_failure():
+    with patch.object(f, "_http_get_impl", return_value={"success": False, "error": "timeout"}):
+        out = f.fetch_html.invoke({"url": "https://down.example"})
+    assert out["success"] is False
+    assert out["error"] == "timeout"
+
+
+def test_fetch_txt_strips_tags():
+    with patch.object(f, "_http_get_impl", return_value=_ok("<p>alpha <b>beta</b></p>")):
+        out = f.fetch_txt.invoke({"url": "https://example.com", "max_length": 500})
+    assert out["success"] is True
+    assert "alpha" in out["content"]
+    assert "<p>" not in out["content"]
+
+
+def test_fetch_markdown_converts_headings():
+    with patch.object(f, "_http_get_impl", return_value=_ok("<h1>Title</h1><p>body</p>")):
+        out = f.fetch_markdown.invoke({"url": "https://example.com", "max_length": 500})
+    assert out["success"] is True
+    assert "Title" in out["content"]
+
+
+def test_fetch_json_parses_and_rejects_invalid():
+    with patch.object(f, "_http_get_impl", return_value=_ok('{"a": 1}', content_type="application/json")):
+        out = f.fetch_json.invoke({"url": "https://api.example/data"})
+    assert out["success"] is True
+    assert out["data"] == {"a": 1}
+
+    with patch.object(f, "_http_get_impl", return_value=_ok("not-json", content_type="text/plain")):
+        bad = f.fetch_json.invoke({"url": "https://api.example/bad"})
+    assert bad["success"] is False
+    assert bad["error"] == "响应的Content-Type不是JSON: text/plain"
+    assert bad["url"] == "https://example.com"
+
+
+def test_fetch_batch_counts_success_and_failure():
+    def _impl(url, **kwargs):
+        if "fail" in url:
+            return {"success": False, "error": "gone"}
+        if url.endswith(".json"):
+            return _ok('{"ok": true}', url=url, content_type="application/json")
+        return _ok("<p>hi</p>", url=url)
+
+    with patch.object(f, "_http_get_impl", side_effect=_impl):
+        html_batch = f.fetch_batch.invoke({"urls": ["https://a", "https://fail"], "format": "html"})
+        json_batch = f.fetch_batch.invoke({"urls": ["https://a.json"], "format": "json"})
+    assert html_batch["total"] == 2
+    assert html_batch["succeeded"] == 1
+    assert html_batch["failed"] == 1
+    assert json_batch["succeeded"] == 1
+    assert json_batch["results"][0]["data"] == {"ok": True}

--- a/server/apps/opspilot/tests/test_tools_jenkins_build_remaining.py
+++ b/server/apps/opspilot/tests/test_tools_jenkins_build_remaining.py
@@ -1,0 +1,99 @@
+"""Jenkins build 工具：参数校验、触发成功/失败、批量查询隔离。"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.opspilot.metis.llm.tools.jenkins import build as build_mod
+
+pytestmark = pytest.mark.unit
+
+
+def _client(**methods):
+    client = MagicMock()
+    for name, value in methods.items():
+        setattr(client, name, value)
+    return client
+
+
+def test_get_client_builds_jenkins_from_runnable_config():
+    cfg = {
+        "items": [
+            {
+                "config": {
+                    "jenkins_url": "https://ci.example.com",
+                    "jenkins_username": "u",
+                    "jenkins_password": "p",
+                }
+            }
+        ]
+    }
+    with (
+        patch(
+            "apps.opspilot.metis.llm.tools.jenkins.connection.build_jenkins_normalized_from_runnable",
+            return_value=cfg,
+        ),
+        patch("apps.opspilot.metis.llm.tools.jenkins.build.jenkins.Jenkins") as jenkins_cls,
+    ):
+        jenkins_cls.return_value = "client"
+        assert build_mod.get_client({"configurable": {}}, instance_name="ci") == "client"
+    jenkins_cls.assert_called_once_with("https://ci.example.com", username="u", password="p")
+
+
+def test_list_jobs_and_trigger_validates_then_returns_build_info():
+    client = _client(
+        get_jobs=lambda: [{"name": "job-a"}],
+        get_job_info=lambda name: {"nextBuildNumber": 9, "url": "https://ci.example.com/job/job-a/"},
+        build_job=lambda name, parameters=None: 77,
+    )
+    with patch.object(build_mod, "get_client", return_value=client):
+        assert build_mod.list_jenkins_jobs.func(config={}) == [{"name": "job-a"}]
+        with pytest.raises(ValueError, match="job_name must be a string"):
+            build_mod.trigger_jenkins_build.func(job_name=1, parameters=None, config={})
+        with pytest.raises(ValueError, match="parameters must be a dictionary or None"):
+            build_mod.trigger_jenkins_build.func(job_name="job-a", parameters=["x"], config={})
+        out = build_mod.trigger_jenkins_build.func(job_name="job-a", parameters={"k": "v"}, config={})
+    assert out == {
+        "status": "triggered",
+        "job_name": "job-a",
+        "queue_id": 77,
+        "build_number": 9,
+        "job_url": "https://ci.example.com/job/job-a/",
+        "build_url": "https://ci.example.com/job/job-a/9/",
+    }
+
+
+def test_trigger_wraps_missing_job_and_build_errors():
+    missing = _client(get_job_info=lambda name: None)
+    with patch.object(build_mod, "get_client", return_value=missing):
+        with pytest.raises(ValueError, match="Error checking job missing: Job missing not found"):
+            build_mod.trigger_jenkins_build.func(job_name="missing", parameters=None, config={})
+
+    exploding = _client(get_job_info=lambda name: (_ for _ in ()).throw(RuntimeError("404")))
+    with patch.object(build_mod, "get_client", return_value=exploding):
+        with pytest.raises(ValueError, match="Error checking job x: 404"):
+            build_mod.trigger_jenkins_build.func(job_name="x", parameters=None, config={})
+
+    fail_build = _client(
+        get_job_info=lambda name: {"nextBuildNumber": 1, "url": "https://ci/job/x/"},
+        build_job=lambda name, parameters=None: (_ for _ in ()).throw(RuntimeError("queue full")),
+    )
+    with patch.object(build_mod, "get_client", return_value=fail_build):
+        with pytest.raises(ValueError, match="Error triggering build for x: queue full"):
+            build_mod.trigger_jenkins_build.func(job_name="x", parameters=None, config={})
+
+
+def test_job_info_batch_continues_after_single_failure():
+    def get_job_info(name):
+        if name == "bad":
+            raise RuntimeError("gone")
+        return {"name": name}
+
+    client = _client(get_job_info=get_job_info)
+    with patch.object(build_mod, "get_client", return_value=client):
+        out = build_mod.get_jenkins_job_info_batch.func(job_names=["ok", "bad"], config={})
+    assert out["total"] == 2
+    assert out["succeeded"] == 1
+    assert out["failed"] == 1
+    assert out["results"][0] == {"input": "ok", "ok": True, "data": {"name": "ok"}}
+    assert out["results"][1]["ok"] is False
+    assert out["results"][1]["error"] == "gone"

--- a/server/apps/opspilot/tests/test_tools_k8s_analysis_service.py
+++ b/server/apps/opspilot/tests/test_tools_k8s_analysis_service.py
@@ -1,0 +1,323 @@
+"""Kubernetes 配置分析工具：配额、网络策略、下一步提示、问题工作负载聚合。
+
+mock kube API 边界，断言 JSON 结构与 fail-closed 错误包装。
+"""
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from kubernetes.client import ApiException
+
+from apps.opspilot.metis.llm.tools.kubernetes import analysis as a
+
+
+def _items(lst):
+    return SimpleNamespace(items=lst)
+
+
+@pytest.fixture
+def core():
+    c = MagicMock()
+    with patch.object(a, "prepare_context", return_value=None), patch.object(a.client, "CoreV1Api", return_value=c):
+        yield c
+
+
+def test_resource_quotas_computes_percentage_and_wraps_api_error(core):
+    quota = SimpleNamespace(
+        metadata=SimpleNamespace(name="q1", namespace="prod"),
+        status=SimpleNamespace(hard={"cpu": "1000m", "count/pods": "10"}, used={"cpu": "500m", "count/pods": "2"}),
+    )
+    core.list_resource_quota_for_all_namespaces.return_value = _items([quota])
+    with patch.object(a, "parse_resource_quantity", side_effect=lambda v: float(str(v).replace("m", "")) if "m" in str(v) else float(v)):
+        out = json.loads(a.check_kubernetes_resource_quotas.invoke({"config": {}}))
+    assert out[0]["name"] == "q1"
+    assert out[0]["usage_percentage"]["cpu"] == 50.0
+    assert out[0]["usage_percentage"]["count/pods"] == 20.0
+
+    core.list_namespaced_resource_quota.side_effect = ApiException(reason="forbidden")
+    err = json.loads(a.check_kubernetes_resource_quotas.invoke({"namespace": "prod", "config": {}}))
+    assert "error" in err
+
+
+def test_network_policies_namespaced_and_cluster():
+    policy = SimpleNamespace(
+        metadata=SimpleNamespace(name="deny-all", namespace="prod"),
+        spec=SimpleNamespace(
+            pod_selector=SimpleNamespace(match_labels={"app": "web"}),
+            policy_types=["Ingress"],
+            ingress=[1],
+            egress=None,
+        ),
+    )
+    net = MagicMock()
+    net.list_network_policy_for_all_namespaces.return_value = _items([policy])
+    net.list_namespaced_network_policy.return_value = _items([policy])
+    with patch.object(a, "prepare_context"), patch.object(a.client, "NetworkingV1Api", return_value=net):
+        all_ns = json.loads(a.check_kubernetes_network_policies.invoke({"config": {}}))
+        named = json.loads(a.check_kubernetes_network_policies.invoke({"namespace": "prod", "config": {}}))
+        net.list_network_policy_for_all_namespaces.side_effect = ApiException(reason="down")
+        err = json.loads(a.check_kubernetes_network_policies.invoke({"config": {}}))
+    assert all_ns[0]["ingress_rules"] == 1
+    assert named[0]["pod_selector"] == {"app": "web"}
+    assert "error" in err
+
+
+def test_persistent_volumes_join_claims(core):
+    pv = SimpleNamespace(
+        metadata=SimpleNamespace(name="pv-1"),
+        spec=SimpleNamespace(
+            capacity={"storage": "10Gi"},
+            access_modes=["ReadWriteOnce"],
+            persistent_volume_reclaim_policy="Retain",
+            storage_class_name="standard",
+        ),
+        status=SimpleNamespace(phase="Bound"),
+    )
+    pvc = SimpleNamespace(
+        metadata=SimpleNamespace(name="claim-1", namespace="prod"),
+        spec=SimpleNamespace(volume_name="pv-1"),
+        status=SimpleNamespace(phase="Bound"),
+    )
+    core.list_persistent_volume.return_value = _items([pv])
+    core.list_persistent_volume_claim_for_all_namespaces.return_value = _items([pvc])
+    out = json.loads(a.check_kubernetes_persistent_volumes.invoke({"config": {}}))
+    assert out[0]["claim"]["name"] == "claim-1"
+    assert out[0]["status"] == "Bound"
+
+
+def test_jobs_report_completions_and_api_error():
+    job = SimpleNamespace(
+        metadata=SimpleNamespace(name="migrate", namespace="prod"),
+        spec=SimpleNamespace(completions=1, parallelism=1),
+        status=SimpleNamespace(succeeded=1, failed=0, active=0, start_time=None, completion_time=None),
+    )
+    cron = SimpleNamespace(
+        metadata=SimpleNamespace(name="nightly", namespace="prod"),
+        spec=SimpleNamespace(schedule="0 1 * * *", suspend=False),
+        status=SimpleNamespace(active=[], last_schedule_time=None),
+    )
+    batch = MagicMock()
+    batch.list_job_for_all_namespaces.return_value = _items([job])
+    batch.list_cron_job_for_all_namespaces.return_value = _items([cron])
+    with patch.object(a, "prepare_context"), patch.object(a.client, "BatchV1Api", return_value=batch):
+        out = json.loads(a.check_kubernetes_jobs.invoke({"config": {}}))
+    assert out["jobs"][0]["succeeded"] == 1
+    assert out["cronjobs"][0]["schedule"] == "0 1 * * *"
+
+    batch.list_job_for_all_namespaces.side_effect = ApiException(reason="down")
+    with patch.object(a, "prepare_context"), patch.object(a.client, "BatchV1Api", return_value=batch):
+        err = json.loads(a.check_kubernetes_jobs.invoke({"config": {}}))
+    assert "error" in err
+
+
+def test_ingress_extracts_hosts_backends_and_lb():
+    ingress = SimpleNamespace(
+        metadata=SimpleNamespace(name="web", namespace="prod"),
+        spec=SimpleNamespace(
+            ingress_class_name="nginx",
+            tls=["secret"],
+            rules=[
+                SimpleNamespace(
+                    host="app.example",
+                    http=SimpleNamespace(
+                        paths=[
+                            SimpleNamespace(
+                                path="/",
+                                path_type="Prefix",
+                                backend=SimpleNamespace(
+                                    service=SimpleNamespace(
+                                        name="web-svc",
+                                        port=SimpleNamespace(number=80),
+                                    )
+                                ),
+                            )
+                        ]
+                    ),
+                )
+            ],
+        ),
+        status=SimpleNamespace(load_balancer=SimpleNamespace(ingress=[SimpleNamespace(ip="1.1.1.1", hostname=None)])),
+    )
+    net = MagicMock()
+    net.list_ingress_for_all_namespaces.return_value = _items([ingress])
+    with patch.object(a, "prepare_context"), patch.object(a.client, "NetworkingV1Api", return_value=net):
+        out = json.loads(a.check_kubernetes_ingress.invoke({"config": {}}))
+    assert out[0]["hosts"] == ["app.example"]
+    assert out[0]["backends"][0]["service_name"] == "web-svc"
+    assert out[0]["load_balancers"][0]["value"] == "1.1.1.1"
+    assert out[0]["tls"] == 1
+
+
+def test_endpoints_ready_and_not_ready():
+    endpoint = SimpleNamespace(
+        metadata=SimpleNamespace(name="web-svc", namespace="prod"),
+        subsets=[
+            SimpleNamespace(
+                addresses=[
+                    SimpleNamespace(
+                        ip="10.0.0.2",
+                        hostname=None,
+                        target_ref=SimpleNamespace(kind="Pod", name="web-0"),
+                    )
+                ],
+                not_ready_addresses=[SimpleNamespace(ip="10.0.0.3", hostname=None, target_ref=None)],
+                ports=[SimpleNamespace(name="http", port=80, protocol="TCP")],
+            )
+        ],
+    )
+    core = MagicMock()
+    core.list_endpoints_for_all_namespaces.return_value = _items([endpoint])
+    with patch.object(a, "prepare_context"), patch.object(a.client, "CoreV1Api", return_value=core):
+        out = json.loads(a.check_kubernetes_endpoints.invoke({"config": {}}))
+    assert out[0]["ready_count"] == 1
+    assert out[0]["not_ready_count"] == 1
+    assert out[0]["ready_addresses"][0]["target_ref"] == "Pod/web-0"
+
+
+def test_hpa_reports_replicas_and_metrics():
+    hpa = SimpleNamespace(
+        metadata=SimpleNamespace(name="web-hpa", namespace="prod"),
+        spec=SimpleNamespace(
+            min_replicas=1,
+            max_replicas=5,
+            scale_target_ref=SimpleNamespace(kind="Deployment", name="web"),
+            metrics=[
+                SimpleNamespace(
+                    type="Resource",
+                    resource=SimpleNamespace(
+                        name="cpu",
+                        target=SimpleNamespace(average_value=None, average_utilization=70),
+                    ),
+                )
+            ],
+        ),
+        status=SimpleNamespace(
+            current_replicas=2,
+            desired_replicas=3,
+            current_metrics=[
+                SimpleNamespace(
+                    type="Resource",
+                    resource=SimpleNamespace(
+                        name="cpu",
+                        current=SimpleNamespace(average_value=None, average_utilization=80),
+                    ),
+                )
+            ],
+            conditions=[SimpleNamespace(type="AbleToScale", status="True", reason="ok", message="")],
+        ),
+    )
+    auto = MagicMock()
+    auto.list_horizontal_pod_autoscaler_for_all_namespaces.return_value = _items([hpa])
+    with patch.object(a, "prepare_context"), patch.object(a.client, "AutoscalingV2Api", return_value=auto):
+        out = json.loads(a.check_kubernetes_hpa_status.invoke({"config": {}}))
+    assert out[0]["target_ref"] == "Deployment/web"
+    assert out[0]["desired_replicas"] == 3
+    assert out[0]["current_metrics"][0]["current_value"] == 80
+
+
+def _deployment(name="web", ns="prod", replicas=1, image="web:latest"):
+    container = SimpleNamespace(
+        name="app",
+        image=image,
+        resources=None,
+        liveness_probe=None,
+        readiness_probe=None,
+        security_context=None,
+    )
+    return SimpleNamespace(
+        metadata=SimpleNamespace(name=name, namespace=ns),
+        spec=SimpleNamespace(
+            replicas=replicas,
+            strategy=SimpleNamespace(type="RollingUpdate"),
+            selector=SimpleNamespace(match_labels={"app": name}),
+            template=SimpleNamespace(
+                spec=SimpleNamespace(
+                    containers=[container],
+                    affinity=None,
+                )
+            ),
+        ),
+    )
+
+
+def test_analyze_deployment_flags_single_replica_and_missing_guards():
+    apps = MagicMock()
+    core = MagicMock()
+    apps.list_deployment_for_all_namespaces.return_value = _items([_deployment()])
+    core.list_namespaced_pod_disruption_budget.side_effect = RuntimeError("no pdb api")
+    with (
+        patch.object(a, "prepare_context"),
+        patch.object(a.client, "AppsV1Api", return_value=apps),
+        patch.object(a.client, "CoreV1Api", return_value=core),
+        patch.object(a, "get_current_cluster_name", return_value="prod-cluster"),
+    ):
+        out = json.loads(a.analyze_deployment_configurations.invoke({"config": {}}))
+    assert out["cluster_name"] == "prod-cluster"
+    assert out["problematic"] == 1
+    issues = {item["issue"] for item in out["issues_detail"]}
+    assert any("单副本" in i for i in issues)
+    assert any("资源限制" in i for i in issues)
+    assert any("存活探针" in i for i in issues)
+    assert any("latest" in i or "标签" in i for i in issues)
+    full = out["_deployments_full"][0]
+    assert full["config_analysis"]["replicas"] == 1
+
+
+def test_analyze_deployment_not_found_and_scope_too_large():
+    apps = MagicMock()
+    core = MagicMock()
+    apps.list_namespaced_deployment.return_value = _items([_deployment("other")])
+    with (
+        patch.object(a, "prepare_context"),
+        patch.object(a.client, "AppsV1Api", return_value=apps),
+        patch.object(a.client, "CoreV1Api", return_value=core),
+        patch.object(a, "get_current_cluster_name", return_value="c"),
+    ):
+        missing = json.loads(a.analyze_deployment_configurations.invoke({"namespace": "prod", "name": "web", "config": {}}))
+    assert missing["error"] == "deployment_not_found"
+
+    crowded = [_deployment(name=f"d{i}", ns="ns-a" if i < 60 else "ns-b") for i in range(101)]
+    apps.list_deployment_for_all_namespaces.return_value = _items(crowded)
+    with (
+        patch.object(a, "prepare_context"),
+        patch.object(a.client, "AppsV1Api", return_value=apps),
+        patch.object(a.client, "CoreV1Api", return_value=core),
+        patch.object(a, "get_current_cluster_name", return_value="c"),
+    ):
+        huge = json.loads(a.analyze_deployment_configurations.invoke({"config": {}}))
+    assert huge["error"] == "scope_too_large"
+    assert huge["total"] == 101
+
+
+def test_daemonset_and_statefulset_status():
+    ds = SimpleNamespace(
+        metadata=SimpleNamespace(name="agent", namespace="kube-system"),
+        status=SimpleNamespace(
+            desired_number_scheduled=3,
+            current_number_scheduled=3,
+            number_ready=2,
+            updated_number_scheduled=3,
+            number_available=2,
+        ),
+        spec=SimpleNamespace(template=SimpleNamespace(spec=SimpleNamespace(node_selector={"pool": "sys"}))),
+    )
+    sts = SimpleNamespace(
+        metadata=SimpleNamespace(name="pg", namespace="db"),
+        spec=SimpleNamespace(replicas=3, service_name="pg", volume_claim_templates=[1, 2]),
+        status=SimpleNamespace(ready_replicas=3, current_replicas=3, updated_replicas=3),
+    )
+    apps = MagicMock()
+    apps.list_daemon_set_for_all_namespaces.return_value = _items([ds])
+    apps.list_stateful_set_for_all_namespaces.return_value = _items([sts])
+    with (
+        patch.object(a, "prepare_context"),
+        patch.object(a.client, "AppsV1Api", return_value=apps),
+        patch.object(a, "get_current_cluster_name", return_value="c1"),
+    ):
+        daemon = json.loads(a.check_kubernetes_daemonsets.invoke({"config": {}}))
+        stateful = json.loads(a.check_kubernetes_statefulsets.invoke({"config": {}}))
+    assert daemon["daemonsets"][0]["ready"] == 2
+    assert daemon["daemonsets"][0]["node_selector"] == {"pool": "sys"}
+    assert stateful["statefulsets"][0]["volume_claim_templates"] == 2
+    assert stateful["statefulsets"][0]["ready_replicas"] == 3

--- a/server/apps/opspilot/tests/test_tools_mysql_monitoring_remaining.py
+++ b/server/apps/opspilot/tests/test_tools_mysql_monitoring_remaining.py
@@ -1,0 +1,177 @@
+"""MySQL 监控剩余：binlog/复制/进程列表/库容量与连接错误包装。"""
+import json
+from unittest.mock import patch
+
+import pytest
+from mysql.connector import Error
+
+from apps.opspilot.metis.llm.tools.mysql import monitoring as mon
+from apps.opspilot.metis.llm.tools.mysql.utils import format_size
+
+pytestmark = pytest.mark.unit
+
+NORMALIZED = {
+    "mode": "single",
+    "legacy_single": True,
+    "items": [{"index": 0, "name": "db1", "raw": {}, "config": {"database": "app"}}],
+}
+
+
+class FakeCursor:
+    def __init__(self, *, rows=None, fetchones=None, fail_on=None):
+        self._rows = rows or []
+        self._fetchones = list(fetchones or [])
+        self._fail_on = fail_on or {}
+        self.last_sql = ""
+
+    def execute(self, sql, params=None):
+        self.last_sql = sql
+        for needle, exc in self._fail_on.items():
+            if needle in sql:
+                raise exc
+        return None
+
+    def fetchall(self):
+        return list(self._rows)
+
+    def fetchone(self):
+        return self._fetchones.pop(0) if self._fetchones else None
+
+    def close(self):
+        return None
+
+
+class FakeConn:
+    def __init__(self, cursor):
+        self._cursor = cursor
+        self.closed = False
+
+    def cursor(self, dictionary=False):
+        return self._cursor
+
+    def close(self):
+        self.closed = True
+
+
+def _run(tool, conn, **kwargs):
+    with (
+        patch.object(mon, "build_mysql_normalized_from_runnable", return_value=NORMALIZED),
+        patch.object(mon, "get_mysql_connection_from_item", return_value=conn),
+    ):
+        return json.loads(tool.invoke({"config": {"configurable": {}}, **kwargs}))
+
+
+def test_database_metrics_wraps_connector_error():
+    conn = FakeConn(FakeCursor())
+    with (
+        patch.object(mon, "build_mysql_normalized_from_runnable", return_value=NORMALIZED),
+        patch.object(mon, "get_mysql_connection_from_item", return_value=conn),
+        patch.object(FakeCursor, "execute", side_effect=Error("gone")),
+    ):
+        out = json.loads(mon.get_database_metrics.invoke({"config": {"configurable": {}}}))
+    assert out == {"error": "gone"}
+    assert conn.closed is True
+
+
+def test_binary_log_on_lists_files_and_swallows_show_binary_logs_error():
+    cursor = FakeCursor(
+        fetchones=[("log_bin", "ON"), ("binlog_format", "ROW"), ("expire_logs_days", "7"), ("binlog_expire_logs_seconds", "0")],
+        rows=[("bin.0001", 2048)],
+    )
+    out = _run(mon.check_binary_log_status, FakeConn(cursor))
+    assert out["log_bin"] == "ON"
+    assert out["binlog_format"] == "ROW"
+    assert out["binlog_file_count"] == 1
+    assert out["binlog_files"][0]["file_size"] == format_size(2048)
+    assert out["total_binlog_size"] == format_size(2048)
+
+    cursor = FakeCursor(
+        fetchones=[("log_bin", "ON"), ("binlog_format", "ROW"), ("expire_logs_days", "7"), ("binlog_expire_logs_seconds", "0")],
+        fail_on={"SHOW BINARY LOGS": Error("no binlog")},
+    )
+    out = _run(mon.check_binary_log_status, FakeConn(cursor))
+    assert out["binlog_files"] == []
+    assert out["binlog_file_count"] == 0
+
+
+def test_replication_falls_back_to_slave_status_and_unconfigured():
+    replica = {
+        "Source_Host": "10.0.0.2",
+        "Source_Port": 3306,
+        "Replica_IO_Running": "Yes",
+        "Replica_SQL_Running": "Yes",
+        "Seconds_Behind_Source": 3,
+        "Retrieved_Gtid_Set": "a:1",
+        "Executed_Gtid_Set": "a:1",
+        "Last_IO_Error": "",
+        "Last_SQL_Error": "",
+        "Relay_Log_Space": 1024,
+    }
+    cursor = FakeCursor(fail_on={"SHOW REPLICA STATUS": Error("old mysql")}, fetchones=[replica])
+    # fetchone used after fallback execute; FakeCursor.fetchone pops fetchones regardless of SQL.
+    out = _run(mon.check_replication_status, FakeConn(cursor))
+    assert out["replication_configured"] is True
+    assert out["source_host"] == "10.0.0.2"
+    assert out["seconds_behind_source"] == 3
+    assert out["relay_log_space"] == format_size(1024)
+
+    cursor = FakeCursor(fetchones=[None])
+    out = _run(mon.check_replication_status, FakeConn(cursor))
+    assert out == {"replication_configured": False, "message": "未配置复制"}
+
+
+def test_processlist_skips_sleep_without_info():
+    cursor = FakeCursor(
+        rows=[
+            {"Id": 1, "User": "app", "Host": "h", "db": "app", "Command": "Query", "Time": 2, "State": "exec", "Info": "SELECT 1"},
+            {"Id": 2, "User": "app", "Host": "h", "db": "app", "Command": "Sleep", "Time": 10, "State": "", "Info": None},
+        ]
+    )
+    out = _run(mon.get_processlist, FakeConn(cursor))
+    assert out["active_process_count"] == 1
+    assert out["processes"][0]["id"] == 1
+
+
+def test_database_size_growth_summarizes_and_details():
+    summary = [{"TABLE_SCHEMA": "app", "table_count": 2, "data_length": 1024, "index_length": 512, "total_size": 1536}]
+    details = [{"TABLE_NAME": "hosts", "DATA_LENGTH": 1024, "INDEX_LENGTH": 512, "total_size": 1536}]
+    conn = FakeConn(FakeCursor())
+    with (
+        patch.object(mon, "build_mysql_normalized_from_runnable", return_value=NORMALIZED),
+        patch.object(mon, "get_mysql_connection_from_item", return_value=conn),
+        patch.object(mon, "execute_readonly_query", side_effect=[summary, details]),
+    ):
+        out = json.loads(mon.check_database_size_growth.invoke({"database": "app", "config": {"configurable": {}}}))
+    assert out["databases"][0]["database"] == "app"
+    assert out["database_detail"]["tables"][0]["table_name"] == "hosts"
+    assert conn.closed is True
+
+
+def test_remaining_tools_wrap_connector_error():
+    conn = FakeConn(FakeCursor())
+    err = Error("gone")
+    cases = [
+        (mon.get_table_metrics, {"database": "app"}),
+        (mon.get_innodb_stats, {}),
+        (mon.get_io_stats, {}),
+        (mon.check_binary_log_status, {}),
+        (mon.check_replication_status, {}),
+        (mon.get_processlist, {}),
+    ]
+    for tool, extra in cases:
+        with (
+            patch.object(mon, "build_mysql_normalized_from_runnable", return_value=NORMALIZED),
+            patch.object(mon, "get_mysql_connection_from_item", return_value=conn),
+            patch.object(FakeCursor, "execute", side_effect=err),
+        ):
+            out = json.loads(tool.invoke({"config": {"configurable": {}}, **extra}))
+        assert out == {"error": "gone"}
+
+    with (
+        patch.object(mon, "build_mysql_normalized_from_runnable", return_value=NORMALIZED),
+        patch.object(mon, "get_mysql_connection_from_item", return_value=conn),
+        patch.object(mon, "execute_readonly_query", side_effect=err),
+    ):
+        out = json.loads(mon.check_database_size_growth.invoke({"config": {"configurable": {}}}))
+    assert out == {"error": "gone"}
+    assert conn.closed is True

--- a/server/apps/opspilot/tests/test_tools_mysql_monitoring_service.py
+++ b/server/apps/opspilot/tests/test_tools_mysql_monitoring_service.py
@@ -1,0 +1,176 @@
+"""MySQL 监控工具：mock 连接与 SHOW GLOBAL STATUS，断言 QPS/TPS。"""
+import json
+from unittest.mock import patch
+
+import pytest
+
+from apps.opspilot.metis.llm.tools.mysql import monitoring as mon
+from apps.opspilot.metis.llm.tools.mysql.utils import calculate_percentage, format_duration, format_size
+
+pytestmark = pytest.mark.unit
+
+NORMALIZED = {
+    "mode": "single",
+    "legacy_single": True,
+    "items": [{"index": 0, "name": "db1", "raw": {}, "config": {}}],
+}
+
+
+class FakeCursor:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def execute(self, sql, params=None):
+        return None
+
+    def fetchall(self):
+        return list(self._rows)
+
+    def close(self):
+        return None
+
+
+class FakeConn:
+    def __init__(self, rows):
+        self._rows = rows
+        self.closed = False
+
+    def cursor(self):
+        return FakeCursor(self._rows)
+
+    def close(self):
+        self.closed = True
+
+
+def test_get_database_metrics_computes_qps_tps():
+    rows = [
+        ("Questions", "100"),
+        ("Com_select", "80"),
+        ("Com_insert", "10"),
+        ("Com_update", "5"),
+        ("Com_delete", "5"),
+        ("Threads_connected", "3"),
+        ("Threads_running", "1"),
+        ("Uptime", "10"),
+        ("Bytes_received", "2048"),
+        ("Bytes_sent", "4096"),
+        ("Slow_queries", "2"),
+    ]
+    conn = FakeConn(rows)
+    with (
+        patch.object(mon, "build_mysql_normalized_from_runnable", return_value=NORMALIZED),
+        patch.object(mon, "get_mysql_connection_from_item", return_value=conn),
+    ):
+        out = json.loads(mon.get_database_metrics.invoke({"config": {"configurable": {}}}))
+    assert out["QPS"] == 10.0
+    assert out["TPS"] == 2.0
+    assert out["Bytes_received_formatted"] == format_size(2048)
+    assert out["Bytes_received_formatted"] == "2.00 KB"
+    assert out["Bytes_sent_formatted"] == format_size(4096)
+    assert out["Bytes_sent_formatted"] == "4.00 KB"
+    assert conn.closed is True
+
+
+def test_get_table_metrics_formats_fragmentation():
+    rows = [
+        {
+            "TABLE_NAME": "hosts",
+            "ENGINE": "InnoDB",
+            "TABLE_ROWS": 100,
+            "DATA_LENGTH": 1024,
+            "INDEX_LENGTH": 512,
+            "DATA_FREE": 256,
+            "AUTO_INCREMENT": 10,
+            "CREATE_TIME": None,
+            "UPDATE_TIME": None,
+        }
+    ]
+    conn = FakeConn([])
+    with (
+        patch.object(
+            mon,
+            "build_mysql_normalized_from_runnable",
+            return_value={**NORMALIZED, "items": [{**NORMALIZED["items"][0], "config": {"database": "app"}}]},
+        ),
+        patch.object(mon, "get_mysql_connection_from_item", return_value=conn),
+        patch.object(mon, "execute_readonly_query", return_value=rows),
+    ):
+        out = json.loads(mon.get_table_metrics.invoke({"config": {"configurable": {}}}))
+    assert out["database"] == "app"
+    assert out["table_count"] == 1
+    table = out["tables"][0]
+    assert table["table_name"] == "hosts"
+    assert table["data_length"] == format_size(1024)
+    assert table["data_length"] == "1.00 KB"
+    assert table["index_length"] == format_size(512)
+    assert table["index_length"] == "512.00 B"
+    assert table["total_size"] == format_size(1536)
+    assert table["total_size"] == "1.50 KB"
+    assert table["data_free"] == format_size(256)
+    assert table["data_free"] == "256.00 B"
+    expected_frag = f"{calculate_percentage(256, 1536)}%"
+    assert table["fragmentation_ratio"] == expected_frag
+    assert table["fragmentation_ratio"] == "16.67%"
+    assert conn.closed is True
+
+
+def test_get_innodb_stats_hit_ratio():
+    rows = [
+        ("Innodb_buffer_pool_pages_total", "100"),
+        ("Innodb_buffer_pool_pages_data", "80"),
+        ("Innodb_buffer_pool_pages_free", "20"),
+        ("Innodb_buffer_pool_pages_dirty", "5"),
+        ("Innodb_buffer_pool_read_requests", "90"),
+        ("Innodb_buffer_pool_reads", "10"),
+        ("Innodb_rows_read", "1"),
+        ("Innodb_rows_inserted", "1"),
+        ("Innodb_rows_updated", "1"),
+        ("Innodb_rows_deleted", "1"),
+        ("Innodb_row_lock_waits", "0"),
+        ("Innodb_row_lock_time", "0"),
+    ]
+    conn = FakeConn(rows)
+    with (
+        patch.object(mon, "build_mysql_normalized_from_runnable", return_value=NORMALIZED),
+        patch.object(mon, "get_mysql_connection_from_item", return_value=conn),
+    ):
+        out = json.loads(mon.get_innodb_stats.invoke({"config": {"configurable": {}}}))
+    assert out["buffer_pool_hit_ratio"] == f"{calculate_percentage(90, 100)}%"
+    assert out["buffer_pool_hit_ratio"] == "90.0%"
+    assert out["buffer_pool_usage"] == f"{calculate_percentage(80, 100)}%"
+    assert out["buffer_pool_usage"] == "80.0%"
+    assert out["Innodb_row_lock_time_formatted"] == format_duration(0)
+    assert conn.closed is True
+
+
+def test_get_io_stats_formats_bytes():
+    rows = [
+        {
+            "FILE_NAME": "/var/lib/mysql/ibdata1",
+            "COUNT_READ": 10,
+            "COUNT_WRITE": 4,
+            "SUM_NUMBER_OF_BYTES_READ": 2048,
+            "SUM_NUMBER_OF_BYTES_WRITE": 1024,
+            "read_latency_ms": 12,
+            "write_latency_ms": 8,
+        }
+    ]
+    conn = FakeConn([])
+    with (
+        patch.object(mon, "build_mysql_normalized_from_runnable", return_value=NORMALIZED),
+        patch.object(mon, "get_mysql_connection_from_item", return_value=conn),
+        patch.object(mon, "execute_readonly_query", return_value=rows),
+    ):
+        out = json.loads(mon.get_io_stats.invoke({"config": {"configurable": {}}}))
+    stat = out["io_stats"][0]
+    assert out["io_file_count"] == 1
+    assert stat["file_name"] == "/var/lib/mysql/ibdata1"
+    assert stat["bytes_read"] == format_size(2048)
+    assert stat["bytes_read"] == "2.00 KB"
+    assert stat["bytes_write"] == format_size(1024)
+    assert stat["bytes_write"] == "1.00 KB"
+    assert stat["read_latency"] == format_duration(12)
+    assert stat["read_latency"] == "12.00ms"
+    assert stat["write_latency"] == format_duration(8)
+    assert stat["write_latency"] == "8.00ms"
+    assert conn.closed is True

--- a/server/apps/opspilot/tests/test_tools_mysql_resources_remaining.py
+++ b/server/apps/opspilot/tests/test_tools_mysql_resources_remaining.py
@@ -1,0 +1,89 @@
+"""MySQL 资源工具剩余：uptime 未知、外层 Error 包装。"""
+import json
+from unittest.mock import patch
+
+import pytest
+from mysql.connector import Error
+
+from apps.opspilot.metis.llm.tools.mysql import resources as res
+
+pytestmark = pytest.mark.unit
+
+NORMALIZED = {
+    "mode": "single",
+    "legacy_single": True,
+    "items": [{"index": 0, "name": "db1", "raw": {}, "config": {"database": "app"}}],
+}
+
+
+class FakeConn:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def test_current_database_info_uptime_unknown_and_outer_error():
+    conn = FakeConn()
+    info = {
+        "version": "8.0",
+        "hostname": "h",
+        "port": 3306,
+        "datadir": "/var/lib/mysql",
+        "character_set_server": "utf8mb4",
+        "collation_server": "utf8mb4_bin",
+        "default_storage_engine": "InnoDB",
+    }
+    with (
+        patch.object(res, "build_mysql_normalized_from_runnable", return_value=NORMALIZED),
+        patch.object(res, "get_mysql_connection_from_item", return_value=conn),
+        patch.object(res, "execute_readonly_query", side_effect=[[info], Error("no pfs")]),
+    ):
+        out = json.loads(res.get_current_database_info.invoke({"config": {"configurable": {}}}))
+    assert out["version"] == "8.0"
+    assert out["uptime_seconds"] == "unknown"
+    assert conn.closed is True
+
+    conn = FakeConn()
+    with (
+        patch.object(res, "build_mysql_normalized_from_runnable", return_value=NORMALIZED),
+        patch.object(res, "get_mysql_connection_from_item", return_value=conn),
+        patch.object(res, "execute_readonly_query", side_effect=Error("gone")),
+    ):
+        out = json.loads(res.get_current_database_info.invoke({"config": {"configurable": {}}}))
+    assert out == {"error": "gone"}
+    assert conn.closed is True
+
+
+def test_remaining_resource_tools_wrap_connector_error():
+    conn = FakeConn()
+    err = Error("gone")
+    cases = [
+        (res.list_mysql_databases, {}),
+        (res.list_mysql_tables, {"database": "app"}),
+        (res.list_mysql_indexes, {"database": "app", "table_name": "hosts"}),
+        (res.list_mysql_schemas, {}),
+        (res.get_table_structure, {"database": "app", "table_name": "hosts"}),
+        (res.list_mysql_users, {}),
+    ]
+    for tool, extra in cases:
+        with (
+            patch.object(res, "build_mysql_normalized_from_runnable", return_value=NORMALIZED),
+            patch.object(res, "get_mysql_connection_from_item", return_value=conn),
+            patch.object(res, "execute_readonly_query", side_effect=err),
+        ):
+            out = json.loads(tool.invoke({"config": {"configurable": {}}, **extra}))
+        assert out == {"error": "gone"}
+    assert conn.closed is True
+
+    conn = FakeConn()
+    with (
+        patch.object(res, "build_mysql_normalized_from_runnable", return_value=NORMALIZED),
+        patch.object(res, "get_mysql_connection_from_item", return_value=conn),
+        patch.object(res, "execute_readonly_query", side_effect=err),
+    ):
+        out = json.loads(res.get_database_config.invoke({"config": {"configurable": {}}}))
+    assert out["total_settings"] == 10
+    assert out["settings"]["innodb_buffer_pool_size"] == {"value": None}
+    assert conn.closed is True

--- a/server/apps/opspilot/tests/test_tools_nodes_setup.py
+++ b/server/apps/opspilot/tests/test_tools_nodes_setup.py
@@ -1,0 +1,63 @@
+"""ToolsNodes.setup：stdio MCP、远程鉴权头、加载失败不中断。"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from apps.opspilot.metis.llm.chain.node import ToolsNodes
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_setup_records_stdio_and_remote_and_continues_on_load_errors():
+    node = ToolsNodes()
+    stdio = SimpleNamespace(
+        name="local",
+        url="stdio-mcp:local",
+        command="python",
+        args=["-m", "demo"],
+        enable_auth=False,
+        transport="",
+    )
+    remote = SimpleNamespace(
+        name="remote",
+        url="https://mcp.example/sse",
+        command="",
+        args=[],
+        enable_auth=True,
+        auth_token="secret-token",
+        transport="sse",
+    )
+    langchain = SimpleNamespace(
+        name="k8s",
+        url="langchain:kubernetes",
+        extra_tools_prompt="k8s tools",
+        extra_param_prompt={},
+        enable_auth=False,
+        transport="",
+    )
+
+    class FakeMCP:
+        def __init__(self, cfg):
+            self.cfg = cfg
+
+        async def get_tools(self):
+            raise RuntimeError("mcp down")
+
+    with (
+        patch.object(ToolsNodes, "get_llm_client", return_value="llm"),
+        patch("apps.opspilot.metis.llm.chain.node.StructuredOutputParser", return_value="parser"),
+        patch("apps.opspilot.metis.llm.chain.node.MultiServerMCPClient", FakeMCP),
+        patch(
+            "apps.opspilot.metis.llm.chain.node.ToolsLoader.load_tools",
+            side_effect=RuntimeError("langchain down"),
+        ),
+    ):
+        await node.setup(SimpleNamespace(tools_servers=[stdio, remote, langchain]))
+
+    assert node.llm == "llm"
+    assert node.mcp_config["local"] == {"command": "python", "args": ["-m", "demo"], "transport": "stdio"}
+    assert node.mcp_config["remote"]["url"] == "https://mcp.example/sse"
+    assert node.mcp_config["remote"]["headers"] == {"Authorization": "secret-token"}
+    assert node.tools == []

--- a/server/apps/opspilot/tests/test_tools_oracle_full_service.py
+++ b/server/apps/opspilot/tests/test_tools_oracle_full_service.py
@@ -14,10 +14,9 @@ import json
 import sys
 from unittest.mock import MagicMock, patch
 
+import oracledb  # noqa: E402
 import pydantic.root_model  # noqa
 import pytest
-
-import oracledb  # noqa: E402
 
 sys.modules["oracledb"] = oracledb  # 防御性重绑, 抵御其他测试文件的 sys.modules 污染
 
@@ -140,11 +139,13 @@ class TestOracleDiagnostics:
         sess_rows = [("ACTIVE", 60), ("INACTIVE", 35)]  # total 95 / 100 = 95%
         user_desc = _desc("USERNAME", "CNT")
         user_rows = [("APP", 50), ("RPT", 45)]
-        fc = FakeConn([
-            ("v$parameter", (param_desc, param_rows)),
-            ("GROUP BY status", (sess_desc, sess_rows)),
-            ("WHERE username IS NOT NULL", (user_desc, user_rows)),
-        ])
+        fc = FakeConn(
+            [
+                ("v$parameter", (param_desc, param_rows)),
+                ("GROUP BY status", (sess_desc, sess_rows)),
+                ("WHERE username IS NOT NULL", (user_desc, user_rows)),
+            ]
+        )
         with _patch(diag, fc):
             out = json.loads(diag.diagnose_connection_issues.invoke({"config": CONFIG}))
         assert out["max_sessions"] == 100
@@ -155,22 +156,38 @@ class TestOracleDiagnostics:
         assert any("90%" in w for w in out["warnings"])
 
     def test_health_check_full_score_path(self):
-        inst = (_desc("INSTANCE_NAME", "HOST_NAME", "VERSION", "STATUS", "DATABASE_STATUS", "STARTUP_TIME"),
-                [("ORCL", "h", "19c", "OPEN", "ACTIVE", "2024")])
-        ts = (_desc("TABLESPACE_NAME", "TOTAL_BYTES", "FREE_BYTES", "USED_BYTES", "USAGE_PCT"),
-              [("USERS", 1000, 100, 900, 90.0)])  # >85 -> warning -5
+        inst = (
+            _desc("INSTANCE_NAME", "HOST_NAME", "VERSION", "STATUS", "DATABASE_STATUS", "STARTUP_TIME"),
+            [("ORCL", "h", "19c", "OPEN", "ACTIVE", "2024")],
+        )
+        ts = (
+            _desc("TABLESPACE_NAME", "TOTAL_BYTES", "FREE_BYTES", "USED_BYTES", "USAGE_PCT"),
+            [("USERS", 1000, 100, 900, 90.0)],
+        )  # >85 -> warning -5
         sess = (_desc("TOTAL_SESSIONS", "ACTIVE_SESSIONS"), [(50, 10)])
-        limit = (_desc("VALUE",), [("170",)])
+        limit = (
+            _desc(
+                "VALUE",
+            ),
+            [("170",)],
+        )
         cache = (_desc("LOGICAL_READS", "PHYSICAL_READS"), [(1000, 100)])  # hit 90% <95 -> -15
-        invalid = (_desc("INVALID_COUNT",), [(2,)])  # >0 -> -5
-        fc = FakeConn([
-            ("v$instance", inst),
-            ("dba_data_files", ts),
-            ("CASE WHEN status = 'ACTIVE'", sess),
-            ("name = 'sessions'", limit),
-            ("v$sysstat", cache),
-            ("dba_objects", invalid),
-        ])
+        invalid = (
+            _desc(
+                "INVALID_COUNT",
+            ),
+            [(2,)],
+        )  # >0 -> -5
+        fc = FakeConn(
+            [
+                ("v$instance", inst),
+                ("dba_data_files", ts),
+                ("CASE WHEN status = 'ACTIVE'", sess),
+                ("name = 'sessions'", limit),
+                ("v$sysstat", cache),
+                ("dba_objects", invalid),
+            ]
+        )
         with _patch(diag, fc):
             out = json.loads(diag.check_database_health.invoke({"config": CONFIG}))
         # 100 -5(ts) -15(cache) -5(invalid) = 75 -> warning
@@ -181,17 +198,36 @@ class TestOracleDiagnostics:
         assert out["checks"]["buffer_cache"]["hit_ratio"] == 90.0
 
     def test_health_check_instance_not_open(self):
-        inst = (_desc("INSTANCE_NAME", "HOST_NAME", "VERSION", "STATUS", "DATABASE_STATUS", "STARTUP_TIME"),
-                [("ORCL", "h", "19c", "MOUNTED", "ACTIVE", "2024")])
-        empty = ([], [])
-        fc = FakeConn([
-            ("v$instance", inst),
-            ("dba_data_files", ([], [])),
-            ("CASE WHEN status = 'ACTIVE'", (_desc("TOTAL_SESSIONS", "ACTIVE_SESSIONS"), [(1, 0)])),
-            ("name = 'sessions'", (_desc("VALUE",), [("170",)])),
-            ("v$sysstat", (_desc("LOGICAL_READS", "PHYSICAL_READS"), [(100, 0)])),
-            ("dba_objects", (_desc("INVALID_COUNT",), [(0,)])),
-        ])
+        inst = (
+            _desc("INSTANCE_NAME", "HOST_NAME", "VERSION", "STATUS", "DATABASE_STATUS", "STARTUP_TIME"),
+            [("ORCL", "h", "19c", "MOUNTED", "ACTIVE", "2024")],
+        )
+        fc = FakeConn(
+            [
+                ("v$instance", inst),
+                ("dba_data_files", ([], [])),
+                ("CASE WHEN status = 'ACTIVE'", (_desc("TOTAL_SESSIONS", "ACTIVE_SESSIONS"), [(1, 0)])),
+                (
+                    "name = 'sessions'",
+                    (
+                        _desc(
+                            "VALUE",
+                        ),
+                        [("170",)],
+                    ),
+                ),
+                ("v$sysstat", (_desc("LOGICAL_READS", "PHYSICAL_READS"), [(100, 0)])),
+                (
+                    "dba_objects",
+                    (
+                        _desc(
+                            "INVALID_COUNT",
+                        ),
+                        [(0,)],
+                    ),
+                ),
+            ]
+        )
         with _patch(diag, fc):
             out = json.loads(diag.check_database_health.invoke({"config": CONFIG}))
         assert out["checks"]["instance"]["status"] == "critical"
@@ -199,10 +235,14 @@ class TestOracleDiagnostics:
         assert out["health_score"] == 70  # -30
 
     def test_dataguard_standby_with_lag(self):
-        role = (_desc("DATABASE_ROLE", "PROTECTION_MODE", "PROTECTION_LEVEL", "SWITCHOVER_STATUS", "DATAGUARD_BROKER"),
-                [("PHYSICAL STANDBY", "MAX PERFORMANCE", "MAX PERFORMANCE", "NOT ALLOWED", "ENABLED")])
-        dg = (_desc("NAME", "VALUE", "TIME_COMPUTED", "DATUM_TIME"),
-              [("transport lag", "+00 00:00:05", "t", "d"), ("apply lag", "+00 00:00:10", "t", "d")])
+        role = (
+            _desc("DATABASE_ROLE", "PROTECTION_MODE", "PROTECTION_LEVEL", "SWITCHOVER_STATUS", "DATAGUARD_BROKER"),
+            [("PHYSICAL STANDBY", "MAX PERFORMANCE", "MAX PERFORMANCE", "NOT ALLOWED", "ENABLED")],
+        )
+        dg = (
+            _desc("NAME", "VALUE", "TIME_COMPUTED", "DATUM_TIME"),
+            [("transport lag", "+00 00:00:05", "t", "d"), ("apply lag", "+00 00:00:10", "t", "d")],
+        )
         fc = FakeConn([("v$database", role), ("v$dataguard_stats", dg)])
         with _patch(diag, fc):
             out = json.loads(diag.check_dataguard_status.invoke({"config": CONFIG}))
@@ -211,10 +251,14 @@ class TestOracleDiagnostics:
         assert out["dg_configured"] is True
 
     def test_dataguard_primary_with_destinations(self):
-        role = (_desc("DATABASE_ROLE", "PROTECTION_MODE", "PROTECTION_LEVEL", "SWITCHOVER_STATUS", "DATAGUARD_BROKER"),
-                [("PRIMARY", "MAX PERFORMANCE", "MAX PERFORMANCE", "TO STANDBY", "ENABLED")])
-        dest = (_desc("DEST_ID", "DEST_NAME", "STATUS", "TYPE", "ERROR", "ARCHIVED_SEQ#", "APPLIED_SEQ#", "GAP_STATUS"),
-                [(2, "LOG_ARCHIVE_DEST_2", "ERROR", "PHYSICAL", "ORA-16401", 100, 95, "NO GAP")])
+        role = (
+            _desc("DATABASE_ROLE", "PROTECTION_MODE", "PROTECTION_LEVEL", "SWITCHOVER_STATUS", "DATAGUARD_BROKER"),
+            [("PRIMARY", "MAX PERFORMANCE", "MAX PERFORMANCE", "TO STANDBY", "ENABLED")],
+        )
+        dest = (
+            _desc("DEST_ID", "DEST_NAME", "STATUS", "TYPE", "ERROR", "ARCHIVED_SEQ#", "APPLIED_SEQ#", "GAP_STATUS"),
+            [(2, "LOG_ARCHIVE_DEST_2", "ERROR", "PHYSICAL", "ORA-16401", 100, 95, "NO GAP")],
+        )
         fc = FakeConn([("v$database", role), ("v$archive_dest_status", dest)])
         with _patch(diag, fc):
             out = json.loads(diag.check_dataguard_status.invoke({"config": CONFIG}))
@@ -228,13 +272,181 @@ class TestOracleDiagnostics:
             out = json.loads(diag.check_dataguard_status.invoke({"config": CONFIG}))
         assert out["error"] == "无法查询v$database"
 
+    def test_connection_issues_eighty_percent_warning_and_outer_error(self):
+        param_desc = _desc("NAME", "VALUE")
+        param_rows = [("processes", "150"), ("sessions", "100")]
+        sess_desc = _desc("STATUS", "CNT")
+        sess_rows = [("ACTIVE", 50), ("INACTIVE", 35)]  # 85 / 100
+        user_desc = _desc("USERNAME", "CNT")
+        fc = FakeConn(
+            [
+                ("v$parameter", (param_desc, param_rows)),
+                ("GROUP BY status", (sess_desc, sess_rows)),
+                ("WHERE username IS NOT NULL", (user_desc, [("APP", 85)])),
+            ]
+        )
+        with _patch(diag, fc):
+            out = json.loads(diag.diagnose_connection_issues.invoke({"config": CONFIG}))
+        assert out["session_usage_percent"] == 85.0
+        assert out["warnings"] == ["会话数使用率超过80%，建议关注连接增长趋势"]
+
+        boom = MagicMock()
+        boom.cursor.side_effect = OracleError("ORA-01031")
+        with _patch(diag, boom):
+            out = json.loads(diag.diagnose_connection_issues.invoke({"config": CONFIG}))
+        assert "ORA-01031" in out["error"]
+        boom.close.assert_called_once()
+
+    def test_lock_conflicts_outer_error(self):
+        boom = MagicMock()
+        boom.cursor.side_effect = OracleError("ORA-00942")
+        with _patch(diag, boom):
+            out = json.loads(diag.diagnose_lock_conflicts.invoke({"config": CONFIG}))
+        assert "ORA-00942" in out["error"]
+        boom.close.assert_called_once()
+
+    def test_health_check_inner_errors_session_bands_and_outer_error(self):
+        fc = FakeConn(
+            [
+                ("v$instance", OracleError("inst-fail")),
+                ("dba_data_files", OracleError("ts-fail")),
+                ("CASE WHEN status = 'ACTIVE'", OracleError("sess-fail")),
+                ("v$sysstat", OracleError("cache-fail")),
+                ("dba_objects", OracleError("inv-fail")),
+            ]
+        )
+        with _patch(diag, fc):
+            out = json.loads(diag.check_database_health.invoke({"config": CONFIG}))
+        assert out["health_status"] == "healthy"
+        assert out["health_score"] == 100
+        assert out["checks"]["instance"]["status"] == "error"
+        assert "inst-fail" in out["checks"]["instance"]["error"]
+        assert out["checks"]["tablespace"]["status"] == "error"
+        assert "ts-fail" in out["checks"]["tablespace"]["error"]
+        assert out["checks"]["sessions"]["status"] == "error"
+        assert "sess-fail" in out["checks"]["sessions"]["error"]
+        assert out["checks"]["buffer_cache"]["status"] == "error"
+        assert "cache-fail" in out["checks"]["buffer_cache"]["error"]
+        assert out["checks"]["invalid_objects"]["status"] == "error"
+        assert "inv-fail" in out["checks"]["invalid_objects"]["error"]
+
+        inst = (
+            _desc("INSTANCE_NAME", "HOST_NAME", "VERSION", "STATUS", "DATABASE_STATUS", "STARTUP_TIME"),
+            [("ORCL", "h", "19c", "MOUNTED", "ACTIVE", "2024")],
+        )
+        sess = (_desc("TOTAL_SESSIONS", "ACTIVE_SESSIONS"), [(95, 10)])
+        limit = (
+            _desc(
+                "VALUE",
+            ),
+            [("100",)],
+        )
+        cache = (_desc("LOGICAL_READS", "PHYSICAL_READS"), [(100, 0)])
+        invalid = (
+            _desc(
+                "INVALID_COUNT",
+            ),
+            [(0,)],
+        )
+        fc = FakeConn(
+            [
+                ("v$instance", inst),
+                ("dba_data_files", ([], [])),
+                ("CASE WHEN status = 'ACTIVE'", sess),
+                ("name = 'sessions'", limit),
+                ("v$sysstat", cache),
+                ("dba_objects", invalid),
+            ]
+        )
+        with _patch(diag, fc):
+            out = json.loads(diag.check_database_health.invoke({"config": CONFIG}))
+        assert out["checks"]["sessions"]["usage_percent"] == 95.0
+        assert out["checks"]["sessions"]["status"] == "critical"
+        assert any("会话数使用率 95.0%，已接近上限" in i for i in out["issues"])
+        assert out["health_score"] == 50  # -30 instance -20 sessions
+        assert out["health_status"] == "critical"
+
+        sess80 = (_desc("TOTAL_SESSIONS", "ACTIVE_SESSIONS"), [(85, 10)])
+        fc = FakeConn(
+            [
+                (
+                    "v$instance",
+                    (
+                        _desc("INSTANCE_NAME", "HOST_NAME", "VERSION", "STATUS", "DATABASE_STATUS", "STARTUP_TIME"),
+                        [("ORCL", "h", "19c", "OPEN", "ACTIVE", "2024")],
+                    ),
+                ),
+                ("dba_data_files", ([], [])),
+                ("CASE WHEN status = 'ACTIVE'", sess80),
+                ("name = 'sessions'", limit),
+                ("v$sysstat", cache),
+                ("dba_objects", invalid),
+            ]
+        )
+        with _patch(diag, fc):
+            out = json.loads(diag.check_database_health.invoke({"config": CONFIG}))
+        assert out["checks"]["sessions"]["status"] == "warning"
+        assert out["issues"] == ["会话数使用率 85.0%"]
+        assert out["health_score"] == 90
+
+    def test_dataguard_stats_error_primary_empty_dest_other_role_and_outer_error(self):
+        role = (
+            _desc("DATABASE_ROLE", "PROTECTION_MODE", "PROTECTION_LEVEL", "SWITCHOVER_STATUS", "DATAGUARD_BROKER"),
+            [("PHYSICAL STANDBY", "MAX PERFORMANCE", "MAX PERFORMANCE", "NOT ALLOWED", "ENABLED")],
+        )
+        fc = FakeConn([("v$database", role), ("v$dataguard_stats", OracleError("ORA-00942"))])
+        with _patch(diag, fc):
+            out = json.loads(diag.check_dataguard_status.invoke({"config": CONFIG}))
+        assert out["dataguard_stats_error"] == "ORA-00942"
+        assert out["dg_configured"] is False
+
+        primary = (
+            _desc("DATABASE_ROLE", "PROTECTION_MODE", "PROTECTION_LEVEL", "SWITCHOVER_STATUS", "DATAGUARD_BROKER"),
+            [("PRIMARY", "MAX PERFORMANCE", "MAX PERFORMANCE", "TO STANDBY", "ENABLED")],
+        )
+        fc = FakeConn([("v$database", primary), ("v$archive_dest_status", ([], []))])
+        with _patch(diag, fc):
+            out = json.loads(diag.check_dataguard_status.invoke({"config": CONFIG}))
+        assert out["archive_destinations"] == []
+        assert out["dg_configured"] is False
+        assert out["message"] == "未发现远程归档目的地，可能未配置Data Guard"
+
+        fc = FakeConn([("v$database", primary), ("v$archive_dest_status", OracleError("ORA-01031"))])
+        with _patch(diag, fc):
+            out = json.loads(diag.check_dataguard_status.invoke({"config": CONFIG}))
+        assert out["archive_dest_error"] == "ORA-01031"
+        assert out["dg_configured"] is False
+        assert out["message"] == "无法查询归档目的地状态，可能未配置Data Guard"
+
+        other = (
+            _desc("DATABASE_ROLE", "PROTECTION_MODE", "PROTECTION_LEVEL", "SWITCHOVER_STATUS", "DATAGUARD_BROKER"),
+            [("FAR SYNC", "MAX PERFORMANCE", "MAX PERFORMANCE", "NOT ALLOWED", "DISABLED")],
+        )
+        fc = FakeConn([("v$database", other)])
+        with _patch(diag, fc):
+            out = json.loads(diag.check_dataguard_status.invoke({"config": CONFIG}))
+        assert out["dg_configured"] is False
+        assert out["message"] == "数据库角色为 FAR SYNC，非标准的PRIMARY/STANDBY角色"
+
+        boom = MagicMock()
+        boom.cursor.side_effect = OracleError("ORA-03114")
+        with _patch(diag, boom):
+            out = json.loads(diag.check_dataguard_status.invoke({"config": CONFIG}))
+        assert "ORA-03114" in out["error"]
+        boom.close.assert_called_once()
+
 
 # ============================ resources ============================
 class TestOracleResources:
     def test_current_database_info(self):
         db = (_desc("NAME", "DB_UNIQUE_NAME", "OPEN_MODE", "LOG_MODE"), [("ORCL", "ORCL", "READ WRITE", "ARCHIVELOG")])
         inst = (_desc("INSTANCE_NAME", "HOST_NAME", "STATUS", "STARTUP_TIME"), [("orcl1", "h", "OPEN", "2024")])
-        ver = (_desc("BANNER",), [("Oracle Database 19c",)])
+        ver = (
+            _desc(
+                "BANNER",
+            ),
+            [("Oracle Database 19c",)],
+        )
         fc = FakeConn([("v$database", db), ("v$instance", inst), ("v$version", ver)])
         with _patch(res, fc):
             out = json.loads(res.get_current_database_info.invoke({"config": CONFIG}))
@@ -271,8 +483,7 @@ class TestOracleResources:
         assert out["tables"][0]["size"] == "0.00 B"
 
     def test_list_indexes(self):
-        desc = _desc("OWNER", "INDEX_NAME", "TABLE_NAME", "INDEX_TYPE", "UNIQUENESS", "STATUS", "NUM_ROWS",
-                     "COLUMN_NAME", "COLUMN_POSITION")
+        desc = _desc("OWNER", "INDEX_NAME", "TABLE_NAME", "INDEX_TYPE", "UNIQUENESS", "STATUS", "NUM_ROWS", "COLUMN_NAME", "COLUMN_POSITION")
         rows = [("APP", "IDX1", "T", "NORMAL", "UNIQUE", "VALID", 100, "ID", 1)]
         fc = FakeConn([("all_indexes", (desc, rows))])
         with _patch(res, fc):
@@ -281,8 +492,7 @@ class TestOracleResources:
         assert out["indexes"][0]["index_name"] == "IDX1"
 
     def test_get_table_structure_with_schema(self):
-        col_desc = _desc("COLUMN_NAME", "DATA_TYPE", "DATA_LENGTH", "DATA_PRECISION", "DATA_SCALE", "NULLABLE",
-                         "DATA_DEFAULT", "COLUMN_ID")
+        col_desc = _desc("COLUMN_NAME", "DATA_TYPE", "DATA_LENGTH", "DATA_PRECISION", "DATA_SCALE", "NULLABLE", "DATA_DEFAULT", "COLUMN_ID")
         col_rows = [("ID", "NUMBER", 22, 10, 0, "N", None, 1)]
         con_desc = _desc("CONSTRAINT_NAME", "CONSTRAINT_TYPE", "STATUS", "COLUMN_NAME", "POSITION")
         con_rows = [("PK_T", "P", "ENABLED", "ID", 1)]
@@ -294,8 +504,7 @@ class TestOracleResources:
         assert out["constraints"][0]["constraint_type"] == "P"
 
     def test_get_table_structure_current_user(self):
-        col_desc = _desc("COLUMN_NAME", "DATA_TYPE", "DATA_LENGTH", "DATA_PRECISION", "DATA_SCALE", "NULLABLE",
-                         "DATA_DEFAULT", "COLUMN_ID")
+        col_desc = _desc("COLUMN_NAME", "DATA_TYPE", "DATA_LENGTH", "DATA_PRECISION", "DATA_SCALE", "NULLABLE", "DATA_DEFAULT", "COLUMN_ID")
         col_rows = [("NAME", "VARCHAR2", 100, None, None, "Y", "'x'", 2)]
         fc = FakeConn([("user_tab_columns", (col_desc, col_rows)), ("user_constraints", ([], []))])
         with _patch(res, fc):
@@ -315,8 +524,20 @@ class TestOracleResources:
         assert out["users"][0]["granted_roles"] == ["CONNECT", "RESOURCE"]
 
     def test_list_users_permission_fallback(self):
-        fc = FakeConn([("dba_users", OracleError("ORA-00942")),
-                       ("FROM DUAL", (_desc("USERNAME",), [("SCOTT",)]))])
+        fc = FakeConn(
+            [
+                ("dba_users", OracleError("ORA-00942")),
+                (
+                    "FROM DUAL",
+                    (
+                        _desc(
+                            "USERNAME",
+                        ),
+                        [("SCOTT",)],
+                    ),
+                ),
+            ]
+        )
         with _patch(res, fc):
             out = json.loads(res.list_oracle_users.invoke({"config": CONFIG}))
         assert "权限不足" in out["error"]
@@ -324,8 +545,7 @@ class TestOracleResources:
 
     def test_get_database_config_formats_sizes(self):
         desc = _desc("NAME", "VALUE", "DISPLAY_VALUE", "DESCRIPTION")
-        rows = [("sga_target", str(2 * 1024 ** 3), "2G", "SGA target"),
-                ("optimizer_mode", "ALL_ROWS", "ALL_ROWS", "optimizer")]
+        rows = [("sga_target", str(2 * 1024**3), "2G", "SGA target"), ("optimizer_mode", "ALL_ROWS", "ALL_ROWS", "optimizer")]
         fc = FakeConn([("v$parameter", (desc, rows))])
         with _patch(res, fc):
             out = json.loads(res.get_database_config.invoke({"config": CONFIG}))
@@ -374,8 +594,7 @@ class TestOracleConnection:
         assert out["service_name"] == "ORCL"
 
     def test_create_connection_makes_dsn(self):
-        with patch.object(conn.oracledb, "makedsn", return_value="DSN") as mk, \
-             patch.object(conn.oracledb, "connect", return_value=MagicMock()) as cn:
+        with patch.object(conn.oracledb, "makedsn", return_value="DSN") as mk, patch.object(conn.oracledb, "connect", return_value=MagicMock()) as cn:
             conn._create_oracle_connection({"host": "h", "port": 1521, "service_name": "S", "user": "u", "password": "p"})
         mk.assert_called_once_with("h", 1521, service_name="S")
         assert cn.call_args.kwargs["dsn"] == "DSN"
@@ -405,15 +624,13 @@ class TestOracleConnection:
         assert a.build_from_flat_config({"host": "fh"})["host"] == "fh"
 
     def test_build_normalized_multi(self):
-        cfg = {"configurable": {"oracle_instances": json.dumps([
-            {"id": "a", "name": "A", "host": "ha"}, {"id": "b", "name": "B", "host": "hb"}])}}
+        cfg = {"configurable": {"oracle_instances": json.dumps([{"id": "a", "name": "A", "host": "ha"}, {"id": "b", "name": "B", "host": "hb"}])}}
         n = conn.build_oracle_normalized_from_runnable(cfg)
         assert n["mode"] == "multi"
         assert len(n["items"]) == 2
 
     def test_build_normalized_single_select(self):
-        cfg = {"configurable": {"oracle_instances": json.dumps([
-            {"id": "a", "name": "A", "host": "ha"}, {"id": "b", "name": "B", "host": "hb"}])}}
+        cfg = {"configurable": {"oracle_instances": json.dumps([{"id": "a", "name": "A", "host": "ha"}, {"id": "b", "name": "B", "host": "hb"}])}}
         n = conn.build_oracle_normalized_from_runnable(cfg, instance_id="a")
         assert n["mode"] == "single"
         assert n["items"][0]["name"] == "A"
@@ -439,9 +656,10 @@ class TestOracleConnection:
             conn.test_oracle_instance({"host": ""})
 
     def test_instances_prompt(self):
-        cfg = {"oracle_instances": json.dumps([
-            {"id": "a", "name": "A", "host": "ha"}, {"id": "b", "name": "B", "host": "hb"}]),
-            "oracle_default_instance_id": "b"}
+        cfg = {
+            "oracle_instances": json.dumps([{"id": "a", "name": "A", "host": "ha"}, {"id": "b", "name": "B", "host": "hb"}]),
+            "oracle_default_instance_id": "b",
+        }
         prompt = conn.get_oracle_instances_prompt(cfg)
         assert "A, B" in prompt
         assert "「B」" in prompt

--- a/server/apps/opspilot/tests/test_tools_oracle_opt_monitor_service.py
+++ b/server/apps/opspilot/tests/test_tools_oracle_opt_monitor_service.py
@@ -1,0 +1,271 @@
+"""Oracle 优化/监控工具：表空间、未用索引、碎片、调优建议与运行指标。
+
+mock get_oracle_connection_from_item，按 SQL 关键字返回 canned 行；
+断言使用率告警、命中率计算、权限不足回退与连接关闭。
+"""
+import json
+import sys
+from unittest.mock import patch
+
+import oracledb
+
+sys.modules["oracledb"] = oracledb
+
+from apps.opspilot.metis.llm.tools.oracle import monitoring as mon  # noqa: E402
+from apps.opspilot.metis.llm.tools.oracle import optimization as opt  # noqa: E402
+
+OracleError = oracledb.Error
+CONFIG = {"configurable": {"host": "127.0.0.1", "port": 1521, "service_name": "ORCL", "user": "sys", "password": "p"}}
+
+
+def _desc(*names):
+    return [(n,) for n in names]
+
+
+class FakeCursor:
+    def __init__(self, matchers):
+        self._matchers = matchers
+        self._desc = None
+        self._rows = []
+        self.closed = False
+
+    @property
+    def description(self):
+        return self._desc
+
+    def execute(self, sql, params=None):
+        if "SET TRANSACTION" in sql:
+            return
+        for substr, payload in self._matchers:
+            if substr in sql:
+                if isinstance(payload, OracleError):
+                    raise payload
+                self._desc, self._rows = payload
+                return
+        self._desc, self._rows = [], []
+
+    def fetchall(self):
+        return list(self._rows)
+
+    def fetchone(self):
+        return self._rows[0] if self._rows else None
+
+    def close(self):
+        self.closed = True
+
+
+class FakeConn:
+    def __init__(self, matchers):
+        self._matchers = matchers
+        self.closed = False
+        self.cursors = []
+
+    def cursor(self):
+        c = FakeCursor(self._matchers)
+        self.cursors.append(c)
+        return c
+
+    def close(self):
+        self.closed = True
+
+
+def _patch(module, fake_conn):
+    return patch.object(module, "get_oracle_connection_from_item", return_value=fake_conn)
+
+
+class TestOracleOptimization:
+    def test_tablespace_usage_warns_above_threshold(self):
+        desc = _desc("TABLESPACE_NAME", "CONTENTS", "STATUS", "TOTAL_BYTES", "MAX_BYTES", "FREE_BYTES", "AUTOEXTENSIBLE")
+        rows = [
+            ("USERS", "PERMANENT", "ONLINE", 1000, 2000, 50, "NO"),  # 95% used
+            ("TEMP", "TEMPORARY", "ONLINE", 1000, 0, 400, "YES"),  # 60% used
+        ]
+        fc = FakeConn([("dba_data_files", (desc, rows))])
+        with _patch(opt, fc):
+            out = json.loads(opt.check_tablespace_usage.invoke({"config": CONFIG}))
+        assert out["total_count"] == 2
+        users = next(ts for ts in out["tablespaces"] if ts["tablespace_name"] == "USERS")
+        assert users["usage_percent"] == 95.0
+        assert out["warning_count"] == 1
+        assert out["warnings"][0]["severity"] == "warning"
+        assert out["warnings"][0]["usage_percent"] == 95.0
+        assert fc.closed is True
+
+    def test_tablespace_usage_error_is_wrapped(self):
+        fc = FakeConn([("dba_data_files", OracleError("ORA-01031"))])
+        with _patch(opt, fc):
+            out = json.loads(opt.check_tablespace_usage.invoke({"config": CONFIG}))
+        assert "ORA-01031" in out["error"]
+        assert fc.closed is True
+
+    def test_unused_indexes_primary_path(self):
+        desc = _desc("OWNER", "INDEX_NAME", "TABLE_NAME", "INDEX_TYPE", "TOTAL_ACCESS_COUNT", "LAST_USED")
+        rows = [("APP", "IDX_UNUSED", "T1", "NORMAL", 0, None)]
+        fc = FakeConn([("dba_index_usage", (desc, rows))])
+        with _patch(opt, fc):
+            out = json.loads(opt.check_unused_indexes.invoke({"config": CONFIG}))
+        assert out["total_count"] == 1
+        assert out["unused_indexes"][0]["detection_method"] == "dba_index_usage"
+        assert "DROP INDEX" in out["recommendation"]
+
+    def test_unused_indexes_falls_back_when_usage_view_missing(self):
+        fallback_desc = _desc("OWNER", "INDEX_NAME", "TABLE_NAME", "INDEX_TYPE")
+        fc = FakeConn(
+            [
+                ("dba_index_usage", OracleError("ORA-00942")),
+                ("v$sql_plan", (fallback_desc, [("APP", "IDX2", "T2", "BITMAP")])),
+            ]
+        )
+        with _patch(opt, fc):
+            out = json.loads(opt.check_unused_indexes.invoke({"db_schema": "app", "config": CONFIG}))
+        assert out["unused_indexes"][0]["detection_method"] == "v$sql_plan_absence"
+        assert out["schema_filter"] == "app"
+
+    def test_table_fragmentation_skips_healthy_tables(self):
+        desc = _desc("OWNER", "TABLE_NAME", "NUM_ROWS", "BLOCKS", "AVG_ROW_LEN", "CHAIN_CNT", "ACTUAL_BYTES")
+        # healthy: fragmentation <= 30 and chain_cnt=0
+        healthy = ("APP", "OK_TAB", 100, 10, 80, 0, 8000)
+        # fragmented: actual much larger than estimated
+        bad = ("APP", "FRAG_TAB", 100, 50, 10, 5, 100000)
+        fc = FakeConn([("dba_tables", (desc, [healthy, bad]))])
+        with _patch(opt, fc):
+            out = json.loads(opt.check_table_fragmentation.invoke({"config": CONFIG}))
+        names = [t["table_name"] for t in out["fragmented_tables"]]
+        assert "FRAG_TAB" in names
+        assert "OK_TAB" not in names
+
+    def test_configuration_tuning_amm_and_low_hit_ratio(self):
+        param_desc = _desc("NAME", "VALUE", "DISPLAY_VALUE")
+        param_rows = [
+            ("sga_target", "0", "0"),
+            ("memory_target", "1073741824", "1G"),
+            ("pga_aggregate_target", "0", "0"),
+            ("shared_pool_size", "1000", "1000"),
+            ("processes", "100", "100"),
+            ("sessions", "200", "200"),
+        ]
+        hit_desc = _desc("HIT_RATIO")
+        sp_desc = _desc("BYTES")
+        redo_desc = _desc("GROUP#", "BYTES", "STATUS")
+        proc_desc = _desc("CNT")
+        fc = FakeConn(
+            [
+                ("FROM v$parameter", (param_desc, param_rows)),
+                ("FROM v$sysstat", (hit_desc, [(0.80,)])),  # 80% -> critical
+                ("v$sgastat", (sp_desc, [(20,)])),  # 2% free of 1000
+                ("FROM v$log", (redo_desc, [(1, 10 * 1024 * 1024, "CURRENT")])),
+                ("FROM v$process", (proc_desc, [(95,)])),
+            ]
+        )
+        with _patch(opt, fc):
+            out = json.loads(opt.check_configuration_tuning.invoke({"config": CONFIG}))
+        items = {r["item"]: r for r in out["recommendations"]}
+        assert "自动内存管理(AMM)" in items
+        assert items["缓冲区缓存命中率"]["severity"] == "critical"
+        assert out["critical_count"] >= 1
+        assert fc.closed is True
+
+
+class TestOracleMonitoring:
+    def test_database_metrics_computes_hit_ratio(self):
+        desc = _desc("NAME", "VALUE")
+        rows = [
+            ("physical reads", 10),
+            ("physical writes", 2),
+            ("redo writes", 1),
+            ("user commits", 5),
+            ("user rollbacks", 1),
+            ("parse count (total)", 8),
+            ("execute count", 20),
+            ("db block gets", 40),
+            ("consistent gets", 60),
+        ]
+        fc = FakeConn([("v$sysstat", (desc, rows))])
+        with _patch(mon, fc):
+            out = json.loads(mon.get_database_metrics.invoke({"config": CONFIG}))
+        # (100-10)/100 = 90%
+        assert out["buffer_cache_hit_ratio"] == "90.0%"
+        assert out["user commits"] == 5
+        assert fc.closed is True
+
+    def test_table_metrics_uses_schema_and_wraps_error(self):
+        size_desc = _desc("TABLE_SIZE")
+        info_desc = _desc("NUM_ROWS", "BLOCKS", "AVG_ROW_LEN", "LAST_ANALYZED")
+        stale_desc = _desc("STALE_STATS")
+        fc = FakeConn(
+            [
+                ("dba_segments", (size_desc, [(4096,)])),
+                ("dba_tab_statistics", (stale_desc, [("YES",)])),
+                ("FROM dba_tables", (info_desc, [(10, 2, 80, None)])),
+            ]
+        )
+        with _patch(mon, fc):
+            out = json.loads(mon.get_table_metrics.invoke({"table_name": "orders", "db_schema": "sales", "config": CONFIG}))
+        assert out["owner"] == "SALES"
+        assert out["table_name"] == "ORDERS"
+        assert out["num_rows"] == 10
+        assert out["table_size_bytes"] == 4096
+        assert out["stale_stats"] == "YES"
+
+        fc_err = FakeConn([("dba_segments", OracleError("ORA-00942"))])
+        with _patch(mon, fc_err):
+            err = json.loads(mon.get_table_metrics.invoke({"table_name": "x", "config": CONFIG}))
+        assert "ORA-00942" in err["error"]
+
+    def test_sga_pga_stats_aggregates_components(self):
+        sga_desc = _desc("NAME", "VALUE")
+        sgastat_desc = _desc("POOL", "NAME", "BYTES")
+        pga_desc = _desc("NAME", "VALUE")
+        hit_desc = _desc("NAME", "VALUE")
+        fc = FakeConn(
+            [
+                ("FROM v$sgastat", (sgastat_desc, [("shared pool", "free memory", 50)])),
+                ("FROM v$pgastat", (pga_desc, [("aggregate PGA target parameter", 200)])),
+                ("FROM v$sysstat", (hit_desc, [("physical reads", 1), ("db block gets", 10), ("consistent gets", 10)])),
+                ("FROM v$sga", (sga_desc, [("Fixed Size", 100), ("Variable Size", 900)])),
+            ]
+        )
+        with _patch(mon, fc):
+            out = json.loads(mon.get_sga_pga_stats.invoke({"config": CONFIG}))
+        assert out["sga_components"]["Total"]
+        assert out["pga_stats"]["aggregate PGA target parameter"] == 200
+        assert out["buffer_cache_hit_ratio"] == "95.0%"
+        assert fc.closed is True
+
+    def test_io_stats_computes_averages(self):
+        desc = _desc("FILE_NAME", "PHYRDS", "PHYWRTS", "READTIM", "WRITETIM")
+        rows = [("/u01/oradata/sys.dbf", 10, 5, 20, 10)]
+        fc = FakeConn([("v$filestat", (desc, rows))])
+        with _patch(mon, fc):
+            out = json.loads(mon.get_io_stats.invoke({"config": CONFIG}))
+        assert out["datafile_count"] == 1
+        assert out["io_stats"][0]["avg_read_time_cs"] == 2.0
+        assert out["io_stats"][0]["avg_write_time_cs"] == 2.0
+
+    def test_redo_log_status_groups_members(self):
+        redo_desc = _desc("GROUP#", "MEMBERS", "BYTES", "STATUS", "SEQUENCE#", "MEMBER")
+        redo_rows = [(1, 2, 104857600, "CURRENT", 10, "/u01/redo01.log"), (1, 2, 104857600, "CURRENT", 10, "/u02/redo01.log")]
+        mode_desc = _desc("LOG_MODE", "FORCE_LOGGING")
+        arch_desc = _desc("NAME", "SEQUENCE#", "STATUS")
+        fc = FakeConn(
+            [
+                ("v$logfile", (redo_desc, redo_rows)),
+                ("v$database", (mode_desc, [("ARCHIVELOG", "YES")])),
+                ("v$archived_log", (arch_desc, [])),
+            ]
+        )
+        with _patch(mon, fc):
+            out = json.loads(mon.check_redo_log_status.invoke({"config": CONFIG}))
+        assert out["log_mode"] == "ARCHIVELOG"
+        assert len(out["redo_log_groups"]) == 1
+        assert out["redo_log_groups"][0]["member_files"] == ["/u01/redo01.log", "/u02/redo01.log"]
+
+    def test_processlist_filters_active_user_sessions(self):
+        desc = _desc("SID", "SERIAL#", "USERNAME", "PROGRAM", "MACHINE", "SQL_ID", "EVENT", "WAIT_CLASS", "SECONDS_IN_WAIT", "STATUS", "TYPE")
+        rows = [(1, 2, "APP", "sqlplus", "host", "abc", "db file sequential read", "User I/O", 3, "ACTIVE", "USER")]
+        fc = FakeConn([("v$session", (desc, rows))])
+        with _patch(mon, fc):
+            out = json.loads(mon.get_processlist.invoke({"active_only": True, "config": CONFIG}))
+        assert out["session_count"] == 1
+        assert out["sessions"][0]["sid"] == 1
+        assert out["sessions"][0]["username"] == "APP"

--- a/server/apps/opspilot/tests/test_tools_postgres_diagnostics_service.py
+++ b/server/apps/opspilot/tests/test_tools_postgres_diagnostics_service.py
@@ -1,0 +1,50 @@
+"""PostgreSQL 诊断：慢查询缺扩展、锁冲突、连接池使用率。"""
+import json
+from unittest.mock import patch
+
+import pytest
+
+from apps.opspilot.metis.llm.tools.postgres import diagnostics as diag
+
+pytestmark = pytest.mark.unit
+CONFIG = {"configurable": {"host": "127.0.0.1"}}
+
+
+def test_diagnose_slow_queries_and_missing_extension():
+    rows = [{"query": "SELECT 1", "calls": 10, "total_time": 5000, "mean_time": 500, "max_time": 800}]
+    with patch.object(diag, "execute_readonly_query", return_value=rows):
+        out = json.loads(diag.diagnose_slow_queries.invoke({"threshold_ms": 100, "config": CONFIG}))
+    assert out["total_slow_queries"] == 1
+    assert out["threshold_ms"] == 100
+    with patch.object(diag, "execute_readonly_query", side_effect=RuntimeError("pg_stat_statements missing")):
+        err = json.loads(diag.diagnose_slow_queries.invoke({"config": CONFIG}))
+    assert "pg_stat_statements" in err["error"]
+    assert "suggestion" in err
+
+
+def test_diagnose_lock_conflicts_flags_blocked():
+    rows = [{"blocked_pid": 11, "blocking_pid": 22, "blocked_duration": "00:00:05"}]
+    with patch.object(diag, "execute_readonly_query", return_value=rows):
+        out = json.loads(diag.diagnose_lock_conflicts.invoke({"config": CONFIG}))
+    assert out["has_conflicts"] is True
+    assert out["total_blocked_queries"] == 1
+    assert out["lock_conflicts"][0]["blocked_pid"] == 11
+    with patch.object(diag, "execute_readonly_query", return_value=[]):
+        empty = json.loads(diag.diagnose_lock_conflicts.invoke({"config": CONFIG}))
+    assert empty["has_conflicts"] is False
+
+
+def test_diagnose_connection_issues_near_limit():
+    def fake_query(sql, params=None, config=None, database=None):
+        if "max_connections" in sql:
+            return [{"max_connections": 10}]
+        if "pg_stat_activity" in sql and "query_start" in sql:
+            return [{"duration": "00:06:00", "query": "SELECT pg_sleep(400)"}]
+        return [{"state": "active", "connection_count": 9}]
+
+    with patch.object(diag, "execute_readonly_query", side_effect=fake_query):
+        out = json.loads(diag.diagnose_connection_issues.invoke({"config": CONFIG}))
+    assert out["current_connections"] == 9
+    assert out["usage_percent"] == 90.0
+    assert out["is_near_limit"] is True
+    assert out["long_running_queries"][0]["query"]

--- a/server/apps/opspilot/tests/test_tools_postgres_query_monitor_service.py
+++ b/server/apps/opspilot/tests/test_tools_postgres_query_monitor_service.py
@@ -1,0 +1,135 @@
+"""PostgreSQL 工具：mock execute_readonly_query，断言热表/未用索引/命中率/慢查询提示。"""
+import json
+from unittest.mock import patch
+
+import pytest
+
+from apps.opspilot.metis.llm.tools.postgres import analysis as analysis_mod
+from apps.opspilot.metis.llm.tools.postgres import monitoring as mon
+from apps.opspilot.metis.llm.tools.postgres import query as query_mod
+from apps.opspilot.metis.llm.tools.postgres import tracing as tracing_mod
+from apps.opspilot.metis.llm.tools.postgres import utils as pg_utils
+
+pytestmark = pytest.mark.unit
+CONFIG = {"configurable": {"host": "127.0.0.1", "port": 5432, "database": "app", "user": "u", "password": "p"}}
+
+
+def _patch(module, rows):
+    return patch.object(module, "execute_readonly_query", return_value=rows)
+
+
+def test_prepare_context_and_formatters():
+    assert pg_utils.prepare_context(None)["host"] == "localhost"
+    ctx = pg_utils.prepare_context(CONFIG)
+    assert ctx["database"] == "app"
+    assert pg_utils.format_size(None) == "0 B"
+    assert pg_utils.format_size(2048) == "2.00 KB"
+    assert pg_utils.format_duration(None) == "0ms"
+    assert pg_utils.format_duration(12) == "12.00ms"
+    assert pg_utils.format_duration(2500) == "2.50s"
+    assert pg_utils.calculate_percentage(1, 0) == 0
+    assert pg_utils.calculate_percentage(1, 4) == 25.0
+
+
+def test_query_table_stats_marks_hot_table_and_filter_path():
+    rows = [
+        {
+            "sequential_scans": 20000,
+            "index_scans": 100,
+            "n_live_tup": 1,
+        }
+    ]
+    with _patch(query_mod, rows):
+        out = json.loads(query_mod.query_table_stats.invoke({"config": CONFIG}))
+    assert out["total_tables"] == 1
+    assert out["tables"][0]["is_hot_table"] is True
+    assert out["tables"][0]["index_scan_ratio"] > 0
+    with _patch(query_mod, []):
+        filtered = json.loads(query_mod.query_table_stats.invoke({"schema_name": "public", "table_filter": "t%", "config": CONFIG}))
+    assert filtered["total_tables"] == 0
+    with patch.object(query_mod, "execute_readonly_query", side_effect=RuntimeError("denied")):
+        err = json.loads(query_mod.query_table_stats.invoke({"config": CONFIG}))
+    assert "denied" in err["error"]
+
+
+def test_query_index_usage_flags_unused():
+    rows = [
+        {"index_scans": 0, "tuples_read": 0, "tuples_fetched": 0, "index_size_bytes": 1024, "index_name": "idx_dead"},
+        {"index_scans": 10, "tuples_read": 100, "tuples_fetched": 80, "index_size_bytes": 2048, "index_name": "idx_hot"},
+    ]
+    with _patch(query_mod, rows):
+        out = json.loads(query_mod.query_index_usage.invoke({"table": "hosts", "config": CONFIG}))
+    unused = [r for r in out["indexes"] if r["is_unused"]]
+    assert len(unused) == 1
+    assert unused[0]["index_name"] == "idx_dead"
+    assert "index_size" in out["indexes"][0]
+
+
+def test_database_metrics_computes_rollback_ratio():
+    rows = [
+        {
+            "database": "app",
+            "temporary_bytes": 2048,
+            "stats_reset": None,
+            "transactions_committed": 90,
+            "transactions_rolled_back": 10,
+        }
+    ]
+    with _patch(mon, rows):
+        out = json.loads(mon.get_database_metrics.invoke({"config": CONFIG}))
+    assert out["total_databases"] == 1
+    db = out["databases"][0]
+    assert db["rollback_ratio"] == 10.0
+    assert db["temporary_size"] == "2.00 KB"
+    assert db["stats_reset"] == "Never"
+
+
+def test_cache_hit_ratio_performance_bands():
+    poor = [{"database": "a", "blocks_hit": 10, "blocks_read": 90}]
+    with _patch(analysis_mod, poor):
+        out = json.loads(analysis_mod.analyze_cache_hit_ratio.invoke({"config": CONFIG}))
+    assert out["performance"] == "poor"
+    assert out["overall_cache_hit_ratio"] == 10.0
+    excellent = [{"database": "a", "blocks_hit": 999, "blocks_read": 1}]
+    with _patch(analysis_mod, excellent):
+        out = json.loads(analysis_mod.analyze_cache_hit_ratio.invoke({"config": CONFIG}))
+    assert out["performance"] == "excellent"
+
+
+def test_top_queries_formats_duration_and_missing_extension():
+    rows = [
+        {
+            "query": "SELECT 1",
+            "total_time": 1500,
+            "mean_time": 15,
+            "min_time": 1,
+            "max_time": 40,
+        }
+    ]
+    with _patch(tracing_mod, rows):
+        out = json.loads(tracing_mod.get_top_queries.invoke({"order_by": "calls", "config": CONFIG}))
+    assert out["total_queries"] == 1
+    assert out["queries"][0]["mean_time_formatted"] == "15.00ms"
+    with patch.object(tracing_mod, "execute_readonly_query", side_effect=RuntimeError("relation pg_stat_statements does not exist")):
+        err = json.loads(tracing_mod.get_top_queries.invoke({"config": CONFIG}))
+    assert "pg_stat_statements" in err["error"]
+    assert "suggestion" in err
+
+
+def test_analyze_connection_pool_idle_recommendation():
+    by_state = [
+        {"state": "idle", "connection_count": 8, "avg_duration_seconds": 12},
+        {"state": "active", "connection_count": 2, "avg_duration_seconds": 1},
+    ]
+    by_app = [{"application_name": "app", "username": "u", "connection_count": 10, "active_count": 2, "idle_count": 8}]
+    idle = [{"pid": 1, "idle_duration": "00:12:00", "query": "SELECT 1"}]
+    calls = [by_state, by_app, idle]
+
+    def fake_query(*args, **kwargs):
+        return calls.pop(0)
+
+    with patch.object(analysis_mod, "execute_readonly_query", side_effect=fake_query):
+        out = json.loads(analysis_mod.analyze_connection_pool_usage.invoke({"config": CONFIG}))
+    assert out["total_connections"] == 10
+    assert out["idle_percent"] == 80.0
+    assert any(r and "连接池" in r for r in out["recommendations"] if r)

--- a/server/apps/opspilot/tests/test_tools_postgres_query_tracing_remaining.py
+++ b/server/apps/opspilot/tests/test_tools_postgres_query_tracing_remaining.py
@@ -1,0 +1,223 @@
+"""PostgreSQL 查询/追踪/监控剩余路径：膨胀分级、I/O 热点、锁链、WAL、会话时长。"""
+import json
+from unittest.mock import patch
+
+import pytest
+
+from apps.opspilot.metis.llm.tools.postgres import monitoring as mon
+from apps.opspilot.metis.llm.tools.postgres import query as query_mod
+from apps.opspilot.metis.llm.tools.postgres import tracing as tracing_mod
+
+pytestmark = pytest.mark.unit
+CONFIG = {"configurable": {"host": "127.0.0.1", "port": 5432, "database": "app", "user": "u", "password": "p"}}
+
+
+def _patch(module, rows):
+    return patch.object(module, "execute_readonly_query", return_value=rows)
+
+
+def test_query_bloat_classifies_critical_and_never_vacuum():
+    rows = [
+        {"dead_tuple_percent": 25, "last_vacuum": None, "last_autovacuum": None, "table_name": "events"},
+        {"dead_tuple_percent": 12, "last_vacuum": "2026-01-01", "last_autovacuum": None, "table_name": "hosts"},
+        {"dead_tuple_percent": 3, "last_vacuum": None, "last_autovacuum": "2026-02-01", "table_name": "ok"},
+    ]
+    with _patch(query_mod, rows):
+        out = json.loads(query_mod.query_bloat_analysis.invoke({"schema_name": "public", "config": CONFIG}))
+    levels = {row["table_name"]: row["bloat_level"] for row in out["tables"]}
+    assert levels["events"] == "critical"
+    assert levels["hosts"] == "warning"
+    assert levels["ok"] == "normal"
+    assert out["critical_bloat_count"] == 1
+    assert out["tables"][0]["last_vacuum"] == "Never"
+    with patch.object(query_mod, "execute_readonly_query", side_effect=RuntimeError("denied")):
+        err = json.loads(query_mod.query_bloat_analysis.invoke({"config": CONFIG}))
+    assert "denied" in err["error"]
+
+
+def test_query_table_io_stats_marks_hot_and_low_cache():
+    rows = [
+        {
+            "heap_blocks_read": 120000,
+            "index_blocks_read": 1,
+            "cache_hit_ratio": 80,
+            "table_name": "hot",
+        },
+        {
+            "heap_blocks_read": 10,
+            "index_blocks_read": 1,
+            "cache_hit_ratio": 99,
+            "table_name": "cold",
+        },
+    ]
+    with _patch(query_mod, rows):
+        out = json.loads(query_mod.query_table_io_stats.invoke({"limit": 20, "config": CONFIG}))
+    by_name = {row["table_name"]: row for row in out["tables"]}
+    assert by_name["hot"]["is_io_intensive"] is True
+    assert by_name["hot"]["has_low_cache_hit"] is True
+    assert by_name["cold"]["is_io_intensive"] is False
+    assert by_name["cold"]["has_low_cache_hit"] is False
+
+
+def test_search_objects_view_pattern_and_error():
+    with _patch(query_mod, [{"object_name": "v_hosts", "object_type": "view"}]):
+        out = json.loads(query_mod.search_objects.invoke({"object_type": "view", "pattern": "v_%", "config": CONFIG}))
+    assert out["total_objects"] == 1
+    assert out["objects"][0]["object_name"] == "v_hosts"
+    with _patch(query_mod, [{"object_name": "all_views"}]):
+        all_views = json.loads(query_mod.search_objects.invoke({"object_type": "view", "config": CONFIG}))
+    assert all_views["total_objects"] == 1
+    with patch.object(query_mod, "execute_readonly_query", side_effect=RuntimeError("timeout")):
+        err = json.loads(query_mod.search_objects.invoke({"object_type": "table", "config": CONFIG}))
+    assert "timeout" in err["error"]
+
+
+def test_trace_lock_chain_empty_and_depth():
+    with _patch(tracing_mod, []):
+        empty = json.loads(tracing_mod.trace_lock_chain.invoke({"config": CONFIG}))
+    assert empty["has_lock_chain"] is False
+    rows = [
+        {"level": 1, "blocked_pid": 11, "blocking_pid": 10},
+        {"level": 2, "blocked_pid": 12, "blocking_pid": 11},
+    ]
+    with _patch(tracing_mod, rows):
+        out = json.loads(tracing_mod.trace_lock_chain.invoke({"config": CONFIG}))
+    assert out["has_lock_chain"] is True
+    assert out["max_chain_depth"] == 2
+    assert out["total_blocked_processes"] == 2
+    assert out["root_blocking_processes"] == 1
+    with patch.object(tracing_mod, "execute_readonly_query", side_effect=RuntimeError("lock denied")):
+        err = json.loads(tracing_mod.trace_lock_chain.invoke({"config": CONFIG}))
+    assert "lock denied" in err["error"]
+
+
+def test_active_sessions_duration_categories():
+    rows = [
+        {
+            "backend_start": "t0",
+            "transaction_start": None,
+            "query_start": "t1",
+            "state_change": None,
+            "query_duration_seconds": 4000,
+            "pid": 1,
+        },
+        {
+            "backend_start": "t0",
+            "transaction_start": "tx",
+            "query_start": None,
+            "state_change": "sc",
+            "query_duration_seconds": 120,
+            "pid": 2,
+        },
+        {
+            "backend_start": "t0",
+            "transaction_start": None,
+            "query_start": "t1",
+            "state_change": None,
+            "query_duration_seconds": 10,
+            "pid": 3,
+        },
+    ]
+    with _patch(tracing_mod, rows):
+        out = json.loads(tracing_mod.get_active_sessions.invoke({"min_duration_seconds": 0, "config": CONFIG}))
+    cats = {row["pid"]: row["duration_category"] for row in out["sessions"]}
+    assert cats[1] == "very_long"
+    assert cats[2] == "medium"
+    assert cats[3] == "short"
+    assert out["long_running_sessions"] == 1
+    assert out["sessions"][0]["transaction_start"] is None
+
+
+def test_analyze_query_pattern_percent_and_missing_extension():
+    rows = [
+        {"query_type": "SELECT", "total_calls": 80, "total_time": 1000, "avg_mean_time": 10},
+        {"query_type": "INSERT", "total_calls": 20, "total_time": 200, "avg_mean_time": 5},
+    ]
+    with _patch(tracing_mod, rows):
+        out = json.loads(tracing_mod.analyze_query_pattern.invoke({"hours": 12, "config": CONFIG}))
+    assert out["total_query_calls"] == 100
+    assert out["analysis_period_hours"] == 12
+    percents = {row["query_type"]: row["call_percent"] for row in out["query_patterns"]}
+    assert percents["SELECT"] == 80.0
+    assert percents["INSERT"] == 20.0
+    with patch.object(tracing_mod, "execute_readonly_query", side_effect=RuntimeError("pg_stat_statements missing")):
+        err = json.loads(tracing_mod.analyze_query_pattern.invoke({"config": CONFIG}))
+    assert "pg_stat_statements" in err["error"]
+
+
+def test_table_metrics_dead_ratio_and_never():
+    rows = [
+        {
+            "live_tuples": 80,
+            "dead_tuples": 20,
+            "last_vacuum": None,
+            "last_autovacuum": None,
+            "last_analyze": None,
+            "last_autoanalyze": None,
+            "table_name": "hosts",
+        }
+    ]
+    with _patch(mon, rows):
+        out = json.loads(mon.get_table_metrics.invoke({"table": "hosts", "config": CONFIG}))
+    assert out["total_tables"] == 1
+    assert out["tables"][0]["dead_tuple_ratio"] == 20.0
+    assert out["tables"][0]["last_vacuum"] == "Never"
+    with _patch(mon, []):
+        all_tables = json.loads(mon.get_table_metrics.invoke({"config": CONFIG}))
+    assert all_tables["table"] is None
+
+
+def test_check_configuration_tuning_attaches_advice():
+    from apps.opspilot.metis.llm.tools.postgres import optimization as opt
+
+    rows = [
+        {"name": "shared_buffers", "setting": "128MB"},
+        {"name": "work_mem", "setting": "4MB"},
+        {"name": "unknown_param", "setting": "1"},
+    ]
+    with patch.object(opt, "execute_readonly_query", return_value=rows):
+        out = json.loads(opt.check_configuration_tuning.invoke({"config": CONFIG}))
+    assert out["total_parameters"] == 3
+    advised = {row["name"]: row.get("advice") for row in out["parameters"]}
+    assert "25%" in advised["shared_buffers"]
+    assert advised["unknown_param"] is None
+    with patch.object(opt, "execute_readonly_query", side_effect=RuntimeError("settings denied")):
+        err = json.loads(opt.check_configuration_tuning.invoke({"config": CONFIG}))
+    assert "settings denied" in err["error"]
+
+    bg = {
+        "checkpoints_timed": 9,
+        "checkpoints_req": 1,
+        "buffers_checkpoint": 50,
+        "buffers_clean": 30,
+        "buffers_backend": 20,
+        "stats_reset": None,
+    }
+    with _patch(mon, [bg]):
+        out = json.loads(mon.get_bgwriter_stats.invoke({"config": CONFIG}))
+    assert out["total_checkpoints"] == 10
+    assert out["timed_checkpoint_ratio"] == 90.0
+    assert out["checkpoint_buffer_ratio"] == 50.0
+    assert out["stats_reset"] == "Never"
+
+    wal_info = {"current_wal_lsn": "0/1", "wal_level": "replica"}
+    wal_stats = {"wal_bytes": 2048, "stats_reset": None}
+
+    def fake_query(sql, params=None, config=None, database=None):
+        if "pg_stat_wal" in sql:
+            return [wal_stats]
+        return [wal_info]
+
+    with patch.object(mon, "execute_readonly_query", side_effect=fake_query):
+        wal = json.loads(mon.get_wal_metrics.invoke({"config": CONFIG}))
+    assert wal["wal_info"]["wal_level"] == "replica"
+    assert wal["wal_stats"]["wal_size"]
+
+    def missing_stat(sql, params=None, config=None, database=None):
+        if "pg_stat_wal" in sql:
+            raise RuntimeError("relation pg_stat_wal does not exist")
+        return [wal_info]
+
+    with patch.object(mon, "execute_readonly_query", side_effect=missing_stat):
+        fallback = json.loads(mon.get_wal_metrics.invoke({"config": CONFIG}))
+    assert "PostgreSQL 14" in fallback["wal_stats"]["note"]

--- a/server/apps/opspilot/tests/test_tools_postgres_resources_opt_service.py
+++ b/server/apps/opspilot/tests/test_tools_postgres_resources_opt_service.py
@@ -1,0 +1,51 @@
+"""PostgreSQL 资源/优化工具：数据库信息、列表、未用索引浪费空间。"""
+import json
+from unittest.mock import patch
+
+import pytest
+
+from apps.opspilot.metis.llm.tools.postgres import optimization as opt
+from apps.opspilot.metis.llm.tools.postgres import resources as res
+
+pytestmark = pytest.mark.unit
+CONFIG = {"configurable": {"host": "127.0.0.1"}}
+
+
+def test_current_database_info_and_error():
+    row = {
+        "database_name": "app",
+        "username": "u",
+        "pg_version": "PostgreSQL 15.4",
+        "current_schema": "public",
+        "search_path": "public",
+    }
+    with patch.object(res, "execute_readonly_query", return_value=[row]):
+        out = json.loads(res.get_current_database_info.invoke({"config": CONFIG}))
+    assert out["current_database"] == "app"
+    assert "15.4" in out["postgres_version"]
+    with patch.object(res, "execute_readonly_query", side_effect=RuntimeError("denied")):
+        err = json.loads(res.get_current_database_info.invoke({"config": CONFIG}))
+    assert "denied" in err["error"]
+
+
+def test_list_postgres_databases_formats_size():
+    rows = [{"name": "app", "size_bytes": 2048, "connections": 3, "owner": "u", "encoding": "UTF8", "collate": "C"}]
+    with patch.object(res, "execute_readonly_query", return_value=rows):
+        out = json.loads(res.list_postgres_databases.invoke({"config": CONFIG}))
+    assert out["total_databases"] == 1
+    assert out["databases"][0]["size"] == "2.00 KB"
+
+
+def test_check_unused_indexes_sums_wasted_space():
+    rows = [
+        {"index_name": "idx_dead", "index_size_bytes": 1024 * 1024, "index_scans": 0, "table_name": "t"},
+    ]
+    with patch.object(opt, "execute_readonly_query", return_value=rows):
+        out = json.loads(opt.check_unused_indexes.invoke({"size_threshold_mb": 1, "config": CONFIG}))
+    assert out["unused_index_count"] == 1
+    assert out["total_wasted_bytes"] == 1024 * 1024
+    assert out["recommendations"][0] == "考虑删除1个未使用的索引,可节省1.00 MB"
+    with patch.object(opt, "execute_readonly_query", return_value=[]):
+        empty = json.loads(opt.check_unused_indexes.invoke({"config": CONFIG}))
+    assert empty["unused_index_count"] == 0
+    assert "未发现" in empty["recommendations"][0]

--- a/server/apps/opspilot/tests/test_tools_redis_json_remaining.py
+++ b/server/apps/opspilot/tests/test_tools_redis_json_remaining.py
@@ -1,0 +1,100 @@
+"""Redis JSON 工具：写入/读取/删除/数组追加成功与 unsupported_feature。"""
+from unittest.mock import patch
+
+import pytest
+from redis.exceptions import RedisError
+
+from apps.opspilot.metis.llm.tools.redis import json as rjson
+
+pytestmark = pytest.mark.unit
+CONFIG = {"configurable": {"host": "127.0.0.1", "port": 6379, "db": 0}}
+
+
+class _JsonCmd:
+    def __init__(self, **returns):
+        self._returns = returns
+
+    def set(self, *a, **k):
+        val = self._returns.get("set")
+        if isinstance(val, Exception):
+            raise val
+        return True
+
+    def get(self, *a, **k):
+        val = self._returns.get("get", {"a": 1})
+        if isinstance(val, Exception):
+            raise val
+        return val
+
+    def delete(self, *a, **k):
+        val = self._returns.get("delete", 1)
+        if isinstance(val, Exception):
+            raise val
+        return val
+
+    def arrappend(self, *a, **k):
+        val = self._returns.get("arrappend", 3)
+        if isinstance(val, Exception):
+            raise val
+        return val
+
+    def objkeys(self, *a, **k):
+        val = self._returns.get("objkeys", ["a"])
+        if isinstance(val, Exception):
+            raise val
+        return val
+
+
+class FakeRedis:
+    def __init__(self, json_cmd, expire_result=True, expire_error=None):
+        self._json_cmd = json_cmd
+        self._expire_result = expire_result
+        self._expire_error = expire_error
+
+    def json(self):
+        return self._json_cmd
+
+    def expire(self, *a, **k):
+        if self._expire_error:
+            raise self._expire_error
+        return self._expire_result
+
+
+def _patch(fake):
+    return patch.object(rjson, "get_redis_connection_from_item", return_value=fake)
+
+
+def test_redis_json_set_parses_json_and_raw_string():
+    fake = FakeRedis(_JsonCmd())
+    with _patch(fake):
+        ok = rjson.redis_json_set.invoke({"name": "doc", "path": "$", "value": '{"a": 1}', "expire_seconds": 10, "config": CONFIG})
+        raw = rjson.redis_json_set.invoke({"name": "doc", "path": "$.x", "value": "not-json", "config": CONFIG})
+    assert ok == {"success": True, "data": {"name": "doc", "path": "$", "expire_seconds": 10}}
+    assert raw["success"] is True
+
+
+def test_redis_json_get_del_arrappend_objkeys_success():
+    fake = FakeRedis(_JsonCmd(get={"a": 1}, delete=1, arrappend=4, objkeys=["a", "b"]))
+    with _patch(fake):
+        got = rjson.redis_json_get.invoke({"name": "doc", "path": "$", "config": CONFIG})
+        deleted = rjson.redis_json_del.invoke({"name": "doc", "path": "$.a", "config": CONFIG})
+        appended = rjson.redis_json_arrappend.invoke({"name": "doc", "path": "$.arr", "values": [1, 2], "config": CONFIG})
+        keys = rjson.redis_json_objkeys.invoke({"name": "doc", "config": CONFIG})
+    assert got == {"success": True, "data": {"a": 1}}
+    assert deleted["data"]["deleted"] == 1
+    assert appended["success"] is True
+    assert keys["data"] == ["a", "b"]
+
+
+def test_redis_json_commands_wrap_unsupported_feature():
+    err = RedisError("no json")
+    fake = FakeRedis(_JsonCmd(set=err, get=err, delete=err, arrappend=err, objkeys=err))
+    with _patch(fake):
+        for result in (
+            rjson.redis_json_set.invoke({"name": "doc", "path": "$", "value": "{}", "config": CONFIG}),
+            rjson.redis_json_get.invoke({"name": "doc", "config": CONFIG}),
+            rjson.redis_json_del.invoke({"name": "doc", "config": CONFIG}),
+            rjson.redis_json_arrappend.invoke({"name": "doc", "path": "$.a", "values": [1], "config": CONFIG}),
+            rjson.redis_json_objkeys.invoke({"name": "doc", "config": CONFIG}),
+        ):
+            assert result == {"success": False, "error": "no json", "error_type": "unsupported_feature"}

--- a/server/apps/opspilot/tests/test_tools_redis_query_engine_remaining.py
+++ b/server/apps/opspilot/tests/test_tools_redis_query_engine_remaining.py
@@ -1,0 +1,82 @@
+"""Redis 搜索工具：索引列表/信息/向量检索成功与 RedisError。"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from redis.exceptions import RedisError
+
+from apps.opspilot.metis.llm.tools.redis import query_engine as qe
+
+pytestmark = pytest.mark.unit
+MOD = "apps.opspilot.metis.llm.tools.redis.query_engine"
+
+
+def _run(func, client, **kwargs):
+    normalized = {"mode": "single", "items": [{"name": "redis-1"}]}
+    with (
+        patch(f"{MOD}.build_redis_normalized_from_runnable", return_value=normalized),
+        patch(f"{MOD}.get_redis_connection_from_item", return_value=client),
+    ):
+        return func(**kwargs)
+
+
+def test_redis_index_helpers_success_and_unsupported():
+    client = MagicMock()
+    client.execute_command.return_value = ["idx-a"]
+    client.ft.return_value.info.return_value = {"num_docs": 3}
+    client.ft.return_value.search.return_value = SimpleNamespace(total=9)
+    assert _run(qe.redis_get_indexes.func, client, config={}) == {"success": True, "data": ["idx-a"]}
+    assert _run(qe.redis_get_index_info.func, client, index_name="idx-a", config={}) == {
+        "success": True,
+        "data": {"num_docs": 3},
+    }
+    assert _run(qe.redis_get_indexed_keys_number.func, client, index_name="idx-a", config={}) == {
+        "success": True,
+        "data": {"index_name": "idx-a", "total": 9},
+    }
+    client.execute_command.side_effect = RedisError("no FT")
+    assert _run(qe.redis_get_indexes.func, client, config={}) == {
+        "success": False,
+        "error": "no FT",
+        "error_type": "unsupported_feature",
+    }
+
+
+def test_redis_vector_hybrid_search_and_create_index():
+    client = MagicMock()
+    client.ft.return_value.create_index.return_value = True
+    assert _run(qe.redis_create_vector_index_hash.func, client, index_name="v", config={}) == {
+        "success": True,
+        "data": {"index_name": "v", "created": True},
+    }
+    doc = SimpleNamespace(id="d1", score="0.1")
+    client.ft.return_value.search.return_value = SimpleNamespace(docs=[doc])
+    searched = _run(
+        qe.redis_vector_search_hash.func,
+        client,
+        query_vector=[0.1, 0.2],
+        index_name="v",
+        config={},
+    )
+    assert searched == {"success": True, "data": [{"id": "d1", "score": "0.1"}]}
+    hybrid = _run(
+        qe.redis_hybrid_search.func,
+        client,
+        query_vector=[0.1, 0.2],
+        filter_expression="@city:beijing",
+        index_name="v",
+        config={},
+    )
+    assert hybrid == {"success": True, "data": [{"id": "d1", "score": "0.1"}]}
+    client.ft.return_value.search.side_effect = RedisError("no module")
+    assert _run(
+        qe.redis_vector_search_hash.func,
+        client,
+        query_vector=[0.1],
+        index_name="v",
+        config={},
+    ) == {
+        "success": False,
+        "error": "no module",
+        "error_type": "unsupported_feature",
+    }

--- a/server/apps/opspilot/tests/test_tools_redis_server_remaining.py
+++ b/server/apps/opspilot/tests/test_tools_redis_server_remaining.py
@@ -1,0 +1,114 @@
+"""Redis server_management 剩余：错误包装、set/zset/json 分派、flushdb 失败。"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from redis.exceptions import RedisError
+
+from apps.opspilot.metis.llm.tools.redis import hash as rh
+from apps.opspilot.metis.llm.tools.redis import json as rjson
+from apps.opspilot.metis.llm.tools.redis import server_management as sm
+from apps.opspilot.metis.llm.tools.redis import set as rset
+from apps.opspilot.metis.llm.tools.redis import sorted_set as rzset
+
+pytestmark = pytest.mark.unit
+CONFIG = {"configurable": {"host": "127.0.0.1", "port": 6379, "db": 0}}
+
+
+class FakeRedis:
+    def __init__(self, **returns):
+        self._returns = returns
+        self.connection_pool = MagicMock()
+        self.connection_pool.connection_kwargs = {"host": "h", "port": 6379, "db": 0}
+
+    def __getattr__(self, name):
+        def _method(*args, **kwargs):
+            val = self._returns.get(name)
+            if isinstance(val, Exception):
+                raise val
+            return val
+
+        return _method
+
+
+def _patch(module, fake):
+    return patch.object(module, "get_redis_connection_from_item", return_value=fake)
+
+
+def test_redis_server_commands_wrap_connection_errors():
+    fake = FakeRedis(
+        ping=RedisError("down"),
+        dbsize=RedisError("down"),
+        info=RedisError("down"),
+        client_list=RedisError("down"),
+        scan=RedisError("down"),
+        type=RedisError("down"),
+        exists=RedisError("down"),
+        expire=RedisError("down"),
+        ttl=RedisError("down"),
+        delete=RedisError("down"),
+        rename=RedisError("down"),
+        flushdb=RedisError("down"),
+    )
+    with _patch(sm, fake):
+        assert sm.redis_ping.invoke({"config": CONFIG}) == {
+            "success": False,
+            "error": "down",
+            "error_type": "connection_error",
+        }
+        assert sm.redis_dbsize.invoke({"config": CONFIG})["error_type"] == "redis_error"
+        assert sm.redis_info.invoke({"section": "memory", "config": CONFIG})["success"] is False
+        assert sm.redis_client_list.invoke({"config": CONFIG})["success"] is False
+        assert sm.redis_scan_keys.invoke({"config": CONFIG})["success"] is False
+        assert sm.redis_key_type.invoke({"key": "k", "config": CONFIG})["success"] is False
+        assert sm.redis_exists.invoke({"key": "k", "config": CONFIG})["success"] is False
+        assert sm.redis_expire.invoke({"key": "k", "seconds": 1, "config": CONFIG})["success"] is False
+        assert sm.redis_ttl.invoke({"key": "k", "config": CONFIG})["success"] is False
+        assert sm.redis_delete.invoke({"key": "k", "config": CONFIG})["success"] is False
+        assert sm.redis_rename.invoke({"old_key": "a", "new_key": "b", "config": CONFIG})["success"] is False
+        flush = sm.redis_flushdb.invoke({"confirm": True, "config": CONFIG})
+        assert flush == {"success": False, "error": "down", "error_type": "redis_error"}
+
+
+def test_redis_get_key_value_set_zset_json_and_summary():
+    sm_client = FakeRedis(exists=1, type="set", ttl=9)
+    set_client = FakeRedis(scard=3, smembers=["a", "b", "c"])
+    with _patch(sm, sm_client), _patch(rset, set_client):
+        out = sm.redis_get_key_value.invoke({"key": "s", "max_items": 2, "config": CONFIG})
+    assert out == {
+        "success": True,
+        "data": {
+            "key": "s",
+            "exists": True,
+            "type": "set",
+            "ttl": 9,
+            "count": 3,
+            "truncated": True,
+            "value": ["a", "b"],
+        },
+    }
+
+    sm_client = FakeRedis(exists=1, type="zset", ttl=4)
+    z_client = FakeRedis(zcard=1, zrange=[{"member": "m", "score": 1.0}])
+    with _patch(sm, sm_client), _patch(rzset, z_client):
+        zout = sm.redis_get_key_value.invoke({"key": "z", "config": CONFIG})
+    assert zout["data"]["type"] == "zset"
+    assert zout["data"]["count"] == 1
+    assert zout["data"]["value"] == [{"member": "m", "score": 1.0}]
+
+    sm_client = FakeRedis(exists=1, type="json", ttl=-1)
+    json_client = FakeRedis()
+    json_client.json = MagicMock(return_value=SimpleNamespace(get=lambda *a, **k: {"n": 1}))
+    with _patch(sm, sm_client), _patch(rjson, json_client):
+        jout = sm.redis_get_key_value.invoke({"key": "j", "config": CONFIG})
+    assert jout["data"]["type"] == "json"
+    assert jout["data"]["value"] == {"n": 1}
+
+    sm_client = FakeRedis(exists=1, type="hash", ttl=1)
+    hash_client = FakeRedis(hgetall={"f": "1"})
+
+    with _patch(sm, sm_client), _patch(rh, hash_client):
+        summary = sm.redis_get_key_summary.invoke({"key": "h", "config": CONFIG})
+    assert summary["data"]["count"] == 1
+    assert summary["data"]["preview"] == {"f": "1"}
+    assert summary["data"]["truncated"] is False

--- a/server/apps/opspilot/tests/test_tools_redis_sorted_set_remaining.py
+++ b/server/apps/opspilot/tests/test_tools_redis_sorted_set_remaining.py
@@ -1,0 +1,60 @@
+"""Redis sorted set 工具：zadd/zrange/zrem/zscore/zcard/zrevrange/zrangebyscore/zrank。"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from redis.exceptions import RedisError
+
+from apps.opspilot.metis.llm.tools.redis import sorted_set as zs
+
+pytestmark = pytest.mark.unit
+CONFIG = {"configurable": {"host": "127.0.0.1", "port": 6379, "db": 0}}
+
+
+@pytest.fixture
+def client():
+    mock = MagicMock()
+    with patch.object(zs, "get_redis_connection_from_item", return_value=mock):
+        yield mock
+
+
+def test_sorted_set_write_read_rank_and_error(client):
+    client.zadd.return_value = 2
+    out = zs.redis_zadd.invoke({"key": "lb", "members": {"a": 1.0, "b": 2.0}, "config": CONFIG})
+    assert out == {"success": True, "data": {"added": 2}, "key": "lb"}
+    client.zadd.assert_called_once_with("lb", {"a": 1.0, "b": 2.0})
+
+    client.zrange.return_value = ["a", "b"]
+    out = zs.redis_zrange.invoke({"key": "lb", "start": 0, "end": -1, "config": CONFIG})
+    assert out["success"] is True
+    assert out["data"] == ["a", "b"]
+    client.zrange.assert_called_once_with("lb", 0, -1, withscores=False)
+
+    client.zrem.return_value = 1
+    out = zs.redis_zrem.invoke({"key": "lb", "member": "a", "config": CONFIG})
+    assert out["data"] == {"removed": 1}
+
+    client.zscore.return_value = 2.5
+    out = zs.redis_zscore.invoke({"key": "lb", "member": "b", "config": CONFIG})
+    assert out["data"] == {"key": "lb", "member": "b", "score": 2.5}
+
+    client.zcard.return_value = 3
+    out = zs.redis_zcard.invoke({"key": "lb", "config": CONFIG})
+    assert out["data"] == {"key": "lb", "count": 3}
+
+    client.zrevrange.return_value = [("b", 2.0)]
+    out = zs.redis_zrevrange.invoke({"key": "lb", "start": 0, "end": 0, "withscores": True, "config": CONFIG})
+    assert out["data"] == [["b", 2.0]]
+    client.zrevrange.assert_called_once_with("lb", 0, 0, withscores=True)
+
+    client.zrangebyscore.return_value = ["b"]
+    out = zs.redis_zrangebyscore.invoke({"key": "lb", "min_score": 1.5, "max_score": 3.0, "config": CONFIG})
+    assert out["data"] == ["b"]
+    client.zrangebyscore.assert_called_once_with("lb", 1.5, 3.0, withscores=False)
+
+    client.zrank.return_value = 0
+    out = zs.redis_zrank.invoke({"key": "lb", "member": "a", "config": CONFIG})
+    assert out["data"] == {"key": "lb", "member": "a", "rank": 0}
+
+    client.zadd.side_effect = RedisError("down")
+    err = zs.redis_zadd.invoke({"key": "lb", "members": {"a": 1.0}, "config": CONFIG})
+    assert err == {"success": False, "error": "down", "error_type": "redis_error"}

--- a/server/apps/opspilot/tests/test_tools_redis_stream_and_set_remaining.py
+++ b/server/apps/opspilot/tests/test_tools_redis_stream_and_set_remaining.py
@@ -1,0 +1,139 @@
+"""Redis stream / set 工具：成功契约与 RedisError 包装。"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from redis.exceptions import RedisError
+
+from apps.opspilot.metis.llm.tools.redis import set as rset
+from apps.opspilot.metis.llm.tools.redis import stream as rstream
+
+pytestmark = pytest.mark.unit
+CONFIG = {"configurable": {"host": "127.0.0.1", "port": 6379, "db": 0}}
+
+
+class FakeRedis:
+    def __init__(self, **returns):
+        self._returns = returns
+        self.connection_pool = MagicMock()
+        self.connection_pool.connection_kwargs = {"host": "h", "port": 6379, "db": 0}
+
+    def __getattr__(self, name):
+        def _method(*args, **kwargs):
+            val = self._returns.get(name)
+            if isinstance(val, Exception):
+                raise val
+            return val
+
+        return _method
+
+
+def _patch(module, fake):
+    return patch.object(module, "get_redis_connection_from_item", return_value=fake)
+
+
+def test_redis_stream_commands_success_and_expire():
+    fake = FakeRedis(
+        xadd="1-0",
+        expire=True,
+        xread=[["s", [["1-0", {"a": "1"}]]]],
+        xrange=[["1-0", {"a": "1"}]],
+        xrevrange=[["2-0", {"b": "2"}]],
+        xdel=1,
+        xgroup_create=True,
+        xreadgroup=[["s", []]],
+        xack=1,
+    )
+    with _patch(rstream, fake):
+        added = rstream.redis_xadd.invoke({"key": "s", "fields": {"a": "1"}, "expiration": 30, "config": CONFIG})
+        read = rstream.redis_xread.invoke({"streams": {"s": "0-0"}, "config": CONFIG})
+        rng = rstream.redis_xrange.invoke({"key": "s", "config": CONFIG})
+        rev = rstream.redis_xrevrange.invoke({"key": "s", "config": CONFIG})
+        deleted = rstream.redis_xdel.invoke({"key": "s", "entry_id": "1-0", "config": CONFIG})
+        group = rstream.redis_xgroup_create.invoke({"key": "s", "group_name": "g", "config": CONFIG})
+        grouped = rstream.redis_xreadgroup.invoke({"group_name": "g", "consumer_name": "c", "streams": {"s": ">"}, "config": CONFIG})
+        acked = rstream.redis_xack.invoke({"key": "s", "group_name": "g", "entry_ids": ["1-0"], "config": CONFIG})
+    assert added == {"success": True, "data": {"key": "s", "entry_id": "1-0", "expiration": 30}}
+    assert read["success"] is True
+    assert rng["key"] == "s"
+    assert rev["success"] is True
+    assert deleted == {"success": True, "data": {"key": "s", "deleted": 1, "entry_id": "1-0"}}
+    assert group["data"]["created"] is True
+    assert grouped["success"] is True
+    assert acked["data"]["acked"] == 1
+
+
+def test_redis_stream_commands_wrap_redis_error():
+    fake = FakeRedis(
+        xadd=RedisError("stream down"),
+        xread=RedisError("stream down"),
+        xrange=RedisError("stream down"),
+        xrevrange=RedisError("stream down"),
+        xdel=RedisError("stream down"),
+        xgroup_create=RedisError("stream down"),
+        xreadgroup=RedisError("stream down"),
+        xack=RedisError("stream down"),
+    )
+    with _patch(rstream, fake):
+        for result in (
+            rstream.redis_xadd.invoke({"key": "s", "fields": {"a": "1"}, "config": CONFIG}),
+            rstream.redis_xread.invoke({"streams": {"s": "0-0"}, "config": CONFIG}),
+            rstream.redis_xrange.invoke({"key": "s", "config": CONFIG}),
+            rstream.redis_xrevrange.invoke({"key": "s", "config": CONFIG}),
+            rstream.redis_xdel.invoke({"key": "s", "entry_id": "1-0", "config": CONFIG}),
+            rstream.redis_xgroup_create.invoke({"key": "s", "group_name": "g", "config": CONFIG}),
+            rstream.redis_xreadgroup.invoke({"group_name": "g", "consumer_name": "c", "streams": {"s": ">"}, "config": CONFIG}),
+            rstream.redis_xack.invoke({"key": "s", "group_name": "g", "entry_ids": ["1-0"], "config": CONFIG}),
+        ):
+            assert result == {"success": False, "error": "stream down", "error_type": "redis_error"}
+
+
+def test_redis_set_commands_success():
+    fake = FakeRedis(
+        sadd=1,
+        smembers={"a", "b"},
+        srem=1,
+        sismember=True,
+        scard=2,
+        sinter={"a"},
+        sunion={"a", "b"},
+        sdiff={"b"},
+    )
+    with _patch(rset, fake):
+        assert rset.redis_sadd.invoke({"key": "s", "member": "a", "config": CONFIG})["data"]["added"] == 1
+        members = rset.redis_smembers.invoke({"key": "s", "config": CONFIG})
+        assert members["success"] is True
+        assert sorted(members["data"]) == ["a", "b"]
+        assert rset.redis_srem.invoke({"key": "s", "member": "a", "config": CONFIG})["data"]["removed"] == 1
+        assert rset.redis_sismember.invoke({"key": "s", "member": "a", "config": CONFIG})["data"]["is_member"] is True
+        assert rset.redis_scard.invoke({"key": "s", "config": CONFIG})["data"]["count"] == 2
+        inter = rset.redis_sinter.invoke({"keys": ["s1", "s2"], "config": CONFIG})
+        assert inter["data"] == ["a"]
+        union = rset.redis_sunion.invoke({"keys": ["s1", "s2"], "config": CONFIG})
+        assert sorted(union["data"]) == ["a", "b"]
+        diff = rset.redis_sdiff.invoke({"keys": ["s1", "s2"], "config": CONFIG})
+        assert diff["data"] == ["b"]
+
+
+def test_redis_set_commands_wrap_redis_error():
+    fake = FakeRedis(
+        sadd=RedisError("set down"),
+        smembers=RedisError("set down"),
+        srem=RedisError("set down"),
+        sismember=RedisError("set down"),
+        scard=RedisError("set down"),
+        sinter=RedisError("set down"),
+        sunion=RedisError("set down"),
+        sdiff=RedisError("set down"),
+    )
+    with _patch(rset, fake):
+        for result in (
+            rset.redis_sadd.invoke({"key": "s", "member": "a", "config": CONFIG}),
+            rset.redis_smembers.invoke({"key": "s", "config": CONFIG}),
+            rset.redis_srem.invoke({"key": "s", "member": "a", "config": CONFIG}),
+            rset.redis_sismember.invoke({"key": "s", "member": "a", "config": CONFIG}),
+            rset.redis_scard.invoke({"key": "s", "config": CONFIG}),
+            rset.redis_sinter.invoke({"keys": ["s1"], "config": CONFIG}),
+            rset.redis_sunion.invoke({"keys": ["s1"], "config": CONFIG}),
+            rset.redis_sdiff.invoke({"keys": ["s1"], "config": CONFIG}),
+        ):
+            assert result == {"success": False, "error": "set down", "error_type": "redis_error"}

--- a/server/apps/opspilot/tests/test_tools_ssh_batch_remaining.py
+++ b/server/apps/opspilot/tests/test_tools_ssh_batch_remaining.py
@@ -1,0 +1,89 @@
+"""SSH 批量上传/探活：空主机拒绝、成功失败汇总、单机异常隔离。"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.opspilot.metis.llm.tools.ssh import batch as batch_mod
+
+pytestmark = pytest.mark.unit
+
+
+def test_batch_upload_rejects_empty_and_isolates_host_errors():
+    with pytest.raises(ValueError, match="主机列表不能为空"):
+        batch_mod.batch_upload_files.func(
+            hosts=[],
+            username="root",
+            local_path="/tmp/a",
+            remote_path="/tmp/b",
+        )
+
+    def fake_upload(**kwargs):
+        if kwargs["host"] == "boom":
+            raise RuntimeError("sftp down")
+        return {"success": kwargs["host"] == "ok", "error": None if kwargs["host"] == "ok" else "denied"}
+
+    upload_tool = MagicMock()
+    upload_tool.invoke.side_effect = lambda payload, config=None: fake_upload(**payload)
+    with patch.object(batch_mod, "upload_file", upload_tool):
+        out = batch_mod.batch_upload_files.func(
+            hosts=["ok", "bad", "boom"],
+            username="root",
+            local_path="/tmp/a.conf",
+            remote_path="/etc/a.conf",
+            password="p",
+        )
+    assert out["total"] == 3
+    assert out["success_count"] == 1
+    assert out["failed_count"] == 2
+    assert out["summary"]["successful_hosts"] == ["ok"]
+    assert set(out["summary"]["failed_hosts"]) == {"bad", "boom"}
+    assert out["results"]["boom"]["error"] == "sftp down"
+    assert out["results"]["ok"]["success"] is True
+
+
+def test_check_hosts_availability_rejects_empty_and_summarizes():
+    with pytest.raises(ValueError, match="主机列表不能为空"):
+        batch_mod.check_hosts_availability.func(hosts=[], username="root")
+
+    def fake_conn(**kwargs):
+        if kwargs["host"] == "raise":
+            raise RuntimeError("timeout")
+        return {"success": kwargs["host"] == "up"}
+
+    connection_tool = MagicMock()
+    connection_tool.invoke.side_effect = lambda payload, config=None: fake_conn(**payload)
+    with patch(
+        "apps.opspilot.metis.llm.tools.ssh.connection.test_ssh_connection",
+        connection_tool,
+    ):
+        out = batch_mod.check_hosts_availability.func(
+            hosts=["up", "down", "raise"],
+            username="root",
+            password="p",
+        )
+    assert out["total"] == 3
+    assert out["available_count"] == 1
+    assert out["unavailable_count"] == 2
+    assert out["available_hosts"] == ["up"]
+    assert set(out["unavailable_hosts"]) == {"down", "raise"}
+    assert out["details"]["raise"]["error"] == "timeout"
+
+
+def test_batch_execute_isolates_command_exceptions():
+    def fake_exec(**kwargs):
+        if kwargs["host"] == "boom":
+            raise RuntimeError("ssh reset")
+        return {"success": True, "stdout": "ok"}
+
+    command_tool = MagicMock()
+    command_tool.invoke.side_effect = lambda payload, config=None: fake_exec(**payload)
+    with patch.object(batch_mod, "ssh_execute_command", command_tool):
+        out = batch_mod.batch_execute_commands.func(
+            hosts=["ok", "boom"],
+            username="root",
+            command="uptime",
+        )
+    assert out["success_count"] == 1
+    assert out["failed_count"] == 1
+    assert out["results"]["boom"]["exit_code"] == -1
+    assert out["results"]["boom"]["error"] == "ssh reset"

--- a/server/apps/opspilot/tests/test_tools_ssh_connection_execute_service.py
+++ b/server/apps/opspilot/tests/test_tools_ssh_connection_execute_service.py
@@ -1,0 +1,115 @@
+"""SSH 连接/执行/批量：mock paramiko 与底层命令，断言成功/失败汇总。"""
+from unittest.mock import MagicMock, patch
+
+import paramiko
+import pytest
+
+from apps.opspilot.metis.llm.tools.ssh import batch as batch_mod
+from apps.opspilot.metis.llm.tools.ssh import connection as conn
+from apps.opspilot.metis.llm.tools.ssh import execute as exe
+from apps.opspilot.metis.llm.tools.ssh.utils import format_command_output, prepare_ssh_config, validate_host_params
+
+pytestmark = pytest.mark.unit
+
+
+def test_validate_host_and_prepare_config():
+    with pytest.raises(ValueError):
+        validate_host_params("", "root")
+    with pytest.raises(ValueError):
+        validate_host_params("10.0.0.1", "")
+    validate_host_params("10.0.0.1", "root")
+    cfg = prepare_ssh_config({"configurable": {"ssh_timeout": 5, "ssh_port": 2222}})
+    assert cfg["timeout"] == 5
+    assert cfg["port"] == 2222
+
+
+def test_format_command_output_success_and_failure():
+    ok = format_command_output("hello\n", "", 0)
+    assert ok["success"] is True
+    assert ok["stdout"] == "hello"
+    bad = format_command_output("", "denied", 1)
+    assert bad["success"] is False
+    assert bad["exit_code"] == 1
+
+
+def test_create_ssh_client_uses_password_and_maps_auth_error():
+    client = MagicMock()
+    with patch("apps.opspilot.metis.llm.tools.ssh.connection.paramiko.SSHClient", return_value=client):
+        out = conn.create_ssh_client("10.0.0.1", "root", password="p")
+    assert out is client
+    client.connect.assert_called_once()
+    assert client.connect.call_args.kwargs["password"] == "p"
+    client.connect.side_effect = paramiko.AuthenticationException("bad")
+    with patch("apps.opspilot.metis.llm.tools.ssh.connection.paramiko.SSHClient", return_value=client):
+        with pytest.raises(paramiko.AuthenticationException, match="SSH认证失败"):
+            conn.create_ssh_client("10.0.0.1", "root", password="p")
+
+
+def test_test_ssh_connection_success_and_failure():
+    client = MagicMock()
+    transport = MagicMock(remote_version="OpenSSH_9")
+    client.get_transport.return_value = transport
+    with patch.object(conn, "create_ssh_client", return_value=client):
+        out = conn.test_ssh_connection.invoke({"host": "10.0.0.1", "username": "root", "password": "p"})
+    assert out["success"] is True
+    assert out["server_info"]["banner"] == "OpenSSH_9"
+    client.close.assert_called_once()
+    with patch.object(conn, "create_ssh_client", side_effect=RuntimeError("down")):
+        failed = conn.test_ssh_connection.invoke({"host": "10.0.0.1", "username": "root", "password": "p"})
+    assert failed["success"] is False
+    assert "down" in failed["error"]
+
+
+def _ssh_streams(stdout="ok\n", stderr="", exit_code=0):
+    stdout_obj = MagicMock()
+    stdout_obj.read.return_value = stdout.encode()
+    stdout_obj.channel.recv_exit_status.return_value = exit_code
+    stderr_obj = MagicMock()
+    stderr_obj.read.return_value = stderr.encode()
+    return MagicMock(), stdout_obj, stderr_obj
+
+
+def test_ssh_execute_command_cwd_env_and_error():
+    client = MagicMock()
+    client.exec_command.return_value = _ssh_streams("done", "", 0)
+    with patch.object(exe, "create_ssh_client", return_value=client):
+        out = exe.ssh_execute_command.invoke(
+            {
+                "host": "10.0.0.1",
+                "username": "root",
+                "password": "p",
+                "command": "ls",
+                "working_directory": "/tmp",
+                "environment": {"A": "1"},
+            }
+        )
+    assert out["success"] is True
+    cmd = client.exec_command.call_args.args[0]
+    assert "cd /tmp" in cmd
+    assert "export A=1" in cmd
+    with patch.object(exe, "create_ssh_client", side_effect=RuntimeError("refused")):
+        failed = exe.ssh_execute_command.invoke({"host": "10.0.0.1", "username": "root", "password": "p", "command": "ls"})
+    assert failed["success"] is False
+    assert failed["exit_code"] == -1
+
+
+def test_batch_execute_rejects_empty_and_summarizes():
+    with pytest.raises(ValueError, match="主机列表不能为空"):
+        batch_mod.batch_execute_commands.func(hosts=[], username="root", command="uptime")
+    command_tool = MagicMock()
+    command_tool.invoke.side_effect = lambda payload, config=None: {
+        "success": payload["host"] != "bad",
+        "stdout": "ok",
+    }
+    with patch.object(batch_mod, "ssh_execute_command", command_tool):
+        out = batch_mod.batch_execute_commands.func(
+            hosts=["good", "bad"],
+            username="root",
+            command="uptime",
+            password="p",
+        )
+    assert out["total"] == 2
+    assert out["success_count"] == 1
+    assert out["failed_count"] == 1
+    assert "good" in out["summary"]["successful_hosts"]
+    assert "bad" in out["summary"]["failed_hosts"]

--- a/server/apps/opspilot/tests/test_tools_ssh_transfer_service.py
+++ b/server/apps/opspilot/tests/test_tools_ssh_transfer_service.py
@@ -1,0 +1,99 @@
+"""SSH SFTP 传输：上传校验本地文件、下载、列目录、删除、递归建目录。"""
+import os
+import stat
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.opspilot.metis.llm.tools.ssh import transfer as t
+
+pytestmark = pytest.mark.unit
+
+
+def _ssh(sftp):
+    client = MagicMock()
+    client.open_sftp.return_value = sftp
+    return client
+
+
+def test_upload_file_requires_existing_file(tmp_path):
+    missing = str(tmp_path / "nope.txt")
+    with pytest.raises(FileNotFoundError, match="本地文件不存在"):
+        t.upload_file.invoke({"host": "h", "username": "u", "local_path": missing, "remote_path": "/r/a.txt", "password": "p"})
+    with pytest.raises(ValueError, match="路径不是文件"):
+        t.upload_file.invoke({"host": "h", "username": "u", "local_path": str(tmp_path), "remote_path": "/r/a.txt", "password": "p"})
+
+
+def test_upload_file_creates_remote_dir_and_puts(tmp_path):
+    local = tmp_path / "a.txt"
+    local.write_text("hello")
+    sftp = MagicMock()
+    sftp.stat.side_effect = IOError("missing")
+    with patch.object(t, "create_ssh_client", return_value=_ssh(sftp)):
+        out = t.upload_file.invoke(
+            {
+                "host": "h",
+                "username": "u",
+                "local_path": str(local),
+                "remote_path": "/opt/app/a.txt",
+                "password": "p",
+                "create_directories": True,
+            }
+        )
+    assert out["success"] is True
+    assert out["bytes_transferred"] == 5
+    sftp.put.assert_called_once_with(str(local), "/opt/app/a.txt")
+    sftp.mkdir.assert_called()
+    sftp.close.assert_called()
+
+
+def test_download_file_creates_local_dir(tmp_path):
+    dest = tmp_path / "nested" / "b.txt"
+    sftp = MagicMock()
+
+    def _get(remote, local):
+        os.makedirs(os.path.dirname(local), exist_ok=True)
+        with open(local, "w") as fh:
+            fh.write("data")
+
+    sftp.get.side_effect = _get
+    with patch.object(t, "create_ssh_client", return_value=_ssh(sftp)):
+        out = t.download_file.invoke(
+            {
+                "host": "h",
+                "username": "u",
+                "remote_path": "/r/b.txt",
+                "local_path": str(dest),
+                "password": "p",
+            }
+        )
+    assert out["success"] is True
+    assert dest.read_text() == "data"
+    assert out["bytes_transferred"] == 4
+
+
+def test_list_remote_directory_skips_hidden_and_splits_dirs():
+    file_item = SimpleNamespace(filename="a.txt", st_size=10, st_mode=stat.S_IFREG | 0o644, st_mtime=1)
+    dir_item = SimpleNamespace(filename="sub", st_size=0, st_mode=stat.S_IFDIR | 0o755, st_mtime=2)
+    hidden = SimpleNamespace(filename=".secret", st_size=1, st_mode=stat.S_IFREG | 0o600, st_mtime=3)
+    sftp = MagicMock()
+    sftp.listdir_attr.return_value = [file_item, dir_item, hidden]
+    with patch.object(t, "create_ssh_client", return_value=_ssh(sftp)):
+        out = t.list_remote_directory.invoke({"host": "h", "username": "u", "remote_path": "/opt", "password": "p"})
+    assert out["total_items"] == 2
+    assert [i["name"] for i in out["files"]] == ["a.txt"]
+    assert [i["name"] for i in out["directories"]] == ["sub"]
+
+
+def test_delete_remote_file_success_and_error():
+    sftp = MagicMock()
+    with patch.object(t, "create_ssh_client", return_value=_ssh(sftp)):
+        out = t.delete_remote_file.invoke({"host": "h", "username": "u", "remote_path": "/tmp/x", "password": "p"})
+    assert out["success"] is True
+    sftp.remove.assert_called_once_with("/tmp/x")
+
+    sftp.remove.side_effect = IOError("denied")
+    with patch.object(t, "create_ssh_client", return_value=_ssh(sftp)):
+        with pytest.raises(Exception, match="删除文件失败"):
+            t.delete_remote_file.invoke({"host": "h", "username": "u", "remote_path": "/tmp/x", "password": "p"})

--- a/server/apps/system_mgmt/tests/test_channel_loglog_viewset_api.py
+++ b/server/apps/system_mgmt/tests/test_channel_loglog_viewset_api.py
@@ -5,10 +5,11 @@
 from unittest.mock import patch
 
 import pytest
-from rest_framework.test import APIClient
+from rest_framework.test import APIClient, APIRequestFactory, force_authenticate
 
 from apps.system_mgmt.models import Channel, UserLoginLog
 from apps.system_mgmt.models.channel import ChannelChoices
+from apps.system_mgmt.viewset.user_login_log_viewset import UserLoginLogViewSet
 
 pytestmark = pytest.mark.django_db
 
@@ -228,3 +229,22 @@ def test_user_login_log_export_excel(super_client):
     resp = super_client.post(f"{V}/user_login_log/export_excel/", {"selected_ids": []}, format="json")
     assert resp.status_code == 200
     assert "spreadsheetml" in resp["Content-Type"]
+
+
+def test_user_login_log_export_excel_rejects_invalid_filters(super_client):
+    from apps.base.models import User as BaseUser
+
+    request = APIRequestFactory().post(
+        "/user_login_log/export_excel/",
+        {"login_time_start": "not-a-datetime"},
+        format="json",
+    )
+    request.COOKIES["current_team"] = "1"
+    force_authenticate(request, user=BaseUser.objects.get(username="chadmin"))
+
+    response = UserLoginLogViewSet.as_view({"post": "export_excel"})(request)
+
+    assert response.status_code == 400
+    assert response.data["message"] == "Invalid filter parameters"
+    assert list(response.data["errors"]) == ["login_time_start"]
+    assert [str(error) for error in response.data["errors"]["login_time_start"]] == ["Enter a valid date/time."]

--- a/server/apps/system_mgmt/tests/test_login_module_viewset_remaining.py
+++ b/server/apps/system_mgmt/tests/test_login_module_viewset_remaining.py
@@ -1,0 +1,130 @@
+"""LoginModuleViewSet 剩余：域名/重名校验、bk_lite 更新与级联删除。"""
+import json
+
+import pytest
+from django_celery_beat.models import IntervalSchedule, PeriodicTask
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.base.tests.factories import UserFactory
+from apps.system_mgmt.models import Group, LoginModule, User
+from apps.system_mgmt.viewset.login_module_viewset import LoginModuleViewSet
+
+pytestmark = pytest.mark.django_db
+factory = APIRequestFactory()
+
+
+def _actor():
+    user = UserFactory(domain="domain.com", is_superuser=True)
+    user.locale = "zh-Hans"
+    return user
+
+
+def _body(resp):
+    return json.loads(resp.content)
+
+
+def _req(action, method, actor, data=None, pk=None):
+    fn = getattr(factory, method)
+    request = fn("/x/", data=data or {}, format="json") if data is not None else fn("/x/")
+    force_authenticate(request, user=actor)
+    kwargs = {} if pk is None else {"pk": pk}
+    return LoginModuleViewSet.as_view({method: action})(request, **kwargs)
+
+
+def test_create_rejects_empty_domain_duplicate_name_and_bk_lite_domain():
+    actor = _actor()
+    empty = _req("create", "post", actor, data={"name": "ldap-a", "source_type": "ldap", "other_config": {}})
+    assert _body(empty)["result"] is False
+    assert _body(empty)["message"] == "创建登录模块需要提供域名。"
+
+    LoginModule.objects.create(name="ldap-a", source_type="ldap", other_config={"domain": "a.com"})
+    dup_name = _req(
+        "create",
+        "post",
+        actor,
+        data={"name": "ldap-a", "source_type": "ldap", "other_config": {"domain": "b.com"}},
+    )
+    assert _body(dup_name)["result"] is False
+    assert _body(dup_name)["message"] == "已存在同名且同类型的登录模块。"
+
+    LoginModule.objects.create(name="lite-a", source_type="bk_lite", other_config={"domain": "lite.com"})
+    dup_domain = _req(
+        "create",
+        "post",
+        actor,
+        data={"name": "ldap-b", "source_type": "ldap", "other_config": {"domain": "lite.com"}},
+    )
+    assert _body(dup_domain)["result"] is False
+    assert _body(dup_domain)["message"] == "该域名的登录模块已存在。"
+
+
+def test_update_bk_lite_validates_domain_name_and_domain_unique():
+    actor = _actor()
+    target = LoginModule.objects.create(name="lite-edit", source_type="bk_lite", other_config={"domain": "old.com"})
+    LoginModule.objects.create(name="lite-other", source_type="bk_lite", other_config={"domain": "taken.com"})
+
+    empty = _req(
+        "update",
+        "put",
+        actor,
+        data={"name": "lite-edit", "source_type": "bk_lite", "other_config": {}},
+        pk=target.id,
+    )
+    assert _body(empty)["result"] is False
+    assert _body(empty)["message"] == "创建登录模块需要提供域名。"
+
+    dup_name = _req(
+        "update",
+        "put",
+        actor,
+        data={"name": "lite-other", "source_type": "bk_lite", "other_config": {"domain": "new.com"}},
+        pk=target.id,
+    )
+    assert _body(dup_name)["result"] is False
+    assert _body(dup_name)["message"] == "已存在同名且同类型的登录模块。"
+
+    dup_domain = _req(
+        "update",
+        "put",
+        actor,
+        data={"name": "lite-edit", "source_type": "bk_lite", "other_config": {"domain": "taken.com"}},
+        pk=target.id,
+    )
+    assert _body(dup_domain)["result"] is False
+    assert _body(dup_domain)["message"] == "该域名的登录模块已存在。"
+
+
+def test_destroy_bk_lite_deletes_domain_users_groups_and_periodic_task():
+    actor = _actor()
+    top = Group.objects.create(name="LiteRoot", parent_id=0, description="lite-desc")
+    Group.objects.create(name="LiteChild", parent_id=top.id, description="lite-desc")
+    User.objects.create(
+        username="lite-user",
+        display_name="u",
+        email="u@lite.com",
+        password="x",
+        domain="lite-del.com",
+        group_list=[],
+    )
+    keep = User.objects.create(
+        username="keep-user",
+        display_name="k",
+        email="k@example.com",
+        password="x",
+        domain="other.com",
+        group_list=[],
+    )
+    schedule = IntervalSchedule.objects.create(every=1, period=IntervalSchedule.HOURS)
+    PeriodicTask.objects.create(name="sync_user_group_lite-del", interval=schedule, task="x")
+    module = LoginModule.objects.create(
+        name="lite-del",
+        source_type="bk_lite",
+        other_config={"domain": "lite-del.com", "root_group": "LiteRoot"},
+    )
+    resp = _req("destroy", "delete", actor, pk=module.id)
+    assert resp.status_code == 204
+    assert not LoginModule.objects.filter(pk=module.id).exists()
+    assert not User.objects.filter(username="lite-user").exists()
+    assert User.objects.filter(pk=keep.pk).exists()
+    assert not Group.objects.filter(description="lite-desc").exists()
+    assert not PeriodicTask.objects.filter(name="sync_user_group_lite-del").exists()

--- a/server/apps/system_mgmt/tests/test_nats_api_login_otp_channel.py
+++ b/server/apps/system_mgmt/tests/test_nats_api_login_otp_channel.py
@@ -1,0 +1,372 @@
+"""system_mgmt.nats_api：登录成功/OTP/改密/通道发送/规则删除。
+
+对照鉴权契约：密码正确签发 JWT；OTP 开启时只发 challenge；禁用账号拒绝；
+caller_token 必须匹配目标用户；未知通道拒绝发送。
+"""
+from datetime import timedelta
+from unittest.mock import patch
+
+import jwt
+import pyotp
+import pytest
+from django.contrib.auth.hashers import make_password
+from django.utils import timezone
+
+from apps.system_mgmt import nats_api
+from apps.system_mgmt.models import Channel, Group, GroupDataRule, Role, SystemSettings, User, UserRule
+from apps.system_mgmt.models.channel import ChannelChoices
+
+pytestmark = pytest.mark.django_db
+
+
+def _user(**kwargs):
+    defaults = dict(
+        username="login-user",
+        display_name="登录用户",
+        email="login-user@example.com",
+        password=make_password("secret-pass"),
+        domain="domain.com",
+        group_list=[1],
+        disabled=False,
+        otp_secret="",
+    )
+    defaults.update(kwargs)
+    return User.objects.create(**defaults)
+
+
+def test_login_success_issues_jwt(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    monkeypatch.setenv("JWT_ALGORITHM", "HS256")
+    user = _user(username="ok-user", password_last_modified=timezone.now())
+    monkeypatch.setattr(
+        nats_api,
+        "_get_pwd_policy_settings",
+        lambda: {
+            "pwd_set_validity_period": 0,
+            "pwd_set_expiry_reminder_days": 7,
+            "pwd_set_max_retry_count": 5,
+            "pwd_set_lock_duration": 60,
+        },
+    )
+    result = nats_api.login("ok-user", "secret-pass")
+    assert result["result"] is True
+    token = result["data"]["token"]
+    payload = jwt.decode(token, "test-secret", algorithms=["HS256"])
+    assert payload["user_id"] == user.id
+    assert result["data"]["username"] == "ok-user"
+    assert result["data"]["password_expiry_reminder"] == ""
+    user.refresh_from_db()
+    assert user.password_error_count == 0
+    assert user.last_login is not None
+
+
+def test_login_rejects_disabled_user(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    _user(username="off-user", disabled=True)
+    result = nats_api.login("off-user", "secret-pass")
+    assert result == {"result": False, "message": "User is disabled"}
+
+
+def test_login_expired_password_blocks_non_admin(monkeypatch):
+    _user(username="expired-user", password_last_modified=timezone.now() - timedelta(days=400))
+    monkeypatch.setattr(
+        nats_api,
+        "_get_pwd_policy_settings",
+        lambda: {
+            "pwd_set_validity_period": 90,
+            "pwd_set_expiry_reminder_days": 7,
+            "pwd_set_max_retry_count": 5,
+            "pwd_set_lock_duration": 60,
+        },
+    )
+    result = nats_api.login("expired-user", "secret-pass")
+    assert result == {
+        "result": False,
+        "message": "您的密码已过期,请联系管理员重置密码。",
+    }
+
+
+def test_login_otp_enabled_returns_challenge_not_token(monkeypatch):
+    user = _user(username="otp-user", otp_secret=pyotp.random_base32())
+    SystemSettings.objects.update_or_create(key="enable_otp", defaults={"value": "1"})
+    monkeypatch.setattr(
+        nats_api,
+        "_get_pwd_policy_settings",
+        lambda: {
+            "pwd_set_validity_period": 0,
+            "pwd_set_expiry_reminder_days": 7,
+            "pwd_set_max_retry_count": 5,
+            "pwd_set_lock_duration": 60,
+        },
+    )
+    result = nats_api.login("otp-user", "secret-pass")
+    assert result["result"] is True
+    assert result["data"]["require_otp"] is True
+    assert result["data"]["challenge_id"]
+    assert "token" not in result["data"]
+    user.refresh_from_db()
+    assert user.otp_secret
+
+
+def test_verify_otp_code_success_and_invalid():
+    secret = pyotp.random_base32()
+    _user(username="otp-check", otp_secret=secret)
+    with patch("apps.system_mgmt.nats_api.check_rate_limit", return_value=(False, 5)):
+        ok = nats_api.verify_otp_code("otp-check", pyotp.TOTP(secret).now(), client_ip="1.1.1.1")
+        bad = nats_api.verify_otp_code("otp-check", "000000", client_ip="1.1.1.1")
+    assert ok == {"result": True, "message": "Verification successful"}
+    assert bad["result"] is False
+    assert "Invalid OTP" in bad["message"]
+
+    missing = nats_api.verify_otp_code_by_user_id(999999, "123456")
+    assert missing["result"] is False
+
+
+def test_verify_otp_login_expired_challenge():
+    with patch("apps.system_mgmt.nats_api.verify_challenge", return_value=None):
+        result = nats_api.verify_otp_login("gone", "123456")
+    assert result["result"] is False
+    assert "challenge" in result["message"].lower()
+
+
+def test_get_user_login_token_first_bind_includes_qr(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    user = _user(username="bind-user", otp_secret="")
+    SystemSettings.objects.update_or_create(key="enable_otp", defaults={"value": "1"})
+    result = nats_api.get_user_login_token(user, "bind-user", skip_token_for_otp=True)
+    assert result["result"] is True
+    assert result["data"]["need_binding"] is True
+    assert result["data"]["qr_code"]
+    user.refresh_from_db()
+    assert user.otp_secret
+
+
+def test_reset_pwd_requires_matching_caller(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    monkeypatch.setenv("JWT_ALGORITHM", "HS256")
+    user = _user(username="self-user")
+    missing = nats_api.reset_pwd("self-user", "domain.com", "Newpass1!")
+    assert missing["result"] is False
+    assert "caller_token" in missing["message"]
+
+    other = _user(username="other-user")
+    token = jwt.encode({"user_id": other.id, "login_time": timezone.now().timestamp()}, "test-secret", algorithm="HS256")
+    mismatch = nats_api.reset_pwd("self-user", "domain.com", "Newpass1!", caller_token=token)
+    assert mismatch["result"] is False
+    assert "Unauthorized" in mismatch["message"]
+
+    self_token = jwt.encode(
+        {"user_id": user.id, "user_id_str": str(user.id), "login_time": timezone.now().timestamp()},
+        "test-secret",
+        algorithm="HS256",
+    )
+    with (
+        patch.object(nats_api, "_verify_token", return_value=user),
+        patch("apps.system_mgmt.nats_api.PasswordValidator.validate_password", return_value=(True, "")),
+    ):
+        ok = nats_api.reset_pwd("self-user", "domain.com", "Newpass1!", caller_token=self_token)
+    assert ok == {"result": True}
+
+
+def test_send_msg_with_channel_missing_and_unsupported():
+    missing = nats_api.send_msg_with_channel(999999, "t", "c", [1])
+    assert missing == {"result": False, "message": "Channel not found"}
+
+    channel = Channel.objects.create(
+        name="wechat",
+        channel_type=ChannelChoices.ENTERPRISE_WECHAT,
+        config={},
+        description="",
+        team=[1],
+    )
+    unsupported = nats_api.send_msg_with_channel(channel.id, "t", "c", [1])
+    assert unsupported == {"result": False, "message": "Unsupported channel type"}
+
+
+def test_send_msg_email_requires_recipients_and_delegates():
+    channel = Channel.objects.create(
+        name="mail",
+        channel_type=ChannelChoices.EMAIL,
+        config={"host": "smtp"},
+        description="",
+        team=[1],
+    )
+    empty = nats_api.send_msg_with_channel(channel.id, "t", "c", [])
+    assert empty["result"] is False
+    assert "recipient" in empty["message"].lower()
+
+    user = _user(username="mail-user")
+    with patch("apps.system_mgmt.nats.channels.send_email", return_value={"result": True}) as send:
+        ok = nats_api.send_msg_with_channel(channel.id, "Hello", "body", [user.id])
+    assert ok == {"result": True}
+    send.assert_called_once()
+
+
+def test_send_msg_wecom_bot_uses_display_names():
+    channel = Channel.objects.create(
+        name="bot",
+        channel_type=ChannelChoices.ENTERPRISE_WECHAT_BOT,
+        config={"webhook": "http://x"},
+        description="",
+        team=[1],
+    )
+    user = _user(username="bot-user", display_name="小明")
+    with patch("apps.system_mgmt.nats.channels.send_by_wecom_bot", return_value={"result": True}) as send:
+        ok = nats_api.send_msg_with_channel(channel.id, "", "hi", [user.id])
+    assert ok == {"result": True}
+    assert "小明" in send.call_args.args[2]
+
+
+def test_delete_rules_removes_instance_and_skips_missing_module():
+    group = Group.objects.create(name="rule-g", parent_id=0)
+    rule = GroupDataRule.objects.create(
+        name="r1",
+        app="opspilot",
+        group_id=group.id,
+        group_name=group.name,
+        rules={"bot": [{"id": 11}, {"id": 22}], "skill": [{"id": 3}]},
+    )
+    skipped = GroupDataRule.objects.create(
+        name="r2",
+        app="opspilot",
+        group_id=group.id,
+        group_name=group.name,
+        rules={"other": [{"id": 11}]},
+    )
+    result = nats_api.delete_rules([group.id], 11, "opspilot", "bot", "")
+    assert result["result"] is True
+    rule.refresh_from_db()
+    assert [item["id"] for item in rule.rules["bot"]] == [22]
+    skipped.refresh_from_db()
+    assert skipped.rules["other"] == [{"id": 11}]
+
+
+def test_get_user_rules_by_app_admin_and_instance_scope():
+    group = Group.objects.create(name="team-a", parent_id=0)
+    admin_role, _ = Role.objects.get_or_create(name="admin", app="")
+    admin = _user(username="rules-admin", role_list=[admin_role.id], group_list=[group.id])
+    admin_result = nats_api.get_user_rules_by_app(group.id, admin.username, "domain.com", "opspilot", "bot")
+    assert admin_result["instance"] == []
+    assert group.id in admin_result["team"]
+
+    normal = _user(username="rules-user", group_list=[group.id], role_list=[])
+    gdr = GroupDataRule.objects.create(
+        name="bot-rule",
+        app="opspilot",
+        group_id=group.id,
+        group_name=group.name,
+        rules={"bot": [{"id": 88, "permission": ["View"]}]},
+    )
+    UserRule.objects.create(username=normal.username, domain="domain.com", group_rule=gdr)
+    scoped = nats_api.get_user_rules_by_app(group.id, normal.username, "domain.com", "opspilot", "bot")
+    assert [item["id"] for item in scoped["instance"]] == [88]
+
+
+def test_get_login_module_domain_list_always_includes_default():
+    result = nats_api.get_login_module_domain_list()
+    assert result["result"] is True
+    assert result["data"][0] == "domain.com"
+
+
+def test_wechat_user_register_issues_token_and_guest_group(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    monkeypatch.setenv("JWT_ALGORITHM", "HS256")
+    guest = Group.objects.create(name="OpsPilotGuest", parent_id=0)
+    with patch("apps.system_mgmt.nats_api.set_opspilot_guest_group_default_rule"):
+        first = nats_api.wechat_user_register("wx-user-1", "微信用户")
+    assert first["result"] is True
+    assert first["data"]["is_first_login"] is True
+    assert first["data"]["username"] == "wx-user-1"
+    assert first["data"]["token"]
+    user = User.objects.get(username="wx-user-1")
+    assert guest.id in user.group_list
+    assert user.last_login is not None
+
+    with patch("apps.system_mgmt.nats_api.set_opspilot_guest_group_default_rule"):
+        again = nats_api.wechat_user_register("wx-user-1", "新昵称忽略")
+    assert again["data"]["is_first_login"] is False
+    assert again["data"]["id"] == first["data"]["id"]
+
+
+def test_get_user_rules_by_module_user_not_found():
+    result = nats_api.get_user_rules_by_module(1, "ghost", "domain.com", "opspilot", "bot")
+    assert result == {"result": False, "message": "User not found"}
+
+
+def test_get_user_rules_by_module_admin_gets_all_permission():
+    group = Group.objects.create(name="mod-admin-g", parent_id=0)
+    admin_role, _ = Role.objects.get_or_create(name="admin", app="")
+    admin = _user(username="mod-admin", role_list=[admin_role.id], group_list=[group.id])
+    result = nats_api.get_user_rules_by_module(group.id, admin.username, "domain.com", "opspilot", "bot")
+    assert result["result"] is True
+    assert result["data"] == {"all": {"instance": [], "team": [group.id]}}
+    assert group.id in result["team"]
+
+
+def test_get_user_rules_by_module_nested_and_flat_rules():
+    group = Group.objects.create(name="mod-user-g", parent_id=0)
+    user = _user(username="mod-user", group_list=[group.id], role_list=[])
+    gdr = GroupDataRule.objects.create(
+        name="mod-rule",
+        app="opspilot",
+        group_id=group.id,
+        group_name=group.name,
+        rules={
+            "provider": {"llm_model": [{"id": 7, "permission": ["View"]}]},
+            "bot": [{"id": 88, "permission": ["View"]}],
+        },
+    )
+    UserRule.objects.create(username=user.username, domain="domain.com", group_rule=gdr)
+    nested = nats_api.get_user_rules_by_module(group.id, user.username, "domain.com", "opspilot", "provider")
+    assert nested["result"] is True
+    assert 7 in [item["id"] if isinstance(item, dict) else item for item in nested["data"]["llm_model"]["instance"]]
+
+
+def test_get_user_rules_by_module_empty_rules_returns_empty_data():
+    group = Group.objects.create(name="mod-empty-g", parent_id=0)
+    user = _user(username="mod-empty", group_list=[group.id], role_list=[])
+    result = nats_api.get_user_rules_by_module(group.id, user.username, "domain.com", "opspilot", "bot")
+    assert result["result"] is True
+    assert result["data"] == {}
+
+
+def test_send_msg_unknown_channel_and_unsupported_type():
+    assert nats_api.send_msg_with_channel(999999, "t", "c", [1]) == {"result": False, "message": "Channel not found"}
+    channel = Channel.objects.create(name="weird", channel_type="unknown-type", config={}, description="", team=[1])
+    out = nats_api.send_msg_with_channel(channel.id, "t", "c", [1])
+    assert out == {"result": False, "message": "Unsupported channel type"}
+
+
+def test_send_msg_email_requires_recipients():
+    channel = Channel.objects.create(
+        name="mail",
+        channel_type=ChannelChoices.EMAIL,
+        config={"smtp_host": "localhost"},
+        description="",
+        team=[1],
+    )
+    out = nats_api.send_msg_with_channel(channel.id, "t", "c", [999999])
+    assert out["result"] is False
+    assert "No valid recipients" in out["message"]
+
+
+def test_search_opspilot_nats_channels_filters_source():
+    Channel.objects.create(
+        name="owned",
+        channel_type=ChannelChoices.NATS,
+        config={"source": nats_api.OPSPILOT_CHANNEL_SOURCE, "bot_id": "11", "node_id": "n1"},
+        description="d",
+        team=[1],
+    )
+    Channel.objects.create(
+        name="other",
+        channel_type=ChannelChoices.NATS,
+        config={"source": "manual", "bot_id": "11"},
+        description="",
+        team=[1],
+    )
+    result = nats_api.search_opspilot_nats_channels(bot_id=11)
+    assert result["result"] is True
+    names = [item["name"] for item in result["data"]]
+    assert names == ["owned"]
+    assert result["data"][0]["node_id"] == "n1"

--- a/server/apps/system_mgmt/tests/test_nats_api_remaining_handlers.py
+++ b/server/apps/system_mgmt/tests/test_nats_api_remaining_handlers.py
@@ -1,0 +1,133 @@
+"""system_mgmt.nats_api 剩余鉴权/通道/OTP/蓝鲸登录契约。"""
+from unittest.mock import patch
+
+import jwt
+import pyotp
+import pytest
+from django.contrib.auth.hashers import make_password
+
+from apps.system_mgmt import nats_api
+from apps.system_mgmt.models import Channel, Group, LoginModule, Role, User
+from apps.system_mgmt.models.channel import ChannelChoices
+
+pytestmark = pytest.mark.django_db
+
+
+def _user(**kwargs):
+    defaults = dict(
+        username="remain-user",
+        display_name="剩余用户",
+        email="remain@example.com",
+        password=make_password("secret-pass"),
+        domain="domain.com",
+        group_list=[1],
+        disabled=False,
+        otp_secret="",
+    )
+    defaults.update(kwargs)
+    return User.objects.create(**defaults)
+
+
+def test_generate_qr_code_by_user_id_missing_and_success():
+    assert nats_api.generate_qr_code_by_user_id(999999) == {"result": False, "message": "User not found"}
+    user = _user(username="qr-user")
+    out = nats_api.generate_qr_code_by_user_id(user.id)
+    assert out["result"] is True
+    assert out["data"]["qr_code"]
+    user.refresh_from_db()
+    assert user.otp_secret
+
+
+def test_verify_otp_code_by_user_id_paths():
+    assert nats_api.verify_otp_code_by_user_id(999999, "000000") == {"result": False, "message": "User not found"}
+    user = _user(username="otp-uid", otp_secret="")
+    assert nats_api.verify_otp_code_by_user_id(user.id, "000000")["message"] == "OTP not configured for this user"
+    secret = pyotp.random_base32()
+    user.otp_secret = secret
+    user.save()
+    code = pyotp.TOTP(secret).now()
+    assert nats_api.verify_otp_code_by_user_id(user.id, code) == {"result": True, "message": "Verification successful"}
+    assert nats_api.verify_otp_code_by_user_id(user.id, "000000")["message"] == "Invalid OTP code"
+
+
+def test_verify_otp_code_missing_user_and_unconfigured():
+    assert nats_api.verify_otp_code("ghost", "000000", "1.1.1.1")["message"] == "User not found"
+    user = _user(username="otp-none", otp_secret="")
+    assert nats_api.verify_otp_code(user.username, "000000", "1.1.1.1")["message"] == "OTP not configured for this user"
+
+
+def test_get_namespace_by_domain_found_and_missing():
+    assert nats_api.get_namespace_by_domain("no.such")["result"] is False
+    LoginModule.objects.create(
+        name="bk-lite-mod",
+        source_type="bk_lite",
+        other_config={"domain": "corp.example", "namespace": "ns-a"},
+    )
+    out = nats_api.get_namespace_by_domain("corp.example")
+    assert out == {"result": True, "data": "ns-a"}
+
+
+def test_bk_lite_user_login_unknown_and_disabled(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    monkeypatch.setenv("JWT_ALGORITHM", "HS256")
+    assert nats_api.bk_lite_user_login("ghost", "domain.com")["result"] is False
+    user = _user(username="bk-disabled", disabled=True)
+    out = nats_api.bk_lite_user_login(user.username, user.domain)
+    assert out == {"result": False, "message": "User is disabled"}
+    enabled = _user(username="bk-ok")
+    ok = nats_api.bk_lite_user_login(enabled.username, enabled.domain)
+    assert ok["result"] is True
+    assert ok["data"]["token"]
+
+
+def test_verify_bk_token_closed_open_and_success(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    monkeypatch.setenv("JWT_ALGORITHM", "HS256")
+    closed = nats_api.verify_bk_token("tok")
+    assert closed["data"]["bk_login_open"] is False
+
+    group = Group.objects.create(name="蓝鲸", parent_id=0)
+    LoginModule.objects.create(
+        name="bk-login",
+        source_type="bk_login",
+        enabled=True,
+        other_config={"bk_url": "https://bk.example", "app_id": "a", "app_token": "t", "root_group": "蓝鲸", "default_roles": []},
+    )
+    empty = nats_api.verify_bk_token("")
+    assert empty["data"]["bk_login_open"] is True
+    assert empty["data"]["user"] == {}
+    assert empty["data"]["url"] == "https://bk.example"
+
+    with patch("apps.system_mgmt.nats_api.get_bk_user_info", return_value=(False, {})):
+        failed = nats_api.verify_bk_token("bad")
+    assert failed["data"]["user"] == {}
+
+    bk_user = {"username": "bk-u1", "domain": "domain.com", "email": "u@bk", "language": "zh-Hans", "time_zone": "Asia/Shanghai"}
+    with patch("apps.system_mgmt.nats_api.get_bk_user_info", return_value=(True, bk_user)):
+        ok = nats_api.verify_bk_token("good")
+    assert ok["data"]["user"]["username"] == "bk-u1"
+    payload = jwt.decode(ok["data"]["user"]["token"], "test-secret", algorithms=["HS256"])
+    assert payload["user_id"] == User.objects.get(username="bk-u1").id
+    assert group.id in User.objects.get(username="bk-u1").group_list
+
+
+def test_search_channel_list_scoped_requires_actor():
+    Channel.objects.create(name="c1", channel_type=ChannelChoices.EMAIL, config={}, description="", team=[1])
+    empty = nats_api.search_channel_list_scoped({}, channel_type="email")
+    assert empty["result"] is True
+    assert empty["data"] == []
+    admin_role, _ = Role.objects.get_or_create(name="admin", app="")
+    admin = _user(username="chan-admin", role_list=[admin_role.id], group_list=[1])
+    scoped = nats_api.search_channel_list_scoped(
+        {
+            "username": admin.username,
+            "domain": admin.domain,
+            "is_superuser": True,
+            "group_list": [1],
+            "current_team": 1,
+        },
+        channel_type="email",
+        teams=[1],
+    )
+    assert scoped["result"] is True
+    assert any(item["name"] == "c1" for item in scoped["data"])

--- a/server/apps/system_mgmt/tests/test_nats_get_user_rules.py
+++ b/server/apps/system_mgmt/tests/test_nats_get_user_rules.py
@@ -1,0 +1,34 @@
+"""NATS 用户规则查询：按组织拆分 guest/normal 规则。"""
+import pytest
+
+from apps.system_mgmt import nats_api
+from apps.system_mgmt.models import Group, GroupDataRule, UserRule
+
+pytestmark = pytest.mark.django_db
+
+
+def test_get_user_rules_empty_and_guest_vs_normal():
+    assert nats_api.get_user_rules(1, "nobody") == {}
+
+    group = Group.objects.create(name="rules-team", parent_id=0)
+    guest = Group.objects.create(name="OpsPilotGuest", parent_id=0)
+    normal_rule = GroupDataRule.objects.create(
+        name="bot-normal",
+        app="opspilot",
+        group_id=group.id,
+        group_name=group.name,
+        rules={"bot": [{"id": 3}]},
+    )
+    guest_rule = GroupDataRule.objects.create(
+        name="bot-guest",
+        app="opspilot",
+        group_id=guest.id,
+        group_name="OpsPilotGuest",
+        rules={"bot": [{"id": 9}]},
+    )
+    UserRule.objects.create(username="rules-u", domain="domain.com", group_rule=normal_rule)
+    UserRule.objects.create(username="rules-u", domain="domain.com", group_rule=guest_rule)
+
+    out = nats_api.get_user_rules(group.id, "rules-u")
+    assert out["opspilot"]["normal"] == {"bot": [{"id": 3}]}
+    assert out["opspilot"]["guest"] == {"bot": [{"id": 9}]}

--- a/server/apps/system_mgmt/tests/test_user_viewset_remaining.py
+++ b/server/apps/system_mgmt/tests/test_user_viewset_remaining.py
@@ -1,0 +1,299 @@
+"""UserViewSet 剩余：列表分页、创建校验、重置密码与状态变更鉴权。"""
+import json
+
+import pytest
+from django.contrib.auth.hashers import check_password
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.base.tests.factories import UserFactory
+from apps.system_mgmt.models import Group, User
+from apps.system_mgmt.viewset.user_viewset import UserViewSet
+
+pytestmark = pytest.mark.django_db
+factory = APIRequestFactory()
+
+
+def _body(resp):
+    return json.loads(resp.content)
+
+
+def _actor(**kwargs):
+    user = UserFactory(domain="domain.com", is_superuser=True)
+    user.group_list = kwargs.get("group_list", [{"id": 1}])
+    user.locale = "zh-Hans"
+    return user
+
+
+def _req(action, method, actor, data=None, query=""):
+    path = f"/x/?{query}" if query else "/x/"
+    fn = getattr(factory, method)
+    request = fn(path) if data is None else fn(path, data=data, format="json")
+    force_authenticate(request, user=actor)
+    return UserViewSet.as_view({method: action})(request)
+
+
+def test_search_user_list_paginates_and_filters():
+    group = Group.objects.create(name="uv-search")
+    actor = _actor(group_list=[{"id": group.id}])
+    User.objects.create(
+        username="uv-alice",
+        display_name="Alice",
+        email="alice@example.com",
+        password="x",
+        group_list=[group.id],
+        domain="domain.com",
+    )
+    User.objects.create(
+        username="uv-bob",
+        display_name="Bob",
+        email="bob@example.com",
+        password="x",
+        group_list=[group.id],
+        domain="domain.com",
+    )
+    User.objects.create(
+        username="uv-other",
+        display_name="Other",
+        email="other@example.com",
+        password="x",
+        group_list=[999],
+        domain="domain.com",
+    )
+    resp = _req("search_user_list", "get", actor, query="search=uv-&page=1&page_size=1")
+    body = _body(resp)
+    assert body["result"] is True
+    assert body["data"]["count"] >= 2
+    assert len(body["data"]["users"]) == 1
+
+
+def test_user_all_and_user_id_all_scope_to_accessible_groups():
+    group = Group.objects.create(name="uv-all")
+    actor = _actor(group_list=[{"id": group.id}])
+    actor.is_superuser = False
+    actor.permission = {"user_group-View"}
+    visible = User.objects.create(
+        username="uv-visible",
+        display_name="可见",
+        email="v@example.com",
+        password="x",
+        group_list=[group.id],
+        domain="domain.com",
+    )
+    User.objects.create(
+        username="uv-hidden",
+        display_name="隐藏",
+        email="h@example.com",
+        password="x",
+        group_list=[888],
+        domain="domain.com",
+    )
+    all_resp = _req("user_all", "get", actor)
+    names = {item["username"] for item in _body(all_resp)["data"]}
+    assert "uv-visible" in names
+    assert "uv-hidden" not in names
+
+    ids_resp = _req("user_id_all", "get", actor)
+    ids = {item["id"] for item in _body(ids_resp)["data"]}
+    assert visible.id in ids
+
+
+def test_create_user_rejects_empty_groups_invalid_role_and_phone():
+    actor = _actor()
+    empty = _req("create_user", "post", actor, data={"username": "n", "groups": []})
+    assert _body(empty)["result"] is False
+    assert _body(empty)["message"] == "至少选择一个组织"
+
+    group = Group.objects.create(name="uv-create")
+    bad_role = _req(
+        "create_user",
+        "post",
+        actor,
+        data={
+            "username": "uv-new",
+            "lastName": "新用户",
+            "email": "n@example.com",
+            "locale": "zh-Hans",
+            "timezone": "Asia/Shanghai",
+            "groups": [group.id],
+            "roles": [987654],
+        },
+    )
+    assert _body(bad_role)["result"] is False
+    assert "987654" in _body(bad_role)["message"]
+
+    bad_phone = _req(
+        "create_user",
+        "post",
+        actor,
+        data={
+            "username": "uv-phone",
+            "lastName": "电话",
+            "email": "p@example.com",
+            "locale": "zh-Hans",
+            "timezone": "Asia/Shanghai",
+            "groups": [group.id],
+            "roles": [],
+            "phone": "abc",
+        },
+    )
+    assert _body(bad_phone) == {"result": False, "message": "手机号格式不正确"}
+
+
+def test_create_user_forbids_unauthorized_group(monkeypatch):
+    group = Group.objects.create(name="uv-scope")
+    actor = _actor()
+    actor.is_superuser = False
+    actor.group_list = [{"id": 1}]
+    actor.permission = {"user_group-Add User"}
+    monkeypatch.setattr(
+        "apps.system_mgmt.viewset.user_viewset.get_unauthorized_group_ids",
+        lambda user, group_ids: [group.id],
+    )
+    resp = _req(
+        "create_user",
+        "post",
+        actor,
+        data={
+            "username": "uv-scope-u",
+            "lastName": "越权",
+            "email": "s@example.com",
+            "locale": "zh-Hans",
+            "timezone": "Asia/Shanghai",
+            "groups": [group.id],
+            "roles": [],
+        },
+    )
+    assert resp.status_code == 403
+    assert _body(resp)["result"] is False
+
+
+def test_create_user_success(monkeypatch):
+    group = Group.objects.create(name="uv-ok")
+    actor = _actor()
+    monkeypatch.setattr("apps.system_mgmt.viewset.user_viewset.log_operation", lambda *a, **k: None)
+    resp = _req(
+        "create_user",
+        "post",
+        actor,
+        data={
+            "username": "uv-created",
+            "lastName": "创建成功",
+            "email": "c@example.com",
+            "locale": "zh-Hans",
+            "timezone": "Asia/Shanghai",
+            "groups": [group.id],
+            "roles": [],
+        },
+    )
+    assert _body(resp) == {"result": True}
+    user = User.objects.get(username="uv-created")
+    assert user.display_name == "创建成功"
+    assert user.group_list == [group.id]
+
+
+def test_reset_password_empty_invalid_and_forbidden(monkeypatch):
+    group = Group.objects.create(name="uv-pwd")
+    actor = _actor()
+    target = User.objects.create(
+        username="uv-pwd-t",
+        display_name="t",
+        email="t@example.com",
+        password="old",
+        group_list=[999],
+        domain="domain.com",
+    )
+    empty = _req("reset_password", "post", actor, data={"id": target.id, "password": ""})
+    assert empty.status_code == 400
+    assert _body(empty) == {"result": False, "message": "密码不能为空"}
+
+    monkeypatch.setattr(
+        "apps.system_mgmt.viewset.user_viewset.PasswordValidator.validate_password",
+        lambda pwd, locale=None: (False, "密码太弱"),
+    )
+    weak = _req("reset_password", "post", actor, data={"id": target.id, "password": "123"})
+    assert weak.status_code == 400
+    assert _body(weak) == {"result": False, "message": "密码太弱"}
+
+    actor.is_superuser = False
+    actor.group_list = [{"id": group.id}]
+    actor.permission = {"user_group-Edit User"}
+    monkeypatch.setattr(
+        "apps.system_mgmt.viewset.user_viewset.PasswordValidator.validate_password",
+        lambda pwd, locale=None: (True, ""),
+    )
+    resp = _req("reset_password", "post", actor, data={"id": target.id, "password": "GoodPass1!"})
+    assert resp.status_code == 403
+    assert _body(resp)["result"] is False
+
+
+def test_reset_password_success(monkeypatch):
+    group = Group.objects.create(name="uv-pwd-ok")
+    actor = _actor(group_list=[{"id": group.id}])
+    target = User.objects.create(
+        username="uv-pwd-ok-t",
+        display_name="t",
+        email="ok@example.com",
+        password="old",
+        group_list=[group.id],
+        domain="domain.com",
+    )
+    monkeypatch.setattr(
+        "apps.system_mgmt.viewset.user_viewset.PasswordValidator.validate_password",
+        lambda pwd, locale=None: (True, ""),
+    )
+    monkeypatch.setattr("apps.system_mgmt.viewset.user_viewset.log_operation", lambda *a, **k: None)
+    resp = _req("reset_password", "post", actor, data={"id": target.id, "password": "GoodPass1!", "temporary": True})
+    assert _body(resp) == {"result": True}
+    target.refresh_from_db()
+    assert target.temporary_pwd is True
+    assert check_password("GoodPass1!", target.password)
+
+
+def test_change_status_validates_and_skips():
+    actor = _actor()
+    empty = _req("change_status", "post", actor, data={"user_ids": [], "action": "enable"})
+    assert empty.status_code == 400
+    assert _body(empty)["message"] == "user_ids 必须是非空列表"
+
+    bad_action = _req("change_status", "post", actor, data={"user_ids": [1], "action": "freeze"})
+    assert bad_action.status_code == 400
+    assert _body(bad_action)["message"] == "action 必须是 enable、disable 或 unlock"
+
+    bad_id = _req("change_status", "post", actor, data={"user_ids": ["x"], "action": "enable"})
+    assert bad_id.status_code == 400
+    assert _body(bad_id)["message"] == "非法的用户 ID: ['x']"
+
+    missing = _req("change_status", "post", actor, data={"user_ids": [999999], "action": "enable"})
+    assert _body(missing)["data"]["skipped"] == [{"id": 999999, "reason": "user_not_found"}]
+
+
+def test_change_status_disable_and_skip_already_disabled(monkeypatch):
+    group = Group.objects.create(name="uv-status")
+    actor = _actor(group_list=[{"id": group.id}])
+    enabled = User.objects.create(
+        username="uv-en",
+        display_name="en",
+        email="en@example.com",
+        password="x",
+        group_list=[group.id],
+        domain="domain.com",
+        disabled=False,
+    )
+    disabled = User.objects.create(
+        username="uv-dis",
+        display_name="dis",
+        email="dis@example.com",
+        password="x",
+        group_list=[group.id],
+        domain="domain.com",
+        disabled=True,
+    )
+    monkeypatch.setattr("apps.system_mgmt.viewset.user_viewset.log_operation", lambda *a, **k: None)
+    monkeypatch.setattr("apps.system_mgmt.viewset.user_viewset.clear_user_permission_cache", lambda *a, **k: None)
+    resp = _req("change_status", "post", actor, data={"user_ids": [enabled.id, disabled.id], "action": "disable"})
+    body = _body(resp)
+    assert body["result"] is True
+    assert body["data"]["success_ids"] == [enabled.id]
+    assert body["data"]["skipped"] == [{"id": disabled.id, "reason": "user_not_enabled"}]
+    enabled.refresh_from_db()
+    assert enabled.disabled is True


### PR DESCRIPTION
## 变更说明

- 基于原 PR #4 的冻结快照，筛选并适配当前 master 可用的测试。
- 补齐 DRF ViewSet actions、NATS handlers、公开 Service 方法及 Management Command handle 的行为覆盖。
- 覆盖 MLOps 六类算法视图、OpsPilot Bot/Memory 与运维工具、System/Node/Monitor/CMDB 等关键路径。
- 仅修改测试代码，不修改生产实现。

## 覆盖率

按排除 tests、migrations 与遗留 tests.py 后的业务源码口径：

- 基线：80.52%（156326 / 194143）
- 当前：81.95%（159109 / 194143）
- 净新增覆盖：2783 行生产代码

## 验证

- 相关测试：543 passed，2 skipped
- Black 23.1.0：通过
- isort 5.10.1：通过
- flake8 7.1.1：通过
- git diff --check：通过