### PR TITLE
fix(监控): 告警阈值百分比单位区分 0-100 与 0.0-1.0

### DIFF
--- a/web/src/app/monitor/(pages)/event/strategy/detail/strategyDetailUtils.ts
+++ b/web/src/app/monitor/(pages)/event/strategy/detail/strategyDetailUtils.ts
@@ -277,6 +277,37 @@ export const getPercentUnitScaleFactor = (
   return null;
 };
 
+/**
+ * 阈值单位下拉展示名：优先 unit_name；percent/percentunit 在名称未标注量纲时补全，
+ * 避免仅用 display_unit（二者皆为 %）时无法区分 0–100 与 0.0–1.0。
+ */
+export const getThresholdUnitSelectLabel = (option: {
+  unit_id: string;
+  unit_name?: string;
+  display_unit?: string;
+}): string => {
+  if (option.unit_id === 'percent') {
+    return option.unit_name?.includes('0-100')
+      ? option.unit_name
+      : 'percent (0-100)';
+  }
+  if (option.unit_id === 'percentunit') {
+    return option.unit_name?.includes('0.0-1.0')
+      ? option.unit_name
+      : 'percentunit (0.0-1.0)';
+  }
+  return option.unit_name || option.display_unit || option.unit_id;
+};
+
+/** 百分比阈值输入占位，明示量纲；其他单位不提示。 */
+export const getThresholdValuePlaceholder = (
+  thresholdUnit: string | null | undefined
+): string => {
+  if (thresholdUnit === 'percent') return '0-100';
+  if (thresholdUnit === 'percentunit') return '0.0-1.0';
+  return '';
+};
+
 /** 阈值单位在 percentunit↔percent 间切换时同步缩放数值，避免误报/漏报。 */
 export const scaleThresholdValuesForUnitChange = <T extends { value: number | null }>(
   thresholds: T[],

--- a/web/src/app/monitor/(pages)/event/strategy/detail/thresholdList.tsx
+++ b/web/src/app/monitor/(pages)/event/strategy/detail/thresholdList.tsx
@@ -9,6 +9,10 @@ import {
   ENUM_COMPARISON_METHOD
 } from '@/app/monitor/constants/event';
 import { cloneDeep } from 'lodash';
+import {
+  getThresholdUnitSelectLabel,
+  getThresholdValuePlaceholder
+} from './strategyDetailUtils';
 
 const { Option } = Select;
 
@@ -87,13 +91,25 @@ const ThresholdList: React.FC<ThresholdListProps> = ({
           </Tooltip>
           <Select
             value={thresholdUnit}
-            style={{ width: 180 }}
+            style={{ width: 220 }}
             showSearch
-            filterOption={(input, option) =>
-              option.label.toLowerCase().includes(input.toLowerCase())
-            }
+            filterOption={(input, option) => {
+              const query = input.toLowerCase();
+              const matched = unitOptions.find(
+                (item) => item.unit_id === option?.value
+              );
+              const candidates = [
+                String(option?.label ?? ''),
+                matched?.display_unit || '',
+                matched?.unit_name || '',
+                matched?.unit_id || ''
+              ];
+              return candidates.some((text) =>
+                text.toLowerCase().includes(query)
+              );
+            }}
             options={unitOptions.map((option) => ({
-              label: option.display_unit || option.unit_name,
+              label: getThresholdUnitSelectLabel(option),
               value: option.unit_id
             }))}
             onChange={handleThresholdUnitChange}
@@ -152,6 +168,7 @@ const ThresholdList: React.FC<ThresholdListProps> = ({
                   style={{ flex: 1 }}
                   value={item.value}
                   addonAfter={getUnitLabel()}
+                  placeholder={getThresholdValuePlaceholder(thresholdUnit)}
                   onChange={(val) => handleValueChange(val, index)}
                 />
               )}

--- a/web/src/app/monitor/locales/en.json
+++ b/web/src/app/monitor/locales/en.json
@@ -127,7 +127,7 @@
       "avg": "AVG",
       "alertConditions": "Alert Conditions",
       "alertThreshold": "Alert Threshold",
-      "thresholdUnitHelp": "The threshold unit is used for input and display. Thresholds are converted to the calculation unit for evaluation, and only units of the same dimension are available.",
+      "thresholdUnitHelp": "The threshold unit is used for input and display. Thresholds are converted to the calculation unit for evaluation, and only units of the same dimension are available. For percentages: percent is 0–100 and percentunit is 0.0–1.0; enter values in the selected scale.",
       "metricPreview": "Metric Preview",
       "noDataAlertName": "No Data Alert Name",
       "noDataAlertLevel": "No Data Alert",

--- a/web/src/app/monitor/locales/zh.json
+++ b/web/src/app/monitor/locales/zh.json
@@ -127,7 +127,7 @@
       "avg": "平均值",
       "alertConditions": "告警条件",
       "alertThreshold": "告警阈值",
-      "thresholdUnitHelp": "阈值单位仅用于输入和展示；告警判断时会自动换算为计算单位。仅可选择相同量纲的单位。",
+      "thresholdUnitHelp": "阈值单位仅用于输入和展示；告警判断时会自动换算为计算单位。仅可选择相同量纲的单位。百分比请注意：percent 为 0–100，percentunit 为 0.0–1.0，请按所选单位填写。",
       "noDataAlertName": "无数据告警名称",
       "noDataAlertLevel": "无数据告警",
       "noTriggerNoDataAlert": "不触发无数据告警",


### PR DESCRIPTION
## Summary
- 告警策略阈值单位下拉对 `percent` / `percentunit` 不再都显示为 `%`，改为带量纲标签（`percent (0-100)` / `percentunit (0.0-1.0)`）
- 阈值输入框增加 `0-100` / `0.0-1.0` 占位提示，帮助文案补充两种百分比量纲说明
- 单位搜索同时匹配展示符、单位名与 unit_id，避免改标签后搜 `%` 失效

## Test plan
- [ ] 打开告警策略编辑，选择百分比类指标，确认阈值「单位」下拉可见两项可区分选项
- [ ] 分别选择 0-100 与 0.0-1.0，确认输入框 placeholder 对应变化，填写 `50` / `0.5` 可正常保存
- [ ] 搜索框输入 `%` 或 `percent` 仍能筛到对应单位
- [ ] 查看帮助问号文案，确认提及两种量纲