### PR TITLE
fix(监控): 指标与公式单位级联区分百分比量纲

### DIFF
--- a/web/src/app/monitor/(pages)/event/strategy/detail/strategyDetailUtils.ts
+++ b/web/src/app/monitor/(pages)/event/strategy/detail/strategyDetailUtils.ts
@@ -6,9 +6,13 @@ import {
   UnitListItem
 } from '@/app/monitor/types';
 import { isStringArray } from '@/app/monitor/utils/common';
+import { getMonitorUnitSelectLabel } from '@/app/monitor/components/monitor-shared/unit-label';
 import { MetricExpressionMode } from './formulaExpressionUtils';
 
 export const FORMULA_DEFAULT_RESULT_UNIT = 'percent';
+
+/** 兼容策略阈值下拉与本地验证脚本。 */
+export const getThresholdUnitSelectLabel = getMonitorUnitSelectLabel;
 
 /** 组织变更后，剔除不再属于候选用户列表的已选通知人 */
 export const pruneNoticeUsers = <T extends string | number>(
@@ -277,28 +281,6 @@ export const getPercentUnitScaleFactor = (
   return null;
 };
 
-/**
- * 阈值单位下拉展示名：优先 unit_name；percent/percentunit 在名称未标注量纲时补全，
- * 避免仅用 display_unit（二者皆为 %）时无法区分 0–100 与 0.0–1.0。
- */
-export const getThresholdUnitSelectLabel = (option: {
-  unit_id: string;
-  unit_name?: string;
-  display_unit?: string;
-}): string => {
-  if (option.unit_id === 'percent') {
-    return option.unit_name?.includes('0-100')
-      ? option.unit_name
-      : 'percent (0-100)';
-  }
-  if (option.unit_id === 'percentunit') {
-    return option.unit_name?.includes('0.0-1.0')
-      ? option.unit_name
-      : 'percentunit (0.0-1.0)';
-  }
-  return option.unit_name || option.display_unit || option.unit_id;
-};
-
 /** 百分比阈值输入占位，明示量纲；其他单位不提示。 */
 export const getThresholdValuePlaceholder = (
   thresholdUnit: string | null | undefined
@@ -335,7 +317,11 @@ export const buildMetricUnitCascaderOptions = (
       children: (group.children || [])
         .filter((item) => !INVALID_THRESHOLD_UNIT_IDS.has(item.value))
         .map((item) => ({
-          label: item.label,
+          label: getMonitorUnitSelectLabel({
+            unit_id: String(item.value),
+            unit_name: item.label,
+            display_unit: item.unit
+          }),
           value: item.value,
           children: []
         }))

--- a/web/src/app/monitor/(pages)/event/strategy/detail/thresholdList.tsx
+++ b/web/src/app/monitor/(pages)/event/strategy/detail/thresholdList.tsx
@@ -10,9 +10,9 @@ import {
 } from '@/app/monitor/constants/event';
 import { cloneDeep } from 'lodash';
 import {
-  getThresholdUnitSelectLabel,
   getThresholdValuePlaceholder
 } from './strategyDetailUtils';
+import { getMonitorUnitSelectLabel } from '@/app/monitor/components/monitor-shared/unit-label';
 
 const { Option } = Select;
 
@@ -109,7 +109,7 @@ const ThresholdList: React.FC<ThresholdListProps> = ({
               );
             }}
             options={unitOptions.map((option) => ({
-              label: getThresholdUnitSelectLabel(option),
+              label: getMonitorUnitSelectLabel(option),
               value: option.unit_id
             }))}
             onChange={handleThresholdUnitChange}

--- a/web/src/app/monitor/components/monitor-shared/unit-label.ts
+++ b/web/src/app/monitor/components/monitor-shared/unit-label.ts
@@ -17,6 +17,28 @@ export const isSerializedStringArray = (input: unknown): input is string => {
   }
 };
 
+/**
+ * 单位选择器展示名（级联 / 下拉）。
+ * percent/percentunit 的 display_unit 同为 %，名称未标注量纲时补全，避免无法区分 0–100 与 0.0–1.0。
+ */
+export const getMonitorUnitSelectLabel = (option: {
+  unit_id: string;
+  unit_name?: string;
+  display_unit?: string;
+}): string => {
+  if (option.unit_id === 'percent') {
+    return option.unit_name?.includes('0-100')
+      ? option.unit_name
+      : 'percent (0-100)';
+  }
+  if (option.unit_id === 'percentunit') {
+    return option.unit_name?.includes('0.0-1.0')
+      ? option.unit_name
+      : 'percentunit (0.0-1.0)';
+  }
+  return option.unit_name || option.display_unit || option.unit_id;
+};
+
 export const resolveMonitorUnitLabel = (
   value: unknown,
   displayUnit?: string,

--- a/web/src/app/monitor/context/commonDataLoader.ts
+++ b/web/src/app/monitor/context/commonDataLoader.ts
@@ -4,6 +4,7 @@ import {
   UnitListItem,
   UserItem,
 } from '@/app/monitor/types';
+import { getMonitorUnitSelectLabel } from '@/app/monitor/components/monitor-shared/unit-label';
 
 interface LoadState {
   requestLoading: boolean;
@@ -42,7 +43,7 @@ export const buildGroupedUnitList = (units: UnitListItem[]): GroupedUnitList[] =
       }
       acc[item.category].push({
         ...item,
-        label: item.unit_name,
+        label: getMonitorUnitSelectLabel(item),
         value: item.unit_id,
         unit: item.display_unit,
       });


### PR DESCRIPTION
## Summary
- 将百分比量纲展示名抽到共享 `getMonitorUnitSelectLabel`，在单位表分组构建时统一标注 `percent (0-100)` / `percentunit (0.0-1.0)`
- 覆盖接入「指标单位」级联与告警策略公式「结果单位」级联，避免仅显示 `percent`/`percentunit` 或 `%` 时无法区分量纲
- 策略阈值下拉复用同一 helper，行为与 #5096 一致

## Test plan
- [ ] 接入 → 编辑 Number 指标 → 单位级联中 Base 下可见可区分的 percent / percentunit
- [ ] 告警策略公式模式 → 结果单位级联同样可区分两种百分比
- [ ] 告警阈值单位下拉仍正常区分，placeholder 仍为 0-100 / 0.0-1.0