### PR TITLE
fix(stargazer): SNMP 采集复用进程级 SnmpEngine，消除每目标 PLY 重算与不回落泄漏

### DIFF
--- a/agents/stargazer/README.md
+++ b/agents/stargazer/README.md
@@ -62,6 +62,8 @@ MONITORING_MAX_ACTIVE_TARGETS=30
 NETWORK_TOPOLOGY_MAX_ACTIVE_TARGETS=30
 TARGET_TASK_WINDOW=160
 SNMP_MAX_IN_FLIGHT=100
+SNMP_ENGINE_MAX_TARGETS=2000
+SNMP_ENGINE_IDLE_SECONDS=300
 SYNC_SDK_MAX_IN_FLIGHT=16
 REMOTE_JOB_MAX_IN_FLIGHT=20
 DEFAULT_ASYNC_MAX_IN_FLIGHT=160
@@ -91,6 +93,16 @@ OUTBOUND_ALLOWED_DOMAINS=
 不再支持用 `0` 隐式关闭边界。
 
 `MAX_ACTIVE_RUNS` 仍保留 run 级准入；满了返回 busy/429。
+
+SNMP 采集在每个 worker 进程内按凭据作用域共享 pysnmp `SnmpEngine`（v1/v2c 共用一个，
+v3 按用户名与密钥组合各一个），不再为每个目标新建 engine：pysnmp 每个 engine 首次解析 OID
+都会用 PLY 重算 SMI 语法表（连同 MIB 模块约 2 MiB、约 50 ms 纯 Python CPU），100 并发一批
+就阻塞事件循环数秒；uvloop 的 sendto 地址缓存（2048 项 LRU）还会经 pysnmp 传输地址对象拖住
+已关闭 engine 的整棵 MIB 树，这是大规模 SNMP 轮次内存不回落与 CPU 饱和的根因（builder 实测
+800 个不可达目标：修复前 RSS 73→1747 MiB、事件循环 P99 延迟最高 7.3 s；修复后 73→115 MiB、
+P99 延迟 ≤25 ms）。`SNMP_ENGINE_MAX_TARGETS` 限制单个 engine 服务过的不同目标地址数
+（每个目标在 pysnmp LCD 中约占 20 KiB），达到后新目标换用新 engine、旧 engine 排空在途请求后关闭；
+`SNMP_ENGINE_IDLE_SECONDS` 是 engine 空闲多久后释放 dispatcher。两者必须为正数，否则启动失败。
 
 `REDIS_MAX_CONNECTIONS` 应不小于目标并发并留租约余量（推荐
 `≳ MAX_ACTIVE_TARGETS`，并按实际辅助请求留出余量）。多 Pod 时还要保证

--- a/agents/stargazer/core/infra/snmp_engine_pool.py
+++ b/agents/stargazer/core/infra/snmp_engine_pool.py
@@ -1,0 +1,452 @@
+"""进程级共享 pysnmp ``SnmpEngine`` 池。
+
+pysnmp 5.1.0 的每个 ``SnmpEngine`` 都持有独立的 MibBuilder；第一次解析 OID 时
+``ObjectIdentity.resolveWithMib`` 会给这个 MibBuilder 新建一个 pysmi ``MibCompiler``，
+而 pysmi 解析器在构造时用 PLY 现场重算整张 SMI 语法 LR 表。每个 engine 连同
+MIB 模块与 LR 表约 2 MiB 常驻、约 50 ms 纯 Python CPU；SNMP 采集若每个目标都新建
+engine，100 并发一批就会阻塞事件循环数秒，而 uvloop 的 sendto 地址缓存
+（``uvloop/dns.pyx`` 的 ``sockaddrs`` LRU，2048 项）又以 pysnmp 的
+``UdpTransportAddress`` 为键、经其 ``_localAddress`` 拖住整个已关闭 engine 的 MIB 树，
+内存因此随目标数线性增长且不回落。
+
+设计要点：
+
+- pysnmp 的 asyncio dispatcher 本身多路复用，一个 engine 能并发服务任意多目标，
+  所以同一事件循环内按“凭据作用域”共享 engine：v1/v2c 目标共用一个（不同
+  community 在 snmpCommunityTable 中可以共存）；v3 按用户名、协议与密钥组合
+  各一个，避免 pysnmp LCD 以 ``(userName, engineId)`` 为键把不同密钥混用。
+- 每个不同目标地址都会在 engine 的 LCD 里留下约 20 KiB 的 snmpTargetAddrTable
+  行，并发在途时无法安全删除，因此按“不同目标数”做代际轮换：达到
+  ``SNMP_ENGINE_MAX_TARGETS`` 后新目标换用新 engine，旧 engine 在途请求排空后关闭。
+- engine 空闲超过 ``SNMP_ENGINE_IDLE_SECONDS`` 后关闭 dispatcher 并释放；进程
+  退出（Sanic ``after_server_stop``）时统一关闭。
+- MIB 编译器进程内只构建一次（PLY LR 表只算一次），之后每一代 engine 都复用
+  同一个编译器对象；数值 OID 采集永远不会真正触发 MIB 编译。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import itertools
+import os
+import time
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any
+
+from core.logger import logger
+
+DEFAULT_SNMP_ENGINE_MAX_TARGETS = 2000
+DEFAULT_SNMP_ENGINE_IDLE_SECONDS = 300.0
+
+_COMMUNITY_SCOPE = "community"
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or not str(raw).strip():
+        return int(default)
+    try:
+        return int(str(raw).strip())
+    except ValueError as exc:
+        raise ValueError(f"{name} must be a positive integer") from exc
+
+
+def _float_env(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or not str(raw).strip():
+        return float(default)
+    try:
+        return float(str(raw).strip())
+    except ValueError as exc:
+        raise ValueError(f"{name} must be a positive number of seconds") from exc
+
+
+@dataclass(frozen=True)
+class SnmpEnginePoolSettings:
+    """共享 engine 的轮换与空闲回收阈值，只从环境变量读取。"""
+
+    max_targets: int = DEFAULT_SNMP_ENGINE_MAX_TARGETS
+    idle_seconds: float = DEFAULT_SNMP_ENGINE_IDLE_SECONDS
+
+    def __post_init__(self) -> None:
+        if isinstance(self.max_targets, bool) or not isinstance(self.max_targets, int) or self.max_targets <= 0:
+            raise ValueError("SNMP_ENGINE_MAX_TARGETS must be a positive integer")
+        if not self.idle_seconds > 0:
+            raise ValueError("SNMP_ENGINE_IDLE_SECONDS must be greater than zero")
+
+    @classmethod
+    def from_env(cls) -> SnmpEnginePoolSettings:
+        return cls(
+            max_targets=_int_env("SNMP_ENGINE_MAX_TARGETS", DEFAULT_SNMP_ENGINE_MAX_TARGETS),
+            idle_seconds=_float_env("SNMP_ENGINE_IDLE_SECONDS", DEFAULT_SNMP_ENGINE_IDLE_SECONDS),
+        )
+
+
+class _SharedEngine:
+    __slots__ = (
+        "scope",
+        "label",
+        "generation",
+        "loop",
+        "engine",
+        "opened_at",
+        "in_flight",
+        "acquisitions",
+        "targets",
+        "idle_handle",
+        "retired",
+        "retire_reason",
+        "closed",
+    )
+
+    def __init__(self, *, scope: str, label: str, generation: int, loop: asyncio.AbstractEventLoop, engine: Any) -> None:
+        self.scope = scope
+        self.label = label
+        self.generation = generation
+        self.loop = loop
+        self.engine = engine
+        self.opened_at = time.monotonic()
+        self.in_flight = 0
+        self.acquisitions = 0
+        self.targets: set[tuple[str, int]] = set()
+        self.idle_handle: asyncio.TimerHandle | None = None
+        self.retired = False
+        self.retire_reason = ""
+        self.closed = False
+
+
+_settings: SnmpEnginePoolSettings | None = None
+_active: dict[str, _SharedEngine] = {}
+_draining: list[_SharedEngine] = []
+_scope_labels: dict[str, str] = {}
+_generations = itertools.count(1)
+_shared_mib_compiler: Any = None
+_shared_mib_destination: str | None = None
+
+
+def snmp_engine_pool_settings() -> SnmpEnginePoolSettings:
+    """首次调用时从环境变量读取；配置非法直接抛 ValueError。"""
+
+    global _settings
+    if _settings is None:
+        _settings = SnmpEnginePoolSettings.from_env()
+    return _settings
+
+
+def configure_snmp_engine_pool(settings: SnmpEnginePoolSettings | None) -> None:
+    """测试或诊断脚本显式覆盖阈值；传 None 恢复为按环境变量读取。"""
+
+    global _settings
+    _settings = settings
+
+
+def _text(value: Any) -> str:
+    return "" if value is None else str(value)
+
+
+def _secret_bytes(value: Any) -> bytes:
+    if value is None:
+        return b""
+    as_octets = getattr(value, "asOctets", None)
+    if callable(as_octets):
+        return bytes(as_octets())
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value)
+    return str(value).encode("utf-8")
+
+
+def snmp_engine_scope(auth_data: Any) -> str:
+    """把 pysnmp 认证对象映射到共享 engine 的作用域键。
+
+    v1/v2c 共用一个作用域；v3 按用户名、安全级别、协议与密钥材料摘要区分，
+    摘要只用于内存字典键，不会被写入日志。
+    """
+
+    from pysnmp.hlapi.auth import CommunityData, UsmUserData
+
+    if isinstance(auth_data, UsmUserData):
+        material = (
+            _text(auth_data.userName),
+            _text(auth_data.securityName),
+            _secret_bytes(auth_data.securityEngineId),
+            _text(auth_data.securityLevel),
+            _text(auth_data.authProtocol),
+            _text(auth_data.authKeyType),
+            _secret_bytes(auth_data.authKey),
+            _text(auth_data.privProtocol),
+            _text(auth_data.privKeyType),
+            _secret_bytes(auth_data.privKey),
+        )
+        digest = hashlib.blake2b(repr(material).encode("utf-8"), digest_size=16).hexdigest()
+        return f"v3:{digest}"
+    if isinstance(auth_data, CommunityData):
+        return _COMMUNITY_SCOPE
+    raise TypeError(f"unsupported SNMP auth data: {type(auth_data).__name__}")
+
+
+def _scope_label(scope: str) -> str:
+    """日志与快照里使用的稳定标签：community 或 v3#N，不含任何密钥材料。"""
+
+    label = _scope_labels.get(scope)
+    if label is None:
+        if scope == _COMMUNITY_SCOPE:
+            label = _COMMUNITY_SCOPE
+        else:
+            v3_count = sum(1 for existing in _scope_labels.values() if existing != _COMMUNITY_SCOPE)
+            label = f"v3#{v3_count + 1}"
+        _scope_labels[scope] = label
+    return label
+
+
+def _attach_shared_mib_compiler(engine: Any) -> None:
+    """让每一代 engine 复用进程内唯一的 MIB 编译器，避免重复构建 PLY 解析器。"""
+
+    global _shared_mib_compiler, _shared_mib_destination
+    mib_builder = engine.getMibBuilder()
+    if _shared_mib_compiler is not None:
+        mib_builder.setMibCompiler(_shared_mib_compiler, _shared_mib_destination)
+        return
+    from pysnmp.smi import compiler as smi_compiler
+
+    smi_compiler.addMibCompiler(mib_builder, ifAvailable=True, ifNotAdded=True)
+    compiler = mib_builder.getMibCompiler()
+    if compiler is not None:
+        _shared_mib_compiler = compiler
+        _shared_mib_destination = smi_compiler.defaultDest
+
+
+def create_snmp_engine() -> Any:
+    """创建一个已装配共享 MIB 编译器的 SnmpEngine；测试可整体替换本函数。"""
+
+    from pysnmp.hlapi.asyncio import SnmpEngine
+
+    engine = SnmpEngine()
+    _attach_shared_mib_compiler(engine)
+    return engine
+
+
+def close_snmp_engine(engine: Any) -> None:
+    """关闭 engine 的 transport dispatcher；未曾发过请求的 engine 没有 dispatcher。"""
+
+    dispatcher = getattr(engine, "transportDispatcher", None)
+    close = getattr(dispatcher, "closeDispatcher", None)
+    if callable(close):
+        close()
+
+
+def _target_key(target: Any) -> tuple[str, int]:
+    host, port = target
+    return str(host), int(port)
+
+
+def _open(scope: str, loop: asyncio.AbstractEventLoop) -> _SharedEngine:
+    started = time.monotonic()
+    engine = create_snmp_engine()
+    holder = _SharedEngine(
+        scope=scope,
+        label=_scope_label(scope),
+        generation=next(_generations),
+        loop=loop,
+        engine=engine,
+    )
+    _active[scope] = holder
+    logger.info(
+        "event=snmp_engine_opened scope=%s generation=%s active_engines=%s draining_engines=%s init_seconds=%.3f",
+        holder.label,
+        holder.generation,
+        len(_active),
+        len(_draining),
+        time.monotonic() - started,
+    )
+    return holder
+
+
+def _close(holder: _SharedEngine, reason: str) -> None:
+    if holder.closed:
+        return
+    holder.closed = True
+    if holder in _draining:
+        _draining.remove(holder)
+    if holder.idle_handle is not None:
+        holder.idle_handle.cancel()
+        holder.idle_handle = None
+    if holder.loop.is_closed():
+        # 事件循环已经结束，dispatcher 随之失效，只能丢弃引用。
+        logger.debug(
+            "event=snmp_engine_dropped scope=%s generation=%s reason=%s",
+            holder.label,
+            holder.generation,
+            reason,
+        )
+        return
+    try:
+        close_snmp_engine(holder.engine)
+    except Exception as exc:  # noqa: BLE001 - 关闭失败不影响采集结果，无需 traceback
+        logger.warning(
+            "event=snmp_engine_close_failed scope=%s generation=%s reason=%s error_type=%s",
+            holder.label,
+            holder.generation,
+            reason,
+            type(exc).__name__,
+        )
+        return
+    logger.info(
+        "event=snmp_engine_closed scope=%s generation=%s reason=%s acquisitions=%s distinct_targets=%s "
+        "lifetime_seconds=%.1f active_engines=%s draining_engines=%s",
+        holder.label,
+        holder.generation,
+        reason,
+        holder.acquisitions,
+        len(holder.targets),
+        time.monotonic() - holder.opened_at,
+        len(_active),
+        len(_draining),
+    )
+
+
+def _retire(holder: _SharedEngine, reason: str) -> None:
+    """把 engine 移出活跃表；在途请求排空（或事件循环已结束）后关闭。"""
+
+    if _active.get(holder.scope) is holder:
+        del _active[holder.scope]
+    if holder.idle_handle is not None:
+        holder.idle_handle.cancel()
+        holder.idle_handle = None
+    holder.retired = True
+    holder.retire_reason = reason
+    if holder.in_flight == 0 or holder.loop.is_closed():
+        _close(holder, reason)
+    elif holder not in _draining:
+        _draining.append(holder)
+
+
+def _close_idle(holder: _SharedEngine) -> None:
+    holder.idle_handle = None
+    if holder.closed or holder.in_flight:
+        return
+    if _active.get(holder.scope) is holder:
+        del _active[holder.scope]
+    _close(holder, "idle")
+
+
+def _acquire(scope: str, target: tuple[str, int]) -> _SharedEngine:
+    loop = asyncio.get_running_loop()
+    settings = snmp_engine_pool_settings()
+    holder = _active.get(scope)
+    if holder is not None and holder.loop is not loop:
+        _retire(holder, "loop_changed")
+        holder = None
+    if holder is not None and target not in holder.targets and len(holder.targets) >= settings.max_targets:
+        _retire(holder, "target_limit")
+        holder = None
+    if holder is None:
+        holder = _open(scope, loop)
+    if holder.idle_handle is not None:
+        holder.idle_handle.cancel()
+        holder.idle_handle = None
+    holder.in_flight += 1
+    holder.acquisitions += 1
+    holder.targets.add(target)
+    return holder
+
+
+def _release(holder: _SharedEngine) -> None:
+    holder.in_flight -= 1
+    if holder.in_flight > 0 or holder.closed:
+        return
+    if holder.retired:
+        _close(holder, holder.retire_reason)
+        return
+    holder.idle_handle = holder.loop.call_later(snmp_engine_pool_settings().idle_seconds, _close_idle, holder)
+
+
+@asynccontextmanager
+async def shared_snmp_engine(auth_data: Any, *, target: Any):
+    """借用当前事件循环内与 ``auth_data`` 同作用域的共享 engine。
+
+    ``target`` 为 ``(host, port)``，用于统计该 engine 已服务的不同目标数以触发代际
+    轮换。上下文退出只是归还引用，不关闭 engine。
+    """
+
+    holder = _acquire(snmp_engine_scope(auth_data), _target_key(target))
+    try:
+        yield holder.engine
+    finally:
+        _release(holder)
+
+
+def close_shared_snmp_engines(reason: str = "shutdown") -> int:
+    """关闭本进程所有共享 engine（包括仍在排空的旧代），返回关闭数量。"""
+
+    holders = list(_active.values()) + list(_draining)
+    _active.clear()
+    _draining.clear()
+    closed = 0
+    for holder in holders:
+        if not holder.closed:
+            _close(holder, reason)
+            closed += 1
+    return closed
+
+
+def snmp_engine_pool_snapshot() -> dict[str, Any]:
+    engines = [
+        {
+            "scope": holder.label,
+            "generation": holder.generation,
+            "state": "draining" if holder.retired else "active",
+            "in_flight": holder.in_flight,
+            "acquisitions": holder.acquisitions,
+            "distinct_targets": len(holder.targets),
+        }
+        for holder in list(_active.values()) + list(_draining)
+    ]
+    return {
+        "active_engines": len(_active),
+        "draining_engines": len(_draining),
+        "mib_compiler_shared": _shared_mib_compiler is not None,
+        "engines": engines,
+    }
+
+
+def reset_snmp_engine_pool(*, drop_mib_compiler: bool = False) -> None:
+    """测试用：关闭全部 engine 并清空作用域标签与配置缓存。"""
+
+    global _settings, _generations, _shared_mib_compiler, _shared_mib_destination
+    close_shared_snmp_engines(reason="reset")
+    _scope_labels.clear()
+    _generations = itertools.count(1)
+    _settings = None
+    if drop_mib_compiler:
+        _shared_mib_compiler = None
+        _shared_mib_destination = None
+
+
+def register_snmp_engine_lifecycle(app) -> None:
+    @app.listener("before_server_start")
+    async def validate_snmp_engine_pool(_app, _loop):
+        # 阈值配置非法时启动失败，而不是在第一批 SNMP 目标上才暴露。
+        snmp_engine_pool_settings()
+
+    @app.listener("after_server_stop")
+    async def close_snmp_engines(_app, _loop):
+        close_shared_snmp_engines(reason="server_stop")
+
+
+__all__ = [
+    "DEFAULT_SNMP_ENGINE_IDLE_SECONDS",
+    "DEFAULT_SNMP_ENGINE_MAX_TARGETS",
+    "SnmpEnginePoolSettings",
+    "close_shared_snmp_engines",
+    "close_snmp_engine",
+    "configure_snmp_engine_pool",
+    "create_snmp_engine",
+    "register_snmp_engine_lifecycle",
+    "reset_snmp_engine_pool",
+    "shared_snmp_engine",
+    "snmp_engine_pool_settings",
+    "snmp_engine_pool_snapshot",
+    "snmp_engine_scope",
+]

--- a/agents/stargazer/docs/configuration-plugin-async-matrix.md
+++ b/agents/stargazer/docs/configuration-plugin-async-matrix.md
@@ -31,9 +31,9 @@
 | `kingbase` | 是 | 继承 `PostgresqlInfo`，使用 `psycopg.AsyncConnection` | PostgreSQL 兼容协议 |
 | `mssql` | 否（线程型 await） | `aioodbc` | 调用方使用 `await`，但 aioodbc 底层通过线程执行 ODBC，按 `sync` 管理 |
 | `mysql` | 是 | `aiomysql.connect()`、异步 cursor | protocol 为异步；同插件 job executor 为远程异步 |
-| `network` | 是 | `pysnmp.hlapi.asyncio.getCmd/nextCmd` | SNMP GET/Walk 直接 `await`，结束时关闭 dispatcher |
+| `network` | 是 | `pysnmp.hlapi.asyncio.getCmd/nextCmd` | SNMP GET/Walk 直接 `await`；`SnmpEngine` 由 `core.infra.snmp_engine_pool` 按凭据作用域进程级共享，空闲或进程退出时才关闭 dispatcher |
 | `network_config_file` | 是 | `scrapli.AsyncScrapli` + `asyncssh` transport | 原 Netmiko 整轮线程包装已移除；保持 host key 严格校验 |
-| `network_topo` | 是 | `pysnmp.hlapi.asyncio.getCmd/nextCmd/bulkCmd` | SNMP 拓扑采集和 fallback 均直接 `await` |
+| `network_topo` | 是 | `pysnmp.hlapi.asyncio.getCmd/nextCmd/bulkCmd` | SNMP 拓扑采集和 fallback 均直接 `await`，与 `network` 共用同一个共享 `SnmpEngine` 池 |
 | `oceanstor` | 是 | `httpx.AsyncClient` | 登录、分页采集和登出均直接 `await` |
 | `opengauss` | 是 | 继承 `PostgresqlInfo`，使用 `psycopg.AsyncConnection` | PostgreSQL 兼容协议 |
 | `oracle` | 是 | `oracledb.connect_async()` | 仅 Oracle Thin async 模式属于原生异步 |

--- a/agents/stargazer/plugins/inputs/network/snmp_facts.py
+++ b/agents/stargazer/plugins/inputs/network/snmp_facts.py
@@ -6,13 +6,13 @@
 import socket
 import time
 
+from core.infra.snmp_engine_pool import shared_snmp_engine
 from core.plugin.error_logging import log_plugin_exception, should_log_plugin_exception
 from pysnmp.hlapi.asyncio import (
     CommunityData,
     ContextData,
     ObjectIdentity,
     ObjectType,
-    SnmpEngine,
     UdpTransportTarget,
     UsmUserData,
     getCmd,
@@ -67,13 +67,6 @@ def _is_prefix_of(root: str, oid) -> bool:
 
 def _as_object_types(oids):
     return [ObjectType(ObjectIdentity(str(oid).lstrip("."))) for oid in oids]
-
-
-def _close_snmp_engine(engine) -> None:
-    dispatcher = getattr(engine, "transportDispatcher", None)
-    close = getattr(dispatcher, "closeDispatcher", None)
-    if callable(close):
-        close()
 
 
 class SnmpFacts:
@@ -235,7 +228,6 @@ class SnmpFacts:
         collect_started_at = time.monotonic()
         probe_timeout = min(self.timeout, 10)
         snmp_auth = self._get_snmp_auth()
-        engine = SnmpEngine()
         context = ContextData()
 
         # 定义 OID
@@ -248,8 +240,9 @@ class SnmpFacts:
             "interfaces": [],  # 确保 interfaces 是一个列表
         }
 
-        try:
-            # 系统 GET 与接口 WALK 共用目标级 Engine，避免重复初始化。
+        # 系统 GET 与接口 WALK 共用进程级共享 Engine（见 core.infra.snmp_engine_pool），
+        # 上下文退出只归还引用，不关闭 dispatcher。
+        async with shared_snmp_engine(snmp_auth, target=(self.host, self.snmp_port)) as engine:
             try:
                 observe = getattr(self._runtime_metrics, "observe", None)
                 if callable(observe):
@@ -342,32 +335,29 @@ class SnmpFacts:
                 raise RuntimeError(f"Error during SNMP interface information collection: {str(e)}")
 
             return results
-        finally:
-            _close_snmp_engine(engine)
 
     async def probe(self):
         """最小只读 SNMP GET（sysName），用于 CredentialAttempt。"""
         from core.collection.contracts import AccessProbeResult, AccessProbeStatus
 
         oid = DefineOid(dotprefix=True)
+        snmp_auth = self._get_snmp_auth()
         # access_probe：固定 10 秒超时、重试 1 次（与正式采集 timeout 解耦）
-        engine = SnmpEngine()
-        try:
-            error_indication, error_status, _error_index, var_binds = await getCmd(
-                engine,
-                self._get_snmp_auth(),
-                self._transport_target(timeout=10, retries=1),
-                ContextData(),
-                ObjectType(ObjectIdentity(oid.sysName.lstrip("."))),
-                lookupMib=False,
-            )
-        except Exception:  # noqa: BLE001 - 不把 SDK 异常正文写入结果
-            return AccessProbeResult(
-                status=AccessProbeStatus.NO_RESPONSE,
-                error_code="snmp_probe_error",
-            )
-        finally:
-            _close_snmp_engine(engine)
+        async with shared_snmp_engine(snmp_auth, target=(self.host, self.snmp_port)) as engine:
+            try:
+                error_indication, error_status, _error_index, var_binds = await getCmd(
+                    engine,
+                    snmp_auth,
+                    self._transport_target(timeout=10, retries=1),
+                    ContextData(),
+                    ObjectType(ObjectIdentity(oid.sysName.lstrip("."))),
+                    lookupMib=False,
+                )
+            except Exception:  # noqa: BLE001 - 不把 SDK 异常正文写入结果
+                return AccessProbeResult(
+                    status=AccessProbeStatus.NO_RESPONSE,
+                    error_code="snmp_probe_error",
+                )
         if error_indication:
             indication = str(error_indication).lower()
             if "timeout" in indication or "no response" in indication:

--- a/agents/stargazer/plugins/inputs/network_topo/snmp_topo.py
+++ b/agents/stargazer/plugins/inputs/network_topo/snmp_topo.py
@@ -4,7 +4,7 @@
 # @Author: windyzhao
 
 try:
-    from pysnmp.hlapi.asyncio import CommunityData, ContextData, ObjectIdentity, ObjectType, SnmpEngine, UdpTransportTarget, UsmUserData
+    from pysnmp.hlapi.asyncio import CommunityData, ContextData, ObjectIdentity, ObjectType, UdpTransportTarget, UsmUserData
     from pysnmp.hlapi.asyncio import bulkCmd as hlapi_bulk_cmd
     from pysnmp.hlapi.asyncio import getCmd as hlapi_get_cmd
     from pysnmp.hlapi.asyncio import nextCmd as hlapi_next_cmd
@@ -17,7 +17,7 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - exercised in environments without optional snmp deps
     _PYSNMP_AVAILABLE = False
     CommunityData = ContextData = ObjectIdentity = ObjectType = None  # type: ignore
-    SnmpEngine = UdpTransportTarget = UsmUserData = None  # type: ignore
+    UdpTransportTarget = UsmUserData = None  # type: ignore
     hlapi_bulk_cmd = hlapi_get_cmd = hlapi_next_cmd = None  # type: ignore
     usmAesCfb128Protocol = usmDESPrivProtocol = None  # type: ignore
     usmHMACMD5AuthProtocol = usmHMACSHAAuthProtocol = None  # type: ignore
@@ -29,6 +29,7 @@ except ModuleNotFoundError:  # pragma: no cover - exercised in environments with
         pass
 
 
+from core.infra.snmp_engine_pool import shared_snmp_engine
 from plugins.inputs.network_topo.protocol_oids import PROTOCOL_OID_GROUPS, flatten_oid_registry, get_oid_meta
 from plugins.inputs.network_topo.protocol_oids import get_root_oid as lookup_root_oid
 from plugins.inputs.network_topo.topology_facts import build_topology_fact as build_protocol_topology_fact
@@ -137,13 +138,6 @@ def _as_object_types(oids):
 
 def _is_ended_value(val) -> bool:
     return val is endOfMibView or isinstance(val, EndOfMibView)
-
-
-def _close_snmp_engine(engine) -> None:
-    dispatcher = getattr(engine, "transportDispatcher", None)
-    close = getattr(dispatcher, "closeDispatcher", None)
-    if callable(close):
-        close()
 
 
 class SnmpAuth(object):
@@ -273,6 +267,10 @@ class SnmpTopo:
             retries=self.transport_opts["retries"],
         )
 
+    def _shared_engine(self):
+        # 与 network 配置采集共用进程级 SnmpEngine 池，不再每目标新建 engine。
+        return shared_snmp_engine(self.auth, target=(self.host, self.snmp_port))
+
     @classmethod
     def _normalize_protocols(cls, enabled_protocols=None, allowed_protocols=None):
         if enabled_protocols is None:
@@ -344,11 +342,8 @@ class SnmpTopo:
         return result
 
     async def _bulk_walk_all(self):
-        engine = SnmpEngine()
-        try:
+        async with self._shared_engine() as engine:
             return await self._bulk_walk_all_with_engine(engine)
-        finally:
-            _close_snmp_engine(engine)
 
     async def _bulk_walk_all_with_engine(self, engine):
         """
@@ -438,15 +433,12 @@ class SnmpTopo:
         return get_oid_meta(root_oid).get("ifindex_type") == "scalar"
 
     async def _next_walk_oid(self, oid, *, ignore_non_increasing_oid=True):
-        engine = SnmpEngine()
-        try:
+        async with self._shared_engine() as engine:
             return await self._next_walk_oid_with_engine(
                 oid,
                 engine,
                 ignore_non_increasing_oid=ignore_non_increasing_oid,
             )
-        finally:
-            _close_snmp_engine(engine)
 
     async def _next_walk_oid_with_engine(self, oid, engine, *, ignore_non_increasing_oid=True):
         target = self._transport_target()
@@ -521,8 +513,7 @@ class SnmpTopo:
         return FallbackOidResult(records=self._format_result(varBindTable, [oid]))
 
     async def _get_scalar_oid(self, oid):
-        engine = SnmpEngine()
-        try:
+        async with self._shared_engine() as engine:
             errorIndication, errorStatus, errorIndex, varBinds = await hlapi_get_cmd(
                 engine,
                 self.auth,
@@ -531,8 +522,6 @@ class SnmpTopo:
                 *self._format_oids([f"{oid}.0"]),
                 lookupMib=False,
             )
-        finally:
-            _close_snmp_engine(engine)
         if errorIndication:
             if self._is_retryable_fallback_error(errorIndication):
                 return FallbackOidResult(records=[], skipped=True)

--- a/agents/stargazer/scripts/benchmark_snmp_scheduler.py
+++ b/agents/stargazer/scripts/benchmark_snmp_scheduler.py
@@ -12,6 +12,7 @@ from dataclasses import asdict, dataclass
 
 from core.collection.metrics import CollectionMetrics
 from core.collection.scheduler import CollectionScheduler
+from core.infra import snmp_engine_pool
 from plugins.inputs.network import snmp_facts
 
 
@@ -93,8 +94,9 @@ async def run_benchmark(
     collector_metrics = _MetricSink()
     scheduler = CollectionScheduler(max_in_flight=concurrency, metrics=scheduler_metrics)
 
-    real_engine = snmp_facts.SnmpEngine
-    real_close = snmp_facts._close_snmp_engine
+    # 共享 engine 池：peak_live_snmp_engines 现在统计的是池内 engine，而非每目标 engine。
+    real_engine = snmp_engine_pool.create_snmp_engine
+    real_close = snmp_engine_pool.close_snmp_engine
     real_get = snmp_facts.getCmd
     live_engines = 0
     peak_live_engines = 0
@@ -119,8 +121,8 @@ async def run_benchmark(
     async def never_respond(*_args, **_kwargs):
         await asyncio.Future()
 
-    snmp_facts.SnmpEngine = instrumented_engine
-    snmp_facts._close_snmp_engine = instrumented_close
+    snmp_engine_pool.create_snmp_engine = instrumented_engine
+    snmp_engine_pool.close_snmp_engine = instrumented_close
     snmp_facts.getCmd = never_respond
 
     timeout_overshoots: list[float] = []
@@ -187,8 +189,9 @@ async def run_benchmark(
             await scheduler.shutdown()
         finally:
             loop.set_exception_handler(previous_exception_handler)
-            snmp_facts.SnmpEngine = real_engine
-            snmp_facts._close_snmp_engine = real_close
+            snmp_engine_pool.close_shared_snmp_engines(reason="benchmark_finished")
+            snmp_engine_pool.create_snmp_engine = real_engine
+            snmp_engine_pool.close_snmp_engine = real_close
             snmp_facts.getCmd = real_get
 
     snapshot = scheduler_metrics.snapshot()

--- a/agents/stargazer/scripts/snmp_connectivity_check.py
+++ b/agents/stargazer/scripts/snmp_connectivity_check.py
@@ -139,6 +139,7 @@ def local_route_probe(host: str, port: int) -> tuple[bool, str]:
 
 async def _snmp_get(host: str, port: int, timeout: float, retries: int, credential: dict):
     """按生产 SnmpFacts 的认证/传输参数，GET 同一个 sysName.0 OID。"""
+    from core.infra.snmp_engine_pool import shared_snmp_engine
     from plugins.inputs.network import snmp_facts
 
     if credential["version"] in {"v2", "v2c"}:
@@ -167,8 +168,7 @@ async def _snmp_get(host: str, port: int, timeout: float, retries: int, credenti
             }[credential["privacy"]],
         )
     target = snmp_facts.UdpTransportTarget((host, port), timeout=timeout, retries=retries)
-    engine = snmp_facts.SnmpEngine()
-    try:
+    async with shared_snmp_engine(auth, target=(host, port)) as engine:
         return await snmp_facts.getCmd(
             engine,
             auth,
@@ -177,8 +177,6 @@ async def _snmp_get(host: str, port: int, timeout: float, retries: int, credenti
             snmp_facts.ObjectType(snmp_facts.ObjectIdentity(SYS_NAME_OID)),
             lookupMib=False,
         )
-    finally:
-        snmp_facts._close_snmp_engine(engine)
 
 
 def _safe_text(value, *, limit: int = 160) -> str:

--- a/agents/stargazer/server.py
+++ b/agents/stargazer/server.py
@@ -6,6 +6,7 @@ from core.collection.host_remote.runtime import register_host_remote_runtime
 from core.config import YamlConfig
 from core.infra.nats import initialize_nats
 from core.infra.redis_client import register_redis_lifecycle
+from core.infra.snmp_engine_pool import register_snmp_engine_lifecycle
 from dotenv import load_dotenv
 from sanic import Sanic
 
@@ -22,6 +23,7 @@ service_name = f"{nats_instance_id}_stargazer"
 nats = initialize_nats(app, service_name=service_name)
 
 register_redis_lifecycle(app)
+register_snmp_engine_lifecycle(app)
 initialize_collection_application(app)
 register_host_remote_runtime(app)
 

--- a/agents/stargazer/tests/test_snmp_engine_pool.py
+++ b/agents/stargazer/tests/test_snmp_engine_pool.py
@@ -1,0 +1,471 @@
+# -*- coding: utf-8 -*-
+"""进程级共享 SnmpEngine 池的行为锁定测试。"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+from core.infra import snmp_engine_pool as pool
+from pysnmp.hlapi.asyncio import (
+    CommunityData,
+    ContextData,
+    ObjectIdentity,
+    ObjectType,
+    UdpTransportTarget,
+    UsmUserData,
+    getCmd,
+    usmAesCfb128Protocol,
+    usmHMACSHAAuthProtocol,
+)
+
+SECRET = "must-not-be-logged"
+
+
+class FakeDispatcher:
+    def __init__(self, fail_close=False):
+        self.closed = 0
+        self.fail_close = fail_close
+
+    def closeDispatcher(self):
+        self.closed += 1
+        if self.fail_close:
+            raise RuntimeError(f"dispatcher secret={SECRET}")
+
+
+class FakeEngine:
+    def __init__(self, fail_close=False):
+        self.transportDispatcher = FakeDispatcher(fail_close=fail_close)
+
+
+class RecordingLogger:
+    def __init__(self):
+        self.calls = []
+
+    def __getattr__(self, level):
+        def _log(message, *args, **kwargs):
+            self.calls.append((level, message, args, kwargs))
+
+        return _log
+
+    def rendered(self, level):
+        return [message % args if args else message for lvl, message, args, _ in self.calls if lvl == level]
+
+    def levels(self):
+        return [lvl for lvl, _, _, _ in self.calls]
+
+
+class FakeApp:
+    def __init__(self):
+        self.listeners = {}
+
+    def listener(self, event):
+        def register(handler):
+            self.listeners[event] = handler
+            return handler
+
+        return register
+
+
+def _community(name="public"):
+    return CommunityData(name)
+
+
+def _usm(auth_key="authkey-one"):
+    return UsmUserData(
+        "admin",
+        authKey=auth_key,
+        privKey="privkey-one",
+        authProtocol=usmHMACSHAAuthProtocol,
+        privProtocol=usmAesCfb128Protocol,
+    )
+
+
+def _unreachable_get(engine, auth, port, timeout=1):
+    return getCmd(
+        engine,
+        auth,
+        UdpTransportTarget(("127.0.0.1", port), timeout=timeout, retries=0),
+        ContextData(),
+        ObjectType(ObjectIdentity("1.3.6.1.2.1.1.5.0")),
+        lookupMib=False,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_pool():
+    pool.reset_snmp_engine_pool()
+    yield
+    pool.reset_snmp_engine_pool()
+
+
+@pytest.fixture
+def fake_engines(monkeypatch):
+    engines = []
+
+    def factory():
+        engine = FakeEngine()
+        engines.append(engine)
+        return engine
+
+    monkeypatch.setattr(pool, "create_snmp_engine", factory)
+    return engines
+
+
+@pytest.fixture
+def settings():
+    def _configure(**overrides):
+        pool.configure_snmp_engine_pool(pool.SnmpEnginePoolSettings(**overrides))
+
+    return _configure
+
+
+@pytest.mark.asyncio
+async def test_same_scope_reuses_one_engine_across_targets_and_calls(fake_engines):
+    async def use(port):
+        async with pool.shared_snmp_engine(_community(), target=("10.0.0.1", port)) as engine:
+            await asyncio.sleep(0.01)
+            return engine
+
+    sequential = [await use(161) for _ in range(3)]
+    concurrent = await asyncio.gather(*(use(1000 + index) for index in range(5)))
+
+    assert len(fake_engines) == 1
+    assert {id(engine) for engine in sequential + concurrent} == {id(fake_engines[0])}
+    assert fake_engines[0].transportDispatcher.closed == 0
+    snapshot = pool.snmp_engine_pool_snapshot()
+    assert snapshot["active_engines"] == 1
+    assert snapshot["draining_engines"] == 0
+    assert snapshot["engines"] == [
+        {
+            "scope": "community",
+            "generation": 1,
+            "state": "active",
+            "in_flight": 0,
+            "acquisitions": 8,
+            "distinct_targets": 6,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_v2c_communities_share_engine_but_v3_key_material_does_not(fake_engines):
+    async def use(auth):
+        async with pool.shared_snmp_engine(auth, target=("10.0.0.2", 161)) as engine:
+            return engine
+
+    public = await use(_community("public"))
+    private = await use(_community("private"))
+    key_one = await use(_usm("authkey-one"))
+    key_one_again = await use(_usm("authkey-one"))
+    key_two = await use(_usm("authkey-two"))
+
+    assert public is private
+    assert key_one is key_one_again
+    assert key_one is not key_two
+    assert key_one is not public
+    assert len(fake_engines) == 3
+    labels = sorted(entry["scope"] for entry in pool.snmp_engine_pool_snapshot()["engines"])
+    assert labels == ["community", "v3#1", "v3#2"]
+
+
+def test_scope_key_never_contains_credential_material():
+    scope = pool.snmp_engine_scope(_usm(SECRET))
+    assert scope.startswith("v3:")
+    assert SECRET not in scope
+    assert "admin" not in scope
+    assert pool.snmp_engine_scope(_community(SECRET)) == "community"
+    with pytest.raises(TypeError):
+        pool.snmp_engine_scope(object())
+
+
+@pytest.mark.asyncio
+async def test_idle_engine_is_closed_after_ttl_and_reopened_on_demand(fake_engines, settings):
+    settings(idle_seconds=0.05)
+
+    async with pool.shared_snmp_engine(_community(), target=("10.0.0.3", 161)):
+        pass
+    assert fake_engines[0].transportDispatcher.closed == 0
+
+    await asyncio.sleep(0.15)
+    assert fake_engines[0].transportDispatcher.closed == 1
+    assert pool.snmp_engine_pool_snapshot()["active_engines"] == 0
+
+    async with pool.shared_snmp_engine(_community(), target=("10.0.0.3", 161)) as engine:
+        assert engine is fake_engines[1]
+    assert pool.snmp_engine_pool_snapshot()["engines"][0]["generation"] == 2
+
+
+@pytest.mark.asyncio
+async def test_reacquire_before_idle_ttl_cancels_pending_close(fake_engines, settings):
+    settings(idle_seconds=0.05)
+
+    for _ in range(4):
+        async with pool.shared_snmp_engine(_community(), target=("10.0.0.4", 161)):
+            pass
+        await asyncio.sleep(0.02)
+
+    assert len(fake_engines) == 1
+    assert fake_engines[0].transportDispatcher.closed == 0
+
+
+@pytest.mark.asyncio
+async def test_target_limit_rotates_generation_and_drains_old_engine(fake_engines, settings):
+    settings(max_targets=2)
+    release = asyncio.Event()
+
+    async def hold(port):
+        async with pool.shared_snmp_engine(_community(), target=("10.0.0.5", port)) as engine:
+            await release.wait()
+            return engine
+
+    holding = asyncio.create_task(hold(1))
+    await asyncio.sleep(0)
+    async with pool.shared_snmp_engine(_community(), target=("10.0.0.5", 2)) as second:
+        pass
+    async with pool.shared_snmp_engine(_community(), target=("10.0.0.5", 3)) as third:
+        pass
+
+    assert second is fake_engines[0]
+    assert third is fake_engines[1]
+    snapshot = pool.snmp_engine_pool_snapshot()
+    assert snapshot["active_engines"] == 1
+    assert snapshot["draining_engines"] == 1
+    assert fake_engines[0].transportDispatcher.closed == 0  # 旧代仍有在途请求，不能关
+
+    release.set()
+    assert await holding is fake_engines[0]
+    assert fake_engines[0].transportDispatcher.closed == 1
+    snapshot = pool.snmp_engine_pool_snapshot()
+    assert snapshot["draining_engines"] == 0
+    assert snapshot["engines"][0]["generation"] == 2
+
+    async with pool.shared_snmp_engine(_community(), target=("10.0.0.5", 3)) as again:
+        assert again is fake_engines[1]  # 已知目标不触发再次轮换
+    assert len(fake_engines) == 2
+
+
+def test_engine_bound_to_finished_loop_is_dropped_without_closing(fake_engines):
+    async def use():
+        async with pool.shared_snmp_engine(_community(), target=("10.0.0.6", 161)) as engine:
+            return engine
+
+    first = asyncio.run(use())
+    second = asyncio.run(use())
+
+    assert first is fake_engines[0]
+    assert second is fake_engines[1]
+    assert first.transportDispatcher.closed == 0
+    assert pool.snmp_engine_pool_snapshot()["active_engines"] == 1
+
+
+@pytest.mark.asyncio
+async def test_exception_inside_context_releases_engine(fake_engines):
+    with pytest.raises(RuntimeError, match="boom"):
+        async with pool.shared_snmp_engine(_community(), target=("10.0.0.7", 161)):
+            raise RuntimeError("boom")
+
+    assert pool.snmp_engine_pool_snapshot()["engines"][0]["in_flight"] == 0
+    assert fake_engines[0].transportDispatcher.closed == 0
+
+
+@pytest.mark.asyncio
+async def test_cancellation_inside_context_releases_engine(fake_engines):
+    started = asyncio.Event()
+
+    async def use():
+        async with pool.shared_snmp_engine(_community(), target=("10.0.0.8", 161)):
+            started.set()
+            await asyncio.sleep(10)
+
+    task = asyncio.create_task(use())
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert pool.snmp_engine_pool_snapshot()["engines"][0]["in_flight"] == 0
+
+
+@pytest.mark.asyncio
+async def test_close_all_closes_active_and_draining_engines(fake_engines, settings):
+    settings(max_targets=1)
+    release = asyncio.Event()
+
+    async def hold():
+        async with pool.shared_snmp_engine(_community(), target=("10.0.0.9", 1)):
+            await release.wait()
+
+    holding = asyncio.create_task(hold())
+    await asyncio.sleep(0)
+    async with pool.shared_snmp_engine(_community(), target=("10.0.0.9", 2)):
+        pass
+    assert pool.snmp_engine_pool_snapshot()["draining_engines"] == 1
+
+    assert pool.close_shared_snmp_engines(reason="server_stop") == 2
+    assert [engine.transportDispatcher.closed for engine in fake_engines] == [1, 1]
+    snapshot = pool.snmp_engine_pool_snapshot()
+    assert snapshot["active_engines"] == 0
+    assert snapshot["draining_engines"] == 0
+    assert snapshot["engines"] == []
+
+    release.set()
+    await holding
+    assert [engine.transportDispatcher.closed for engine in fake_engines] == [1, 1]
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_logs_use_templates_with_lazy_args_and_no_secrets(fake_engines, settings, monkeypatch):
+    settings(idle_seconds=0.05)
+    recorder = RecordingLogger()
+    monkeypatch.setattr(pool, "logger", recorder)
+
+    async with pool.shared_snmp_engine(_community(SECRET), target=("10.0.0.10", 161)):
+        pass
+    async with pool.shared_snmp_engine(_usm(SECRET), target=("10.0.0.10", 161)):
+        pass
+    await asyncio.sleep(0.15)
+
+    assert recorder.levels() == ["info", "info", "info", "info"]
+    for _, message, args, kwargs in recorder.calls:
+        assert "%s" in message  # 稳定模板
+        assert args  # 惰性独立参数
+        assert not kwargs
+    rendered = recorder.rendered("info")
+    assert rendered[0].startswith("event=snmp_engine_opened scope=community generation=1 active_engines=1 draining_engines=0 init_seconds=")
+    assert rendered[1].startswith("event=snmp_engine_opened scope=v3#1 generation=2 active_engines=2 draining_engines=0 init_seconds=")
+    assert rendered[2].startswith(
+        "event=snmp_engine_closed scope=community generation=1 reason=idle acquisitions=1 distinct_targets=1 lifetime_seconds="
+    )
+    assert rendered[2].endswith("active_engines=1 draining_engines=0")
+    assert rendered[3].startswith("event=snmp_engine_closed scope=v3#1 generation=2 reason=idle ")
+    assert all(SECRET not in line and "admin" not in line for line in rendered)
+
+
+@pytest.mark.asyncio
+async def test_close_failure_logs_single_warning_without_traceback(monkeypatch):
+    engines = []
+
+    def factory():
+        engine = FakeEngine(fail_close=True)
+        engines.append(engine)
+        return engine
+
+    monkeypatch.setattr(pool, "create_snmp_engine", factory)
+    recorder = RecordingLogger()
+    monkeypatch.setattr(pool, "logger", recorder)
+
+    async with pool.shared_snmp_engine(_community(), target=("10.0.0.11", 161)):
+        pass
+    assert pool.close_shared_snmp_engines(reason="server_stop") == 1
+
+    assert recorder.levels() == ["info", "warning"]
+    _, message, args, kwargs = recorder.calls[1]
+    assert "%s" in message
+    assert "exc_info" not in kwargs
+    rendered = message % args
+    assert rendered == "event=snmp_engine_close_failed scope=community generation=1 reason=server_stop error_type=RuntimeError"
+    assert SECRET not in rendered
+    assert engines[0].transportDispatcher.closed == 1
+    assert pool.snmp_engine_pool_snapshot()["active_engines"] == 0
+
+
+def test_settings_from_env_defaults_and_validation(monkeypatch):
+    monkeypatch.delenv("SNMP_ENGINE_MAX_TARGETS", raising=False)
+    monkeypatch.delenv("SNMP_ENGINE_IDLE_SECONDS", raising=False)
+    assert pool.SnmpEnginePoolSettings.from_env() == pool.SnmpEnginePoolSettings(max_targets=2000, idle_seconds=300.0)
+
+    monkeypatch.setenv("SNMP_ENGINE_MAX_TARGETS", "50")
+    monkeypatch.setenv("SNMP_ENGINE_IDLE_SECONDS", "1.5")
+    assert pool.SnmpEnginePoolSettings.from_env() == pool.SnmpEnginePoolSettings(max_targets=50, idle_seconds=1.5)
+
+    for name, value in (
+        ("SNMP_ENGINE_MAX_TARGETS", "0"),
+        ("SNMP_ENGINE_MAX_TARGETS", "-5"),
+        ("SNMP_ENGINE_MAX_TARGETS", "many"),
+        ("SNMP_ENGINE_IDLE_SECONDS", "0"),
+        ("SNMP_ENGINE_IDLE_SECONDS", "-1"),
+        ("SNMP_ENGINE_IDLE_SECONDS", "soon"),
+    ):
+        monkeypatch.setenv("SNMP_ENGINE_MAX_TARGETS", "50")
+        monkeypatch.setenv("SNMP_ENGINE_IDLE_SECONDS", "1.5")
+        monkeypatch.setenv(name, value)
+        with pytest.raises(ValueError, match=name):
+            pool.SnmpEnginePoolSettings.from_env()
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_validates_settings_at_start_and_closes_engines_at_stop(fake_engines, monkeypatch):
+    app = FakeApp()
+    pool.register_snmp_engine_lifecycle(app)
+    assert set(app.listeners) == {"before_server_start", "after_server_stop"}
+
+    monkeypatch.setenv("SNMP_ENGINE_MAX_TARGETS", "nope")
+    with pytest.raises(ValueError, match="SNMP_ENGINE_MAX_TARGETS"):
+        await app.listeners["before_server_start"](app, None)
+
+    monkeypatch.setenv("SNMP_ENGINE_MAX_TARGETS", "10")
+    await app.listeners["before_server_start"](app, None)
+    assert pool.snmp_engine_pool_settings().max_targets == 10
+
+    async with pool.shared_snmp_engine(_community(), target=("10.0.0.12", 161)):
+        pass
+    await app.listeners["after_server_stop"](app, None)
+    assert fake_engines[0].transportDispatcher.closed == 1
+    assert pool.snmp_engine_pool_snapshot()["active_engines"] == 0
+
+
+@pytest.mark.asyncio
+async def test_real_engines_share_one_mib_compiler_and_build_parser_once(monkeypatch):
+    """锁定根因：进程内只构建一次 pysmi/PLY 解析器，之后每一代 engine 复用同一编译器。"""
+
+    import ply.yacc as yacc
+
+    pool.reset_snmp_engine_pool(drop_mib_compiler=True)
+    real_yacc = yacc.yacc
+    yacc_calls = []
+
+    def counting_yacc(*args, **kwargs):
+        yacc_calls.append(1)
+        return real_yacc(*args, **kwargs)
+
+    monkeypatch.setattr(yacc, "yacc", counting_yacc)
+
+    async with pool.shared_snmp_engine(_community(), target=("127.0.0.1", 40001)) as community_engine:
+        indication, _status, _index, _binds = await _unreachable_get(community_engine, _community(), 40001)
+    assert "timeout" in str(indication).lower()
+    assert len(yacc_calls) == 1
+
+    async with pool.shared_snmp_engine(_usm(), target=("127.0.0.1", 40002)) as usm_engine:
+        await _unreachable_get(usm_engine, _usm(), 40002)
+    assert usm_engine is not community_engine
+    assert len(yacc_calls) == 1
+    assert community_engine.getMibBuilder().getMibCompiler() is usm_engine.getMibBuilder().getMibCompiler()
+    assert pool.snmp_engine_pool_snapshot()["mib_compiler_shared"] is True
+
+    async with pool.shared_snmp_engine(_community(), target=("127.0.0.1", 40003)) as engine:
+        assert engine is community_engine
+        await _unreachable_get(engine, _community(), 40003)
+    assert len(yacc_calls) == 1
+    assert pool.close_shared_snmp_engines(reason="test") == 2
+
+
+@pytest.mark.asyncio
+async def test_one_shared_engine_multiplexes_concurrent_targets_with_independent_timeouts():
+    auth = _community()
+
+    async def probe(port):
+        async with pool.shared_snmp_engine(auth, target=("127.0.0.1", port)) as engine:
+            indication, _status, _index, _binds = await _unreachable_get(engine, auth, port, timeout=1)
+            return engine, indication
+
+    started = time.monotonic()
+    results = await asyncio.gather(*(probe(41000 + index) for index in range(8)))
+    elapsed = time.monotonic() - started
+
+    assert len({id(engine) for engine, _ in results}) == 1
+    assert all("timeout" in str(indication).lower() for _, indication in results)
+    assert elapsed < 4.0  # 8 个目标各 1 秒超时并发进行，而不是串行 8 秒
+    assert pool.snmp_engine_pool_snapshot()["engines"][0]["in_flight"] == 0
+    assert pool.close_shared_snmp_engines(reason="test") == 1

--- a/agents/stargazer/tests/test_snmp_facts_probe.py
+++ b/agents/stargazer/tests/test_snmp_facts_probe.py
@@ -1,6 +1,33 @@
+import asyncio
+
 import pytest
 from core.collection.contracts import AccessProbeStatus
+from core.infra import snmp_engine_pool
 from plugins.inputs.network.snmp_facts import SnmpFacts
+
+
+@pytest.fixture(autouse=True)
+def _fake_shared_engines(monkeypatch):
+    """探测测试不需要真实 pysnmp engine：用假工厂替换共享池，并在用例前后清空池。"""
+
+    engines = []
+
+    class FakeDispatcher:
+        def __init__(self):
+            self.closed = 0
+
+        def closeDispatcher(self):
+            self.closed += 1
+
+    class FakeEngine:
+        def __init__(self):
+            self.transportDispatcher = FakeDispatcher()
+            engines.append(self)
+
+    snmp_engine_pool.reset_snmp_engine_pool()
+    monkeypatch.setattr(snmp_engine_pool, "create_snmp_engine", FakeEngine)
+    yield engines
+    snmp_engine_pool.reset_snmp_engine_pool()
 
 
 def _make_facts(**overrides):
@@ -81,6 +108,71 @@ async def test_snmp_probe_is_native_async(monkeypatch):
     monkeypatch.setattr("plugins.inputs.network.snmp_facts.getCmd", fake_get_cmd)
     result = await facts.probe()
     assert result.status == AccessProbeStatus.READY
+
+
+@pytest.mark.asyncio
+async def test_snmp_probe_sdk_exception_maps_to_probe_error_and_releases_engine(monkeypatch, _fake_shared_engines):
+    facts = _make_facts()
+
+    async def broken_get_cmd(*_args, **_kwargs):
+        raise RuntimeError("community=must-not-leak")
+
+    monkeypatch.setattr("plugins.inputs.network.snmp_facts.getCmd", broken_get_cmd)
+    result = await facts.probe()
+    assert result.status == AccessProbeStatus.NO_RESPONSE
+    assert result.error_code == "snmp_probe_error"
+    assert len(_fake_shared_engines) == 1
+    assert _fake_shared_engines[0].transportDispatcher.closed == 0
+    assert snmp_engine_pool.snmp_engine_pool_snapshot()["engines"][0]["in_flight"] == 0
+
+
+@pytest.mark.asyncio
+async def test_snmp_probe_and_collect_reuse_one_engine_instance_in_process(monkeypatch, _fake_shared_engines):
+    """同一进程内多次 probe/collect（不同目标）共用同一个 engine 实例，且不按目标关闭。"""
+
+    io_engines = []
+
+    class FakeOid:
+        def __init__(self, text):
+            self._text = text
+
+        def prettyPrint(self):
+            return self._text
+
+    class FakeVal:
+        def __init__(self, text):
+            self._text = text
+            self._value = text.encode()
+
+        def prettyPrint(self):
+            return self._text
+
+    async def fake_get_cmd(engine, *_args, **_kwargs):
+        io_engines.append(engine)
+        await asyncio.sleep(0.005)
+        return (None, 0, 0, [(FakeOid("1.3.6.1.2.1.1.5.0"), FakeVal("switch-a"))])
+
+    async def fake_next_cmd(engine, *_args, **_kwargs):
+        io_engines.append(engine)
+        return (None, 0, 0, [])
+
+    monkeypatch.setattr("plugins.inputs.network.snmp_facts.getCmd", fake_get_cmd)
+    monkeypatch.setattr("plugins.inputs.network.snmp_facts.nextCmd", fake_next_cmd)
+
+    probes = [_make_facts(host=f"127.0.0.{index}").probe() for index in range(1, 5)]
+    collects = [_make_facts(host=f"127.0.0.{index}").collect() for index in range(1, 5)]
+    results = await asyncio.gather(*probes, *collects)
+
+    assert all(result.status == AccessProbeStatus.READY for result in results[:4])
+    assert all(result["system"]["sysname"] == "switch-a" for result in results[4:])
+    assert len(_fake_shared_engines) == 1
+    assert {id(engine) for engine in io_engines} == {id(_fake_shared_engines[0])}
+    assert _fake_shared_engines[0].transportDispatcher.closed == 0
+    snapshot = snmp_engine_pool.snmp_engine_pool_snapshot()
+    assert snapshot["active_engines"] == 1
+    assert snapshot["engines"][0]["in_flight"] == 0
+    assert snapshot["engines"][0]["acquisitions"] == 8
+    assert snapshot["engines"][0]["distinct_targets"] == 4
 
 
 @pytest.mark.asyncio

--- a/agents/stargazer/tests/test_snmp_plugins_native_async.py
+++ b/agents/stargazer/tests/test_snmp_plugins_native_async.py
@@ -9,8 +9,35 @@ import inspect
 import pytest
 from core.collection.contracts import AccessProbeStatus
 from core.collection.metrics import CollectionMetrics
+from core.infra import snmp_engine_pool
 from plugins.inputs.network.snmp_facts import SnmpFacts
 from plugins.inputs.network_topo.snmp_topo import SnmpTopo
+
+
+@pytest.fixture(autouse=True)
+def _reset_snmp_engine_pool():
+    snmp_engine_pool.reset_snmp_engine_pool()
+    yield
+    snmp_engine_pool.reset_snmp_engine_pool()
+
+
+def _install_fake_engines(monkeypatch):
+    """用假 engine 替换池的工厂；返回 (已创建 engine 列表, closeDispatcher 调用记录)。"""
+
+    engines = []
+    closed = []
+
+    class FakeDispatcher:
+        def closeDispatcher(self):
+            closed.append(True)
+
+    class FakeEngine:
+        def __init__(self):
+            self.transportDispatcher = FakeDispatcher()
+            engines.append(self)
+
+    monkeypatch.setattr(snmp_engine_pool, "create_snmp_engine", FakeEngine)
+    return engines, closed
 
 
 async def _heartbeat_during(awaitable, minimum_ticks: int = 5):
@@ -32,17 +59,36 @@ async def _heartbeat_during(awaitable, minimum_ticks: int = 5):
         assert ticks >= minimum_ticks, "event_loop_stalled"
 
 
+class FakeOid:
+    def __init__(self, text):
+        self._text = text
+
+    def prettyPrint(self):
+        return self._text
+
+
+class FakeVal:
+    def __init__(self, text):
+        self._text = text
+        self._value = text.encode() if isinstance(text, str) else text
+
+    def prettyPrint(self):
+        return self._text
+
+
+def _system_var_binds():
+    return [
+        (FakeOid("1.3.6.1.2.1.1.1.0"), FakeVal("desc")),
+        (FakeOid("1.3.6.1.2.1.1.2.0"), FakeVal("1.3.6")),
+        (FakeOid("1.3.6.1.2.1.1.4.0"), FakeVal("admin")),
+        (FakeOid("1.3.6.1.2.1.1.5.0"), FakeVal("sw")),
+        (FakeOid("1.3.6.1.2.1.1.6.0"), FakeVal("rack")),
+    ]
+
+
 @pytest.mark.asyncio
 async def test_snmp_facts_probe_does_not_stall(monkeypatch):
-    closed = []
-
-    class FakeDispatcher:
-        def closeDispatcher(self):
-            closed.append(True)
-
-    class FakeEngine:
-        def __init__(self):
-            self.transportDispatcher = FakeDispatcher()
+    engines, closed = _install_fake_engines(monkeypatch)
 
     facts = SnmpFacts(
         {
@@ -58,27 +104,17 @@ async def test_snmp_facts_probe_does_not_stall(monkeypatch):
         return (None, 0, 0, [("1.3.6.1.2.1.1.5.0", "sw")])
 
     monkeypatch.setattr("plugins.inputs.network.snmp_facts.getCmd", slow_get)
-    monkeypatch.setattr("plugins.inputs.network.snmp_facts.SnmpEngine", FakeEngine)
     result = await _heartbeat_during(facts.probe())
     assert result.status == AccessProbeStatus.READY
-    assert closed == [True]
+    assert len(engines) == 1
+    assert closed == []  # 共享 engine 不随单目标结束而关闭
 
 
 @pytest.mark.asyncio
 async def test_snmp_facts_collect_does_not_stall(monkeypatch):
-    closed = []
-    engines = []
+    engines, closed = _install_fake_engines(monkeypatch)
     io_engines = []
     metrics = CollectionMetrics()
-
-    class FakeDispatcher:
-        def closeDispatcher(self):
-            closed.append(True)
-
-    class FakeEngine:
-        def __init__(self):
-            self.transportDispatcher = FakeDispatcher()
-            engines.append(self)
 
     facts = SnmpFacts(
         {
@@ -90,36 +126,10 @@ async def test_snmp_facts_collect_does_not_stall(monkeypatch):
         }
     )
 
-    class FakeOid:
-        def __init__(self, text):
-            self._text = text
-
-        def prettyPrint(self):
-            return self._text
-
-    class FakeVal:
-        def __init__(self, text):
-            self._text = text
-            self._value = text.encode() if isinstance(text, str) else text
-
-        def prettyPrint(self):
-            return self._text
-
     async def fake_get(engine, *_args, **_kwargs):
         io_engines.append(engine)
         await asyncio.sleep(0.05)
-        return (
-            None,
-            0,
-            0,
-            [
-                (FakeOid("1.3.6.1.2.1.1.1.0"), FakeVal("desc")),
-                (FakeOid("1.3.6.1.2.1.1.2.0"), FakeVal("1.3.6")),
-                (FakeOid("1.3.6.1.2.1.1.4.0"), FakeVal("admin")),
-                (FakeOid("1.3.6.1.2.1.1.5.0"), FakeVal("sw")),
-                (FakeOid("1.3.6.1.2.1.1.6.0"), FakeVal("rack")),
-            ],
-        )
+        return (None, 0, 0, _system_var_binds())
 
     async def fake_next(engine, *_args, **_kwargs):
         io_engines.append(engine)
@@ -128,52 +138,89 @@ async def test_snmp_facts_collect_does_not_stall(monkeypatch):
 
     monkeypatch.setattr("plugins.inputs.network.snmp_facts.getCmd", fake_get)
     monkeypatch.setattr("plugins.inputs.network.snmp_facts.nextCmd", fake_next)
-    monkeypatch.setattr("plugins.inputs.network.snmp_facts.SnmpEngine", FakeEngine)
     result = await _heartbeat_during(facts.list_all_resources())
     assert result["success"] is True
     assert result["result"]["network_system"][0]["sysname"] == "sw"
     assert result["result"]["network_interfaces"] == []
     assert len(engines) == 1
     assert io_engines == [engines[0], engines[0]]
-    assert closed == [True]
+    assert closed == []
     assert metrics.snapshot()["snmp_collect_to_first_io_seconds_p99"] >= 0
 
 
 @pytest.mark.asyncio
-async def test_snmp_facts_walk_failure_closes_shared_engine_once(monkeypatch):
-    engines = []
-    closed = []
+async def test_snmp_facts_walk_failure_keeps_shared_engine_for_next_target(monkeypatch):
+    engines, closed = _install_fake_engines(monkeypatch)
+    io_engines = []
 
-    class FakeDispatcher:
-        def closeDispatcher(self):
-            closed.append(True)
-
-    class FakeEngine:
-        def __init__(self):
-            engines.append(self)
-            self.transportDispatcher = FakeDispatcher()
-
-    async def fake_get(*_args, **_kwargs):
+    async def fake_get(engine, *_args, **_kwargs):
+        io_engines.append(engine)
         return (None, 0, 0, [])
 
     async def broken_next(*_args, **_kwargs):
         raise RuntimeError("walk failed")
 
-    facts = SnmpFacts(
-        {
-            "host": "127.0.0.1",
-            "version": "v2",
-            "community": "public",
-        }
-    )
-    monkeypatch.setattr("plugins.inputs.network.snmp_facts.SnmpEngine", FakeEngine)
+    async def fake_next(engine, *_args, **_kwargs):
+        io_engines.append(engine)
+        return (None, 0, 0, [])
+
     monkeypatch.setattr("plugins.inputs.network.snmp_facts.getCmd", fake_get)
     monkeypatch.setattr("plugins.inputs.network.snmp_facts.nextCmd", broken_next)
 
+    facts = SnmpFacts({"host": "127.0.0.1", "version": "v2", "community": "public"})
     with pytest.raises(RuntimeError, match="SNMP interface information collection"):
         await facts.collect()
+    assert len(engines) == 1
+    assert closed == []
+    assert snmp_engine_pool.snmp_engine_pool_snapshot()["engines"][0]["in_flight"] == 0
+
+    monkeypatch.setattr("plugins.inputs.network.snmp_facts.nextCmd", fake_next)
+    next_facts = SnmpFacts({"host": "127.0.0.2", "version": "v2", "community": "public"})
+    result = await next_facts.collect()
+    assert result["system"]["ip_addr"] == "127.0.0.2"
+    assert len(engines) == 1
+    assert io_engines == [engines[0]] * 3
+    assert closed == []
+
+
+@pytest.mark.asyncio
+async def test_snmp_facts_collect_and_probe_share_one_engine_per_process(monkeypatch):
+    """同一进程内多次 collect/probe（不同目标、串行与并发）都复用同一个 engine 实例。"""
+
+    engines, closed = _install_fake_engines(monkeypatch)
+    io_engines = []
+
+    async def fake_get(engine, *_args, **_kwargs):
+        io_engines.append(engine)
+        await asyncio.sleep(0.01)
+        return (None, 0, 0, _system_var_binds())
+
+    async def fake_next(engine, *_args, **_kwargs):
+        io_engines.append(engine)
+        await asyncio.sleep(0.01)
+        return (None, 0, 0, [])
+
+    monkeypatch.setattr("plugins.inputs.network.snmp_facts.getCmd", fake_get)
+    monkeypatch.setattr("plugins.inputs.network.snmp_facts.nextCmd", fake_next)
+
+    def make(host):
+        return SnmpFacts({"host": host, "version": "v2c", "community": "public", "snmp_port": 161})
+
+    for index in range(1, 4):
+        assert (await make(f"127.0.0.{index}").probe()).status == AccessProbeStatus.READY
+        assert (await make(f"127.0.0.{index}").collect())["system"]["sysname"] == "sw"
+    await asyncio.gather(*(make(f"127.0.0.{index}").collect() for index in range(4, 8)))
+    await asyncio.gather(*(make(f"127.0.0.{index}").probe() for index in range(4, 8)))
 
     assert len(engines) == 1
+    assert io_engines
+    assert {id(engine) for engine in io_engines} == {id(engines[0])}
+    assert closed == []
+    snapshot = snmp_engine_pool.snmp_engine_pool_snapshot()
+    assert snapshot["active_engines"] == 1
+    assert snapshot["engines"][0]["in_flight"] == 0
+    assert snapshot["engines"][0]["distinct_targets"] == 7
+    assert snmp_engine_pool.close_shared_snmp_engines(reason="test") == 1
     assert closed == [True]
 
 
@@ -191,6 +238,39 @@ async def test_snmp_topo_list_all_resources_does_not_stall(monkeypatch):
     result = await _heartbeat_during(collector.list_all_resources())
     assert result["success"] is True
     assert result["result"]["network_topo"][0]["val"] == "eth0"
+
+
+@pytest.mark.asyncio
+async def test_snmp_topo_bulk_walk_and_fallback_share_one_engine(monkeypatch):
+    engines, closed = _install_fake_engines(monkeypatch)
+    io_engines = []
+
+    async def fake_bulk(engine, *_args, **_kwargs):
+        io_engines.append(engine)
+        return (None, 0, 0, [])
+
+    async def fake_next(engine, *_args, **_kwargs):
+        io_engines.append(engine)
+        return (None, 0, 0, [])
+
+    async def fake_get(engine, *_args, **_kwargs):
+        io_engines.append(engine)
+        return (None, 0, 0, [])
+
+    monkeypatch.setattr("plugins.inputs.network_topo.snmp_topo.hlapi_bulk_cmd", fake_bulk)
+    monkeypatch.setattr("plugins.inputs.network_topo.snmp_topo.hlapi_next_cmd", fake_next)
+    monkeypatch.setattr("plugins.inputs.network_topo.snmp_topo.hlapi_get_cmd", fake_get)
+
+    first = SnmpTopo({"host": "127.0.0.1", "version": "v2c", "community": "public"})
+    second = SnmpTopo({"host": "127.0.0.2", "version": "v2c", "community": "public"})
+    assert await first._bulk_walk_all() == []
+    assert await second._bulk_walk_all() == []
+    assert (await first._next_walk_oid("1.3.6.1.2.1.2.2.1.2"))[3] == []
+    assert (await second._get_scalar_oid("1.3.6.1.2.1.1.5")).records == []
+
+    assert len(engines) == 1
+    assert io_engines == [engines[0]] * 4
+    assert closed == []
 
 
 @pytest.mark.asyncio
@@ -232,6 +312,17 @@ def test_snmp_modules_have_no_to_thread():
     assert "asyncio.to_thread" not in inspect.getsource(topo_mod)
 
 
+def test_snmp_modules_never_create_per_target_engines():
+    import plugins.inputs.network.snmp_facts as facts_mod
+    import plugins.inputs.network_topo.snmp_topo as topo_mod
+
+    for module in (facts_mod, topo_mod):
+        source = inspect.getsource(module)
+        assert "SnmpEngine()" not in source
+        assert "closeDispatcher" not in source
+        assert "shared_snmp_engine" in source
+
+
 @pytest.mark.asyncio
 async def test_real_pysnmp_dispatchers_close_cleanly_after_concurrent_cancellation():
     """不替换 getCmd，锁定真实 pysnmp Future 取消后的 callback 边界。"""
@@ -258,6 +349,13 @@ async def test_real_pysnmp_dispatchers_close_cleanly_after_concurrent_cancellati
 
     try:
         await asyncio.gather(*(cancel_one(index) for index in range(32)))
+        await asyncio.sleep(0.1)
+        snapshot = snmp_engine_pool.snmp_engine_pool_snapshot()
+        assert snapshot["active_engines"] == 1
+        assert snapshot["engines"][0]["in_flight"] == 0
+        assert snapshot["engines"][0]["distinct_targets"] == 32
+        # 共享 engine 在仍有已取消的在途请求时关闭，也不得产生事件循环回调错误
+        assert snmp_engine_pool.close_shared_snmp_engines(reason="test") == 1
         await asyncio.sleep(0.1)
     finally:
         loop.set_exception_handler(previous_handler)

--- a/specs/changes/stargazer-stateless-async-collection/snmp-engine-pool-fix-report-2026-09-02.md
+++ b/specs/changes/stargazer-stateless-async-collection/snmp-engine-pool-fix-report-2026-09-02.md
@@ -1,0 +1,89 @@
+# SNMP 采集 SnmpEngine 每目标泄漏修复报告（2026-09-02）
+
+## 结论
+
+- 8-31 生产事故（250 并发、事件循环延迟 14 s、RSS 4.8 GiB 不回落）的根因是 `snmp_facts.py`
+  与 `snmp_topo.py` **每个目标新建 pysnmp `SnmpEngine`**（collect / probe / bulk / next / get 共 5 处）。
+- 修复：新增 `core/infra/snmp_engine_pool.py`，同一事件循环内按凭据作用域共享 engine
+  （v1/v2c 共用一个，v3 按用户名+协议+密钥摘要各一个），进程内只构建一次 pysmi/PLY MIB 编译器，
+  engine 按不同目标数代际轮换（`SNMP_ENGINE_MAX_TARGETS`，默认 2000）、空闲释放
+  （`SNMP_ENGINE_IDLE_SECONDS`，默认 300）、Sanic `after_server_stop` 统一关闭。
+- builder A/B 实测（1 worker，`SNMP_MAX_IN_FLIGHT=100`，2×400 个 10.255.0.0/16 不可达目标）：
+
+| 指标 | 修复前（master `fd8d598ae`） | 修复后（本分支） |
+|---|---|---|
+| RSS 基线 | 73 MiB | 73 MiB |
+| 400 目标后 RSS | 930 MiB | 105 MiB |
+| 800 目标后 RSS | 1747 MiB | 115 MiB |
+| 空闲 60 s 后 RSS | 1784 MiB | 115 MiB |
+| `malloc_trim(0)` 后 RSS | 1742 MiB | 113 MiB |
+| 存活 `ply.yacc.LRParser` / `LRItem` | 800 / 807 200 | 1 / 1 009 |
+| gc 跟踪对象数 | 4 930 546 | 173 145 |
+| 忙碌期 CPU%（max / p90 / 中位） | 99.7 / 99.7 / 0.9 | 18.0 / 9.5 / 0.1 |
+| 忙碌期事件循环 P99 延迟 ms（max / p90 / 中位） | 7304 / 1260 / 492 | 25.2 / 2.5 / 1.5 |
+| 400 目标批次墙钟 | ≈110 s | ≈85 s |
+
+修复后 800 目标 RSS 增长 42 MiB（验收阈值 <200 MiB），`ply/yacc.py` 存活对象只有一份
+（1 009 个 LRItem，而非修复前的 80 万），空闲与 trim 后不再有可回收的碎片（115→113 MiB）。
+
+## 根因链（pysnmp 5.1.0 / pysmi 1.2.1 / ply 3.11 / uvloop 0.21）
+
+1. 每个 `SnmpEngine()` 自带独立 `MibBuilder` 并加载一整套 MIB 模块（`SNMPv2-SMI`、`SNMPv2-TM`、
+   `SNMP-TARGET-MIB`……）；`ObjectIdentity.resolveWithMib` 调 `addMibCompiler(ifNotAdded=True)`，
+   短路条件 `mibBuilder.getMibCompiler()` 是 per-engine 的，所以每个 engine 都会新建 `MibCompiler`，
+   pysmi 解析器构造时 `yacc.yacc(write_tables=False)` 现场重算 LR 表。`lookupMib=False` 只管响应侧，挡不住。
+   预热后单个 engine 的成本：`SnmpEngine()` ≈20 ms + 编译器/LR 表 ≈25 ms，合计 ≈50 ms 纯 Python CPU、
+   ≈2.1 MiB 常驻；100 并发一批同时到期就是 5 s 以上的事件循环阻塞（实测 P99 7.3 s）。
+2. **为什么关闭后不回落**：`gc.get_referrers` 从 `LRParser` 向上追到的引用链是
+   `LRParser ← SmiParser.parser ← MibCompiler ← MibBuilder ← MIB 模块命名空间 ← SnmpUDPAddress 类
+   ← SnmpUDPAddress 实例 ← UdpTransportAddress._localAddress ← uvloop.loop.LruCache`。
+   uvloop 在 `dns.pyx` 里用模块级 `sockaddrs = LruCache(maxsize=2048)` 缓存 sendto 的 Python 地址→sockaddr，
+   键就是 pysnmp 传给 `transport.sendto()` 的 `UdpTransportAddress`（tuple 子类，带 `_localAddress`），
+   而该属性是本 engine 生成的 MIB 类实例，于是每个不同目标地址都把一个**已经 closeDispatcher 的 engine**
+   整棵 MIB 树拖住，直到 2048 项 LRU 把它挤出去。2048 × 2.1 MiB ≈ 4.3 GiB，与生产 4.8 GiB 不回落吻合；
+   `gc.collect()` 返回 0 也因此正常——它们都是可达的。
+3. 共享 engine 后，缓存键指向的是长期存活的共享 engine；代际轮换关闭的旧 engine 仍可能被最多
+   2048 条地址键短暂拖住（每代 ≤ `SNMP_ENGINE_MAX_TARGETS` 条 LCD 行 ≈ 21 KiB/目标），
+   属于有界残留（实测第二代出现后 RSS 仅 +10 MiB）。
+
+## 代码变更
+
+- `core/infra/snmp_engine_pool.py`（新增）：`shared_snmp_engine(auth, target=(host, port))` 异步上下文借用
+  engine；`snmp_engine_scope()` 派生作用域键（密钥材料只做 blake2b 摘要、只留在内存，日志用 `community` /
+  `v3#N` 标签）；代际轮换、空闲关闭、`close_shared_snmp_engines()`、`register_snmp_engine_lifecycle(app)`；
+  `create_snmp_engine()` 装配进程内唯一的 MIB 编译器。生命周期日志
+  `event=snmp_engine_opened|closed|close_failed|dropped`，模板 + 惰性参数，无 traceback、无凭据。
+- `plugins/inputs/network/snmp_facts.py`、`plugins/inputs/network_topo/snmp_topo.py`：5 处 `SnmpEngine()`
+  改为借用共享 engine，删除 `_close_snmp_engine`；超时/重试语义（`timeout=10, retries=1`、probe 固定 10 s×1）不变。
+- `server.py`：注册 engine 池生命周期（启动时校验阈值配置，非法则启动失败；停止时关闭）。
+- `scripts/snmp_connectivity_check.py`、`scripts/benchmark_snmp_scheduler.py`：改走池（benchmark 的
+  `peak_live_snmp_engines` 语义变为池内 engine 数）。
+- 文档：`README.md` 并发与超时段、`docs/configuration-plugin-async-matrix.md`。
+
+## 测试
+
+- 新增 `tests/test_snmp_engine_pool.py`（18 例）：同作用域复用、v3 密钥隔离、空闲关闭与重开、代际轮换
+  排空、循环结束丢弃、异常/取消归还、全量关闭、日志模板/惰性参数/敏感哨兵/单一告警无 traceback、
+  环境变量校验、Sanic 生命周期，以及真实 pysnmp：进程内 `yacc.yacc` 只调用一次且两代 engine 共用
+  同一编译器、单 engine 并发 8 目标独立超时。
+- 更新 `tests/test_snmp_plugins_native_async.py`、`tests/test_snmp_facts_probe.py`：断言同一进程内多次
+  collect/probe（串行、并发、不同目标）共用同一 engine 实例且不按目标关闭；拓扑插件三条路径共用 engine；
+  源码级断言插件不再出现 `SnmpEngine()` / `closeDispatcher`；真实 pysnmp 32 目标并发取消后关闭共享 engine
+  无事件循环回调错误。
+- 命令：`cd agents/stargazer && uv run pytest tests/test_snmp_engine_pool.py tests/test_snmp_facts_probe.py
+  tests/test_snmp_plugins_native_async.py`（33 passed）。全量 `tests/`：修复后 939 passed / 86 failed / 37 errors，
+  失败与错误集合是 master 基线（916 passed / 88 failed / 37 errors）的子集，均为缺少可选云 SDK
+  （`oss2` 等）与主机采集环境相关的既有失败，无回归。
+
+## 复现与测量方法
+
+见 claude_space memory `stargazer-builder-concurrency-testbed`（builder `/data/snmp-engine-fix/`：
+`setup_testbed.sh` 起 before/after 两容器，`/__memdump`、`/__trim`、`/__referrers` 诊断路由，
+`run_load.sh` + `finish_load.sh` 驱动，`summarize_logs.py` 解析 `collection_capacity` 日志得到 CPU/延迟/RSS 时间线）。
+
+## 后续
+
+- `SANIC_WORKERS` 默认值（PR #5109 已撤回）应按修复后的曲线重评：单 worker 800 目标仅 +42 MiB。
+- 共享一个 UDP socket 服务全部目标：在途 ≤ `SNMP_MAX_IN_FLIGHT`（100）时接收缓冲区余量充足，
+  若未来把在途放大到数千，需评估 `SO_RCVBUF`。
+- 若需进一步压缩旧代 engine 残留，可在轮换时用 `lcd.unconfigure` 清 LCD 行，但只能在该代在途为 0 时做。


### PR DESCRIPTION
## 背景与根因

8-31 stargazer 生产事故（250 并发、事件循环延迟 14 s、RSS 4.8 GiB 不回落）的根因是 `snmp_facts.py` 与 `snmp_topo.py` **每个目标新建 pysnmp `SnmpEngine`**（collect / probe / bulk / next / get 共 5 处）：

- 每个 engine 自带独立 MibBuilder，并在首次解析 OID 时新建 pysmi `MibCompiler`、用 PLY 现场重算 SMI 语法 LR 表。预热后单个 engine ≈2.1 MiB 常驻、≈50 ms 纯 Python CPU；100 并发一批同时到期就是 5 s 以上的事件循环阻塞。`lookupMib=False` 只管响应侧，挡不住这条路径。
- **关闭后不回落的真正持有者是 uvloop**：`uvloop/dns.pyx` 的模块级 `sockaddrs = LruCache(maxsize=2048)` 以 pysnmp 传给 `sendto()` 的 `UdpTransportAddress`（tuple 子类，带 `_localAddress`）为键，而该属性是本 engine 生成的 MIB 类实例，于是每个不同目标地址都把一个已 `closeDispatcher` 的 engine 整棵 MIB 树拖住，直到 2048 项 LRU 挤出。2048 × 2.1 MiB ≈ 4.3 GiB，与生产 4.8 GiB 吻合，`gc.collect()` 回收 0 也因此正常。引用链由测试台 `/__referrers` 路由从 `ply.yacc.LRParser` 向上追引用实测得出。

## 变更

- 新增 `agents/stargazer/core/infra/snmp_engine_pool.py`：`shared_snmp_engine(auth, target=(host, port))` 异步上下文借用共享 engine。
  - 同一事件循环内按凭据作用域共享：v1/v2c 共用一个（不同 community 在 snmpCommunityTable 可共存）；v3 按用户名、安全级别、协议、密钥材料的 blake2b 摘要各一个（pysnmp LCD 以 `(userName, engineId)` 为键，同名不同密钥共用会串）。摘要只留在内存，日志用 `community` / `v3#N` 标签。
  - 进程内 MIB 编译器只构建一次并注入后续每一代 engine，PLY LR 表不再重算。
  - 按不同目标数代际轮换（`SNMP_ENGINE_MAX_TARGETS`，默认 2000；每个目标在 LCD 留 ≈21 KiB 行，在途时无法安全删除），旧代在途排空后关闭；空闲释放（`SNMP_ENGINE_IDLE_SECONDS`，默认 300）；`after_server_stop` 统一关闭；阈值配置非法时启动失败。
  - 生命周期日志 `event=snmp_engine_opened|closed|close_failed|dropped`，稳定模板 + 惰性参数，无 traceback、无凭据。
- `snmp_facts.py`、`snmp_topo.py` 五处 `SnmpEngine()` 改为借用共享 engine，删除 `_close_snmp_engine`；超时/重试语义不变（`timeout=10, retries=1`，probe 固定 10 s × 1）。
- `server.py` 注册 engine 池生命周期；`scripts/snmp_connectivity_check.py`、`scripts/benchmark_snmp_scheduler.py` 同步改造（benchmark 的 `peak_live_snmp_engines` 语义变为池内 engine 数）。
- 文档：`README.md` 并发与超时段新增两个环境变量说明；`docs/configuration-plugin-async-matrix.md`；报告 `specs/changes/stargazer-stateless-async-collection/snmp-engine-pool-fix-report-2026-09-02.md`。

## 验证

builder A/B 实测（镜像依赖 + 挂载源码，1 worker，`SNMP_MAX_IN_FLIGHT=100`，2 × 400 个 10.255.0.0/16 不可达目标）：

| 指标 | 修复前（master） | 修复后 |
|---|---|---|
| 400 / 800 目标后 RSS | 930 / 1747 MiB | 105 / 115 MiB |
| 空闲 60 s / `malloc_trim` 后 RSS | 1784 / 1742 MiB | 115 / 113 MiB |
| 存活 `ply.yacc` LRParser / LRItem | 800 / 807 200 | 1 / 1 009 |
| 忙碌期 CPU%（max / p90） | 99.7 / 99.7 | 18.0 / 9.5 |
| 事件循环 P99 延迟 ms（max / p90 / 中位） | 7304 / 1260 / 492 | 25.2 / 2.5 / 1.5 |
| 400 目标批次墙钟 | ≈110 s | ≈85 s |

- `cd agents/stargazer && uv run pytest tests/test_snmp_engine_pool.py tests/test_snmp_facts_probe.py tests/test_snmp_plugins_native_async.py`：33 passed。新增用例覆盖同作用域复用、v3 密钥隔离、空闲关闭与重开、代际轮换排空、异常/取消归还、日志模板与敏感哨兵、环境变量校验、Sanic 生命周期，以及真实 pysnmp 下 `yacc.yacc` 只调用一次、单 engine 并发 8 目标独立超时、同进程多次 collect/probe 共用同一 engine 实例。
- 全量 `tests/`：修复后 939 passed / 86 failed / 37 errors，失败与错误集合是 master 基线（916 passed / 88 failed / 37 errors）的子集，均为缺少可选云 SDK（`oss2` 等）与主机采集环境相关的既有失败，无回归。
- pre-commit（pyupgrade / black / isort / flake8）全部通过。

## 评审提示

- 共享一个 UDP socket 服务全部目标：在途 ≤ `SNMP_MAX_IN_FLIGHT`（100）时接收缓冲区余量充足；若未来把在途放到数千，需评估 `SO_RCVBUF`。
- 轮换关闭的旧代 engine 仍可能被 uvloop 的 2048 项地址缓存短暂拖住，属于有界残留（实测第二代出现后 RSS 仅 +10 MiB）。
- `SANIC_WORKERS` 默认值（#5109 已撤回）建议按修复后的曲线重评：单 worker 800 目标仅 +42 MiB。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
