### PR TITLE
fix(监控): LLM 队列分布环图全零时空态

### DIFF
--- a/web/src/app/monitor/dashboards/objects/llamaserver/config.ts
+++ b/web/src/app/monitor/dashboards/objects/llamaserver/config.ts
@@ -341,6 +341,8 @@ export const LLAMASERVER_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       centerMetric: 'llamacpp_processing',
       centerCaption: '处理中',
       centerUnit: 'counts',
+      // 空闲实例 gauge 常为 0；全 0 占比无业务含义，与时延等面板统一为空态。
+      emptyWhenAllZero: true,
       guide: [
         {
           label: '队列分布',

--- a/web/src/app/monitor/dashboards/objects/sglang/config.ts
+++ b/web/src/app/monitor/dashboards/objects/sglang/config.ts
@@ -327,6 +327,8 @@ export const SGLANG_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       centerMetric: 'sglang_running_reqs',
       centerCaption: '运行中',
       centerUnit: 'counts',
+      // 空闲实例 gauge 常为 0；全 0 占比无业务含义，与时延等面板统一为空态。
+      emptyWhenAllZero: true,
       guide: [
         {
           label: '队列分布',

--- a/web/src/app/monitor/dashboards/objects/vllm/config.ts
+++ b/web/src/app/monitor/dashboards/objects/vllm/config.ts
@@ -480,6 +480,8 @@ export const VLLM_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       centerMetric: 'vllm_requests_running',
       centerCaption: '运行中',
       centerUnit: 'counts',
+      // 空闲实例 gauge 常为 0；全 0 占比无业务含义，与时延等面板统一为空态。
+      emptyWhenAllZero: true,
       guide: [
         {
           label: '队列分布',


### PR DESCRIPTION
## Summary
- vLLM / SGLang / LlamaServer「请求队列分布」环图启用 `emptyWhenAllZero`
- 空闲实例 gauge 全为 0 时展示「暂无数据」，不再显示中心大 0 / 0% 占比
- 与拨测类面板（ping/website/tcp）已有空态约定对齐；顶部 KPI 真零读数未改

## Test plan
- [ ] 打开空闲 vLLM 实例看板：请求队列分布应为「暂无数据」，时延拆解仍为空态
- [ ] 对 SGLang、LlamaServer 同样确认全零环图空态
- [ ] 有运行中/排队非零请求时，环图正常显示占比与中心数值