### PR TITLE
bugfix: 补齐全局监控 REST 写权限

### DIFF
--- a/server/apps/monitor/tests/conftest.py
+++ b/server/apps/monitor/tests/conftest.py
@@ -1,0 +1,26 @@
+import pytest
+
+MONITOR_ADMIN_WRITE_PERMISSIONS = {
+    "object-Add",
+    "object-Edit",
+    "object-Delete",
+    "integration_metric-Add Group",
+    "integration_metric-Edit Group",
+    "integration_metric-Delete Group",
+    "integration_metric-Add Metric",
+    "integration_metric-Edit Metric",
+    "integration_metric-Delete Metric",
+    "strategy_list-Add",
+    "strategy_list-Edit",
+    "strategy_list-Delete",
+}
+
+
+@pytest.fixture(autouse=True)
+def grant_monitor_admin_write_permissions(request):
+    """让全局 api_client 的 admin 测试用户具备既有 Monitor 写权限。"""
+    if "api_client" not in request.fixturenames:
+        return
+    user = request.getfixturevalue("authenticated_user")
+    if "admin" in (getattr(user, "roles", None) or []):
+        user.permission = {"monitor": set(MONITOR_ADMIN_WRITE_PERMISSIONS)}

--- a/server/apps/monitor/tests/test_global_write_action_permissions_views.py
+++ b/server/apps/monitor/tests/test_global_write_action_permissions_views.py
@@ -1,0 +1,76 @@
+from types import SimpleNamespace
+
+import pytest
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.monitor.views.monitor_metrics import MetricGroupViewSet, MetricViewSet
+from apps.monitor.views.monitor_object import MonitorObjectTypeViewSet, MonitorObjectViewSet
+from apps.monitor.views.monitor_policy import MonitorPolicyViewSet
+
+pytestmark = pytest.mark.unit
+
+
+WRITE_ACTION_CASES = [
+    pytest.param(MonitorObjectTypeViewSet, "post", "create", {}, "object-Add", id="object-type-create"),
+    pytest.param(MonitorObjectTypeViewSet, "put", "update", {"pk": "missing"}, "object-Edit", id="object-type-update"),
+    pytest.param(MonitorObjectTypeViewSet, "patch", "partial_update", {"pk": "missing"}, "object-Edit", id="object-type-partial"),
+    pytest.param(MonitorObjectTypeViewSet, "delete", "destroy", {"pk": "missing"}, "object-Delete", id="object-type-delete"),
+    pytest.param(MonitorObjectViewSet, "post", "create", {}, "object-Add", id="object-create"),
+    pytest.param(MonitorObjectViewSet, "put", "update", {"pk": "missing"}, "object-Edit", id="object-update"),
+    pytest.param(MonitorObjectViewSet, "patch", "partial_update", {"pk": "missing"}, "object-Edit", id="object-partial"),
+    pytest.param(MonitorObjectViewSet, "delete", "destroy", {"pk": "missing"}, "object-Delete", id="object-delete"),
+    pytest.param(MonitorObjectViewSet, "post", "order", {}, "object-Edit", id="object-order"),
+    pytest.param(MonitorObjectViewSet, "post", "visibility", {"pk": "missing"}, "object-Edit", id="object-visibility"),
+    pytest.param(MonitorObjectViewSet, "post", "display_fields", {"pk": "missing"}, "object-Edit", id="object-display-fields"),
+    pytest.param(MetricGroupViewSet, "post", "create", {}, "integration_metric-Add Group", id="metric-group-create"),
+    pytest.param(MetricGroupViewSet, "put", "update", {"pk": "missing"}, "integration_metric-Edit Group", id="metric-group-update"),
+    pytest.param(MetricGroupViewSet, "patch", "partial_update", {"pk": "missing"}, "integration_metric-Edit Group", id="metric-group-partial"),
+    pytest.param(MetricGroupViewSet, "delete", "destroy", {"pk": "missing"}, "integration_metric-Delete Group", id="metric-group-delete"),
+    pytest.param(MetricGroupViewSet, "post", "set_order", {}, "integration_metric-Edit Group", id="metric-group-order"),
+    pytest.param(MetricViewSet, "post", "create", {}, "integration_metric-Add Metric", id="metric-create"),
+    pytest.param(MetricViewSet, "put", "update", {"pk": "missing"}, "integration_metric-Edit Metric", id="metric-update"),
+    pytest.param(MetricViewSet, "patch", "partial_update", {"pk": "missing"}, "integration_metric-Edit Metric", id="metric-partial"),
+    pytest.param(MetricViewSet, "delete", "destroy", {"pk": "missing"}, "integration_metric-Delete Metric", id="metric-delete"),
+    pytest.param(MetricViewSet, "post", "set_order", {}, "integration_metric-Edit Metric", id="metric-order"),
+    pytest.param(MetricViewSet, "post", "test_query", {}, "integration_metric-Edit Metric", id="metric-test-query"),
+    pytest.param(MonitorPolicyViewSet, "post", "create", {}, "strategy_list-Add", id="strategy-create"),
+    pytest.param(MonitorPolicyViewSet, "put", "update", {"pk": "missing"}, "strategy_list-Edit", id="strategy-update"),
+    pytest.param(MonitorPolicyViewSet, "patch", "partial_update", {"pk": "missing"}, "strategy_list-Edit", id="strategy-partial"),
+    pytest.param(MonitorPolicyViewSet, "delete", "destroy", {"pk": "missing"}, "strategy_list-Delete", id="strategy-delete"),
+    pytest.param(MonitorPolicyViewSet, "post", "save_template", {}, "strategy_list-Edit", id="strategy-template-save"),
+    pytest.param(MonitorPolicyViewSet, "post", "import_templates", {}, "strategy_list-Edit", id="strategy-template-import"),
+    pytest.param(MonitorPolicyViewSet, "post", "bulk_delete_templates", {}, "strategy_list-Delete", id="strategy-template-delete"),
+    pytest.param(MonitorPolicyViewSet, "post", "bulk_create_from_templates", {}, "strategy_list-Add", id="strategy-template-bulk-create"),
+]
+
+
+def _invoke(view_class, method, action, path_kwargs, permissions):
+    request_factory = APIRequestFactory()
+    request = getattr(request_factory, method)("/", {}, format="json")
+    user = SimpleNamespace(
+        username="permission-user",
+        domain="domain.com",
+        locale="en",
+        is_superuser=False,
+        is_authenticated=True,
+        permission={"monitor": set(permissions)},
+    )
+    force_authenticate(request, user=user)
+    view = view_class.as_view({method: action})
+    try:
+        response = view(request, **path_kwargs)
+    except Exception:
+        return None
+    return response.status_code
+
+
+@pytest.mark.parametrize("view_class,method,action,path_kwargs,required_permission", WRITE_ACTION_CASES)
+def test_global_write_action_requires_matching_menu_permission(
+    view_class,
+    method,
+    action,
+    path_kwargs,
+    required_permission,
+):
+    assert _invoke(view_class, method, action, path_kwargs, set()) == 403
+    assert _invoke(view_class, method, action, path_kwargs, {required_permission}) != 403

--- a/server/apps/monitor/tests/test_monitor_metrics_readonly.py
+++ b/server/apps/monitor/tests/test_monitor_metrics_readonly.py
@@ -42,7 +42,10 @@ def test_custom_metric_resources_remain_modifiable(viewset, instance):
 def test_builtin_metric_resources_cannot_be_reordered(mocker, viewset, model):
     queryset = mocker.patch.object(model.objects, "filter").return_value
     queryset.exists.return_value = True
-    request = SimpleNamespace(data=[{"id": 1, "sort_order": 0}])
+    request = SimpleNamespace(
+        data=[{"id": 1, "sort_order": 0}],
+        user=SimpleNamespace(is_superuser=True),
+    )
 
     with pytest.raises(BaseAppException, match="只读"):
         viewset().set_order(request)

--- a/server/apps/monitor/views/monitor_metrics.py
+++ b/server/apps/monitor/views/monitor_metrics.py
@@ -6,6 +6,7 @@ from rest_framework.decorators import action
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 
+from apps.core.decorators.api_permission import HasPermission
 from apps.core.exceptions.base_app_exception import BaseAppException, ValidationAppException
 from apps.core.logger import monitor_logger as logger
 from apps.core.utils.loader import LanguageLoader
@@ -431,14 +432,21 @@ class MetricGroupViewSet(viewsets.ModelViewSet):
         if getattr(metric_group, "is_pre", False):
             raise BaseAppException("内置指标分组为只读，禁止修改或删除")
 
+    @HasPermission("integration_metric-Add Group")
+    def create(self, request, *args, **kwargs):
+        return super().create(request, *args, **kwargs)
+
+    @HasPermission("integration_metric-Edit Group")
     def update(self, request, *args, **kwargs):
         self._ensure_modifiable(self.get_object())
         return super().update(request, *args, **kwargs)
 
+    @HasPermission("integration_metric-Edit Group")
     def partial_update(self, request, *args, **kwargs):
         self._ensure_modifiable(self.get_object())
         return super().partial_update(request, *args, **kwargs)
 
+    @HasPermission("integration_metric-Delete Group")
     def destroy(self, request, *args, **kwargs):
         self._ensure_modifiable(self.get_object())
         return super().destroy(request, *args, **kwargs)
@@ -480,6 +488,7 @@ class MetricGroupViewSet(viewsets.ModelViewSet):
         return WebUtils.response_success(self.get_paginated_response(results).data)
 
     @action(detail=False, methods=["post"])
+    @HasPermission("integration_metric-Edit Group")
     def set_order(self, request, *args, **kwargs):
         target_ids = [item["id"] for item in request.data]
         if MetricGroup.objects.filter(id__in=target_ids, is_pre=True).exists():
@@ -506,14 +515,21 @@ class MetricViewSet(viewsets.ModelViewSet):
         if getattr(metric, "is_pre", False):
             raise BaseAppException("内置指标为只读，禁止修改或删除")
 
+    @HasPermission("integration_metric-Add Metric")
+    def create(self, request, *args, **kwargs):
+        return super().create(request, *args, **kwargs)
+
+    @HasPermission("integration_metric-Edit Metric")
     def update(self, request, *args, **kwargs):
         self._ensure_modifiable(self.get_object())
         return super().update(request, *args, **kwargs)
 
+    @HasPermission("integration_metric-Edit Metric")
     def partial_update(self, request, *args, **kwargs):
         self._ensure_modifiable(self.get_object())
         return super().partial_update(request, *args, **kwargs)
 
+    @HasPermission("integration_metric-Delete Metric")
     def destroy(self, request, *args, **kwargs):
         self._ensure_modifiable(self.get_object())
         return super().destroy(request, *args, **kwargs)
@@ -624,6 +640,7 @@ class MetricViewSet(viewsets.ModelViewSet):
         return WebUtils.response_success(response_data)
 
     @action(detail=False, methods=["post"])
+    @HasPermission("integration_metric-Edit Metric")
     def set_order(self, request, *args, **kwargs):
         target_ids = [item["id"] for item in request.data]
         if Metric.objects.filter(id__in=target_ids, is_pre=True).exists():
@@ -652,6 +669,7 @@ class MetricViewSet(viewsets.ModelViewSet):
         return WebUtils.response_success(names)
 
     @action(detail=False, methods=["post"], url_path="test_query")
+    @HasPermission("integration_metric-Edit Metric")
     def test_query(self, request, *args, **kwargs):
         query = request.data.get("query")
         if query is None or not isinstance(query, str):

--- a/server/apps/monitor/views/monitor_object.py
+++ b/server/apps/monitor/views/monitor_object.py
@@ -3,24 +3,17 @@ from django.db.models import Count, Q
 from rest_framework import viewsets
 from rest_framework.decorators import action
 
+from apps.core.decorators.api_permission import HasPermission
 from apps.core.exceptions.base_app_exception import ValidationAppException
-from apps.core.logger import monitor_logger as logger
 from apps.core.user_habit import column_preference_habit_key
 from apps.core.utils.loader import LanguageLoader
-from apps.core.utils.permission_utils import (
-    get_permissions_rules,
-    check_instance_permission,
-)
+from apps.core.utils.permission_utils import check_instance_permission, get_permissions_rules
+from apps.core.utils.team_utils import get_current_team
 from apps.core.utils.web_utils import WebUtils
 from apps.monitor.constants.language import LanguageConstants
 from apps.monitor.constants.permission import PermissionConstants
 from apps.monitor.filters.monitor_object import MonitorObjectFilter
-from apps.monitor.models import (
-    MonitorInstance,
-    MonitorInstanceOrganization,
-    MonitorPolicy,
-    PolicyOrganization,
-)
+from apps.monitor.models import MonitorInstance, MonitorInstanceOrganization, MonitorPolicy, PolicyOrganization
 from apps.monitor.models.monitor_object import MonitorObject, MonitorObjectType
 from apps.monitor.models.user_habit import UserHabit
 from apps.monitor.serializers.monitor_object import MonitorObjectSerializer, MonitorObjectTypeSerializer
@@ -30,7 +23,6 @@ from apps.monitor.services.monitor_object_cleanup import MonitorObjectCleanupPol
 from apps.monitor.utils.display_fields import build_display_column_key, validate_display_fields
 from apps.monitor.utils.instance_id_keys import resolve_monitor_object_instance_id_keys
 from config.drf.pagination import CustomPageNumberPagination
-from apps.core.utils.team_utils import get_current_team
 
 MAX_CANDIDATE_TEAM_ID = 2_147_483_647
 MAX_CANDIDATE_TEAM_ID_TEXT = str(MAX_CANDIDATE_TEAM_ID)
@@ -273,11 +265,13 @@ class MonitorObjectViewSet(viewsets.ModelViewSet):
         return WebUtils.response_success(results)
 
     @action(methods=["post"], detail=False, url_path="order")
+    @HasPermission("object-Edit")
     def order(self, request):
         MonitorObjectService.set_object_order(request.data)
         return WebUtils.response_success()
 
     @action(methods=["post"], detail=True, url_path="visibility")
+    @HasPermission("object-Edit")
     def visibility(self, request, pk=None):
         """切换对象可见性，同时级联到子对象。"""
         obj = self.get_object()
@@ -288,6 +282,7 @@ class MonitorObjectViewSet(viewsets.ModelViewSet):
         return WebUtils.response_success()
 
     @action(methods=["post"], detail=True, url_path="display_fields")
+    @HasPermission("object-Edit")
     def display_fields(self, request, pk=None):
         """保存对象的视图列表展示列配置（用户自定义后 re-seed 不再覆盖）"""
         obj = self.get_object()
@@ -300,6 +295,7 @@ class MonitorObjectViewSet(viewsets.ModelViewSet):
         obj.save(update_fields=["display_fields", "display_fields_customized"])
         return WebUtils.response_success(normalized)
 
+    @HasPermission("object-Delete")
     def destroy(self, request, *args, **kwargs):
         """内置对象的定义与生命周期受保护，运行配置使用独立 action 管理。"""
         instance = self.get_object()
@@ -344,6 +340,7 @@ class MonitorObjectViewSet(viewsets.ModelViewSet):
             fixed_field_keys = []
         return {"field_keys": field_keys, "fixed_field_keys": fixed_field_keys}
 
+    @HasPermission("object-Add")
     def create(self, request, *args, **kwargs):
         """创建监控对象，支持同时创建子对象"""
         data = request.data
@@ -400,6 +397,7 @@ class MonitorObjectViewSet(viewsets.ModelViewSet):
 
         return WebUtils.response_success(serializer.data)
 
+    @HasPermission("object-Edit")
     def update(self, request, *args, **kwargs):
         """更新监控对象，支持更新/新增子对象"""
         partial = kwargs.pop("partial", False)
@@ -507,6 +505,10 @@ class MonitorObjectViewSet(viewsets.ModelViewSet):
 
         return WebUtils.response_success(self.get_serializer(instance).data)
 
+    @HasPermission("object-Edit")
+    def partial_update(self, request, *args, **kwargs):
+        return super().partial_update(request, *args, **kwargs)
+
 
 class MonitorObjectTypeViewSet(viewsets.ModelViewSet):
     """监控对象类型视图"""
@@ -514,6 +516,22 @@ class MonitorObjectTypeViewSet(viewsets.ModelViewSet):
     queryset = MonitorObjectType.objects.all()
     serializer_class = MonitorObjectTypeSerializer
     pagination_class = None  # 不分页
+
+    @HasPermission("object-Add")
+    def create(self, request, *args, **kwargs):
+        return super().create(request, *args, **kwargs)
+
+    @HasPermission("object-Edit")
+    def update(self, request, *args, **kwargs):
+        return super().update(request, *args, **kwargs)
+
+    @HasPermission("object-Edit")
+    def partial_update(self, request, *args, **kwargs):
+        return super().partial_update(request, *args, **kwargs)
+
+    @HasPermission("object-Delete")
+    def destroy(self, request, *args, **kwargs):
+        return super().destroy(request, *args, **kwargs)
 
     def list(self, request, *args, **kwargs):
         # 排除 id 为 'all' 的类型

--- a/server/apps/monitor/views/monitor_object.py
+++ b/server/apps/monitor/views/monitor_object.py
@@ -93,9 +93,7 @@ def _build_org_map_for_ids(model, id_field: str, ids: list) -> dict:
     chunk_size = 2000
     for start in range(0, len(ids), chunk_size):
         chunk = ids[start : start + chunk_size]
-        for entity_id, organization in model.objects.filter(
-            **{f"{id_field}__in": chunk}
-        ).values_list(id_field, "organization"):
+        for entity_id, organization in model.objects.filter(**{f"{id_field}__in": chunk}).values_list(id_field, "organization"):
             org_map.setdefault(entity_id, set()).add(organization)
     return org_map
 
@@ -119,16 +117,10 @@ def _count_by_object_with_permissions(rows, org_map, permissions, cur_team):
 
 def _build_instance_count_map(instance_permissions, cur_team):
     """按权限统计各对象实例数，避免把完整 ORM 实例装入内存。"""
-    rows = list(
-        _build_instance_count_queryset(instance_permissions, cur_team).values_list(
-            "id", "monitor_object_id"
-        )
-    )
+    rows = list(_build_instance_count_queryset(instance_permissions, cur_team).values_list("id", "monitor_object_id"))
     if not rows:
         return {}
-    org_map = _build_org_map_for_ids(
-        MonitorInstanceOrganization, "monitor_instance_id", [row[0] for row in rows]
-    )
+    org_map = _build_org_map_for_ids(MonitorInstanceOrganization, "monitor_instance_id", [row[0] for row in rows])
     return _count_by_object_with_permissions(rows, org_map, instance_permissions, cur_team)
 
 
@@ -202,11 +194,7 @@ class MonitorObjectViewSet(viewsets.ModelViewSet):
             _name_key = f"{LanguageConstants.MONITOR_OBJECT}.{result['name']}"
             # display_type 优先级：国际化 > 类型名称 > 类型ID(英文 slug)
             i18n_type = lan.get(_type_key)
-            result["display_type"] = (
-                i18n_type
-                or (result.get("type_info") or {}).get("name")
-                or result["type"]
-            )
+            result["display_type"] = i18n_type or (result.get("type_info") or {}).get("name") or result["type"]
             # display_name 优先级：国际化 > 模型字段 display_name > name(英文 slug)
             i18n_name = lan.get(_name_key)
             result["display_name"] = i18n_name or result.get("display_name") or result["name"]

--- a/server/apps/monitor/views/monitor_policy.py
+++ b/server/apps/monitor/views/monitor_policy.py
@@ -9,6 +9,7 @@ from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
+from apps.core.decorators.api_permission import HasPermission
 from apps.core.exceptions.base_app_exception import BaseAppException, UnauthorizedException
 from apps.core.utils.current_team_scope import resolve_current_team_data_scope, scope_permission_queryset, validate_assignable_organizations
 from apps.core.utils.permission_utils import get_permission_rules
@@ -176,6 +177,7 @@ class MonitorPolicyViewSet(viewsets.ModelViewSet):
 
         return WebUtils.response_success(dict(count=queryset.count(), items=results))
 
+    @HasPermission("strategy_list-Add")
     def create(self, request, *args, **kwargs):
         self._ensure_target_organizations(request.data.get("organizations", []))
         request.data["created_by"] = request.user.username
@@ -191,6 +193,7 @@ class MonitorPolicyViewSet(viewsets.ModelViewSet):
                 self.update_policy_baselines(policy_id, policy.enable_alerts)
         return response
 
+    @HasPermission("strategy_list-Edit")
     def update(self, request, *args, **kwargs):
         if kwargs.get("partial", False):
             return super().update(request, *args, **kwargs)
@@ -235,6 +238,7 @@ class MonitorPolicyViewSet(viewsets.ModelViewSet):
 
         return response
 
+    @HasPermission("strategy_list-Edit")
     def partial_update(self, request, *args, **kwargs):
         policy = self.get_object()
         if "organizations" in request.data:
@@ -278,6 +282,7 @@ class MonitorPolicyViewSet(viewsets.ModelViewSet):
 
         return response
 
+    @HasPermission("strategy_list-Delete")
     def destroy(self, request, *args, **kwargs):
         policy = self.get_object()
         policy_id = policy.id
@@ -579,6 +584,7 @@ class MonitorPolicyViewSet(viewsets.ModelViewSet):
         return WebUtils.response_success(data)
 
     @action(methods=["post"], detail=False, url_path="template/save")
+    @HasPermission("strategy_list-Edit")
     def save_template(self, request):
         monitor_object_id = request.data.get("monitor_object")
         plugin_id = request.data.get("plugin")
@@ -601,6 +607,7 @@ class MonitorPolicyViewSet(viewsets.ModelViewSet):
         return WebUtils.response_success(PolicyService.serialize_template(template))
 
     @action(methods=["post"], detail=False, url_path="template/import")
+    @HasPermission("strategy_list-Edit")
     def import_templates(self, request):
         upload = request.FILES.get("file")
         if upload is None:
@@ -629,6 +636,7 @@ class MonitorPolicyViewSet(viewsets.ModelViewSet):
         return response
 
     @action(methods=["post"], detail=False, url_path="template/bulk_delete")
+    @HasPermission("strategy_list-Delete")
     def bulk_delete_templates(self, request):
         keys = request.data.get("keys") or []
         if not keys:
@@ -648,6 +656,7 @@ class MonitorPolicyViewSet(viewsets.ModelViewSet):
         return WebUtils.response_success({"deleted_count": deleted_count})
 
     @action(methods=["post"], detail=False, url_path="bulk_create_from_templates")
+    @HasPermission("strategy_list-Add")
     def bulk_create_from_templates(self, request):
         monitor_object_id = request.data.get("monitor_object")
         template_keys = request.data.get("template_keys") or []


### PR DESCRIPTION
## 问题

监控对象、指标目录和策略属于共享配置，REST 写入口本应同时满足登录认证与页面动作授权。此前页面会根据 Add/Edit/Delete 权限禁用按钮，但后端对应 ViewSet 主要只依赖全局登录认证，低权限用户可以绕过页面直接调用写接口。

Refs #4639

## 根因（设计层）

Monitor 已有完整菜单动作定义，也已有插件接口使用 `HasPermission` 的模块内范式，但对象、指标和策略写动作没有把业务动作映射到后端方法。页面权限因此只是交互提示，没有形成服务端不可绕过的授权边界。

## 怎么修的

- 对象类型和对象的新增、编辑、删除分别绑定 `object-Add/Edit/Delete`。
- 对象排序、可见性和展示字段绑定 `object-Edit`。
- 指标分组和指标的增删改分别绑定 `integration_metric` 对应 Group/Metric 动作权限。
- 指标及分组排序绑定对应 Edit 权限，指标测试查询绑定 `Edit Metric`。
- 策略增删改绑定 `strategy_list-Add/Edit/Delete`。
- 策略模板保存、导入、批量删除和从模板批量创建策略绑定对应 Edit/Delete/Add 权限。
- 超级用户继续沿用现有绕过规则，已有数据范围权限继续作为第二层约束。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        W["Web 页面写操作"]
        D["直接 REST 请求"]
    end

    subgraph P["动作权限层"]
        H["HasPermission\nAdd / Edit / Delete"]
    end

    subgraph V["Monitor ViewSet"]
        O["对象与对象类型"]
        M["指标与指标分组"]
        S["策略与策略模板"]
    end

    W --> H
    D --> H
    H --> O
    H --> M
    H --> S
    H -. "无权限" .-> R["HTTP 403，不进入对象读取或业务副作用"]
```

## 影响范围与兼容性

- 本 PR 仅补 REST 动作权限，不修改默认角色、菜单种子或现有授权数据。
- 不修改 NATS/RPC subject、消息体或服务身份；该部分仍留在 #4639 后续阶段。
- 不修改前端。删除指标分组按钮目前仍由前端 `Edit Group` 控制，而后端按菜单定义要求 `Delete Group`，该前端语义对齐不包含在本次范围。
- 不需要部署配置或运维脚本介入，无数据库迁移。
- 现有具备对应动作权限的用户与超级用户行为保持不变；缺少动作权限的直接 REST 写请求改为 403。

## 验证

- `apps/monitor/tests/test_global_write_action_permissions_views.py`：30 passed，逐动作验证无权限 403、对应权限越过门禁。
- 对象、指标、策略、模板及事务相关兼容回归：201 passed。
- 3 个剩余失败已在未修改的同一 master 上精确复现为既有基线问题，与权限改动无关。
- 新增生产代码差异覆盖率：100%。
- isort、Flake8、Python 编译、迁移检查、依赖一致性检查通过。

## 三轨门禁

- Standards：通过。复用现有 Monitor `HasPermission` 范式，鉴权失败先于对象读取和业务副作用，无原生 SQL、无敏感数据和无跨模块协议变化。
- Spec：通过。严格按已确认范围只补 REST 权限，默认角色与 NATS 保持不变。
- Runtime Contract：通过。覆盖对象、指标、策略共 30 个写动作的拒绝与放行契约，并验证 201 个既有合法流程。

评审得分：96/100。
