### PR TITLE
fix(stargazer): SANIC_WORKERS 默认值改回 1，多进程改为显式放开

### DIFF
--- a/agents/stargazer/.env.example
+++ b/agents/stargazer/.env.example
@@ -41,8 +41,10 @@ PUBLISH_TOTAL_TIMEOUT=120
 # 生产 metrics 只使用覆盖 metrics.* 的 JetStream；关闭时启动校验失败，不静默回退 Core NATS
 NATS_METRICS_JETSTREAM_ENABLED=true
 METRICS_ENCODE_WORKERS=2
-# Sanic 进程数（每进程独立 GIL，用于绕开单进程 CPU 天花板）
-SANIC_WORKERS=4
+# Sanic 进程数，默认 1。Run 绑定接收进程不跨进程，每进程各持一份 MAX_ACTIVE_TARGETS，
+# 调大会把容器总并发按倍数放大。注意：此处仅影响 python server.py 直跑；容器内由
+# supervisor 启动命令读取 shell 环境变量，须通过容器 env 设置，改本文件不生效。
+SANIC_WORKERS=1
 PUBLISH_WORKERS=4
 NATS_JS_PUBLISH_MAX_PENDING=256
 NATS_JS_PUBLISH_MAX_PENDING_BYTES=33554432

--- a/agents/stargazer/server.py
+++ b/agents/stargazer/server.py
@@ -36,4 +36,4 @@ async def show_banner(app, loop):
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=8083, workers=int(os.getenv("SANIC_WORKERS", "4")))
+    app.run(host="0.0.0.0", port=8083, workers=int(os.getenv("SANIC_WORKERS", "1")))

--- a/agents/stargazer/support-files/docker/Dockerfile
+++ b/agents/stargazer/support-files/docker/Dockerfile
@@ -9,8 +9,10 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Sanic 进程数：每进程独立 GIL，用于绕开单进程 CPU 天花板；可在运行时用 -e 覆盖
-ENV SANIC_WORKERS=4
+# Sanic 进程数，默认 1。采集 Run 绑定在接收请求的进程内不跨进程，且每个进程各持一份
+# MAX_ACTIVE_TARGETS：调大只能分摊多个独立 Run，容器总并发会按倍数放大。确认容器
+# 并发口径后再用 -e SANIC_WORKERS=N 显式放开。
+ENV SANIC_WORKERS=1
 
 WORKDIR /app
 

--- a/agents/stargazer/support-files/supervisor/service.conf
+++ b/agents/stargazer/support-files/supervisor/service.conf
@@ -1,5 +1,5 @@
 [program:service]
-command=sh -c 'exec sanic server:app --host=0.0.0.0 --port=8083 --workers=${SANIC_WORKERS:-4}'
+command=sh -c 'exec sanic server:app --host=0.0.0.0 --port=8083 --workers=${SANIC_WORKERS:-1}'
 directory=/app
 user=root
 autostart=true


### PR DESCRIPTION
## 背景

#5100 把 `SANIC_WORKERS` 默认值设为 4，依据是单进程 GIL 天花板（实测容器可用 6.45 核，进程 CPU 却卡在 100%）。这个判断本身成立，但漏算了一个约束，导致默认 4 在当前架构下没有一个好的配置。

## 漏算的约束：Run 绑定接收进程，不跨进程

[api/collect.py `_submit_collection_run`](../blob/master/agents/stargazer/api/collect.py) 直接把 Run 提交给进程内的 `get_collection_application()`，全仓没有跨进程分发（无 `multiprocessing` / `ProcessPoolExecutor`）。`MAX_ACTIVE_TARGETS` / `TARGET_TASK_WINDOW` 都是进程内信号量，每个 worker 各持一份。于是：

| 配置 | 容器总并发 | 单个 Run 上限 | 问题 |
|---|---|---|---|
| 4 × 160 | 640 | 160 | 总并发按倍数放大 |
| 4 × 40 | 160 | 40 | 单 Run 无法在其它类型空闲时借满 |
| 1 × 160 | 160 | 160 | 与推荐生产配置一致 |

且事故的形态恰是**单个大 Run**（`cmdb_37` 一轮 2046 目标）——它无论如何都压在同一个事件循环上，多 worker 只能分摊多个独立 Run，解决不了它。真正的解法是目标级多进程执行架构（1 个协调进程 + N 个 SNMP 执行进程），那是另一个规模的改动。

在此之前，默认 1、需要时显式放开，比「默认 4、部署时记得改回 1」少一个踩坑点。

## 改动

四处默认值 4 → 1，与 #5100 对称：`server.py`、`.env.example`、`Dockerfile`、`supervisor/service.conf`。注释改为说明**为什么默认 1、调大的代价是什么**，并在 `.env.example` 里点明：容器内 worker 数由 supervisor 启动命令的 shell 环境变量决定，`.env` 是 `load_dotenv` 在 Python 进程内加载、发生在 shell 展开之后，**改 `.env` 对容器不生效**，须用容器 env。

## Reviewer 需要知道的

**一个待产品方裁定的口径矛盾**（本 PR 不处理）：`.env.example:23` 写的是「**单进程**目标硬上限」，而「全容器严格不超过 160」是另一种口径。若 160 本就是单进程口径，4×160=640 是配置语义的自然结果，「不可接受」需要另外的理由（设备侧压力 / NATS JS 窗口 ×4 / 内存 ×4）；若是全容器口径，注释需要改。本 PR 选默认 1 在两种口径下都安全。

**另一个相关事实**：`SNMP_MAX_IN_FLIGHT=100` 是容量组**硬门**（`scheduler.py:320-322`，不参与软配额借槽），与 `CONFIGURATION_MAX_ACTIVE_TARGETS=100` 恰好相等——SNMP 配置采集 Run 实际上限是 100 而非 160，「单一类型可借满 160」对 SNMP 不成立。与本 PR 无关，记录在此。

## 验证

- supervisor 配置：真实 supervisor 解析通过；shell 展开未设置 → `--workers=1`，显式 `SANIC_WORKERS=4` → `--workers=4`
- `server.py`：py_compile / flake8 / black / isort 全部通过
- 全仓 `git grep SANIC_WORKERS`：除这四处外无其它引用，无遗漏
- pre-commit hook 因私有源 `bkrepo.cwoa.net` 需认证无法安装环境（同 #5100），故 `--no-verify` 提交并手动跑了等价检查

## 实测验证（builder 10.10.24.35，2026-09-02）

用 `bklite/stargazer:latest` 镜像的依赖 + 挂载 `origin/master` 源码，独立 redis/nats，`PROBE_TIMEOUT=15`，目标为不可达网段（每目标 ≈20s 超时），`CAPACITY_LOG_INTERVAL=3` 每 3 秒采样 `collection_capacity`。

| 实验 | 配置 | 提交 | 观察 | 耗时 |
|---|---|---|---|---|
| A | 2 worker × `MAX_ACTIVE_TARGETS=4` | 1 个 Run，12 目标 | 落在 `Srv 0`；`Srv 0` 全程 `4/4`、等待 8→4→0；**`Srv 1` 全程 `0/4`**；13 条 Run 日志全在 `Srv 0` | **62.3s**（3 批） |
| B | 同上 | 4 个 Run 并发，各 6 目标 | SO_REUSEPORT 分到 `Srv 0`×2 / `Srv 1`×2；两 worker 各 `4/4`，**容器总在飞 = 8**；目标级日志 18/18 对称 | 3 个 62s、1 个 41.5s |
| C1 | **1 worker** × `MAX_ACTIVE_TARGETS=8`，`SNMP_MAX_IN_FLIGHT=8` | 1 个 Run，12 目标 | `8/8`，2 批 | **42.0s** |
| C2 | 1 worker × `MAX_ACTIVE_TARGETS=8`，**`SNMP_MAX_IN_FLIGHT=4`** | 1 个 Run，12 目标 | **卡在 `4/8`**，3 批 | **62.4s** |

- A 与 C1 是同一容器总并发（8）下的对照：多 worker 时单 Run 只能用到一个进程的配额（62.3s），单 worker 时用满全局（42.0s）——**Run 绑定接收进程、不跨进程借槽**，实测成立。
- B 证明 **容器总并发 = worker 数 × `MAX_ACTIVE_TARGETS`**，多 worker 只对多个独立 Run 有分摊效果。
- C2 证明 **`SNMP_MAX_IN_FLIGHT` 是硬门、不参与软配额借槽**：全局 8、软配额 8，SNMP Run 仍被卡在 4。

## 补充：4 worker 的内存实测与泄漏定位（builder，2026-09-02）

生产默认并发（160 / 100·30·30 / SNMP 100）不设内存限制，不可达目标：

| | 空闲 | 满载峰值（每 worker 800 目标后） | 负载结束 150s 后 |
|---|---|---|---|
| `SANIC_WORKERS=4` | 306 MiB | **6.83 GiB** | 6.83 GiB（不回落） |
| `SANIC_WORKERS=1` | 146 MiB | 1.78 GiB | 1.78 GiB（不回落） |

单进程曲线两组完全重合：**≈2 MiB/目标、与 worker 数无关，总量 ×N**。事件循环 P99 8.2s vs 7.8s，多 worker 对单进程延迟无改善。

**根因已定位**（tracemalloc）：`snmp_facts.py` 每目标 `SnmpEngine()` 两次 → 每个 engine 独立 MibBuilder → `addMibCompiler(ifNotAdded=True)` 的短路判断 `mibBuilder.getMibCompiler()` 是 per-engine 的、永不命中 → pysmi `yacc.yacc(write_tables=False)` **每目标现场重算整张 SMI 语法 LR 表**。800 目标后 gc.collect 仍有 336 MiB Python 对象存活（`ply/yacc.py` 204 MiB、≈17 份 LR 表被引用），`malloc_trim` 再回收 314 MiB——约三成真泄漏、七成分配器碎片。这同时是事故里 CPU 脉冲式饱和的来源，修法是进程级复用 SnmpEngine，另开 PR 处理。

对本 PR 的含义：泄漏在任何 worker 数下都存在，默认 4 只是把它放大 4 倍；在它修复前默认 1 是唯一安全值。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


