### PR TITLE
fix(opspilot): 加固 K8s 工具取证，避免字符串入参与探针 path 丢失

### DIFF
--- a/server/apps/opspilot/metis/llm/agent/tool_execution_planner.py
+++ b/server/apps/opspilot/metis/llm/agent/tool_execution_planner.py
@@ -58,25 +58,27 @@ _MONITOR_CATALOG_HINT = (
     "禁止返回空 steps，不要改去规划 SSH/top/htop。"
 )
 
-# 告警 RCA：缺 namespace 时必须先反查一次；反查收口后禁止重复规划该工具。
+# 告警 RCA：缺 namespace 时必须先反查；禁止用扫全集群当反查。取证链由智能体 prompt 决定。
 _K8S_NAMESPACE_LOOKUP_HINT = (
     "能力导读：若告警/问题含 Pod 或工作负载名称但未给出 namespace，"
-    "第一步必须规划 resolve_k8s_target_from_alert（其会反查命名空间）"
-    "或 list_kubernetes_pods / list_kubernetes_events（namespace 留空）完成反查；"
+    "第一步必须规划 resolve_k8s_target_from_alert（按对象名定点反查命名空间）；"
+    "禁止用 list_kubernetes_pods / list_kubernetes_events 扫全集群来找 namespace。"
     "该工具对同一告警只能调用一次；返回 resolved=false、lookup_exhausted、conclusive 或 namespace 仍为空时，"
     "禁止再用相同参数重试，也禁止规划 diagnose_kubernetes_pod_issues、"
     "get_kubernetes_pod_logs、get_resource_events_timeline 等必填 namespace 的工具，"
     "直接总结「当前集群无法定位该对象」。"
     "在拿到 namespace 之前，禁止规划上述必填 namespace 的工具。"
+    "反查只是前置，后续取证/诊断步骤须对齐助手任务说明，不要只规划反查就结束。"
 )
 
-_K8S_NAMESPACE_LOOKUP_TOOLS = frozenset(
+_K8S_NAMESPACE_RESOLVE_TOOL = "resolve_k8s_target_from_alert"
+_K8S_NAMESPACE_SCAN_TOOLS = frozenset(
     {
-        "resolve_k8s_target_from_alert",
         "list_kubernetes_pods",
         "list_kubernetes_events",
     }
 )
+_K8S_NAMESPACE_LOOKUP_TOOLS = frozenset({_K8S_NAMESPACE_RESOLVE_TOOL})
 
 # 调用前通常已需要明确 namespace；若计划包含它们且未先反查，则服务端改写计划。
 _K8S_NAMESPACE_REQUIRED_TOOLS = frozenset(
@@ -91,9 +93,12 @@ _K8S_NAMESPACE_REQUIRED_TOOLS = frozenset(
     }
 )
 
-# 8K 分步执行：工具结果与中间 AI 文本必须远小于窗口，否则步内多轮会二次溢出。
+# 8K 分步执行基线：工具结果与中间 AI 文本必须远小于窗口，否则步内多轮会二次溢出。
+# 更大窗口按输入工作预算同比放大，并由单条消息 20% 封顶（CJK 按 1 字 1 token）。
 _DEFAULT_PLANNED_TOOL_RESULT_CHARS = 1500
 _DEFAULT_PLANNED_AI_TEXT_CHARS = 1000
+_PLANNED_COMPACT_BASELINE_WORKING_TOKENS = 6800  # derive_llm_working_budget(8000, scene_output_default=4000)
+_PLANNED_COMPACT_SINGLE_MESSAGE_RATIO = 20
 _TRUNCATION_SUFFIX = "\n...(truncated)"
 
 _FENCE_RE = re.compile(r"```(?:json|JSON)?\s*([\s\S]*?)```", re.MULTILINE)
@@ -105,6 +110,7 @@ _EMPTY_MESSAGE_REPLY_RE = re.compile(
 # 8K 上下文模型下，规划目录必须远小于窗口；描述过长会挤掉用户问题并诱发模型复读工具文档。
 _DEFAULT_CATALOG_DESCRIPTION_LIMIT = 48
 _DEFAULT_CATALOG_CHAR_BUDGET = 3500
+_DEFAULT_AGENT_PROMPT_CHAR_BUDGET = 2000
 
 # 规划器哨兵：表示本步需要 DeepAgent 技能运行时(read_file SKILL.md / execute 等),
 # 不是真实可调业务工具；执行层会换成 FS 常驻工具可见。
@@ -159,6 +165,57 @@ def is_context_size_error(exc: BaseException | str) -> bool:
         "llm_context_window_exceeded",
     )
     return any(needle in text for needle in needles)
+
+
+def _coerce_positive_int(value: Any) -> int | None:
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return None
+    if number <= 0:
+        return None
+    return number
+
+
+def resolve_planned_execution_compact_limits(
+    *,
+    input_working_tokens: Any = None,
+    single_message_tokens: Any = None,
+) -> tuple[int, int]:
+    """按输入工作预算放大分步执行截断上限；缺预算时回退 8K 的 1500/1000 字。"""
+    working = _coerce_positive_int(input_working_tokens)
+    if working is None:
+        return _DEFAULT_PLANNED_TOOL_RESULT_CHARS, _DEFAULT_PLANNED_AI_TEXT_CHARS
+
+    tool_chars = max(
+        _DEFAULT_PLANNED_TOOL_RESULT_CHARS,
+        _DEFAULT_PLANNED_TOOL_RESULT_CHARS * working // _PLANNED_COMPACT_BASELINE_WORKING_TOKENS,
+    )
+    ai_chars = max(
+        _DEFAULT_PLANNED_AI_TEXT_CHARS,
+        _DEFAULT_PLANNED_AI_TEXT_CHARS * working // _PLANNED_COMPACT_BASELINE_WORKING_TOKENS,
+    )
+    single = _coerce_positive_int(single_message_tokens)
+    if single is None:
+        single = working * _PLANNED_COMPACT_SINGLE_MESSAGE_RATIO // 100
+    cap = max(_DEFAULT_PLANNED_TOOL_RESULT_CHARS, single)
+    return min(tool_chars, cap), min(ai_chars, cap)
+
+
+def planned_execution_compact_limits_for_request(graph_request: Any) -> tuple[int, int]:
+    extra = getattr(graph_request, "extra_config", None) or {}
+    if not isinstance(extra, dict):
+        extra = {}
+    trim = getattr(graph_request, "message_trim_config", None)
+    single: Any = None
+    if isinstance(trim, dict):
+        single = trim.get("max_single_message_tokens")
+    elif trim is not None:
+        single = getattr(trim, "max_single_message_tokens", None)
+    return resolve_planned_execution_compact_limits(
+        input_working_tokens=extra.get("input_working_tokens"),
+        single_message_tokens=single,
+    )
 
 
 def _truncate_text(text: str, max_chars: int) -> str:
@@ -423,33 +480,53 @@ def enforce_k8s_namespace_lookup_first(
     *,
     max_steps: int,
 ) -> ToolExecutionPlan:
-    """若计划使用需 namespace 的工具，且此前未安排反查，则在该步前插入反查。"""
-    lookup = [name for name in ("resolve_k8s_target_from_alert", "list_kubernetes_pods", "list_kubernetes_events") if name in available_names]
-    if not lookup:
+    """若计划使用需 namespace 的工具，且此前未安排反查，则在该步前插入反查。
+
+    定位前去掉全集群 list_kubernetes_pods / list_kubernetes_events，避免用扫全量当反查。
+    """
+    if _K8S_NAMESPACE_RESOLVE_TOOL not in available_names:
         return plan
 
-    first_required_idx: int | None = None
+    anchor_idx: int | None = None
     for index, step in enumerate(plan.steps):
-        if any(tool in _K8S_NAMESPACE_LOOKUP_TOOLS for tool in step.tools):
-            # 反查已出现在需 namespace 工具之前（或同批更早步骤）。
-            return plan
+        if _K8S_NAMESPACE_RESOLVE_TOOL in step.tools or any(tool in _K8S_NAMESPACE_REQUIRED_TOOLS for tool in step.tools):
+            anchor_idx = index
+            break
+
+    cleaned: list[ToolExecutionStep] = []
+    for index, step in enumerate(plan.steps):
+        tools = list(step.tools)
+        if _K8S_NAMESPACE_RESOLVE_TOOL in tools:
+            tools = [tool for tool in tools if tool not in _K8S_NAMESPACE_SCAN_TOOLS]
+        elif anchor_idx is not None and index < anchor_idx:
+            tools = [tool for tool in tools if tool not in _K8S_NAMESPACE_SCAN_TOOLS]
+        if not tools:
+            continue
+        if tools != list(step.tools):
+            cleaned.append(step.model_copy(update={"tools": tools}))
+        else:
+            cleaned.append(step)
+
+    first_required_idx: int | None = None
+    for index, step in enumerate(cleaned):
+        if _K8S_NAMESPACE_RESOLVE_TOOL in step.tools:
+            return ToolExecutionPlan(goal=plan.goal, steps=cleaned)
         if any(tool in _K8S_NAMESPACE_REQUIRED_TOOLS for tool in step.tools):
             first_required_idx = index
             break
     if first_required_idx is None:
-        return plan
+        return ToolExecutionPlan(goal=plan.goal, steps=cleaned)
 
-    preferred = lookup[0]
     lookup_step = ToolExecutionStep(
         objective="反查目标命名空间与定位信息",
-        tools=[preferred],
+        tools=[_K8S_NAMESPACE_RESOLVE_TOOL],
     )
-    steps = [*plan.steps[:first_required_idx], lookup_step, *plan.steps[first_required_idx:]]
+    steps = [*cleaned[:first_required_idx], lookup_step, *cleaned[first_required_idx:]]
     if len(steps) > max_steps:
         steps = steps[:max_steps]
     logger.info(
         "DeepAgent 规划硬校验：已在需 namespace 步骤前插入反查 tool=%s index=%s",
-        preferred,
+        _K8S_NAMESPACE_RESOLVE_TOOL,
         first_required_idx,
     )
     return ToolExecutionPlan(goal=plan.goal, steps=steps)
@@ -457,7 +534,7 @@ def enforce_k8s_namespace_lookup_first(
 
 def drop_k8s_followup_steps_after_unresolved_target(steps: Sequence[ToolExecutionStep]) -> list[ToolExecutionStep]:
     """反查已收口后，去掉重复反查和仍依赖 namespace 的后续步骤。"""
-    skip = _K8S_NAMESPACE_LOOKUP_TOOLS | _K8S_NAMESPACE_REQUIRED_TOOLS
+    skip = _K8S_NAMESPACE_LOOKUP_TOOLS | _K8S_NAMESPACE_SCAN_TOOLS | _K8S_NAMESPACE_REQUIRED_TOOLS
     kept: list[ToolExecutionStep] = []
     for step in steps or []:
         if any(tool in skip for tool in (step.tools or [])):
@@ -482,6 +559,16 @@ def merge_replanned_pending_steps(
             continue
         merged.append(step)
     return merged
+
+
+def _agent_task_brief(agent_system_prompt: str, *, limit: int = _DEFAULT_AGENT_PROMPT_CHAR_BUDGET) -> str:
+    """规划器用的智能体 prompt 摘要：去掉附件强制规则模板，并截断以保住 8K 窗口。"""
+    text = _ATTACHMENT_FORCE_RULE_BLOCK_RE.sub("", agent_system_prompt or "").strip()
+    if not text:
+        return ""
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + "…"
 
 
 def looks_like_attachment_file_task(user_message: str = "", agent_system_prompt: str = "") -> bool:
@@ -880,6 +967,7 @@ class ToolExecutionPlanner:
             f"最多 {self._max_steps} 个步骤，每步最多 {self._max_tools_per_step} 个工具。"
             "只列出必须调用工具的执行步骤，并从目录选择精确工具名；"
             "纯分析或最终总结不要列为步骤，系统会在工具执行后单独完成。"
+            "规划须对齐「助手任务说明」中的目标；目录「能力导读」只约束工具前置条件，不改写任务目标。"
             "若用户要查平台已纳管主机/实例的指标或告警，且目录含 monitor_* 或能力导读，"
             "必须规划对应 monitor_* 步骤，禁止返回空 steps。"
             "若目录含 generate_attachment_file，且任务是生成报告/月报/文档/Markdown/.md 文件，"
@@ -899,9 +987,13 @@ class ToolExecutionPlanner:
         failure_text: str,
         tools: Sequence[BaseTool],
         skill_packages: Sequence[Any] = (),
+        agent_system_prompt: str = "",
     ) -> str:
+        brief = _agent_task_brief(agent_system_prompt)
+        agent_block = f"助手任务说明（来自智能体 prompt，规划须对齐其目标；工具名只从目录选择）:\n{brief}\n\n" if brief else ""
         return (
             f"用户问题:\n{user_message}\n\n"
+            f"{agent_block}"
             f"已完成步骤:\n{completed_text}\n\n"
             f"最近失败或新证据:\n{failure_text}\n\n"
             f"紧凑工具目录:\n{self._catalog(tools, skill_packages)}"
@@ -943,7 +1035,14 @@ class ToolExecutionPlanner:
         failure_text = failure.strip() or "无"
         packages = [item for item in (skill_packages or []) if isinstance(item, dict)]
         system_prompt = self._system_prompt()
-        task_prompt = self._task_prompt(user_message, completed_text, failure_text, tools, packages)
+        task_prompt = self._task_prompt(
+            user_message,
+            completed_text,
+            failure_text,
+            tools,
+            packages,
+            agent_system_prompt=agent_system_prompt,
+        )
         primary_messages = [
             SystemMessage(content=system_prompt),
             HumanMessage(content=task_prompt),

--- a/server/apps/opspilot/metis/llm/chain/deepagent_assembly.py
+++ b/server/apps/opspilot/metis/llm/chain/deepagent_assembly.py
@@ -60,22 +60,39 @@ class DeepAgentAssemblyMixin:
     _STEP_STUB_RE = re.compile(r"^执行结果\s*\d+\s*$")
 
     @classmethod
-    def _planned_step_already_answered(cls, messages) -> bool:
-        """单步已写出给用户看的正文时，跳过总结轮，避免再复述一遍。"""
-        for message in reversed(messages or []):
+    def _iter_planned_assistant_text(cls, messages):
+        for message in messages or []:
             if not isinstance(message, AIMessage):
                 continue
             if getattr(message, "tool_calls", None):
                 continue
             text = str(getattr(message, "content", "") or "").strip()
-            if not text:
-                continue
+            if text:
+                yield text
+
+    @classmethod
+    def _planned_output_has_markdown_table(cls, messages) -> bool:
+        return any(cls._MARKDOWN_TABLE_RE.search(text) for text in cls._iter_planned_assistant_text(messages))
+
+    @classmethod
+    def _planned_step_already_answered(cls, messages) -> bool:
+        """步骤已写出给用户看的正文时，跳过总结轮，避免再复述一遍。"""
+        for text in reversed(list(cls._iter_planned_assistant_text(messages))):
             if cls._MARKDOWN_TABLE_RE.search(text):
                 return True
             if cls._STEP_STUB_RE.match(text):
                 return False
             return len(text) >= 15
         return False
+
+    @classmethod
+    def _should_skip_planned_summary(cls, messages, *, completed_step_count: int) -> bool:
+        """单步已作答，或多步里已经出现过完整表格时，不再跑总结轮。"""
+        if not cls._planned_step_already_answered(messages):
+            return False
+        if completed_step_count <= 1:
+            return True
+        return cls._planned_output_has_markdown_table(messages)
 
     @staticmethod
     def _plan_is_skills_only(candidate_plan) -> bool:
@@ -145,7 +162,8 @@ class DeepAgentAssemblyMixin:
             "401、kubeconfig 无效、连接参数缺失或解密失败时不要改参重试，把错误原样告诉用户并结束本步。"
             "工具抛出 AttributeError/TypeError 等实现异常时不要重试，把错误告诉用户。"
             "403 仅在可换 namespace 或实例时最多改参 1 次，否则把权限错误告诉用户。"
-            "工具成功后用一两句话直接回答用户并结束本步，禁止再写第二份重复说明。"
+            "工具成功后用一两句话直接回答用户并结束本步，禁止再写第二份重复说明，"
+            "也不要把同一张表或同一份名单再输出一遍。"
         )
 
     @staticmethod
@@ -205,6 +223,7 @@ class DeepAgentAssemblyMixin:
         graph_request,
         token_usage_accumulator,
     ):
+        from apps.opspilot.metis.llm.agent.tool_execution_planner import planned_execution_compact_limits_for_request
         from apps.opspilot.metis.llm.common.token_usage import TokenUsageAccumulator
         from apps.opspilot.metis.llm.middleware.context_window import ContextWindowMiddleware
         from apps.opspilot.metis.llm.middleware.planned_execution_limits import (
@@ -220,6 +239,8 @@ class DeepAgentAssemblyMixin:
             ToolResultCompactionMiddleware,
             ToolVisibilityMiddleware,
         )
+
+        max_tool_chars, max_ai_chars = planned_execution_compact_limits_for_request(graph_request)
 
         visibility_middleware = ToolVisibilityMiddleware(
             business_tools=registered_tools,
@@ -241,7 +262,7 @@ class DeepAgentAssemblyMixin:
             visibility_middleware,
             skill_guard,
             ToolExceptionAsResultMiddleware(),
-            ToolResultCompactionMiddleware(),
+            ToolResultCompactionMiddleware(max_tool_chars=max_tool_chars, max_ai_chars=max_ai_chars),
             ContextWindowMiddleware(graph_request=graph_request, isolated_llm=isolated_llm),
             limit_middleware,
         ]
@@ -285,6 +306,8 @@ _build_interrupt_on = DeepAgentAssemblyMixin._build_interrupt_on
 _build_lightweight_system_prompt = DeepAgentAssemblyMixin._build_lightweight_system_prompt
 _plan_is_skills_only = DeepAgentAssemblyMixin._plan_is_skills_only
 _planned_step_already_answered = DeepAgentAssemblyMixin._planned_step_already_answered
+_planned_output_has_markdown_table = DeepAgentAssemblyMixin._planned_output_has_markdown_table
+_should_skip_planned_summary = DeepAgentAssemblyMixin._should_skip_planned_summary
 _planned_tool_step_guidance = DeepAgentAssemblyMixin._planned_tool_step_guidance
 _should_use_lightweight_after_empty_plan = DeepAgentAssemblyMixin._should_use_lightweight_after_empty_plan
 _should_use_lightweight_direct_reply = DeepAgentAssemblyMixin._should_use_lightweight_direct_reply

--- a/server/apps/opspilot/metis/llm/chain/node.py
+++ b/server/apps/opspilot/metis/llm/chain/node.py
@@ -3060,9 +3060,11 @@ class ToolsNodes(
                         "当前没有可用工具，不要继续调用工具；"
                         "请用一两句告知用户查看上方报告与修复建议，不要重复 Markdown 表格或声称数据被截断。"
                     )
-                elif len(completed_steps) == 1 and self._planned_step_already_answered(collected_output_messages):
-                    # 单步已经把答案写进正文（技能表 / 工具一两句话）。
-                    # 再跑总结轮会换个说法复述，用户看到两份结果。
+                elif self._should_skip_planned_summary(
+                    collected_output_messages,
+                    completed_step_count=len(completed_steps),
+                ):
+                    # 步骤正文已经给过表格或完整答案。再跑总结轮会换个说法复述。
                     result = {"messages": list(agent_state.get("messages") or [])}
                     final_message = None
                 else:
@@ -3071,7 +3073,7 @@ class ToolsNodes(
                         f"已完成步骤及结果：\n{completed_text}\n\n"
                         "现在向用户给出最终答案。当前没有可用工具，不要继续调用工具；"
                         "请基于已有证据直接总结结论、依据和下一步建议。"
-                        "用户已经看过步骤里的表格或清单时，不要再输出表格、不要重复名单，最多补一两句。"
+                        "禁止再输出 Markdown 表格或重复名单；用户若已看过步骤结果，最多补一两句。"
                     )
                 if final_message is not None:
                     final_payload = {

--- a/server/apps/opspilot/metis/llm/middleware/tool_runtime.py
+++ b/server/apps/opspilot/metis/llm/middleware/tool_runtime.py
@@ -9,6 +9,8 @@ from langchain.agents.middleware import AgentMiddleware, ModelRequest, ModelResp
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.tools import BaseTool
 
+from apps.core.logger import opspilot_logger as logger
+from apps.core.logger import safe_exception_info
 from apps.opspilot.metis.llm.agent.tool_execution_planner import (
     _DEFAULT_PLANNED_AI_TEXT_CHARS,
     _DEFAULT_PLANNED_TOOL_RESULT_CHARS,
@@ -364,6 +366,12 @@ class ToolExceptionAsResultMiddleware(AgentMiddleware):
         call = getattr(request, "tool_call", None) or {}
         name = str(call.get("name") or "unknown")
         call_id = str(call.get("id") or "")
+        logger.error(
+            "event=agent_tool_failed failed_stage=tool_call error_type=%s tool_name=%s",
+            type(exc).__name__,
+            name,
+            exc_info=safe_exception_info(exc),
+        )
         text = str(exc).strip() or f"{type(exc).__name__}: tool execution failed"
         return ToolMessage(
             content=text[:2000],
@@ -386,7 +394,7 @@ class ToolExceptionAsResultMiddleware(AgentMiddleware):
 
 
 class ToolResultCompactionMiddleware(AgentMiddleware):
-    """分步执行步内：每次模型调用前截断过长工具结果，避免 8K 窗口二次溢出。"""
+    """分步执行步内：每次模型调用前截断过长工具结果，上限随输入工作预算放大。"""
 
     def __init__(
         self,

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/analysis.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/analysis.py
@@ -9,7 +9,7 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 
 from apps.core.logger import opspilot_logger as logger
-from apps.opspilot.metis.llm.tools.kubernetes.utils import get_current_cluster_name, parse_resource_quantity, prepare_context
+from apps.opspilot.metis.llm.tools.kubernetes.utils import coerce_int, get_current_cluster_name, parse_resource_quantity, prepare_context
 
 _K8S_ANALYSIS_DETAIL_CACHE = OrderedDict()
 _K8S_ANALYSIS_DETAIL_CACHE_LOCK = Lock()
@@ -671,8 +671,8 @@ def analyze_deployment_configurations(  # noqa: C901
     namespace, name = resolve_deployment_analysis_scope(namespace, name, config)
 
     # 硬上限保护
-    limit = max(1, min(int(limit or 50), 50))
-    offset = max(0, int(offset or 0))
+    limit = coerce_int(limit, 50, lo=1, hi=50)
+    offset = coerce_int(offset, 0, lo=0, hi=1_000_000)
 
     try:
         prepare_context(config)

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/batch_operations.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/batch_operations.py
@@ -10,6 +10,7 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 from loguru import logger
 
+from apps.opspilot.metis.llm.tools.kubernetes.instance_scope import prepare_point_instance
 from apps.opspilot.metis.llm.tools.kubernetes.utils import coerce_bool, prepare_context
 
 
@@ -28,7 +29,9 @@ def _log_operation(operation: str, namespace: str, resource_type: str, count: in
 
 
 @tool()
-def batch_restart_pods(namespace, label_selector=None, pod_names=None, wait_for_ready: bool = False, config: RunnableConfig = None):
+def batch_restart_pods(  # noqa: C901
+    namespace, label_selector=None, pod_names=None, wait_for_ready: bool = False, instance_name=None, config: RunnableConfig = None
+):
     """
     批量重启Pod，提升运维效率
 
@@ -54,6 +57,7 @@ def batch_restart_pods(namespace, label_selector=None, pod_names=None, wait_for_
         wait_for_ready (bool, optional): 是否等待所有Pod就绪，默认False
             - False: 异步重启，立即返回（推荐批量操作）
             - True: 等待所有Pod就绪再返回（耗时长）
+        instance_name (str, optional): 多实例时必须指定集群
         config (RunnableConfig): 工具配置（自动传递）
 
     Returns:
@@ -92,6 +96,9 @@ def batch_restart_pods(namespace, label_selector=None, pod_names=None, wait_for_
     → batch_restart_pods(namespace="prod", pod_names=["pod-1", "pod-2", "pod-3"])
     ```
     """
+    config, err = prepare_point_instance(config, instance_name)
+    if err:
+        return err
     prepare_context(config)
     wait_for_ready = coerce_bool(wait_for_ready, False)
 
@@ -392,7 +399,7 @@ def find_configmap_consumers(configmap_name, namespace, config: RunnableConfig =
 
 
 @tool()
-def cleanup_failed_pods(namespace=None, include_evicted: bool = True, config: RunnableConfig = None):
+def cleanup_failed_pods(namespace=None, include_evicted: bool = True, instance_name=None, config: RunnableConfig = None):
     """
     批量清理失败的Pod，释放资源
 
@@ -412,6 +419,7 @@ def cleanup_failed_pods(namespace=None, include_evicted: bool = True, config: Ru
     Args:
         namespace (str, optional): 命名空间，None=所有命名空间
         include_evicted (bool, optional): 是否清理Evicted Pod，默认True
+        instance_name (str, optional): 多实例时必须指定集群
         config (RunnableConfig): 工具配置（自动传递）
 
     Returns:
@@ -457,6 +465,9 @@ def cleanup_failed_pods(namespace=None, include_evicted: bool = True, config: Ru
     → cleanup_failed_pods()
     ```
     """
+    config, err = prepare_point_instance(config, instance_name)
+    if err:
+        return err
     prepare_context(config)
     include_evicted = coerce_bool(include_evicted, True)
 

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/batch_operations.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/batch_operations.py
@@ -10,7 +10,7 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 from loguru import logger
 
-from apps.opspilot.metis.llm.tools.kubernetes.utils import prepare_context
+from apps.opspilot.metis.llm.tools.kubernetes.utils import coerce_bool, prepare_context
 
 
 def _log_operation(operation: str, namespace: str, resource_type: str, count: int):
@@ -28,7 +28,7 @@ def _log_operation(operation: str, namespace: str, resource_type: str, count: in
 
 
 @tool()
-def batch_restart_pods(namespace, label_selector=None, pod_names=None, wait_for_ready=False, config: RunnableConfig = None):
+def batch_restart_pods(namespace, label_selector=None, pod_names=None, wait_for_ready: bool = False, config: RunnableConfig = None):
     """
     批量重启Pod，提升运维效率
 
@@ -93,6 +93,7 @@ def batch_restart_pods(namespace, label_selector=None, pod_names=None, wait_for_
     ```
     """
     prepare_context(config)
+    wait_for_ready = coerce_bool(wait_for_ready, False)
 
     try:
         core_v1 = client.CoreV1Api()
@@ -391,7 +392,7 @@ def find_configmap_consumers(configmap_name, namespace, config: RunnableConfig =
 
 
 @tool()
-def cleanup_failed_pods(namespace=None, include_evicted=True, config: RunnableConfig = None):
+def cleanup_failed_pods(namespace=None, include_evicted: bool = True, config: RunnableConfig = None):
     """
     批量清理失败的Pod，释放资源
 
@@ -457,6 +458,7 @@ def cleanup_failed_pods(namespace=None, include_evicted=True, config: RunnableCo
     ```
     """
     prepare_context(config)
+    include_evicted = coerce_bool(include_evicted, True)
 
     try:
         core_v1 = client.CoreV1Api()

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/cluster.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/cluster.py
@@ -8,6 +8,7 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 
 from apps.core.logger import opspilot_logger as logger
+from apps.opspilot.metis.llm.tools.kubernetes.instance_scope import prepare_point_instance
 from apps.opspilot.metis.llm.tools.kubernetes.utils import prepare_context
 
 _DESCRIBE_TYPE_ALIASES = {
@@ -366,7 +367,7 @@ def explain_kubernetes_resource(resource_type, config: RunnableConfig = None):
 
 
 @tool()
-def describe_kubernetes_resource(resource_type, resource_name, namespace=None, config: RunnableConfig = None):
+def describe_kubernetes_resource(resource_type, resource_name, namespace=None, instance_name=None, config: RunnableConfig = None):
     """
     描述指定的Kubernetes资源
 
@@ -376,12 +377,16 @@ def describe_kubernetes_resource(resource_type, resource_name, namespace=None, c
         resource_type (str): 资源类型 (pod, deployment, statefulset/sts, service, node, namespace)
         resource_name (str): 资源名称
         namespace (str, optional): 命名空间，某些资源类型需要
+        instance_name (str, optional): 多实例时必须指定集群
         config (RunnableConfig): 工具配置
 
     Returns:
         str: JSON格式的资源详细描述
     """
     try:
+        config, instance_error = prepare_point_instance(config, instance_name)
+        if instance_error:
+            return instance_error
         prepare_context(config)
 
         core_v1 = client.CoreV1Api()

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/data_collection.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/data_collection.py
@@ -8,15 +8,21 @@ import re
 import threading
 from datetime import datetime, timezone
 
+from kubernetes import client
+from kubernetes.client import ApiException
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 
+from apps.core.logger import opspilot_logger as logger
+from apps.core.logger import safe_exception_info
 from apps.opspilot.metis.llm.tools.kubernetes.cluster import describe_kubernetes_resource
+from apps.opspilot.metis.llm.tools.kubernetes.instance_scope import bind_instance_config, route_alert_cluster
 from apps.opspilot.metis.llm.tools.kubernetes.node_diagnostics import diagnose_node_issues
 from apps.opspilot.metis.llm.tools.kubernetes.optimization import compare_deployment_revisions
 from apps.opspilot.metis.llm.tools.kubernetes.remediation import get_deployment_revision_history
 from apps.opspilot.metis.llm.tools.kubernetes.resources import get_kubernetes_pod_logs, get_kubernetes_previous_pod_logs
 from apps.opspilot.metis.llm.tools.kubernetes.tracing import get_resource_events_timeline, trace_service_chain
+from apps.opspilot.metis.llm.tools.kubernetes.utils import coerce_int, prepare_context
 
 
 def _configurable(config: RunnableConfig = None):
@@ -24,11 +30,7 @@ def _configurable(config: RunnableConfig = None):
 
 
 def _build_instance_config(config: RunnableConfig, instance: dict):
-    configurable = copy.deepcopy(_configurable(config))
-    configurable["instance_id"] = instance.get("id")
-    configurable["instance_name"] = instance.get("name")
-    configurable["kubeconfig_data"] = instance.get("kubeconfig_data", "")
-    return {"configurable": configurable}
+    return bind_instance_config(config, instance)
 
 
 def _get_target_instances(config: RunnableConfig = None, instance_name=None, instance_id=None):
@@ -80,27 +82,11 @@ def _json_or_raw(value):
     return value
 
 
-def _lookup_payload_error(value) -> str | None:
-    payload = _json_or_raw(value)
-    if isinstance(payload, dict):
-        err = payload.get("error")
-        if err not in (None, "", [], {}):
-            return str(err)
-    if isinstance(payload, str) and payload.strip():
-        from apps.opspilot.metis.llm.common.tool_failure import is_non_replanable_tool_failure
-
-        if is_non_replanable_tool_failure(payload):
-            return payload.strip()
-    return None
-
-
 def _cluster_config_error(config: RunnableConfig = None) -> str | None:
     """kubeconfig 无效时尽早返回，避免被包装成「缺 namespace / 缺标识」。"""
     configurable = _configurable(config)
     if not configurable.get("kubernetes_instances") and not configurable.get("kubeconfig_data"):
         return None
-    from apps.opspilot.metis.llm.tools.kubernetes.utils import prepare_context
-
     try:
         prepare_context(config)
     except Exception as exc:
@@ -117,6 +103,25 @@ def _unresolved_connection_result(target: dict, error: str) -> str:
     if not payload.get("reason"):
         payload["reason"] = error
     return json.dumps(payload, ensure_ascii=False)
+
+
+def _log_resolve_failed(failed_stage, error_type, instance_name=None, *, exc=None):
+    instance = instance_name or "-"
+    if exc is not None:
+        logger.error(
+            "event=k8s_alert_resolve_failed failed_stage=%s error_type=%s instance_name=%s",
+            failed_stage,
+            error_type,
+            instance,
+            exc_info=safe_exception_info(exc),
+        )
+        return
+    logger.warning(
+        "event=k8s_alert_resolve_failed failed_stage=%s error_type=%s instance_name=%s",
+        failed_stage,
+        error_type,
+        instance,
+    )
 
 
 def _evidence_block(value=None, *, status=None, error=None):
@@ -231,18 +236,46 @@ _K8S_KIND_NAMES = frozenset(
 K8S_TARGET_RESOLVE_TOOL_NAME = "resolve_k8s_target_from_alert"
 _resolve_cache_local = threading.local()
 
+# 控制面静态 Pod：kube-scheduler-minikube、kube-apiserver-<node> 等固定在 kube-system。
+_KUBE_SYSTEM_STATIC_POD_NAMES = frozenset(
+    {
+        "kube-apiserver",
+        "kube-scheduler",
+        "kube-controller-manager",
+        "kube-proxy",
+    }
+)
+_KUBE_SYSTEM_STATIC_POD_PREFIXES = (
+    "kube-apiserver-",
+    "kube-scheduler-",
+    "kube-controller-manager-",
+    "kube-proxy-",
+)
+
+
+def _copy_label(labels: dict, key: str, *values) -> None:
+    if labels.get(key) not in (None, "", [], {}):
+        return
+    for value in values:
+        if value not in (None, "", [], {}):
+            labels[key] = value
+            return
+
 
 def _extract_labels(alert):
     labels = alert.get("labels") or {}
     labels = dict(labels) if isinstance(labels, dict) else {}
+    tags = alert.get("tags") if isinstance(alert.get("tags"), dict) else {}
     # 模型常把 pod_name/namespace/name/kind 放在告警顶层而不是 labels 里
     for key in (
         "pod",
         "pod_name",
         "name",
+        "object_name",
         "namespace",
         "cluster",
         "cluster_id",
+        "cluster_name",
         "resource_name",
         "resource_type",
         "kind",
@@ -255,11 +288,30 @@ def _extract_labels(alert):
         value = alert.get(key)
         if value not in (None, "", [], {}) and not labels.get(key):
             labels[key] = value
+    _copy_label(
+        labels,
+        "cluster",
+        labels.get("cluster_name"),
+        tags.get("cluster"),
+        tags.get("cluster_name"),
+        alert.get("location"),
+        alert.get("push_source_id"),
+    )
+    _copy_label(labels, "resource_name", labels.get("object_name"), alert.get("object_name"))
+    _copy_label(labels, "name", labels.get("object_name"), alert.get("object_name"))
+    _copy_label(labels, "namespace", tags.get("namespace"))
+    _copy_label(labels, "kind", tags.get("kind"), tags.get("resource_type"))
+    service_name = str(labels.get("service") or labels.get("service_name") or "").strip().lower()
+    if service_name in _K8S_ALERT_SOURCE_NAMES:
+        labels.pop("service", None)
+        if str(labels.get("service_name") or "").strip().lower() in _K8S_ALERT_SOURCE_NAMES:
+            labels.pop("service_name", None)
     return labels
 
 
 _PAREN_GROUP_RE = re.compile(r"[（(]([^）)]+)[）)]")
 _POD_LIKE_NAME_RE = re.compile(r"\b([a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:-[a-f0-9]{5,10}){1,2})\b", re.IGNORECASE)
+_DNS1123_HYPHEN_NAME_RE = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", re.IGNORECASE)
 _NOTIFICATION_TITLE_RE = re.compile(r"告警[：:]\s*(.+?)(?:\n|$)")
 _NOTIFICATION_CONTENT_RE = re.compile(r"内容[：:]\s*(.+?)(?:\n|$)")
 _NOTIFICATION_TIME_RE = re.compile(r"告警时间[：:]*\s*(.+?)(?:\n|$)")
@@ -321,7 +373,7 @@ def _coerce_alert_payload(alert_payload) -> dict:
 
 def _merge_paren_labels(payload: dict) -> dict:
     labels = dict(payload.get("labels") or {}) if isinstance(payload.get("labels"), dict) else {}
-    blob = "\n".join(str(payload.get(key) or "") for key in ("title", "name", "message", "summary", "detail", "content", "_raw_text"))
+    blob = "\n".join(str(payload.get(key) or "") for key in ("title", "name", "object_name", "message", "summary", "detail", "content", "_raw_text"))
     for key, value in _parse_k8s_paren_tuple(blob).items():
         if value and not labels.get(key):
             labels[key] = value
@@ -365,12 +417,21 @@ def _guess_resource_name_from_text(*texts: str) -> str | None:
         match = _POD_LIKE_NAME_RE.search(text)
         if match:
             return match.group(1)
+        for token in re.findall(r"[A-Za-z0-9][A-Za-z0-9._-]*", text):
+            if _is_hyphenated_object_name(token):
+                return token
     return None
 
 
+def _is_hyphenated_object_name(text: str) -> bool:
+    """静态 Pod / STS 名（kube-scheduler-minikube、nacos-0）没有 ReplicaSet hash。"""
+    candidate = str(text or "").strip()
+    return bool(candidate) and "-" in candidate and bool(_DNS1123_HYPHEN_NAME_RE.fullmatch(candidate))
+
+
 def _flat_object_name(labels: dict) -> str | None:
-    """顶层 name：仅在 kind 为 K8s 资源或名字像 Pod 时采用，避免把告警标题当对象名。"""
-    candidate = labels.get("name")
+    """顶层 name：仅在 kind 为 K8s 资源或名字像对象时采用，避免把告警标题当对象名。"""
+    candidate = labels.get("name") or labels.get("object_name")
     if candidate in (None, "", [], {}):
         return None
     text = str(candidate).strip()
@@ -379,7 +440,7 @@ def _flat_object_name(labels: dict) -> str | None:
     kind = str(labels.get("kind") or labels.get("resource_type") or "").lower()
     if kind in _K8S_KIND_NAMES:
         return text
-    if _POD_LIKE_NAME_RE.fullmatch(text):
+    if _POD_LIKE_NAME_RE.fullmatch(text) or _is_hyphenated_object_name(text):
         return text
     return None
 
@@ -456,19 +517,75 @@ def _alert_resolve_fingerprint(alert: dict, config: RunnableConfig = None) -> st
 
 
 def _resolve_alert_cache(config: RunnableConfig = None) -> dict:
-    """同一线程内缓存反查结果。LangChain invoke 会复制 config，不能只写 configurable。"""
-    configurable = _configurable(config)
-    existing = configurable.get("_k8s_resolve_alert_cache")
-    if isinstance(existing, dict):
-        _resolve_cache_local.entries = existing
-        return existing
+    """同一线程内缓存反查结果。不写入 configurable：其中含 callback/锁，deepcopy 会失败。"""
     cache = getattr(_resolve_cache_local, "entries", None)
     if not isinstance(cache, dict):
         cache = {}
         _resolve_cache_local.entries = cache
-    if configurable:
-        configurable["_k8s_resolve_alert_cache"] = cache
     return cache
+
+
+def _infer_kube_system_namespace(resource_name, resource_type=None) -> str | None:
+    """控制面静态 Pod 无需扫集群即可落到 kube-system。"""
+    name = str(resource_name or "").strip().lower()
+    if not name:
+        return None
+    kind = str(resource_type or "pod").strip().lower()
+    if kind not in ("", "pod"):
+        return None
+    if name in _KUBE_SYSTEM_STATIC_POD_NAMES:
+        return "kube-system"
+    if any(name.startswith(prefix) for prefix in _KUBE_SYSTEM_STATIC_POD_PREFIXES):
+        return "kube-system"
+    return None
+
+
+def _lookup_namespaces_by_resource_name(resource_name: str, config: RunnableConfig = None) -> tuple[list, list, str | None]:
+    """按对象名定点反查 namespace，禁止 list 全集群 Pod/Events。"""
+    name = str(resource_name or "").strip()
+    if not name or not _DNS1123_HYPHEN_NAME_RE.fullmatch(name):
+        return [], [], None
+    try:
+        prepare_context(config)
+        core_v1 = client.CoreV1Api()
+        pods_resp = core_v1.list_pod_for_all_namespaces(field_selector=f"metadata.name={name}")
+        pods = []
+        for pod in pods_resp.items or []:
+            meta = getattr(pod, "metadata", None)
+            pod_name = getattr(meta, "name", None) if meta is not None else None
+            namespace = getattr(meta, "namespace", None) if meta is not None else None
+            if pod_name and namespace:
+                pods.append({"name": pod_name, "namespace": namespace})
+        if pods:
+            return pods, [], None
+
+        events_resp = core_v1.list_event_for_all_namespaces(field_selector=f"involvedObject.name={name}")
+        events = []
+        for event in events_resp.items or []:
+            involved = getattr(event, "involved_object", None)
+            kind = getattr(involved, "kind", None) if involved is not None else None
+            obj_name = getattr(involved, "name", None) if involved is not None else None
+            namespace = getattr(event, "namespace", None)
+            if not namespace:
+                namespace = getattr(getattr(event, "metadata", None), "namespace", None)
+            if not namespace:
+                continue
+            if kind and obj_name:
+                object_ref = f"{kind}/{obj_name}"
+            else:
+                object_ref = obj_name or ""
+            events.append({"object": object_ref, "namespace": namespace})
+        return [], events, None
+    except ApiException as exc:
+        return [], [], str(exc).strip() or type(exc).__name__
+
+
+def _apply_inferred_namespace(target: dict, namespace: str, lookup_kind: str) -> dict:
+    target["namespace"] = namespace
+    target["namespace_lookup"] = lookup_kind
+    target["missing_data"] = [item for item in (target.get("missing_data") or []) if item != "namespace"]
+    target["reason"] = None
+    return target
 
 
 def _apply_namespace_lookup(target: dict, pods: list, events: list) -> dict:
@@ -527,16 +644,19 @@ def _build_k8s_target_from_alert(alert: dict) -> dict:
     message = alert.get("message") or ""
     detail = alert.get("detail") or ""
     resource_type_label = str(labels.get("resource_type") or labels.get("kind") or "").lower()
+    if resource_type_label in {"k8s_pod", "k8spod"}:
+        resource_type_label = "pod"
     flat_name = _flat_object_name(labels)
 
     pod_name = _first_non_empty(
         labels.get("pod"),
         labels.get("pod_name"),
         labels.get("resource_name") if resource_type_label in ("", "pod") else None,
+        labels.get("object_name") if resource_type_label in ("", "pod") else None,
         flat_name if resource_type_label in ("", "pod") else None,
     )
     if not pod_name:
-        pod_name = _guess_resource_name_from_text(title, message, detail)
+        pod_name = _guess_resource_name_from_text(title, message, detail, labels.get("object_name"), labels.get("name"))
 
     target = {
         "cluster": labels.get("cluster") or labels.get("cluster_id"),
@@ -594,8 +714,9 @@ def normalize_alert_event(alert_payload, config: RunnableConfig = None):
 
 @tool()
 def resolve_k8s_target_from_alert(normalized_alert, config: RunnableConfig = None):
-    """从标准化告警解析 K8s 目标；缺 namespace 时反查一次 Pod/Events。
+    """从标准化告警解析 K8s 目标；缺 namespace 时按对象名定点反查，不扫全集群。
 
+    控制面静态 Pod（kube-scheduler-* 等）直接落到 kube-system。
     同一告警参数只应调用一次。返回 resolved=false 且 conclusive/lookup_exhausted 时
     表示对象当前不可见或标识不足，禁止用相同参数重试。
     """
@@ -622,52 +743,81 @@ def resolve_k8s_target_from_alert(normalized_alert, config: RunnableConfig = Non
     if isinstance(cached, str) and cached:
         return cached
 
-    target = _build_k8s_target_from_alert(alert)
+    target = {}
+    try:
+        target = _build_k8s_target_from_alert(alert)
 
-    connection_error = _cluster_config_error(config)
-    if connection_error:
-        result = _unresolved_connection_result(target, connection_error)
+        routed_config, route_extra = route_alert_cluster(target.get("cluster"), config)
+        for key in ("instance_name", "instance_id", "cluster_mismatch", "instance_names"):
+            if route_extra.get(key) not in (None, "", [], {}):
+                target[key] = route_extra[key]
+        if route_extra.get("route_error"):
+            target["reason"] = route_extra["route_error"]
+            _log_resolve_failed("cluster_route", "route_error", target.get("instance_name"))
+            result = _unresolved_connection_result(target, route_extra["route_error"])
+            cache[fingerprint] = result
+            return result
+        config = routed_config
+
+        connection_error = _cluster_config_error(config)
+        if connection_error:
+            _log_resolve_failed("cluster_config", "connection_error", target.get("instance_name"))
+            result = _unresolved_connection_result(target, connection_error)
+            cache[fingerprint] = result
+            return result
+
+        needs_lookup = bool(target.get("resource_name") or target.get("pod_name")) and not target.get("namespace")
+        if needs_lookup:
+            resource_name = target.get("pod_name") or target.get("resource_name")
+            inferred = _infer_kube_system_namespace(resource_name, target.get("resource_type"))
+            if inferred:
+                target = _apply_inferred_namespace(target, inferred, "control_plane_convention")
+            else:
+                try:
+                    pods, events, lookup_error = _lookup_namespaces_by_resource_name(resource_name, config)
+                except Exception as lookup_exc:
+                    _log_resolve_failed(
+                        "namespace_lookup",
+                        type(lookup_exc).__name__,
+                        target.get("instance_name"),
+                        exc=lookup_exc,
+                    )
+                    result = _unresolved_connection_result(target, str(lookup_exc).strip() or type(lookup_exc).__name__)
+                    cache[fingerprint] = result
+                    return result
+                if lookup_error:
+                    _log_resolve_failed("namespace_lookup", "lookup_error", target.get("instance_name"))
+                    result = _unresolved_connection_result(target, lookup_error)
+                    cache[fingerprint] = result
+                    return result
+                target = _apply_namespace_lookup(target, pods, events)
+
+        if target.get("resource_type") and target.get("resource_name") and target.get("namespace"):
+            target["resolved"] = True
+            if not target.get("reason"):
+                target["reason"] = None
+        elif target.get("resource_type") and target.get("resource_name") and not target.get("namespace"):
+            target["resolved"] = False
+            target["missing_data"] = list(dict.fromkeys((target.get("missing_data") or []) + ["namespace"]))
+            if not target.get("reason"):
+                target["reason"] = "Missing namespace after pods/events reverse lookup"
+            _mark_target_conclusive(target, lookup_exhausted=True)
+
+        result = json.dumps(target, ensure_ascii=False)
+        cache[fingerprint] = result
+        logger.info(
+            "event=k8s_alert_resolve_finished resolved=%s conclusive=%s instance_name=%s missing_data=%s",
+            bool(target.get("resolved")),
+            bool(target.get("conclusive")),
+            target.get("instance_name") or "-",
+            ",".join(target.get("missing_data") or []) or "-",
+        )
+        return result
+    except Exception as exc:
+        _log_resolve_failed("resolve", type(exc).__name__, target.get("instance_name"), exc=exc)
+        result = _unresolved_connection_result(target, type(exc).__name__)
         cache[fingerprint] = result
         return result
-
-    needs_lookup = bool(target.get("resource_name") or target.get("pod_name")) and not target.get("namespace")
-    if needs_lookup:
-        from apps.opspilot.metis.llm.tools.kubernetes.resources import list_kubernetes_events, list_kubernetes_pods
-
-        try:
-            pods_raw = list_kubernetes_pods.invoke({"namespace": None}, config=config)
-            events_raw = list_kubernetes_events.invoke({"namespace": None}, config=config)
-        except Exception as lookup_exc:
-            result = _unresolved_connection_result(target, str(lookup_exc).strip() or type(lookup_exc).__name__)
-            cache[fingerprint] = result
-            return result
-        lookup_error = _lookup_payload_error(pods_raw) or _lookup_payload_error(events_raw)
-        if lookup_error:
-            result = _unresolved_connection_result(target, lookup_error)
-            cache[fingerprint] = result
-            return result
-        pods = _json_or_raw(pods_raw) or []
-        events = _json_or_raw(events_raw) or []
-        if not isinstance(pods, list):
-            pods = []
-        if not isinstance(events, list):
-            events = []
-        target = _apply_namespace_lookup(target, pods, events)
-
-    if target.get("resource_type") and target.get("resource_name") and target.get("namespace"):
-        target["resolved"] = True
-        if not target.get("reason"):
-            target["reason"] = None
-    elif target.get("resource_type") and target.get("resource_name") and not target.get("namespace"):
-        target["resolved"] = False
-        target["missing_data"] = list(dict.fromkeys((target.get("missing_data") or []) + ["namespace"]))
-        if not target.get("reason"):
-            target["reason"] = "Missing namespace after pods/events reverse lookup"
-        _mark_target_conclusive(target, lookup_exhausted=True)
-
-    result = json.dumps(target, ensure_ascii=False)
-    cache[fingerprint] = result
-    return result
 
 
 def _collect_pod_context(target, scope):
@@ -675,8 +825,8 @@ def _collect_pod_context(target, scope):
     pod_name = target.get("pod_name") or target.get("resource_name")
     container_name = target.get("container_name")
     node_name = target.get("node_name")
-    minutes = int((scope or {}).get("time_window_minutes") or 60)
-    lines = int((scope or {}).get("log_lines") or 100)
+    minutes = coerce_int((scope or {}).get("time_window_minutes"), 60, lo=1, hi=10080)
+    lines = coerce_int((scope or {}).get("log_lines"), 100, lo=1, hi=10000)
 
     resource_snapshot = _json_or_raw(describe_kubernetes_resource.invoke({"resource_type": "pod", "resource_name": pod_name, "namespace": namespace}))
     resource_snapshot = _enrich_pod_snapshot(resource_snapshot)
@@ -732,7 +882,7 @@ def _collect_pod_context(target, scope):
 
 def _collect_node_context(target, scope):
     node_name = target.get("node_name") or target.get("resource_name")
-    minutes = int((scope or {}).get("time_window_minutes") or 60)
+    minutes = coerce_int((scope or {}).get("time_window_minutes"), 60, lo=1, hi=10080)
     return {
         "resource_snapshot": _json_or_raw(describe_kubernetes_resource.invoke({"resource_type": "node", "resource_name": node_name})),
         "events_timeline": _json_or_raw(

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/data_collection.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/data_collection.py
@@ -251,6 +251,17 @@ _KUBE_SYSTEM_STATIC_POD_PREFIXES = (
     "kube-controller-manager-",
     "kube-proxy-",
 )
+# kube-proxy-exporter 等监控组件不是控制面静态 Pod。
+_KUBE_SYSTEM_NON_NODE_NAME_TOKENS = frozenset(
+    {
+        "exporter",
+        "metrics",
+        "operator",
+        "sidecar",
+        "prometheus",
+        "grafana",
+    }
+)
 
 
 def _copy_label(labels: dict, key: str, *values) -> None:
@@ -311,7 +322,7 @@ def _extract_labels(alert):
 
 _PAREN_GROUP_RE = re.compile(r"[（(]([^）)]+)[）)]")
 _POD_LIKE_NAME_RE = re.compile(r"\b([a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:-[a-f0-9]{5,10}){1,2})\b", re.IGNORECASE)
-_DNS1123_HYPHEN_NAME_RE = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", re.IGNORECASE)
+_DNS1123_HYPHEN_NAME_RE = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$", re.IGNORECASE)
 _NOTIFICATION_TITLE_RE = re.compile(r"告警[：:]\s*(.+?)(?:\n|$)")
 _NOTIFICATION_CONTENT_RE = re.compile(r"内容[：:]\s*(.+?)(?:\n|$)")
 _NOTIFICATION_TIME_RE = re.compile(r"告警时间[：:]*\s*(.+?)(?:\n|$)")
@@ -535,7 +546,15 @@ def _infer_kube_system_namespace(resource_name, resource_type=None) -> str | Non
         return None
     if name in _KUBE_SYSTEM_STATIC_POD_NAMES:
         return "kube-system"
-    if any(name.startswith(prefix) for prefix in _KUBE_SYSTEM_STATIC_POD_PREFIXES):
+    for prefix in _KUBE_SYSTEM_STATIC_POD_PREFIXES:
+        if not name.startswith(prefix):
+            continue
+        remainder = name[len(prefix) :]
+        if not remainder:
+            continue
+        tokens = remainder.replace(".", "-").split("-")
+        if any(token in _KUBE_SYSTEM_NON_NODE_NAME_TOKENS for token in tokens):
+            return None
         return "kube-system"
     return None
 
@@ -543,8 +562,10 @@ def _infer_kube_system_namespace(resource_name, resource_type=None) -> str | Non
 def _lookup_namespaces_by_resource_name(resource_name: str, config: RunnableConfig = None) -> tuple[list, list, str | None]:
     """按对象名定点反查 namespace，禁止 list 全集群 Pod/Events。"""
     name = str(resource_name or "").strip()
-    if not name or not _DNS1123_HYPHEN_NAME_RE.fullmatch(name):
+    if not name:
         return [], [], None
+    if not _DNS1123_HYPHEN_NAME_RE.fullmatch(name):
+        return [], [], f"资源名不符合 DNS-1123 subdomain: {name}"
     try:
         prepare_context(config)
         core_v1 = client.CoreV1Api()

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/diagnostics.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/diagnostics.py
@@ -7,7 +7,8 @@ from kubernetes.client import ApiException
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 
-from apps.opspilot.metis.llm.tools.kubernetes.utils import format_bytes, parse_resource_quantity, prepare_context
+from apps.opspilot.metis.llm.tools.kubernetes.instance_scope import prepare_point_instance, run_scan_tool
+from apps.opspilot.metis.llm.tools.kubernetes.utils import coerce_int, format_bytes, parse_resource_quantity, prepare_context
 
 _EVENT_TIME_MIN = datetime.min.replace(tzinfo=timezone.utc)
 
@@ -22,7 +23,7 @@ def _event_sort_time(event):
 
 
 @tool()
-def get_failed_kubernetes_pods(config: RunnableConfig = None):
+def get_failed_kubernetes_pods(instance_name=None, config: RunnableConfig = None):
     """
     发现集群中所有失败或异常的Pod
 
@@ -65,6 +66,10 @@ def get_failed_kubernetes_pods(config: RunnableConfig = None):
     - 分析镜像问题 → 检查imageRegistry配置和Secret
     - 需要恢复服务 → 使用 restart_pod 或 delete_kubernetes_resource
     """
+    return run_scan_tool(config, instance_name, _get_failed_kubernetes_pods_on_instance)
+
+
+def _get_failed_kubernetes_pods_on_instance(config: RunnableConfig = None):
     prepare_context(config)
     try:
         core_v1 = client.CoreV1Api()
@@ -170,7 +175,7 @@ def _not_ready_pod_record(pod) -> dict:
 
 
 @tool()
-def get_not_ready_kubernetes_pods(namespace=None, config: RunnableConfig = None):
+def get_not_ready_kubernetes_pods(namespace=None, instance_name=None, config: RunnableConfig = None):
     """
     发现 Running 但未就绪的 Pod（Readiness 失败入口）
 
@@ -185,8 +190,13 @@ def get_not_ready_kubernetes_pods(namespace=None, config: RunnableConfig = None)
 
     Args:
         namespace (str, optional): 命名空间；省略则扫描全部命名空间
+        instance_name (str, optional): 多实例时指定集群；省略则扫描全部已配置实例
         config (RunnableConfig): 工具配置（自动传递）
     """
+    return run_scan_tool(config, instance_name, lambda bound: _get_not_ready_kubernetes_pods_on_instance(namespace, bound))
+
+
+def _get_not_ready_kubernetes_pods_on_instance(namespace, config: RunnableConfig = None):
     prepare_context(config)
     try:
         core_v1 = client.CoreV1Api()
@@ -207,7 +217,7 @@ def get_not_ready_kubernetes_pods(namespace=None, config: RunnableConfig = None)
 
 
 @tool()
-def get_pending_kubernetes_pods(config: RunnableConfig = None):
+def get_pending_kubernetes_pods(instance_name=None, config: RunnableConfig = None):
     """
     发现无法调度或启动的Pending状态Pod
 
@@ -248,6 +258,10 @@ def get_pending_kubernetes_pods(config: RunnableConfig = None):
     - 检查节点状态 → 使用 diagnose_node_issues
     - 存储问题 → 使用 check_kubernetes_persistent_volumes
     """
+    return run_scan_tool(config, instance_name, _get_pending_kubernetes_pods_on_instance)
+
+
+def _get_pending_kubernetes_pods_on_instance(config: RunnableConfig = None):
     prepare_context(config)
     try:
         core_v1 = client.CoreV1Api()
@@ -293,7 +307,7 @@ def get_pending_kubernetes_pods(config: RunnableConfig = None):
 
 
 @tool()
-def get_high_restart_kubernetes_pods(restart_threshold: int = 5, config: RunnableConfig = None):
+def get_high_restart_kubernetes_pods(restart_threshold: int = 5, instance_name=None, config: RunnableConfig = None):
     """
     发现频繁重启的不稳定Pod
 
@@ -343,6 +357,11 @@ def get_high_restart_kubernetes_pods(restart_threshold: int = 5, config: Runnabl
     - 查看完整事件历史 → 使用 get_resource_events_timeline
     - 查看容器日志 → 使用 get_kubernetes_pod_logs
     """
+    restart_threshold = coerce_int(restart_threshold, 5, lo=0, hi=10000)
+    return run_scan_tool(config, instance_name, lambda bound: _get_high_restart_kubernetes_pods_on_instance(restart_threshold, bound))
+
+
+def _get_high_restart_kubernetes_pods_on_instance(restart_threshold, config: RunnableConfig = None):
     prepare_context(config)
     try:
         core_v1 = client.CoreV1Api()
@@ -645,7 +664,7 @@ def get_kubernetes_orphaned_resources(config: RunnableConfig = None):
 
 
 @tool()
-def diagnose_kubernetes_pod_issues(namespace, pod_name, config: RunnableConfig = None):  # noqa: C901
+def diagnose_kubernetes_pod_issues(namespace, pod_name, instance_name=None, config: RunnableConfig = None):  # noqa: C901
     """
     深度诊断单个Pod的所有问题 - 一站式故障排查
 
@@ -696,6 +715,9 @@ def diagnose_kubernetes_pod_issues(namespace, pod_name, config: RunnableConfig =
     - 需要重启恢复 → 使用 restart_pod
     - 卷挂载问题 → 使用 check_kubernetes_persistent_volumes
     """
+    config, instance_error = prepare_point_instance(config, instance_name)
+    if instance_error:
+        return instance_error
     prepare_context(config)
     try:
         core_v1 = client.CoreV1Api()

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/diagnostics_advanced.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/diagnostics_advanced.py
@@ -7,11 +7,12 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 from loguru import logger
 
+from apps.opspilot.metis.llm.tools.kubernetes.instance_scope import prepare_point_instance, run_scan_tool
 from apps.opspilot.metis.llm.tools.kubernetes.utils import coerce_int, parse_resource_quantity, prepare_context
 
 
 @tool()
-def diagnose_pending_pod_issues(pod_name, namespace, config: RunnableConfig = None):  # noqa: C901
+def diagnose_pending_pod_issues(pod_name, namespace, instance_name=None, config: RunnableConfig = None):  # noqa: C901
     """
     诊断Pod Pending调度失败的根本原因
 
@@ -33,6 +34,7 @@ def diagnose_pending_pod_issues(pod_name, namespace, config: RunnableConfig = No
     Args:
         pod_name (str): Pod名称（必填）
         namespace (str): 命名空间（必填）
+        instance_name (str, optional): 多实例时必须指定集群
         config (RunnableConfig): 工具配置（自动传递）
 
     Returns:
@@ -66,6 +68,9 @@ def diagnose_pending_pod_issues(pod_name, namespace, config: RunnableConfig = No
     - 此工具只诊断Pending Pod，对于Running/Failed Pod请使用其他工具
     - 诊断结果基于当前集群状态，添加节点后可能变化
     """
+    config, err = prepare_point_instance(config, instance_name)
+    if err:
+        return err
     prepare_context(config)
 
     try:
@@ -402,7 +407,7 @@ def check_network_policies_blocking(source_namespace, source_pod=None, target_na
 
 
 @tool()
-def check_pvc_capacity(namespace=None, threshold_percent: int = 80, config: RunnableConfig = None):
+def check_pvc_capacity(namespace=None, threshold_percent: int = 80, instance_name=None, config: RunnableConfig = None):
     """
     检查PVC（持久化存储）使用率，识别磁盘满风险
 
@@ -426,6 +431,7 @@ def check_pvc_capacity(namespace=None, threshold_percent: int = 80, config: Runn
             - 80: 标准预警阈值
             - 90: 高风险阈值
             - 50: 提前规划容量
+        instance_name (str, optional): 多实例时指定集群；省略则扫描全部已配置实例
         config (RunnableConfig): 工具配置（自动传递）
 
     Returns:
@@ -459,8 +465,16 @@ def check_pvc_capacity(namespace=None, threshold_percent: int = 80, config: Runn
     3. 日志占用：容器日志未rotate，占满磁盘
     4. emptyDir满：超过节点磁盘限制
     """
-    prepare_context(config)
     threshold_percent = coerce_int(threshold_percent, 80, lo=1, hi=100)
+
+    def _run(bound_config):
+        return _check_pvc_capacity_on_instance(namespace, threshold_percent, bound_config)
+
+    return run_scan_tool(config, instance_name, _run)
+
+
+def _check_pvc_capacity_on_instance(namespace, threshold_percent, config: RunnableConfig = None):
+    prepare_context(config)
 
     try:
         core_v1 = client.CoreV1Api()

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/diagnostics_advanced.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/diagnostics_advanced.py
@@ -1,17 +1,17 @@
 """Kubernetes高级诊断工具 - P0高频缺失场景"""
 import json
-from datetime import datetime, timezone
-from typing import Dict, List, Optional
+
+from kubernetes import client
 from kubernetes.client import ApiException
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
-from kubernetes import client
 from loguru import logger
-from apps.opspilot.metis.llm.tools.kubernetes.utils import prepare_context, parse_resource_quantity
+
+from apps.opspilot.metis.llm.tools.kubernetes.utils import coerce_int, parse_resource_quantity, prepare_context
 
 
 @tool()
-def diagnose_pending_pod_issues(pod_name, namespace, config: RunnableConfig = None):
+def diagnose_pending_pod_issues(pod_name, namespace, config: RunnableConfig = None):  # noqa: C901
     """
     诊断Pod Pending调度失败的根本原因
 
@@ -77,9 +77,7 @@ def diagnose_pending_pod_issues(pod_name, namespace, config: RunnableConfig = No
             pod = core_v1.read_namespaced_pod(pod_name, namespace)
         except ApiException as e:
             if e.status == 404:
-                return json.dumps({
-                    "error": f"Pod不存在: {namespace}/{pod_name}"
-                })
+                return json.dumps({"error": f"Pod不存在: {namespace}/{pod_name}"})
             raise
 
         result = {
@@ -90,7 +88,7 @@ def diagnose_pending_pod_issues(pod_name, namespace, config: RunnableConfig = No
             "issues": [],
             "node_candidates": [],
             "recommendations": [],
-            "diagnosis_summary": ""
+            "diagnosis_summary": "",
         }
 
         # 检查Pod是否真的是Pending
@@ -104,20 +102,17 @@ def diagnose_pending_pod_issues(pod_name, namespace, config: RunnableConfig = No
                 if condition.type == "PodScheduled" and condition.status == "False":
                     result["pending_reason"] = condition.reason
                     if condition.message:
-                        result["issues"].append({
-                            "category": "scheduling",
-                            "severity": "critical",
-                            "message": f"调度失败: {condition.reason}",
-                            "details": condition.message
-                        })
+                        result["issues"].append(
+                            {"category": "scheduling", "severity": "critical", "message": f"调度失败: {condition.reason}", "details": condition.message}
+                        )
 
         # 2. 检查资源需求
         resource_requests = {"cpu": 0, "memory": 0}
         if pod.spec.containers:
             for container in pod.spec.containers:
                 if container.resources and container.resources.requests:
-                    cpu_req = parse_resource_quantity(container.resources.requests.get('cpu', '0'))
-                    mem_req = parse_resource_quantity(container.resources.requests.get('memory', '0'))
+                    cpu_req = parse_resource_quantity(container.resources.requests.get("cpu", "0"))
+                    mem_req = parse_resource_quantity(container.resources.requests.get("memory", "0"))
                     resource_requests["cpu"] += cpu_req
                     resource_requests["memory"] += mem_req
 
@@ -133,9 +128,9 @@ def diagnose_pending_pod_issues(pod_name, namespace, config: RunnableConfig = No
 
             node_name = node.metadata.name
             allocatable = node.status.allocatable or {}
-            allocatable_cpu = parse_resource_quantity(allocatable.get('cpu', '0'))
-            allocatable_memory = parse_resource_quantity(allocatable.get('memory', '0'))
-            allocatable_pods = int(allocatable.get('pods', '110'))
+            allocatable_cpu = parse_resource_quantity(allocatable.get("cpu", "0"))
+            allocatable_memory = parse_resource_quantity(allocatable.get("memory", "0"))
+            allocatable_pods = int(allocatable.get("pods", "110"))
 
             # 计算已使用
             used_cpu = 0
@@ -150,8 +145,8 @@ def diagnose_pending_pod_issues(pod_name, namespace, config: RunnableConfig = No
                     if p.spec.containers:
                         for c in p.spec.containers:
                             if c.resources and c.resources.requests:
-                                used_cpu += parse_resource_quantity(c.resources.requests.get('cpu', '0'))
-                                used_memory += parse_resource_quantity(c.resources.requests.get('memory', '0'))
+                                used_cpu += parse_resource_quantity(c.resources.requests.get("cpu", "0"))
+                                used_memory += parse_resource_quantity(c.resources.requests.get("memory", "0"))
 
             available_cpu = allocatable_cpu - used_cpu
             available_memory = allocatable_memory - used_memory
@@ -161,33 +156,28 @@ def diagnose_pending_pod_issues(pod_name, namespace, config: RunnableConfig = No
                 "available_cpu": available_cpu,
                 "available_memory": available_memory,
                 "available_pods": available_pods,
-                "can_fit": (
-                    available_cpu >= resource_requests["cpu"]
-                    and available_memory >= resource_requests["memory"]
-                    and available_pods >= 1
-                )
+                "can_fit": (available_cpu >= resource_requests["cpu"] and available_memory >= resource_requests["memory"] and available_pods >= 1),
             }
 
         # 检查是否有节点能满足资源需求
         candidates_by_resource = [n for n, r in node_resources.items() if r["can_fit"]]
 
         if not candidates_by_resource:
-            result["issues"].append({
-                "category": "resource",
-                "severity": "critical",
-                "message": "没有节点有足够资源",
-                "details": f"需要CPU: {resource_requests['cpu']:.2f}核, 内存: {resource_requests['memory'] / (1024**3):.2f}Gi"
-            })
+            result["issues"].append(
+                {
+                    "category": "resource",
+                    "severity": "critical",
+                    "message": "没有节点有足够资源",
+                    "details": f"需要CPU: {resource_requests['cpu']:.2f}核, 内存: {resource_requests['memory'] / (1024**3):.2f}Gi",
+                }
+            )
             result["recommendations"].append("增加集群节点或减少Pod的资源requests")
 
         # 4. 检查节点亲和性
         if pod.spec.node_selector:
-            result["issues"].append({
-                "category": "affinity",
-                "severity": "high",
-                "message": "配置了NodeSelector",
-                "details": f"NodeSelector: {pod.spec.node_selector}"
-            })
+            result["issues"].append(
+                {"category": "affinity", "severity": "high", "message": "配置了NodeSelector", "details": f"NodeSelector: {pod.spec.node_selector}"}
+            )
 
             # 检查有多少节点匹配selector
             matching_nodes = 0
@@ -211,25 +201,19 @@ def diagnose_pending_pod_issues(pod_name, namespace, config: RunnableConfig = No
                 tolerated = False
                 if pod.spec.tolerations:
                     for toleration in pod.spec.tolerations:
-                        if (toleration.key == taint.key
+                        if (
+                            toleration.key == taint.key
                             and (not toleration.value or toleration.value == taint.value)
-                                and (not toleration.effect or toleration.effect == taint.effect)):
+                            and (not toleration.effect or toleration.effect == taint.effect)
+                        ):
                             tolerated = True
                             break
 
                 if not tolerated and taint.effect in ["NoSchedule", "NoExecute"]:
-                    taints_blocking.append({
-                        "node": node_name,
-                        "taint": f"{taint.key}={taint.value}:{taint.effect}"
-                    })
+                    taints_blocking.append({"node": node_name, "taint": f"{taint.key}={taint.value}:{taint.effect}"})
 
         if taints_blocking:
-            result["issues"].append({
-                "category": "taint",
-                "severity": "high",
-                "message": "节点污点阻止调度",
-                "details": f"有{len(taints_blocking)}个节点的污点无法容忍"
-            })
+            result["issues"].append({"category": "taint", "severity": "high", "message": "节点污点阻止调度", "details": f"有{len(taints_blocking)}个节点的污点无法容忍"})
             result["recommendations"].append("为Pod添加Toleration或移除节点污点")
 
         # 6. 检查PVC绑定
@@ -240,20 +224,14 @@ def diagnose_pending_pod_issues(pod_name, namespace, config: RunnableConfig = No
                     try:
                         pvc = core_v1.read_namespaced_persistent_volume_claim(pvc_name, namespace)
                         if pvc.status.phase != "Bound":
-                            result["issues"].append({
-                                "category": "pvc",
-                                "severity": "critical",
-                                "message": f"PVC未绑定: {pvc_name}",
-                                "details": f"PVC状态: {pvc.status.phase}"
-                            })
+                            result["issues"].append(
+                                {"category": "pvc", "severity": "critical", "message": f"PVC未绑定: {pvc_name}", "details": f"PVC状态: {pvc.status.phase}"}
+                            )
                             result["recommendations"].append(f"检查PVC {pvc_name} 是否有可用的PV")
                     except ApiException:
-                        result["issues"].append({
-                            "category": "pvc",
-                            "severity": "critical",
-                            "message": f"PVC不存在: {pvc_name}",
-                            "details": "Pod引用了不存在的PVC"
-                        })
+                        result["issues"].append(
+                            {"category": "pvc", "severity": "critical", "message": f"PVC不存在: {pvc_name}", "details": "Pod引用了不存在的PVC"}
+                        )
 
         # 7. 检查镜像拉取
         if pod.status.container_statuses:
@@ -261,15 +239,15 @@ def diagnose_pending_pod_issues(pod_name, namespace, config: RunnableConfig = No
                 if container.state.waiting:
                     reason = container.state.waiting.reason
                     if reason in ["ImagePullBackOff", "ErrImagePull"]:
-                        result["issues"].append({
-                            "category": "image",
-                            "severity": "critical",
-                            "message": f"镜像拉取失败: {container.name}",
-                            "details": container.state.waiting.message or reason
-                        })
-                        result["recommendations"].append(
-                            f"检查镜像地址是否正确、镜像仓库凭据是否配置、网络是否可达"
+                        result["issues"].append(
+                            {
+                                "category": "image",
+                                "severity": "critical",
+                                "message": f"镜像拉取失败: {container.name}",
+                                "details": container.state.waiting.message or reason,
+                            }
                         )
+                        result["recommendations"].append("检查镜像地址是否正确、镜像仓库凭据是否配置、网络是否可达")
 
         # 8. 生成诊断总结
         if len(result["issues"]) == 0:
@@ -286,11 +264,7 @@ def diagnose_pending_pod_issues(pod_name, namespace, config: RunnableConfig = No
 
     except Exception as e:
         logger.error(f"诊断Pending Pod失败: {str(e)}")
-        return json.dumps({
-            "error": f"诊断失败: {str(e)}",
-            "pod_name": pod_name,
-            "namespace": namespace
-        })
+        return json.dumps({"error": f"诊断失败: {str(e)}", "pod_name": pod_name, "namespace": namespace})
 
 
 @tool()
@@ -342,7 +316,6 @@ def check_network_policies_blocking(source_namespace, source_pod=None, target_na
 
     try:
         networking_v1 = client.NetworkingV1Api()
-        core_v1 = client.CoreV1Api()
 
         logger.info(f"检查NetworkPolicy阻断: {source_namespace} -> {target_namespace}")
 
@@ -355,7 +328,7 @@ def check_network_policies_blocking(source_namespace, source_pod=None, target_na
             "ingress_blocked": False,
             "blocking_policies": [],
             "recommendations": [],
-            "diagnosis_summary": ""
+            "diagnosis_summary": "",
         }
 
         # 1. 获取源命名空间的NetworkPolicy
@@ -365,7 +338,7 @@ def check_network_policies_blocking(source_namespace, source_pod=None, target_na
                 policy_info = {
                     "name": np.metadata.name,
                     "pod_selector": np.spec.pod_selector.match_labels if np.spec.pod_selector.match_labels else {},
-                    "policy_types": np.spec.policy_types or []
+                    "policy_types": np.spec.policy_types or [],
                 }
                 result["source_policies"].append(policy_info)
 
@@ -374,12 +347,9 @@ def check_network_policies_blocking(source_namespace, source_pod=None, target_na
                     if not np.spec.egress:
                         # 没有egress规则 = 默认deny all
                         result["egress_blocked"] = True
-                        result["blocking_policies"].append({
-                            "policy": np.metadata.name,
-                            "namespace": source_namespace,
-                            "type": "Egress",
-                            "reason": "未定义Egress规则，默认拒绝所有出站流量"
-                        })
+                        result["blocking_policies"].append(
+                            {"policy": np.metadata.name, "namespace": source_namespace, "type": "Egress", "reason": "未定义Egress规则，默认拒绝所有出站流量"}
+                        )
         except ApiException as e:
             if e.status != 404:
                 logger.warning(f"获取源命名空间NetworkPolicy失败: {str(e)}")
@@ -392,7 +362,7 @@ def check_network_policies_blocking(source_namespace, source_pod=None, target_na
                     policy_info = {
                         "name": np.metadata.name,
                         "pod_selector": np.spec.pod_selector.match_labels if np.spec.pod_selector.match_labels else {},
-                        "policy_types": np.spec.policy_types or []
+                        "policy_types": np.spec.policy_types or [],
                     }
                     result["target_policies"].append(policy_info)
 
@@ -401,12 +371,9 @@ def check_network_policies_blocking(source_namespace, source_pod=None, target_na
                         if not np.spec.ingress:
                             # 没有ingress规则 = 默认deny all
                             result["ingress_blocked"] = True
-                            result["blocking_policies"].append({
-                                "policy": np.metadata.name,
-                                "namespace": target_namespace,
-                                "type": "Ingress",
-                                "reason": "未定义Ingress规则，默认拒绝所有入站流量"
-                            })
+                            result["blocking_policies"].append(
+                                {"policy": np.metadata.name, "namespace": target_namespace, "type": "Ingress", "reason": "未定义Ingress规则，默认拒绝所有入站流量"}
+                            )
             except ApiException as e:
                 if e.status != 404:
                     logger.warning(f"获取目标命名空间NetworkPolicy失败: {str(e)}")
@@ -421,28 +388,21 @@ def check_network_policies_blocking(source_namespace, source_pod=None, target_na
             if result["ingress_blocked"]:
                 blocked_types.append("入站Ingress")
             result["diagnosis_summary"] = f"NetworkPolicy阻断了{'/'.join(blocked_types)}流量"
-            result["recommendations"].append(
-                "检查NetworkPolicy规则，为需要通信的Pod添加相应的Egress/Ingress规则"
-            )
+            result["recommendations"].append("检查NetworkPolicy规则，为需要通信的Pod添加相应的Egress/Ingress规则")
         else:
             result["diagnosis_summary"] = "配置了NetworkPolicy但未发现明显阻断（需要详细分析Pod标签匹配）"
-            result["recommendations"].append(
-                "NetworkPolicy规则较复杂，建议人工检查Pod标签是否匹配policy selector"
-            )
+            result["recommendations"].append("NetworkPolicy规则较复杂，建议人工检查Pod标签是否匹配policy selector")
 
         logger.info(f"NetworkPolicy检查完成: {result['diagnosis_summary']}")
         return json.dumps(result, ensure_ascii=False, indent=2)
 
     except Exception as e:
         logger.error(f"检查NetworkPolicy失败: {str(e)}")
-        return json.dumps({
-            "error": f"检查失败: {str(e)}",
-            "source_namespace": source_namespace
-        })
+        return json.dumps({"error": f"检查失败: {str(e)}", "source_namespace": source_namespace})
 
 
 @tool()
-def check_pvc_capacity(namespace=None, threshold_percent=80, config: RunnableConfig = None):
+def check_pvc_capacity(namespace=None, threshold_percent: int = 80, config: RunnableConfig = None):
     """
     检查PVC（持久化存储）使用率，识别磁盘满风险
 
@@ -500,10 +460,10 @@ def check_pvc_capacity(namespace=None, threshold_percent=80, config: RunnableCon
     4. emptyDir满：超过节点磁盘限制
     """
     prepare_context(config)
+    threshold_percent = coerce_int(threshold_percent, 80, lo=1, hi=100)
 
     try:
         core_v1 = client.CoreV1Api()
-        storage_v1 = client.StorageV1Api()
 
         logger.info(f"检查PVC容量, namespace={namespace}, threshold={threshold_percent}%")
 
@@ -526,7 +486,7 @@ def check_pvc_capacity(namespace=None, threshold_percent=80, config: RunnableCon
             "high_usage_pvcs": [],
             "recommendations": [],
             "total_capacity": 0,
-            "total_pvcs": 0
+            "total_pvcs": 0,
         }
 
         # 构建PVC到Pod的映射
@@ -546,7 +506,7 @@ def check_pvc_capacity(namespace=None, threshold_percent=80, config: RunnableCon
             pvc_key = f"{pvc.metadata.namespace}/{pvc.metadata.name}"
 
             # 解析容量
-            capacity_str = pvc.status.capacity.get('storage', '0') if pvc.status.capacity else '0'
+            capacity_str = pvc.status.capacity.get("storage", "0") if pvc.status.capacity else "0"
             capacity_bytes = parse_resource_quantity(capacity_str)
             result["total_capacity"] += capacity_bytes
             result["total_pvcs"] += 1
@@ -559,27 +519,19 @@ def check_pvc_capacity(namespace=None, threshold_percent=80, config: RunnableCon
                 "capacity_bytes": capacity_bytes,
                 "storage_class": pvc.spec.storage_class_name,
                 "access_modes": pvc.spec.access_modes or [],
-                "mounted_by": pvc_to_pods.get(pvc_key, [])
+                "mounted_by": pvc_to_pods.get(pvc_key, []),
             }
 
             result["pvc_list"].append(pvc_info)
 
             # 检查未绑定的PVC
             if pvc.status.phase == "Pending":
-                result["pending_pvcs"].append({
-                    "name": pvc.metadata.name,
-                    "namespace": pvc.metadata.namespace,
-                    "requested_capacity": capacity_str
-                })
-                result["recommendations"].append(
-                    f"PVC {pvc.metadata.name} 未绑定，检查是否有可用的PV或动态provisioner"
-                )
+                result["pending_pvcs"].append({"name": pvc.metadata.name, "namespace": pvc.metadata.namespace, "requested_capacity": capacity_str})
+                result["recommendations"].append(f"PVC {pvc.metadata.name} 未绑定，检查是否有可用的PV或动态provisioner")
 
         # 生成总结建议
         if len(result["pending_pvcs"]) > 0:
-            result["recommendations"].insert(0,
-                                             f"发现{len(result['pending_pvcs'])}个未绑定的PVC，可能导致Pod无法启动"
-                                             )
+            result["recommendations"].insert(0, f"发现{len(result['pending_pvcs'])}个未绑定的PVC，可能导致Pod无法启动")
 
         if result["total_pvcs"] == 0:
             result["recommendations"].append("集群中没有PVC，如果应用需要持久化存储请创建PVC")
@@ -589,7 +541,4 @@ def check_pvc_capacity(namespace=None, threshold_percent=80, config: RunnableCon
 
     except Exception as e:
         logger.error(f"检查PVC容量失败: {str(e)}")
-        return json.dumps({
-            "error": f"检查失败: {str(e)}",
-            "namespace": namespace
-        })
+        return json.dumps({"error": f"检查失败: {str(e)}", "namespace": namespace})

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/exec_ops.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/exec_ops.py
@@ -10,7 +10,8 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 
 from apps.core.logger import opspilot_logger as logger
-from apps.opspilot.metis.llm.tools.kubernetes.utils import prepare_context
+from apps.opspilot.metis.llm.tools.kubernetes.instance_scope import prepare_point_instance
+from apps.opspilot.metis.llm.tools.kubernetes.utils import coerce_int, prepare_context
 
 _ALLOWED_EXEC_BINARIES = frozenset({"curl", "nslookup", "dig", "env", "hostname", "date", "wget", "ping", "ss", "ip"})
 _UNSAFE_TOKEN_RE = re.compile(r"[;&|`$<>\n\r]")
@@ -36,11 +37,7 @@ def _normalize_exec_command(command):
 
 
 def _clamp_timeout(timeout) -> int:
-    try:
-        value = int(timeout)
-    except (TypeError, ValueError):
-        value = _DEFAULT_EXEC_TIMEOUT
-    return max(_MIN_EXEC_TIMEOUT, min(_MAX_EXEC_TIMEOUT, value))
+    return coerce_int(timeout, _DEFAULT_EXEC_TIMEOUT, lo=_MIN_EXEC_TIMEOUT, hi=_MAX_EXEC_TIMEOUT)
 
 
 @tool()
@@ -49,7 +46,8 @@ def exec_in_pod(
     pod_name,
     command,
     container=None,
-    timeout=None,
+    timeout: int | None = None,
+    instance_name=None,
     config: RunnableConfig = None,
 ):
     """
@@ -64,6 +62,9 @@ def exec_in_pod(
         return json.dumps({"success": False, "error": error}, ensure_ascii=False)
     if not namespace or not pod_name:
         return json.dumps({"success": False, "error": "需要指定 namespace 和 pod_name"}, ensure_ascii=False)
+    config, instance_error = prepare_point_instance(config, instance_name)
+    if instance_error:
+        return instance_error
 
     prepare_context(config)
     timeout_seconds = _clamp_timeout(timeout if timeout is not None else _DEFAULT_EXEC_TIMEOUT)

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/instance_scope.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/instance_scope.py
@@ -1,0 +1,204 @@
+"""Kubernetes 多实例路由：定点取证必选实例，扫描类可扇出。"""
+
+from __future__ import annotations
+
+import copy
+import json
+
+from langchain_core.runnables import RunnableConfig
+
+from apps.opspilot.metis.llm.tools.kubernetes.connection import get_kubernetes_instances_from_configurable, resolve_kubernetes_instance
+
+# LangGraph configurable 含 callback/accumulator 等带锁对象，禁止 deepcopy 整份 config。
+_INSTANCE_BIND_KEYS = (
+    "kubernetes_instances",
+    "kubeconfig_data",
+    "instance_name",
+    "instance_id",
+)
+
+
+def _configurable(config: RunnableConfig | None) -> dict:
+    if not config:
+        return {}
+    raw = config.get("configurable") or {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _instance_bind_configurable(config: RunnableConfig | None) -> dict:
+    source = _configurable(config)
+    bound = {}
+    for key in _INSTANCE_BIND_KEYS:
+        if key not in source:
+            continue
+        value = source[key]
+        bound[key] = copy.deepcopy(value) if key == "kubernetes_instances" else value
+    return bound
+
+
+def configured_instances(config: RunnableConfig | None) -> list[dict]:
+    return get_kubernetes_instances_from_configurable(_configurable(config))
+
+
+def instance_display_names(instances: list[dict]) -> list[str]:
+    names = []
+    for item in instances or []:
+        name = item.get("name")
+        if name:
+            names.append(str(name))
+    return names
+
+
+def bind_instance_config(config: RunnableConfig | None, instance: dict) -> dict:
+    configurable = _instance_bind_configurable(config)
+    configurable["instance_id"] = instance.get("id")
+    configurable["instance_name"] = instance.get("name")
+    if instance.get("kubeconfig_data"):
+        configurable["kubeconfig_data"] = instance.get("kubeconfig_data")
+    return {"configurable": configurable}
+
+
+def bind_instance_name(config: RunnableConfig | None, instance_name=None, instance_id=None) -> dict:
+    if not instance_name and not instance_id:
+        return config or {}
+    instances = configured_instances(config)
+    if not instances:
+        configurable = _instance_bind_configurable(config)
+        if instance_name:
+            configurable["instance_name"] = instance_name
+        if instance_id:
+            configurable["instance_id"] = instance_id
+        return {"configurable": configurable}
+    instance = resolve_kubernetes_instance(instances, instance_name=instance_name, instance_id=instance_id)
+    return bind_instance_config(config, instance)
+
+
+def _already_bound(config: RunnableConfig | None) -> bool:
+    configurable = _configurable(config)
+    return bool(configurable.get("instance_name") or configurable.get("instance_id"))
+
+
+def point_instance_error(config: RunnableConfig | None, instance_name=None) -> str | None:
+    """定点取证：多实例且未指定/未绑定实例时返回错误 JSON。"""
+    if instance_name or _already_bound(config):
+        return None
+    instances = configured_instances(config)
+    if len(instances) <= 1:
+        return None
+    names = "、".join(instance_display_names(instances)) or "未命名"
+    return json.dumps(
+        {
+            "error": f"已配置多个 Kubernetes 实例（{names}），请指定 instance_name",
+            "instance_names": instance_display_names(instances),
+        },
+        ensure_ascii=False,
+    )
+
+
+def prepare_point_instance(config: RunnableConfig | None, instance_name=None) -> tuple[dict | None, str | None]:
+    """返回 (绑定后的 config, 错误 JSON)。错误非空时不要继续调用集群 API。"""
+    error = point_instance_error(config, instance_name)
+    if error:
+        return None, error
+    if instance_name:
+        try:
+            return bind_instance_name(config, instance_name=instance_name), None
+        except ValueError as exc:
+            return None, json.dumps({"error": str(exc)}, ensure_ascii=False)
+    return config or {}, None
+
+
+def scan_instances(config: RunnableConfig | None, instance_name=None) -> list[dict] | None:
+    """扫描范围。返回 None 表示沿用当前 config（单实例或已绑定）；返回列表则需扇出。"""
+    if instance_name:
+        return None
+    if _already_bound(config):
+        return None
+    instances = configured_instances(config)
+    if len(instances) <= 1:
+        return None
+    return instances
+
+
+def wrap_scan_payload(cluster_name: str, raw: str) -> dict:
+    payload = raw
+    if isinstance(raw, str):
+        text = raw.strip()
+        if text and text[0] in "{[":
+            try:
+                payload = json.loads(text)
+            except Exception:
+                payload = {"raw": raw}
+        else:
+            payload = {"raw": raw}
+    if isinstance(payload, dict) and payload.get("error"):
+        return {"cluster": cluster_name, "error": payload.get("error")}
+    if isinstance(payload, list):
+        return {"cluster": cluster_name, "items": payload}
+    if isinstance(payload, dict):
+        wrapped = dict(payload)
+        wrapped["cluster"] = cluster_name
+        return wrapped
+    return {"cluster": cluster_name, "items": payload}
+
+
+def run_scan_tool(config: RunnableConfig | None, instance_name, run_single) -> str:
+    """run_single(bound_config) -> JSON/文本。多实例未指定时扇出；坏实例记 error。"""
+    if instance_name:
+        try:
+            bound = bind_instance_name(config, instance_name=instance_name)
+        except ValueError as exc:
+            return json.dumps({"error": str(exc)}, ensure_ascii=False)
+        return run_single(bound)
+
+    scoped = scan_instances(config, instance_name=None)
+    if scoped is None:
+        return run_single(config)
+
+    results = []
+    for instance in scoped:
+        name = instance.get("name") or instance.get("id") or "unknown"
+        bound = bind_instance_config(config, instance)
+        try:
+            results.append(wrap_scan_payload(str(name), run_single(bound)))
+        except Exception as exc:
+            results.append({"cluster": str(name), "error": str(exc).strip() or type(exc).__name__})
+    return json.dumps({"mode": "multi_instance", "instances": results}, ensure_ascii=False)
+
+
+def route_alert_cluster(cluster, config: RunnableConfig | None) -> tuple[dict | None, dict]:
+    """按告警集群名绑定实例。返回 (bound_config_or_None, extra_fields_for_target)。"""
+    extra = {}
+    instances = configured_instances(config)
+    if not instances:
+        return config or {}, extra
+
+    names = instance_display_names(instances)
+    names_text = "、".join(names) if names else "未命名"
+
+    if len(instances) == 1:
+        instance = instances[0]
+        extra["instance_name"] = instance.get("name")
+        extra["instance_id"] = instance.get("id")
+        cluster_text = str(cluster).strip() if cluster not in (None, "", [], {}) else ""
+        if cluster_text:
+            try:
+                resolve_kubernetes_instance(instances, instance_name=cluster_text)
+            except ValueError:
+                extra["cluster_mismatch"] = f"告警集群 {cluster_text} 与唯一实例 {instance.get('name')} 不一致"
+        return bind_instance_config(config, instance), extra
+
+    cluster_text = str(cluster).strip() if cluster not in (None, "", [], {}) else ""
+    if not cluster_text:
+        extra["route_error"] = f"告警未提供集群标识，已配置多个实例，无法路由。已配置实例: {names_text}"
+        extra["instance_names"] = names
+        return None, extra
+    try:
+        instance = resolve_kubernetes_instance(instances, instance_name=cluster_text)
+    except ValueError:
+        extra["route_error"] = f"告警集群 {cluster_text} 未绑定实例。已配置实例: {names_text}"
+        extra["instance_names"] = names
+        return None, extra
+    extra["instance_name"] = instance.get("name")
+    extra["instance_id"] = instance.get("id")
+    return bind_instance_config(config, instance), extra

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/metrics.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/metrics.py
@@ -8,6 +8,7 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 
 from apps.core.logger import opspilot_logger as logger
+from apps.opspilot.metis.llm.tools.kubernetes.instance_scope import run_scan_tool
 from apps.opspilot.metis.llm.tools.kubernetes.utils import prepare_context
 
 _METRICS_GROUP = "metrics.k8s.io"
@@ -52,12 +53,16 @@ def _pod_usage_item(item: dict) -> dict:
 
 
 @tool()
-def get_kubernetes_pods_top(namespace=None, pod_name=None, config: RunnableConfig = None):
+def get_kubernetes_pods_top(namespace=None, pod_name=None, instance_name=None, config: RunnableConfig = None):
     """
     查询 Pod CPU/内存用量（Metrics Server，类似 kubectl top pods）
 
     用于区分探针过紧、CPU throttle、内存压力。Metrics Server 未安装时返回 metrics_available=false。
     """
+    return run_scan_tool(config, instance_name, lambda bound: _get_kubernetes_pods_top_on_instance(namespace, pod_name, bound))
+
+
+def _get_kubernetes_pods_top_on_instance(namespace, pod_name, config: RunnableConfig = None):
     prepare_context(config)
     try:
         api = client.CustomObjectsApi()
@@ -78,10 +83,14 @@ def get_kubernetes_pods_top(namespace=None, pod_name=None, config: RunnableConfi
 
 
 @tool()
-def get_kubernetes_nodes_top(node_name=None, config: RunnableConfig = None):
+def get_kubernetes_nodes_top(node_name=None, instance_name=None, config: RunnableConfig = None):
     """
     查询节点 CPU/内存用量（Metrics Server，类似 kubectl top nodes）
     """
+    return run_scan_tool(config, instance_name, lambda bound: _get_kubernetes_nodes_top_on_instance(node_name, bound))
+
+
+def _get_kubernetes_nodes_top_on_instance(node_name, config: RunnableConfig = None):
     prepare_context(config)
     try:
         api = client.CustomObjectsApi()

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/optimization.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/optimization.py
@@ -13,7 +13,7 @@ from apps.opspilot.metis.llm.tools.kubernetes.utils import coerce_int, parse_res
 
 
 @tool()
-def check_scaling_capacity(namespace, replicas: int, resource_requirements=None, config: RunnableConfig = None):
+def check_scaling_capacity(namespace, replicas: int, resource_requirements=None, instance_name=None, config: RunnableConfig = None):
     """
     扩容前的容量校验，避免资源不足导致Pending
 
@@ -37,6 +37,7 @@ def check_scaling_capacity(namespace, replicas: int, resource_requirements=None,
             格式: {"cpu": "100m", "memory": "128Mi"}
             - 如果提供：精确计算CPU和内存是否满足
             - 如果不提供：只检查Pod数量容量，强烈建议补充
+        instance_name (str, optional): 多实例时必须指定集群
         config (RunnableConfig): 工具配置（自动传递）
 
     Returns:
@@ -66,6 +67,9 @@ def check_scaling_capacity(namespace, replicas: int, resource_requirements=None,
     - 不考虑节点亲和性、污点等高级调度策略
     - 实际调度结果可能因调度器策略而异
     """
+    config, err = prepare_point_instance(config, instance_name)
+    if err:
+        return err
     try:
         replicas = coerce_int(replicas, lo=0, hi=10000)
     except ValueError:
@@ -591,6 +595,31 @@ def _probe_action_field(action, *names):
     return None
 
 
+def _json_safe_probe_value(value):
+    """探针 port/command 可能是 IntOrString 或 mock，转成 json.dumps 可接受的类型。"""
+    if value is None or isinstance(value, (str, int, bool)):
+        return value
+    if isinstance(value, float):
+        return value if value == value and value not in (float("inf"), float("-inf")) else str(value)
+    if isinstance(value, (list, tuple)):
+        return [_json_safe_probe_value(item) for item in value]
+    int_val = getattr(value, "int_val", None)
+    if int_val is None:
+        int_val = getattr(value, "int", None)
+    str_val = getattr(value, "str_val", None)
+    if str_val is None:
+        str_val = getattr(value, "str", None)
+    if isinstance(int_val, int) and not isinstance(int_val, bool):
+        return int_val
+    if isinstance(str_val, str) and str_val:
+        return str_val
+    try:
+        json.dumps(value)
+        return value
+    except (TypeError, ValueError, OverflowError):
+        return str(value)
+
+
 def _serialize_probe(probe) -> dict:
     """序列化探针；http_get 等可能是不完整 mock，一律 getattr。"""
     payload = {
@@ -609,30 +638,30 @@ def _serialize_probe(probe) -> dict:
     if http_get:
         payload["http_get"] = {
             "path": _probe_action_field(http_get, "path"),
-            "port": _probe_action_field(http_get, "port"),
+            "port": _json_safe_probe_value(_probe_action_field(http_get, "port")),
             "scheme": _probe_action_field(http_get, "scheme"),
             "host": _probe_action_field(http_get, "host"),
         }
     tcp_socket = getattr(probe, "tcp_socket", None)
     if tcp_socket:
         payload["tcp_socket"] = {
-            "port": _probe_action_field(tcp_socket, "port"),
+            "port": _json_safe_probe_value(_probe_action_field(tcp_socket, "port")),
             "host": _probe_action_field(tcp_socket, "host"),
         }
     exec_action = getattr(probe, "_exec", None)
     if exec_action:
-        payload["exec_command"] = _probe_action_field(exec_action, "command")
+        payload["exec_command"] = _json_safe_probe_value(_probe_action_field(exec_action, "command"))
     grpc = getattr(probe, "grpc", None)
     if grpc:
         payload["grpc"] = {
-            "port": _probe_action_field(grpc, "port"),
+            "port": _json_safe_probe_value(_probe_action_field(grpc, "port")),
             "service": _probe_action_field(grpc, "service"),
         }
     return payload
 
 
 @tool()
-def compare_deployment_revisions(deployment_name, namespace, revision1: int, revision2: int, config: RunnableConfig = None):
+def compare_deployment_revisions(deployment_name, namespace, revision1: int, revision2: int, instance_name=None, config: RunnableConfig = None):
     """
     对比Deployment版本差异，理解变更内容
 
@@ -656,6 +685,7 @@ def compare_deployment_revisions(deployment_name, namespace, revision1: int, rev
         revision1 (int): 第一个版本号（必填）
         revision2 (int): 第二个版本号（必填）
             提示：使用 get_deployment_revision_history 查看可用版本
+        instance_name (str, optional): 多实例时必须指定集群
         config (RunnableConfig): 工具配置（自动传递）
 
     Returns:
@@ -689,6 +719,9 @@ def compare_deployment_revisions(deployment_name, namespace, revision1: int, rev
     步骤4: 建议回滚到rev2
     ```
     """
+    config, err = prepare_point_instance(config, instance_name)
+    if err:
+        return err
     try:
         revision1 = coerce_int(revision1, lo=1, hi=10_000_000)
         revision2 = coerce_int(revision2, lo=1, hi=10_000_000)

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/optimization.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/optimization.py
@@ -8,11 +8,12 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 from loguru import logger
 
-from apps.opspilot.metis.llm.tools.kubernetes.utils import parse_resource_quantity, prepare_context
+from apps.opspilot.metis.llm.tools.kubernetes.instance_scope import prepare_point_instance
+from apps.opspilot.metis.llm.tools.kubernetes.utils import coerce_int, parse_resource_quantity, prepare_context
 
 
 @tool()
-def check_scaling_capacity(namespace, replicas, resource_requirements=None, config: RunnableConfig = None):
+def check_scaling_capacity(namespace, replicas: int, resource_requirements=None, config: RunnableConfig = None):
     """
     扩容前的容量校验，避免资源不足导致Pending
 
@@ -65,6 +66,10 @@ def check_scaling_capacity(namespace, replicas, resource_requirements=None, conf
     - 不考虑节点亲和性、污点等高级调度策略
     - 实际调度结果可能因调度器策略而异
     """
+    try:
+        replicas = coerce_int(replicas, lo=0, hi=10000)
+    except ValueError:
+        return json.dumps({"error": "replicas 必须是整数", "namespace": namespace})
     prepare_context(config)
 
     try:
@@ -404,6 +409,7 @@ def validate_probe_configuration(
     namespace=None,
     resource_type=None,
     resource_name=None,
+    instance_name=None,
     config: RunnableConfig = None,
 ):
     """
@@ -438,9 +444,8 @@ def validate_probe_configuration(
     Returns:
         JSON格式，包含：
         - containers_analysis[]: 每个容器的探针分析
-          - liveness_probe: 存活探针配置（type、delay、timeout等）
-          - readiness_probe: 就绪探针配置
-          - startup_probe: 启动探针配置
+          - liveness_probe / readiness_probe / startup_probe:
+            configured、type、delay/timeout/threshold，以及 http_get.path/port/scheme、tcp_socket.port、exec_command、grpc
           - issues[]: 发现的配置问题
           - recommendations[]: 改进建议
         - probe_score: 探针配置评分（如"4/6"表示3个容器中2个配置完整）
@@ -463,6 +468,9 @@ def validate_probe_configuration(
     - initialDelaySeconds应大于应用启动时间
     - 对于慢启动应用（如Java），建议配置Startup探针
     """
+    config, instance_error = prepare_point_instance(config, instance_name)
+    if instance_error:
+        return instance_error
     prepare_context(config)
     kind, name, target_error = _resolve_probe_target(deployment_name, namespace, resource_type, resource_name)
     if target_error:
@@ -488,14 +496,7 @@ def validate_probe_configuration(
             # 分析Liveness Probe
             if container.liveness_probe:
                 liveness = container.liveness_probe
-                container_analysis["liveness_probe"] = {
-                    "configured": True,
-                    "type": _get_probe_type(liveness),
-                    "initial_delay_seconds": liveness.initial_delay_seconds or 0,
-                    "period_seconds": liveness.period_seconds or 10,
-                    "timeout_seconds": liveness.timeout_seconds or 1,
-                    "failure_threshold": liveness.failure_threshold or 3,
-                }
+                container_analysis["liveness_probe"] = _serialize_probe(liveness)
 
                 # 检查配置合理性
                 if liveness.initial_delay_seconds == 0:
@@ -512,15 +513,7 @@ def validate_probe_configuration(
 
             # 分析Readiness Probe
             if container.readiness_probe:
-                readiness = container.readiness_probe
-                container_analysis["readiness_probe"] = {
-                    "configured": True,
-                    "type": _get_probe_type(readiness),
-                    "initial_delay_seconds": readiness.initial_delay_seconds or 0,
-                    "period_seconds": readiness.period_seconds or 10,
-                    "timeout_seconds": readiness.timeout_seconds or 1,
-                    "failure_threshold": readiness.failure_threshold or 3,
-                }
+                container_analysis["readiness_probe"] = _serialize_probe(container.readiness_probe)
             else:
                 container_analysis["readiness_probe"] = {"configured": False}
                 container_analysis["issues"].append("未配置Readiness探针")
@@ -528,14 +521,7 @@ def validate_probe_configuration(
 
             # 分析Startup Probe (K8S 1.16+)
             if hasattr(container, "startup_probe") and container.startup_probe:
-                startup = container.startup_probe
-                container_analysis["startup_probe"] = {
-                    "configured": True,
-                    "type": _get_probe_type(startup),
-                    "initial_delay_seconds": startup.initial_delay_seconds or 0,
-                    "period_seconds": startup.period_seconds or 10,
-                    "failure_threshold": startup.failure_threshold or 3,
-                }
+                container_analysis["startup_probe"] = _serialize_probe(container.startup_probe)
             else:
                 container_analysis["startup_probe"] = {"configured": False}
 
@@ -596,8 +582,57 @@ def _get_probe_type(probe):
         return "unknown"
 
 
+def _probe_action_field(action, *names):
+    if action is None:
+        return None
+    for name in names:
+        if hasattr(action, name):
+            return getattr(action, name)
+    return None
+
+
+def _serialize_probe(probe) -> dict:
+    """序列化探针；http_get 等可能是不完整 mock，一律 getattr。"""
+    payload = {
+        "configured": True,
+        "type": _get_probe_type(probe),
+        "initial_delay_seconds": getattr(probe, "initial_delay_seconds", None) or 0,
+        "period_seconds": getattr(probe, "period_seconds", None) or 10,
+        "timeout_seconds": getattr(probe, "timeout_seconds", None) or 1,
+        "failure_threshold": getattr(probe, "failure_threshold", None) or 3,
+        "http_get": None,
+        "tcp_socket": None,
+        "exec_command": None,
+        "grpc": None,
+    }
+    http_get = getattr(probe, "http_get", None)
+    if http_get:
+        payload["http_get"] = {
+            "path": _probe_action_field(http_get, "path"),
+            "port": _probe_action_field(http_get, "port"),
+            "scheme": _probe_action_field(http_get, "scheme"),
+            "host": _probe_action_field(http_get, "host"),
+        }
+    tcp_socket = getattr(probe, "tcp_socket", None)
+    if tcp_socket:
+        payload["tcp_socket"] = {
+            "port": _probe_action_field(tcp_socket, "port"),
+            "host": _probe_action_field(tcp_socket, "host"),
+        }
+    exec_action = getattr(probe, "_exec", None)
+    if exec_action:
+        payload["exec_command"] = _probe_action_field(exec_action, "command")
+    grpc = getattr(probe, "grpc", None)
+    if grpc:
+        payload["grpc"] = {
+            "port": _probe_action_field(grpc, "port"),
+            "service": _probe_action_field(grpc, "service"),
+        }
+    return payload
+
+
 @tool()
-def compare_deployment_revisions(deployment_name, namespace, revision1, revision2, config: RunnableConfig = None):
+def compare_deployment_revisions(deployment_name, namespace, revision1: int, revision2: int, config: RunnableConfig = None):
     """
     对比Deployment版本差异，理解变更内容
 
@@ -654,6 +689,11 @@ def compare_deployment_revisions(deployment_name, namespace, revision1, revision
     步骤4: 建议回滚到rev2
     ```
     """
+    try:
+        revision1 = coerce_int(revision1, lo=1, hi=10_000_000)
+        revision2 = coerce_int(revision2, lo=1, hi=10_000_000)
+    except ValueError:
+        return json.dumps({"error": "revision1/revision2 必须是整数", "deployment_name": deployment_name, "namespace": namespace})
     prepare_context(config)
 
     try:

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/remediation.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/remediation.py
@@ -11,7 +11,7 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 from loguru import logger
 
-from apps.opspilot.metis.llm.tools.kubernetes.utils import prepare_context
+from apps.opspilot.metis.llm.tools.kubernetes.utils import coerce_bool, coerce_int, prepare_context
 
 
 def _log_operation(operation: str, namespace: str, resource_type: str, resource_name: str):
@@ -100,6 +100,8 @@ def restart_pod(
             "ungated": True,
         },
     )
+    wait_for_ready = coerce_bool(wait_for_ready, True)
+    timeout = coerce_int(timeout, 60, lo=1, hi=600)
     prepare_context(config)
 
     try:
@@ -244,6 +246,10 @@ def scale_deployment(deployment_name: str, namespace: str, replicas: int, config
     - 缩容：建议逐步缩容，观察服务影响
     - 生产环境：谨慎缩容到0副本（会导致服务完全下线）
     """
+    try:
+        replicas = coerce_int(replicas, lo=0, hi=10000)
+    except ValueError:
+        return json.dumps({"success": False, "error": "replicas 必须是整数", "resource_name": deployment_name, "namespace": namespace})
     # TODO(security F022): gate behind human approval + namespace allow-list
     logger.warning(
         "UNGATED destructive K8S operation",
@@ -464,6 +470,10 @@ def rollback_deployment(deployment_name: str, namespace: str, revision: Optional
     - 生产环境回滚建议先在测试环境验证
     - 回滚后观察服务状态，确认问题已解决
     """
+    try:
+        revision = coerce_int(revision, lo=1, hi=10_000_000, allow_none=True)
+    except ValueError:
+        return json.dumps({"success": False, "error": "revision 必须是整数", "deployment_name": deployment_name, "namespace": namespace})
     # TODO(security F022): gate behind human approval + namespace allow-list
     logger.warning(
         "UNGATED destructive K8S operation",
@@ -673,7 +683,7 @@ def delete_kubernetes_resource(
 
 
 @tool()
-def wait_for_pod_ready(pod_name, namespace, timeout=60, config: RunnableConfig = None):
+def wait_for_pod_ready(pod_name, namespace, timeout: int = 60, config: RunnableConfig = None):
     """
     等待Pod就绪，验证操作成功
 
@@ -717,6 +727,7 @@ def wait_for_pod_ready(pod_name, namespace, timeout=60, config: RunnableConfig =
     - 超时不代表Pod永远不会就绪，只是超过等待时间
     """
     prepare_context(config)
+    timeout = coerce_int(timeout, 60, lo=1, hi=600)
 
     try:
         core_v1 = client.CoreV1Api()

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/remediation.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/remediation.py
@@ -11,6 +11,7 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 from loguru import logger
 
+from apps.opspilot.metis.llm.tools.kubernetes.instance_scope import prepare_point_instance
 from apps.opspilot.metis.llm.tools.kubernetes.utils import coerce_bool, coerce_int, prepare_context
 
 
@@ -34,6 +35,7 @@ def restart_pod(
     namespace: str,
     wait_for_ready: bool = True,
     timeout: int = 60,
+    instance_name=None,
     config: RunnableConfig = None,
 ):
     """
@@ -61,6 +63,7 @@ def restart_pod(
         timeout (int, optional): 等待超时时间（秒），默认60
             - 仅在wait_for_ready=True时生效
             - 超时不代表失败，只是不再等待
+        instance_name (str, optional): 多实例时必须指定集群
         config (RunnableConfig): 工具配置（自动传递）
 
     Returns:
@@ -89,6 +92,9 @@ def restart_pod(
     - 重启前确认是由控制器管理的Pod
     - 建议使用wait_for_ready=True，确保新Pod启动成功
     """
+    config, err = prepare_point_instance(config, instance_name)
+    if err:
+        return err
     # TODO(security F022): gate behind human approval + namespace allow-list
     logger.warning(
         "UNGATED destructive K8S operation",
@@ -195,7 +201,7 @@ def restart_pod(
 
 
 @tool()
-def scale_deployment(deployment_name: str, namespace: str, replicas: int, config: RunnableConfig = None):
+def scale_deployment(deployment_name: str, namespace: str, replicas: int, instance_name=None, config: RunnableConfig = None):
     """
     扩缩容Deployment或StatefulSet - 应对流量变化
 
@@ -219,6 +225,7 @@ def scale_deployment(deployment_name: str, namespace: str, replicas: int, config
             - >当前副本数: 扩容操作
             - <当前副本数: 缩容操作
             - 0: 完全停止服务（谨慎使用）
+        instance_name (str, optional): 多实例时必须指定集群
         config (RunnableConfig): 工具配置（自动传递）
 
     Returns:
@@ -246,6 +253,9 @@ def scale_deployment(deployment_name: str, namespace: str, replicas: int, config
     - 缩容：建议逐步缩容，观察服务影响
     - 生产环境：谨慎缩容到0副本（会导致服务完全下线）
     """
+    config, err = prepare_point_instance(config, instance_name)
+    if err:
+        return err
     try:
         replicas = coerce_int(replicas, lo=0, hi=10000)
     except ValueError:
@@ -419,7 +429,7 @@ def get_deployment_revision_history(deployment_name, namespace, config: Runnable
 
 
 @tool()
-def rollback_deployment(deployment_name: str, namespace: str, revision: Optional[int] = None, config: RunnableConfig = None):
+def rollback_deployment(deployment_name: str, namespace: str, revision: Optional[int] = None, instance_name=None, config: RunnableConfig = None):
     """
     回滚Deployment到指定版本，快速恢复服务
 
@@ -444,6 +454,7 @@ def rollback_deployment(deployment_name: str, namespace: str, revision: Optional
             - None: 自动回滚到前一个版本（最常用）
             - 2: 回滚到revision 2
             - 使用 get_deployment_revision_history 查看可用版本
+        instance_name (str, optional): 多实例时必须指定集群
         config (RunnableConfig): 工具配置（自动传递）
 
     Returns:
@@ -470,6 +481,9 @@ def rollback_deployment(deployment_name: str, namespace: str, revision: Optional
     - 生产环境回滚建议先在测试环境验证
     - 回滚后观察服务状态，确认问题已解决
     """
+    config, err = prepare_point_instance(config, instance_name)
+    if err:
+        return err
     try:
         revision = coerce_int(revision, lo=1, hi=10_000_000, allow_none=True)
     except ValueError:
@@ -573,6 +587,7 @@ def delete_kubernetes_resource(
     resource_name: str,
     namespace: str,
     grace_period: int = 30,
+    instance_name=None,
     config: RunnableConfig = None,
 ):
     """
@@ -599,6 +614,7 @@ def delete_kubernetes_resource(
             - 30: 给Pod足够时间清理资源（推荐）
             - 0: 立即强制删除（谨慎使用）
             - 60: 对于需要长时间清理的应用
+        instance_name (str, optional): 多实例时必须指定集群
         config (RunnableConfig): 工具配置（自动传递）
 
     Returns:
@@ -621,6 +637,9 @@ def delete_kubernetes_resource(
     - 批量删除 → 使用 cleanup_failed_pods
     - 删除前检查依赖 → 使用 find_configmap_consumers
     """
+    config, err = prepare_point_instance(config, instance_name)
+    if err:
+        return err
     # TODO(security F022): gate behind human approval + namespace allow-list
     logger.warning(
         "UNGATED destructive K8S operation",
@@ -683,7 +702,7 @@ def delete_kubernetes_resource(
 
 
 @tool()
-def wait_for_pod_ready(pod_name, namespace, timeout: int = 60, config: RunnableConfig = None):
+def wait_for_pod_ready(pod_name, namespace, timeout: int = 60, instance_name=None, config: RunnableConfig = None):
     """
     等待Pod就绪，验证操作成功
 
@@ -706,6 +725,7 @@ def wait_for_pod_ready(pod_name, namespace, timeout: int = 60, config: RunnableC
             - 60: 适用于大部分应用
             - 120: 对于启动慢的应用（如Java）
             - 30: 对于快速启动的应用
+        instance_name (str, optional): 多实例时必须指定集群
         config (RunnableConfig): 工具配置（自动传递）
 
     Returns:
@@ -726,6 +746,9 @@ def wait_for_pod_ready(pod_name, namespace, timeout: int = 60, config: RunnableC
     - 如果Pod处于Failed状态，会立即返回失败
     - 超时不代表Pod永远不会就绪，只是超过等待时间
     """
+    config, err = prepare_point_instance(config, instance_name)
+    if err:
+        return err
     prepare_context(config)
     timeout = coerce_int(timeout, 60, lo=1, hi=600)
 

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/resources.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/resources.py
@@ -9,7 +9,8 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 
 from apps.core.logger import opspilot_logger as logger
-from apps.opspilot.metis.llm.tools.kubernetes.utils import prepare_context
+from apps.opspilot.metis.llm.tools.kubernetes.instance_scope import prepare_point_instance, run_scan_tool
+from apps.opspilot.metis.llm.tools.kubernetes.utils import coerce_bool, coerce_int, prepare_context
 
 
 @tool()
@@ -67,7 +68,7 @@ def get_kubernetes_namespaces(config: RunnableConfig):
 
 
 @tool()
-def list_kubernetes_pods(namespace=None, config: RunnableConfig = None):
+def list_kubernetes_pods(namespace=None, instance_name=None, config: RunnableConfig = None):
     """
     查看Pod列表和基本状态
 
@@ -93,6 +94,7 @@ def list_kubernetes_pods(namespace=None, config: RunnableConfig = None):
             - None: 查看整个集群的Pod
             - "default": 只看default命名空间
             - "prod": 只看生产环境
+        instance_name (str, optional): 多实例时指定集群；省略则扫描全部已配置实例
         config (RunnableConfig): 工具配置（自动传递）
 
     Returns:
@@ -115,6 +117,14 @@ def list_kubernetes_pods(namespace=None, config: RunnableConfig = None):
     - 查看Pod日志 → 使用 get_kubernetes_pod_logs
     - 检查资源使用 → 使用 get_kubernetes_node_capacity
     """
+
+    def _run(bound_config):
+        return _list_kubernetes_pods_on_instance(namespace, bound_config)
+
+    return run_scan_tool(config, instance_name, _run)
+
+
+def _list_kubernetes_pods_on_instance(namespace, config: RunnableConfig = None):
     prepare_context(config)
     core_v1 = client.CoreV1Api()
     try:
@@ -196,7 +206,7 @@ def list_kubernetes_nodes(config: RunnableConfig):
 
 
 @tool()
-def list_kubernetes_deployments(namespace=None, limit=30, offset=0, config: RunnableConfig = None):
+def list_kubernetes_deployments(namespace=None, limit: int = 30, offset: int = 0, config: RunnableConfig = None):
     """
     List deployments with optional namespace filter and pagination.
 
@@ -210,8 +220,8 @@ def list_kubernetes_deployments(namespace=None, limit=30, offset=0, config: Runn
         JSON with fields: items (list), total (int), returned (int), offset (int), has_more (bool).
     """
     prepare_context(config)
-    limit = max(1, min(int(limit or 30), 50))
-    offset = max(0, int(offset or 0))
+    limit = coerce_int(limit, 30, lo=1, hi=50)
+    offset = coerce_int(offset, 0, lo=0, hi=1_000_000)
 
     apps_v1 = client.AppsV1Api()
     try:
@@ -377,7 +387,7 @@ def list_kubernetes_events(namespace=None, config: RunnableConfig = None):
 
 
 @tool()
-def get_kubernetes_resource_yaml(namespace, resource_type, resource_name, config: RunnableConfig = None):
+def get_kubernetes_resource_yaml(namespace, resource_type, resource_name, instance_name=None, config: RunnableConfig = None):
     """
     Retrieves the YAML configuration for a specified Kubernetes resource.
 
@@ -390,6 +400,7 @@ def get_kubernetes_resource_yaml(namespace, resource_type, resource_name, config
             Supported types: 'pod', 'deployment', 'service', 'configmap',
             'secret', 'job'
         resource_name (str): The name of the specific resource to retrieve.
+        instance_name (str, optional): 多实例时必须指定集群
         config (RunnableConfig): Configuration for the tool.
 
     Returns:
@@ -399,6 +410,9 @@ def get_kubernetes_resource_yaml(namespace, resource_type, resource_name, config
         ApiException: If there is an error communicating with the Kubernetes API
         ValueError: If an unsupported resource type is specified
     """
+    config, instance_error = prepare_point_instance(config, instance_name)
+    if instance_error:
+        return instance_error
     prepare_context(config)
     try:
         core_v1 = client.CoreV1Api()
@@ -441,7 +455,9 @@ def get_kubernetes_resource_yaml(namespace, resource_type, resource_name, config
 
 
 @tool()
-def get_kubernetes_pod_logs(namespace, pod_name, container=None, lines=100, tail=True, config: RunnableConfig = None):
+def get_kubernetes_pod_logs(
+    namespace, pod_name, container=None, lines: int = 100, tail: bool = True, instance_name=None, config: RunnableConfig = None
+):
     """
     获取Pod容器日志 - 定位应用程序错误
 
@@ -495,7 +511,12 @@ def get_kubernetes_pod_logs(namespace, pod_name, container=None, lines=100, tail
     - 日志显示网络错误 → 使用 trace_service_chain 检查服务链路
     - 需要重启恢复 → 使用 restart_pod
     """
+    config, instance_error = prepare_point_instance(config, instance_name)
+    if instance_error:
+        return instance_error
     prepare_context(config)
+    lines = coerce_int(lines, 100, lo=1, hi=10000)
+    tail = coerce_bool(tail, True)
     try:
         core_v1 = client.CoreV1Api()
 
@@ -549,7 +570,9 @@ def get_kubernetes_pod_logs(namespace, pod_name, container=None, lines=100, tail
 
 
 @tool()
-def get_kubernetes_previous_pod_logs(namespace, pod_name, container=None, lines=100, tail=True, config: RunnableConfig = None):
+def get_kubernetes_previous_pod_logs(
+    namespace, pod_name, container=None, lines: int = 100, tail: bool = True, instance_name=None, config: RunnableConfig = None
+):
     """
     获取Pod容器上一次实例的日志，用于重启类故障采集。
 
@@ -559,12 +582,18 @@ def get_kubernetes_previous_pod_logs(namespace, pod_name, container=None, lines=
         container (str, optional): 容器名称，多容器Pod建议显式指定
         lines (int, optional): 日志行数，默认100
         tail (bool, optional): True=最后N行，False=开头N行
+        instance_name (str, optional): 多实例时必须指定集群
         config (RunnableConfig): 工具配置
 
     Returns:
         str: previous 容器日志文本，或错误信息
     """
+    config, instance_error = prepare_point_instance(config, instance_name)
+    if instance_error:
+        return instance_error
     prepare_context(config)
+    lines = coerce_int(lines, 100, lo=1, hi=10000)
+    tail = coerce_bool(tail, True)
     try:
         core_v1 = client.CoreV1Api()
 

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/resources.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/resources.py
@@ -206,7 +206,7 @@ def list_kubernetes_nodes(config: RunnableConfig):
 
 
 @tool()
-def list_kubernetes_deployments(namespace=None, limit: int = 30, offset: int = 0, config: RunnableConfig = None):
+def list_kubernetes_deployments(namespace=None, limit: int = 30, offset: int = 0, instance_name=None, config: RunnableConfig = None):
     """
     List deployments with optional namespace filter and pagination.
 
@@ -214,14 +214,23 @@ def list_kubernetes_deployments(namespace=None, limit: int = 30, offset: int = 0
         namespace (str, optional): Namespace to filter. If None, returns all namespaces.
         limit (int, optional): Maximum number of deployments to return (default 30, max 50).
         offset (int, optional): Number of deployments to skip for pagination (default 0).
+        instance_name (str, optional): 多实例时指定集群；省略则扫描全部已配置实例
         config (RunnableConfig): Configuration for the tool.
 
     Returns:
         JSON with fields: items (list), total (int), returned (int), offset (int), has_more (bool).
     """
-    prepare_context(config)
     limit = coerce_int(limit, 30, lo=1, hi=50)
     offset = coerce_int(offset, 0, lo=0, hi=1_000_000)
+
+    def _run(bound_config):
+        return _list_kubernetes_deployments_on_instance(namespace, limit, offset, bound_config)
+
+    return run_scan_tool(config, instance_name, _run)
+
+
+def _list_kubernetes_deployments_on_instance(namespace, limit, offset, config: RunnableConfig = None):
+    prepare_context(config)
 
     apps_v1 = client.AppsV1Api()
     try:
@@ -339,13 +348,14 @@ def list_kubernetes_services(namespace=None, config: RunnableConfig = None):
 
 
 @tool()
-def list_kubernetes_events(namespace=None, config: RunnableConfig = None):
+def list_kubernetes_events(namespace=None, instance_name=None, config: RunnableConfig = None):
     """
     List events with optional namespace filter
 
     Args:
         namespace (str, optional): The namespace to filter events by.
             If None, events from all namespaces will be returned. Defaults to None.
+        instance_name (str, optional): 多实例时指定集群；省略则扫描全部已配置实例
         config (RunnableConfig): Configuration for the tool.
 
     Returns:
@@ -359,6 +369,14 @@ def list_kubernetes_events(namespace=None, config: RunnableConfig = None):
             - first_time (str): Timestamp when event first occurred
             - last_time (str): Timestamp when event last occurred
     """
+
+    def _run(bound_config):
+        return _list_kubernetes_events_on_instance(namespace, bound_config)
+
+    return run_scan_tool(config, instance_name, _run)
+
+
+def _list_kubernetes_events_on_instance(namespace, config: RunnableConfig = None):
     prepare_context(config)
     try:
         core_v1 = client.CoreV1Api()

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/tracing.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/tracing.py
@@ -1,17 +1,22 @@
 """Kubernetes链路追踪和关联分析工具"""
 import json
 from datetime import datetime, timezone
-from typing import Dict, List, Optional
+
+from kubernetes import client
 from kubernetes.client import ApiException
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
-from kubernetes import client
 from loguru import logger
-from apps.opspilot.metis.llm.tools.kubernetes.utils import prepare_context
+
+from apps.opspilot.metis.llm.tools.kubernetes.instance_scope import prepare_point_instance
+from apps.opspilot.metis.llm.tools.kubernetes.utils import coerce_int, prepare_context
+
+_DEFAULT_EVENT_HOURS = 24
+_MAX_EVENT_HOURS = 168
 
 
 @tool()
-def trace_service_chain(service_name, namespace, config: RunnableConfig = None):
+def trace_service_chain(service_name, namespace, config: RunnableConfig = None):  # noqa: C901
     """
     追踪Service调用链，从Service → Endpoint → Pod，定位流量异常
 
@@ -65,7 +70,7 @@ def trace_service_chain(service_name, namespace, config: RunnableConfig = None):
             "trace_time": datetime.now(timezone.utc).isoformat(),
             "chain": {},
             "issues": [],
-            "recommendations": []
+            "recommendations": [],
         }
 
         # 1. 检查Service本身
@@ -76,31 +81,19 @@ def trace_service_chain(service_name, namespace, config: RunnableConfig = None):
                 "type": service.spec.type,
                 "cluster_ip": service.spec.cluster_ip,
                 "ports": [
-                    {
-                        "name": port.name,
-                        "port": port.port,
-                        "target_port": str(port.target_port),
-                        "protocol": port.protocol
-                    } for port in (service.spec.ports or [])
+                    {"name": port.name, "port": port.port, "target_port": str(port.target_port), "protocol": port.protocol}
+                    for port in (service.spec.ports or [])
                 ],
-                "selector": service.spec.selector or {}
+                "selector": service.spec.selector or {},
             }
             result["chain"]["service"] = service_info
 
             if not service.spec.selector:
-                result["issues"].append({
-                    "severity": "high",
-                    "component": "service",
-                    "message": "Service没有配置selector，无法路由到任何Pod"
-                })
+                result["issues"].append({"severity": "high", "component": "service", "message": "Service没有配置selector，无法路由到任何Pod"})
         except ApiException as e:
             if e.status == 404:
                 result["chain"]["service"] = {"exists": False}
-                result["issues"].append({
-                    "severity": "critical",
-                    "component": "service",
-                    "message": f"Service不存在: {service_name}"
-                })
+                result["issues"].append({"severity": "critical", "component": "service", "message": f"Service不存在: {service_name}"})
                 return json.dumps(result)
             raise
 
@@ -114,45 +107,33 @@ def trace_service_chain(service_name, namespace, config: RunnableConfig = None):
                 for subset in endpoints.subsets:
                     if subset.addresses:
                         for addr in subset.addresses:
-                            ready_addresses.append({
-                                "ip": addr.ip,
-                                "target_ref": f"{addr.target_ref.kind}/{addr.target_ref.name}" if addr.target_ref else None
-                            })
+                            ready_addresses.append(
+                                {"ip": addr.ip, "target_ref": f"{addr.target_ref.kind}/{addr.target_ref.name}" if addr.target_ref else None}
+                            )
                     if subset.not_ready_addresses:
                         for addr in subset.not_ready_addresses:
-                            not_ready_addresses.append({
-                                "ip": addr.ip,
-                                "target_ref": f"{addr.target_ref.kind}/{addr.target_ref.name}" if addr.target_ref else None
-                            })
+                            not_ready_addresses.append(
+                                {"ip": addr.ip, "target_ref": f"{addr.target_ref.kind}/{addr.target_ref.name}" if addr.target_ref else None}
+                            )
 
             endpoints_info = {
                 "exists": True,
                 "ready_addresses": ready_addresses,
                 "not_ready_addresses": not_ready_addresses,
                 "ready_count": len(ready_addresses),
-                "not_ready_count": len(not_ready_addresses)
+                "not_ready_count": len(not_ready_addresses),
             }
             result["chain"]["endpoints"] = endpoints_info
 
             if len(ready_addresses) == 0:
-                result["issues"].append({
-                    "severity": "critical",
-                    "component": "endpoints",
-                    "message": "没有就绪的Endpoint，Service无法转发流量"
-                })
+                result["issues"].append({"severity": "critical", "component": "endpoints", "message": "没有就绪的Endpoint，Service无法转发流量"})
                 if len(not_ready_addresses) > 0:
-                    result["recommendations"].append(
-                        "有未就绪的Endpoint，请检查Pod的就绪探针配置和Pod健康状态"
-                    )
+                    result["recommendations"].append("有未就绪的Endpoint，请检查Pod的就绪探针配置和Pod健康状态")
 
         except ApiException as e:
             if e.status == 404:
                 result["chain"]["endpoints"] = {"exists": False}
-                result["issues"].append({
-                    "severity": "critical",
-                    "component": "endpoints",
-                    "message": "Endpoints不存在，可能是selector不匹配"
-                })
+                result["issues"].append({"severity": "critical", "component": "endpoints", "message": "Endpoints不存在，可能是selector不匹配"})
 
         # 3. 检查匹配的Pod
         if service.spec.selector:
@@ -164,53 +145,34 @@ def trace_service_chain(service_name, namespace, config: RunnableConfig = None):
                 container_statuses = []
                 if pod.status.container_statuses:
                     for container in pod.status.container_statuses:
-                        container_statuses.append({
-                            "name": container.name,
-                            "ready": container.ready,
-                            "restart_count": container.restart_count
-                        })
+                        container_statuses.append({"name": container.name, "ready": container.ready, "restart_count": container.restart_count})
 
                 pod_info = {
                     "name": pod.metadata.name,
                     "phase": pod.status.phase,
                     "pod_ip": pod.status.pod_ip,
                     "node": pod.spec.node_name,
-                    "containers": container_statuses
+                    "containers": container_statuses,
                 }
                 pod_list.append(pod_info)
 
                 # 检查Pod问题
                 if pod.status.phase != "Running":
-                    result["issues"].append({
-                        "severity": "high",
-                        "component": "pod",
-                        "message": f"Pod {pod.metadata.name} 状态异常: {pod.status.phase}"
-                    })
+                    result["issues"].append({"severity": "high", "component": "pod", "message": f"Pod {pod.metadata.name} 状态异常: {pod.status.phase}"})
 
                 # 检查容器就绪状态
                 if pod.status.container_statuses:
                     for container in pod.status.container_statuses:
                         if not container.ready:
-                            result["issues"].append({
-                                "severity": "medium",
-                                "component": "pod",
-                                "message": f"Pod {pod.metadata.name} 的容器 {container.name} 未就绪"
-                            })
+                            result["issues"].append(
+                                {"severity": "medium", "component": "pod", "message": f"Pod {pod.metadata.name} 的容器 {container.name} 未就绪"}
+                            )
 
-            result["chain"]["pods"] = {
-                "count": len(pod_list),
-                "pods": pod_list
-            }
+            result["chain"]["pods"] = {"count": len(pod_list), "pods": pod_list}
 
             if len(pod_list) == 0:
-                result["issues"].append({
-                    "severity": "critical",
-                    "component": "pods",
-                    "message": f"没有匹配selector的Pod: {service.spec.selector}"
-                })
-                result["recommendations"].append(
-                    "请检查Deployment/StatefulSet的Pod模板标签是否与Service的selector匹配"
-                )
+                result["issues"].append({"severity": "critical", "component": "pods", "message": f"没有匹配selector的Pod: {service.spec.selector}"})
+                result["recommendations"].append("请检查Deployment/StatefulSet的Pod模板标签是否与Service的selector匹配")
 
         # 4. 检查Ingress (如果有)
         try:
@@ -222,25 +184,15 @@ def trace_service_chain(service_name, namespace, config: RunnableConfig = None):
                     for rule in ingress.spec.rules:
                         if rule.http and rule.http.paths:
                             for path in rule.http.paths:
-                                if (path.backend and path.backend.service
-                                        and path.backend.service.name == service_name):
-                                    matching_ingresses.append({
-                                        "name": ingress.metadata.name,
-                                        "host": rule.host or "*",
-                                        "path": path.path,
-                                        "path_type": path.path_type
-                                    })
+                                if path.backend and path.backend.service and path.backend.service.name == service_name:
+                                    matching_ingresses.append(
+                                        {"name": ingress.metadata.name, "host": rule.host or "*", "path": path.path, "path_type": path.path_type}
+                                    )
 
             if matching_ingresses:
-                result["chain"]["ingress"] = {
-                    "exists": True,
-                    "ingresses": matching_ingresses
-                }
+                result["chain"]["ingress"] = {"exists": True, "ingresses": matching_ingresses}
             else:
-                result["chain"]["ingress"] = {
-                    "exists": False,
-                    "message": "没有Ingress指向此Service"
-                }
+                result["chain"]["ingress"] = {"exists": False, "message": "没有Ingress指向此Service"}
         except ApiException:
             # Ingress API可能不可用
             result["chain"]["ingress"] = {"exists": False, "message": "无法检查Ingress"}
@@ -263,15 +215,11 @@ def trace_service_chain(service_name, namespace, config: RunnableConfig = None):
 
     except Exception as e:
         logger.error(f"追踪服务链路失败: {namespace}/{service_name}, 错误: {str(e)}")
-        return json.dumps({
-            "error": f"追踪服务链路失败: {str(e)}",
-            "service_name": service_name,
-            "namespace": namespace
-        })
+        return json.dumps({"error": f"追踪服务链路失败: {str(e)}", "service_name": service_name, "namespace": namespace})
 
 
 @tool()
-def get_resource_events_timeline(resource_type, resource_name, namespace, hours=24, config: RunnableConfig = None):
+def get_resource_events_timeline(resource_type, resource_name, namespace, hours: int = 24, instance_name=None, config: RunnableConfig = None):
     """
     获取资源的事件时间线，追溯问题演变过程
 
@@ -314,7 +262,11 @@ def get_resource_events_timeline(resource_type, resource_name, namespace, hours=
     - 发现OOM事件 → 使用 check_oom_events 专项检查
     - 发现调度失败 → 使用 diagnose_pending_pod_issues 诊断
     """
+    config, instance_error = prepare_point_instance(config, instance_name)
+    if instance_error:
+        return instance_error
     prepare_context(config)
+    hours = coerce_int(hours, _DEFAULT_EVENT_HOURS, lo=1, hi=_MAX_EVENT_HOURS)
 
     try:
         core_v1 = client.CoreV1Api()
@@ -322,10 +274,7 @@ def get_resource_events_timeline(resource_type, resource_name, namespace, hours=
 
         # 获取所有相关事件
         field_selector = f"involvedObject.name={resource_name},involvedObject.kind={resource_type}"
-        events = core_v1.list_namespaced_event(
-            namespace,
-            field_selector=field_selector
-        )
+        events = core_v1.list_namespaced_event(namespace, field_selector=field_selector)
 
         # 计算时间过滤
         now = datetime.now(timezone.utc)
@@ -336,26 +285,24 @@ def get_resource_events_timeline(resource_type, resource_name, namespace, hours=
         for event in events.items:
             event_time = event.last_timestamp or event.first_timestamp or event.metadata.creation_timestamp
             if event_time and event_time.timestamp() >= cutoff_time:
-                timeline.append({
-                    "timestamp": event_time.isoformat(),
-                    "type": event.type,
-                    "reason": event.reason,
-                    "message": event.message,
-                    "count": event.count or 1,
-                    "first_seen": event.first_timestamp.isoformat() if event.first_timestamp else None,
-                    "last_seen": event.last_timestamp.isoformat() if event.last_timestamp else None,
-                    "source": event.source.component if event.source else None
-                })
+                timeline.append(
+                    {
+                        "timestamp": event_time.isoformat(),
+                        "type": event.type,
+                        "reason": event.reason,
+                        "message": event.message,
+                        "count": event.count or 1,
+                        "first_seen": event.first_timestamp.isoformat() if event.first_timestamp else None,
+                        "last_seen": event.last_timestamp.isoformat() if event.last_timestamp else None,
+                        "source": event.source.component if event.source else None,
+                    }
+                )
 
         # 按时间排序
         timeline.sort(key=lambda x: x["timestamp"])
 
         # 统计事件类型
-        event_summary = {
-            "Normal": 0,
-            "Warning": 0,
-            "Error": 0
-        }
+        event_summary = {"Normal": 0, "Warning": 0, "Error": 0}
         for event in timeline:
             event_type = event["type"]
             if event_type in event_summary:
@@ -368,7 +315,7 @@ def get_resource_events_timeline(resource_type, resource_name, namespace, hours=
             "time_range_hours": hours,
             "total_events": len(timeline),
             "event_summary": event_summary,
-            "timeline": timeline
+            "timeline": timeline,
         }
 
         logger.info(f"事件时间线获取完成: {len(timeline)}个事件")
@@ -376,16 +323,11 @@ def get_resource_events_timeline(resource_type, resource_name, namespace, hours=
 
     except ApiException as e:
         logger.error(f"获取事件时间线失败: {str(e)}")
-        return json.dumps({
-            "error": f"获取事件时间线失败: {str(e)}",
-            "resource_type": resource_type,
-            "resource_name": resource_name,
-            "namespace": namespace
-        })
+        return json.dumps({"error": f"获取事件时间线失败: {str(e)}", "resource_type": resource_type, "resource_name": resource_name, "namespace": namespace})
 
 
 @tool()
-def analyze_pod_restart_pattern(namespace=None, min_restarts: int = 3, config: RunnableConfig = None):
+def analyze_pod_restart_pattern(namespace=None, min_restarts: int = 3, config: RunnableConfig = None):  # noqa: C901
     """
     深度分析Pod重启模式，定位根本原因
 
@@ -436,6 +378,7 @@ def analyze_pod_restart_pattern(namespace=None, min_restarts: int = 3, config: R
     - 需要重启Pod → 使用 restart_pod
     """
     prepare_context(config)
+    min_restarts = coerce_int(min_restarts, 3, lo=0, hi=10000)
 
     try:
         core_v1 = client.CoreV1Api()
@@ -464,7 +407,7 @@ def analyze_pod_restart_pattern(namespace=None, min_restarts: int = 3, config: R
                         "current_state": {},
                         "last_state": {},
                         "restart_reasons": [],
-                        "severity": "unknown"
+                        "severity": "unknown",
                     }
 
                     # 分析当前状态
@@ -472,7 +415,7 @@ def analyze_pod_restart_pattern(namespace=None, min_restarts: int = 3, config: R
                         analysis["current_state"] = {
                             "status": "waiting",
                             "reason": container.state.waiting.reason,
-                            "message": container.state.waiting.message
+                            "message": container.state.waiting.message,
                         }
                         if container.state.waiting.reason == "CrashLoopBackOff":
                             analysis["severity"] = "critical"
@@ -480,14 +423,14 @@ def analyze_pod_restart_pattern(namespace=None, min_restarts: int = 3, config: R
                     elif container.state.running:
                         analysis["current_state"] = {
                             "status": "running",
-                            "started_at": container.state.running.started_at.isoformat() if container.state.running.started_at else None
+                            "started_at": container.state.running.started_at.isoformat() if container.state.running.started_at else None,
                         }
                     elif container.state.terminated:
                         analysis["current_state"] = {
                             "status": "terminated",
                             "reason": container.state.terminated.reason,
                             "exit_code": container.state.terminated.exit_code,
-                            "message": container.state.terminated.message
+                            "message": container.state.terminated.message,
                         }
 
                     # 分析上一次状态（重启原因）
@@ -498,7 +441,7 @@ def analyze_pod_restart_pattern(namespace=None, min_restarts: int = 3, config: R
                             "exit_code": last_term.exit_code,
                             "started_at": last_term.started_at.isoformat() if last_term.started_at else None,
                             "finished_at": last_term.finished_at.isoformat() if last_term.finished_at else None,
-                            "message": last_term.message
+                            "message": last_term.message,
                         }
 
                         # 根据退出码判断原因
@@ -526,18 +469,13 @@ def analyze_pod_restart_pattern(namespace=None, min_restarts: int = 3, config: R
                     # 获取相关事件
                     try:
                         events = core_v1.list_namespaced_event(
-                            pod.metadata.namespace,
-                            field_selector=f"involvedObject.name={pod.metadata.name},involvedObject.kind=Pod"
+                            pod.metadata.namespace, field_selector=f"involvedObject.name={pod.metadata.name},involvedObject.kind=Pod"
                         )
 
                         recent_events = []
                         for event in events.items:
                             if event.reason in ["BackOff", "Failed", "Killing", "Unhealthy"]:
-                                recent_events.append({
-                                    "reason": event.reason,
-                                    "message": event.message,
-                                    "count": event.count
-                                })
+                                recent_events.append({"reason": event.reason, "message": event.message, "count": event.count})
 
                         if recent_events:
                             analysis["recent_events"] = recent_events[:5]  # 最近5个相关事件
@@ -566,7 +504,7 @@ def analyze_pod_restart_pattern(namespace=None, min_restarts: int = 3, config: R
             "namespace": namespace or "all",
             "min_restarts_threshold": min_restarts,
             "total_problematic_containers": len(restart_analysis),
-            "analysis": restart_analysis
+            "analysis": restart_analysis,
         }
 
         logger.info(f"Pod重启分析完成: 发现{len(restart_analysis)}个问题容器")
@@ -574,14 +512,11 @@ def analyze_pod_restart_pattern(namespace=None, min_restarts: int = 3, config: R
 
     except Exception as e:
         logger.error(f"分析Pod重启模式失败: {str(e)}")
-        return json.dumps({
-            "error": f"分析Pod重启模式失败: {str(e)}",
-            "namespace": namespace
-        })
+        return json.dumps({"error": f"分析Pod重启模式失败: {str(e)}", "namespace": namespace})
 
 
 @tool()
-def check_oom_events(namespace=None, hours=24, config: RunnableConfig = None):
+def check_oom_events(namespace=None, hours: int = 24, config: RunnableConfig = None):
     """
     检查OOM（Out of Memory）事件，识别内存配置问题
 
@@ -635,6 +570,7 @@ def check_oom_events(namespace=None, hours=24, config: RunnableConfig = None):
     - 建议结合日志分析，排查是否真实需要这么多内存
     """
     prepare_context(config)
+    hours = coerce_int(hours, _DEFAULT_EVENT_HOURS, lo=1, hi=_MAX_EVENT_HOURS)
 
     try:
         core_v1 = client.CoreV1Api()
@@ -656,14 +592,16 @@ def check_oom_events(namespace=None, hours=24, config: RunnableConfig = None):
             if event.reason in ["OOMKilling", "FailedKillPod"] or "OOM" in (event.message or ""):
                 event_time = event.last_timestamp or event.first_timestamp or event.metadata.creation_timestamp
                 if event_time and event_time.timestamp() >= cutoff_time:
-                    oom_events.append({
-                        "timestamp": event_time.isoformat(),
-                        "namespace": event.metadata.namespace,
-                        "pod_name": event.involved_object.name if event.involved_object else None,
-                        "reason": event.reason,
-                        "message": event.message,
-                        "count": event.count or 1
-                    })
+                    oom_events.append(
+                        {
+                            "timestamp": event_time.isoformat(),
+                            "namespace": event.metadata.namespace,
+                            "pod_name": event.involved_object.name if event.involved_object else None,
+                            "reason": event.reason,
+                            "message": event.message,
+                            "count": event.count or 1,
+                        }
+                    )
 
         # 获取当前有OOM历史的Pod
         oom_pods = []
@@ -676,10 +614,7 @@ def check_oom_events(namespace=None, hours=24, config: RunnableConfig = None):
             if pod.status.container_statuses:
                 for container in pod.status.container_statuses:
                     # 检查上次终止状态
-                    if (container.last_state
-                        and container.last_state.terminated
-                            and container.last_state.terminated.reason == "OOMKilled"):
-
+                    if container.last_state and container.last_state.terminated and container.last_state.terminated.reason == "OOMKilled":
                         # 获取资源配置
                         container_spec = None
                         for c in pod.spec.containers:
@@ -695,16 +630,20 @@ def check_oom_events(namespace=None, hours=24, config: RunnableConfig = None):
                             if container_spec.resources.requests:
                                 memory_request = container_spec.resources.requests.get("memory", "未设置")
 
-                        oom_pods.append({
-                            "pod_name": pod.metadata.name,
-                            "namespace": pod.metadata.namespace,
-                            "container_name": container.name,
-                            "restart_count": container.restart_count,
-                            "memory_limit": memory_limit,
-                            "memory_request": memory_request,
-                            "last_oom_time": container.last_state.terminated.finished_at.isoformat() if container.last_state.terminated.finished_at else None,
-                            "exit_code": container.last_state.terminated.exit_code
-                        })
+                        oom_pods.append(
+                            {
+                                "pod_name": pod.metadata.name,
+                                "namespace": pod.metadata.namespace,
+                                "container_name": container.name,
+                                "restart_count": container.restart_count,
+                                "memory_limit": memory_limit,
+                                "memory_request": memory_request,
+                                "last_oom_time": container.last_state.terminated.finished_at.isoformat()
+                                if container.last_state.terminated.finished_at
+                                else None,
+                                "exit_code": container.last_state.terminated.exit_code,
+                            }
+                        )
 
         # 生成建议
         recommendations = []
@@ -723,7 +662,7 @@ def check_oom_events(namespace=None, hours=24, config: RunnableConfig = None):
             "total_oom_pods": len(oom_pods),
             "oom_events": sorted(oom_events, key=lambda x: x["timestamp"], reverse=True),
             "oom_pods": oom_pods,
-            "recommendations": recommendations
+            "recommendations": recommendations,
         }
 
         logger.info(f"OOM检查完成: {len(oom_events)}个事件, {len(oom_pods)}个Pod")
@@ -731,7 +670,4 @@ def check_oom_events(namespace=None, hours=24, config: RunnableConfig = None):
 
     except Exception as e:
         logger.error(f"检查OOM事件失败: {str(e)}")
-        return json.dumps({
-            "error": f"检查OOM事件失败: {str(e)}",
-            "namespace": namespace
-        })
+        return json.dumps({"error": f"检查OOM事件失败: {str(e)}", "namespace": namespace})

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/tracing.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/tracing.py
@@ -8,7 +8,7 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 from loguru import logger
 
-from apps.opspilot.metis.llm.tools.kubernetes.instance_scope import prepare_point_instance
+from apps.opspilot.metis.llm.tools.kubernetes.instance_scope import prepare_point_instance, run_scan_tool
 from apps.opspilot.metis.llm.tools.kubernetes.utils import coerce_int, prepare_context
 
 _DEFAULT_EVENT_HOURS = 24
@@ -16,7 +16,7 @@ _MAX_EVENT_HOURS = 168
 
 
 @tool()
-def trace_service_chain(service_name, namespace, config: RunnableConfig = None):  # noqa: C901
+def trace_service_chain(service_name, namespace, instance_name=None, config: RunnableConfig = None):  # noqa: C901
     """
     追踪Service调用链，从Service → Endpoint → Pod，定位流量异常
 
@@ -37,6 +37,7 @@ def trace_service_chain(service_name, namespace, config: RunnableConfig = None):
     Args:
         service_name (str): Service名称（必填）
         namespace (str): 命名空间（必填）
+        instance_name (str, optional): 多实例时必须指定集群
         config (RunnableConfig): 工具配置（自动传递）
 
     Returns:
@@ -56,6 +57,9 @@ def trace_service_chain(service_name, namespace, config: RunnableConfig = None):
     - 此工具只检查配置和状态，不检查网络策略和DNS
     - 如需网络诊断，配合 check_network_policies_blocking 使用
     """
+    config, err = prepare_point_instance(config, instance_name)
+    if err:
+        return err
     prepare_context(config)
 
     try:
@@ -327,7 +331,7 @@ def get_resource_events_timeline(resource_type, resource_name, namespace, hours:
 
 
 @tool()
-def analyze_pod_restart_pattern(namespace=None, min_restarts: int = 3, config: RunnableConfig = None):  # noqa: C901
+def analyze_pod_restart_pattern(namespace=None, min_restarts: int = 3, instance_name=None, config: RunnableConfig = None):  # noqa: C901
     """
     深度分析Pod重启模式，定位根本原因
 
@@ -357,6 +361,7 @@ def analyze_pod_restart_pattern(namespace=None, min_restarts: int = 3, config: R
             - 3: 找出所有有重启迹象的Pod（推荐）
             - 5: 只关注重启较多的Pod
             - 10: 只看严重频繁重启的Pod
+        instance_name (str, optional): 多实例时指定集群；省略则扫描全部已配置实例
         config (RunnableConfig): 工具配置（自动传递）
 
     Returns:
@@ -377,8 +382,16 @@ def analyze_pod_restart_pattern(namespace=None, min_restarts: int = 3, config: R
     - 查看容器日志 → 使用 get_kubernetes_pod_logs
     - 需要重启Pod → 使用 restart_pod
     """
-    prepare_context(config)
     min_restarts = coerce_int(min_restarts, 3, lo=0, hi=10000)
+
+    def _run(bound_config):
+        return _analyze_pod_restart_pattern_on_instance(namespace, min_restarts, bound_config)
+
+    return run_scan_tool(config, instance_name, _run)
+
+
+def _analyze_pod_restart_pattern_on_instance(namespace, min_restarts, config: RunnableConfig = None):  # noqa: C901
+    prepare_context(config)
 
     try:
         core_v1 = client.CoreV1Api()
@@ -516,7 +529,7 @@ def analyze_pod_restart_pattern(namespace=None, min_restarts: int = 3, config: R
 
 
 @tool()
-def check_oom_events(namespace=None, hours: int = 24, config: RunnableConfig = None):
+def check_oom_events(namespace=None, hours: int = 24, instance_name=None, config: RunnableConfig = None):
     """
     检查OOM（Out of Memory）事件，识别内存配置问题
 
@@ -541,6 +554,7 @@ def check_oom_events(namespace=None, hours: int = 24, config: RunnableConfig = N
             - 24: 查看最近一天的OOM（常规检查）
             - 1: 只看最近一小时（快速定位刚发生的OOM）
             - 168: 查看一周内的OOM（分析长期趋势）
+        instance_name (str, optional): 多实例时指定集群；省略则扫描全部已配置实例
         config (RunnableConfig): 工具配置（自动传递）
 
     Returns:
@@ -569,8 +583,16 @@ def check_oom_events(namespace=None, hours: int = 24, config: RunnableConfig = N
     - OOM通常表示内存配置不足，但也可能是应用内存泄漏
     - 建议结合日志分析，排查是否真实需要这么多内存
     """
-    prepare_context(config)
     hours = coerce_int(hours, _DEFAULT_EVENT_HOURS, lo=1, hi=_MAX_EVENT_HOURS)
+
+    def _run(bound_config):
+        return _check_oom_events_on_instance(namespace, hours, bound_config)
+
+    return run_scan_tool(config, instance_name, _run)
+
+
+def _check_oom_events_on_instance(namespace, hours, config: RunnableConfig = None):
+    prepare_context(config)
 
     try:
         core_v1 = client.CoreV1Api()

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/utils.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/utils.py
@@ -2,6 +2,7 @@
 
 import base64
 import io
+import math
 import os
 import threading
 
@@ -303,8 +304,11 @@ def coerce_int(value, default=None, *, lo=None, hi=None, allow_none=False):
         parsed = int(default)
     else:
         try:
-            parsed = int(float(str(value).strip()))
-        except (TypeError, ValueError) as exc:
+            as_float = float(str(value).strip())
+            if not math.isfinite(as_float):
+                raise ValueError("non-finite number")
+            parsed = int(as_float)
+        except (TypeError, ValueError, OverflowError) as exc:
             if default is not None:
                 parsed = int(default)
             else:

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/utils.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/utils.py
@@ -8,8 +8,8 @@ import threading
 import yaml
 from kubernetes import config
 
-from apps.core.utils.ssrf_validator import SSRFValidator
 from apps.core.logger import opspilot_logger as logger
+from apps.core.utils.ssrf_validator import SSRFValidator
 
 # 线程局部存储，用于传递当前操作的集群名
 _thread_local = threading.local()
@@ -222,8 +222,7 @@ def prepare_context(cfg):
             try:
                 _, active_context = config.list_kube_config_contexts()
                 if active_context:
-                    _set_current_cluster_name(active_context.get("context", {}).get("cluster", "")
-                                             or active_context.get("name", ""))
+                    _set_current_cluster_name(active_context.get("context", {}).get("cluster", "") or active_context.get("name", ""))
             except Exception:
                 pass
     except Exception as e:
@@ -292,3 +291,40 @@ def parse_resource_quantity(quantity_str):
         return float(quantity_str)
     except ValueError:
         return 0
+
+
+def coerce_int(value, default=None, *, lo=None, hi=None, allow_none=False):
+    """把 LLM 工具入参转成 int。模型常把数字编成字符串，未标注类型时不会自动转换。"""
+    if value is None or value == "":
+        if allow_none:
+            return None
+        if default is None:
+            raise ValueError("missing integer")
+        parsed = int(default)
+    else:
+        try:
+            parsed = int(float(str(value).strip()))
+        except (TypeError, ValueError) as exc:
+            if default is not None:
+                parsed = int(default)
+            else:
+                raise ValueError("invalid integer") from exc
+    if lo is not None:
+        parsed = max(lo, parsed)
+    if hi is not None:
+        parsed = min(hi, parsed)
+    return parsed
+
+
+def coerce_bool(value, default=False):
+    """把 LLM 工具入参转成 bool。字符串 \"false\" 在 Python 里为真，必须显式识别。"""
+    if isinstance(value, bool):
+        return value
+    if value is None or value == "":
+        return default
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "y", "on"}:
+        return True
+    if text in {"0", "false", "no", "n", "off"}:
+        return False
+    return default

--- a/server/apps/opspilot/tests/test_deepagent_engine_service.py
+++ b/server/apps/opspilot/tests/test_deepagent_engine_service.py
@@ -655,8 +655,36 @@ class TestBuildDeepagentNodes:
                 },
             )
         middlewares = captured["create_kwargs"]["middleware"]
-        assert any(isinstance(item, ToolResultCompactionMiddleware) for item in middlewares)
+        compaction = next(item for item in middlewares if isinstance(item, ToolResultCompactionMiddleware))
+        assert compaction._max_tool_chars == 1500
+        assert compaction._max_ai_chars == 1000
         assert any(isinstance(item, ContextWindowMiddleware) for item in middlewares)
+
+    def test_runtime_middleware_scales_tool_compaction_with_working_budget(self):
+        from apps.opspilot.metis.llm.middleware.tool_runtime import ToolResultCompactionMiddleware
+
+        node = ToolsNodes()
+        node.all_tools = [_tool("list_kubernetes_events")]
+        req = _request(
+            user_message="查事件",
+            extra_config={"input_working_tokens": 186_000},
+            message_trim_config={"max_single_message_tokens": 37_200},
+        )
+        captured = {}
+        with patch.object(ToolsNodes, "_build_knowledge_retrieve_tool", return_value=None):
+            self._run_wrapper(
+                node,
+                req,
+                captured,
+                plan_payload={
+                    "goal": "查事件",
+                    "steps": [{"objective": "读事件", "tools": ["list_kubernetes_events"]}],
+                },
+            )
+        middlewares = captured["create_kwargs"]["middleware"]
+        compaction = next(item for item in middlewares if isinstance(item, ToolResultCompactionMiddleware))
+        assert compaction._max_tool_chars == 37_200
+        assert compaction._max_ai_chars == 27_352
 
     def test_planned_step_prepare_passes_active_tools(self):
         seen_tool_names = []
@@ -1303,6 +1331,31 @@ class TestBuildDeepagentNodes:
         assert len(result["messages"]) == 1
         assert result["messages"][0].content == table
 
+    def test_planned_execution_skips_summary_when_earlier_step_already_showed_table(self):
+        node = ToolsNodes()
+        node.all_tools = [_tool("list_kubernetes_pods"), _tool("list_kubernetes_events")]
+        req = _request(user_message="统计今天 pod 重启")
+        captured = {}
+        table = "| Pod | 重启次数 |\n" "| --- | --- |\n" "| calico-kube-controllers | 9 |"
+
+        with patch.object(ToolsNodes, "_build_knowledge_retrieve_tool", return_value=None):
+            result = self._run_wrapper(
+                node,
+                req,
+                captured,
+                plan_payload={
+                    "goal": "统计重启",
+                    "steps": [
+                        {"objective": "取重启次数", "tools": ["list_kubernetes_pods"]},
+                        {"objective": "取最后重启时间", "tools": ["list_kubernetes_events"]},
+                    ],
+                },
+                agent_reply=table,
+            )
+
+        assert len(captured["ainvoke_messages"]) == 2
+        assert all(table in str(getattr(message, "content", "") or "") for message in result["messages"] if getattr(message, "type", "") == "ai")
+
     def test_progressive_disabled_skips_planner_and_binds_all_tools(self, monkeypatch):
         monkeypatch.setenv("OPSPILOT_DEEPAGENT_PROGRESSIVE_TOOLS", "0")
         assert is_progressive_tools_enabled() is False
@@ -1330,6 +1383,21 @@ def test_planned_step_already_answered_detects_markdown_table():
     assert ToolsNodes._planned_step_already_answered([AIMessage(content=table)]) is True
     assert ToolsNodes._planned_step_already_answered([AIMessage(content="执行结果 1")]) is False
     assert ToolsNodes._planned_step_already_answered([ToolMessage(content=table, tool_call_id="t1")]) is False
+
+
+def test_should_skip_planned_summary_for_multi_step_table():
+    from langchain_core.messages import AIMessage
+
+    table = "| Pod | 重启次数 |\n| --- | --- |\n| a | 1 |"
+    later = "以上名单累计重启均发生在 24 小时前，今天 0 次。"
+    messages = [AIMessage(content=table), AIMessage(content=later)]
+    assert ToolsNodes._planned_output_has_markdown_table(messages) is True
+    assert ToolsNodes._should_skip_planned_summary(messages, completed_step_count=3) is True
+    stubs = [AIMessage(content="执行结果 1"), AIMessage(content="执行结果 2")]
+    assert ToolsNodes._should_skip_planned_summary(stubs, completed_step_count=2) is False
+    prose = [AIMessage(content="已拿到事件时间，今天没有新的重启。")]
+    assert ToolsNodes._should_skip_planned_summary(prose, completed_step_count=2) is False
+    assert ToolsNodes._should_skip_planned_summary(prose, completed_step_count=1) is True
 
 
 def test_planned_step_already_answered_detects_tool_sentence():

--- a/server/apps/opspilot/tests/test_deepagent_runtime_policy.py
+++ b/server/apps/opspilot/tests/test_deepagent_runtime_policy.py
@@ -1,4 +1,8 @@
+import io
 import json
+import logging
+import traceback
+from contextlib import contextmanager
 from types import SimpleNamespace
 
 import pytest
@@ -6,10 +10,26 @@ from langchain.agents.middleware import ModelRequest, ModelResponse
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.tools import StructuredTool
 
+from apps.core.logger import SafeLogException, opspilot_logger
 from apps.opspilot.metis.llm.agent.tool_execution_planner import CompletedExecutionStep, ToolExecutionPlanner
 from apps.opspilot.metis.llm.common.token_usage import TokenUsageAccumulator
 from apps.opspilot.metis.llm.middleware.token_usage import TokenUsageTrackingMiddleware
 from apps.opspilot.metis.llm.middleware.tool_runtime import SkillExecutionGuardMiddleware, ToolVisibilityMiddleware
+
+_TOOL_SECRET_SENTINEL = "kubeconfig-hunter2-not-for-logs"
+
+
+@contextmanager
+def _capture_opspilot_formatted_logs():
+    output = io.StringIO()
+    handler = logging.StreamHandler(output)
+    handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+    opspilot_logger.addHandler(handler)
+    try:
+        yield output
+    finally:
+        opspilot_logger.removeHandler(handler)
+
 
 pytestmark = pytest.mark.unit
 
@@ -239,6 +259,56 @@ def test_tool_exception_middleware_returns_error_tool_message():
     assert result.tool_call_id == "c1"
     assert "无法加载 Kubernetes 配置" in result.content
     assert "Invalid base64" in result.content
+
+
+def test_tool_exception_middleware_logs_once_without_exception_payload(caplog):
+    from apps.opspilot.metis.llm.middleware.tool_runtime import ToolExceptionAsResultMiddleware
+
+    middleware = ToolExceptionAsResultMiddleware()
+    original = TypeError(f"cannot pickle '_thread.lock' object {_TOOL_SECRET_SENTINEL}")
+
+    def boom(_req):
+        raise original
+
+    req = SimpleNamespace(tool_call={"name": "resolve_k8s_target_from_alert", "id": "c1", "args": {}})
+    caplog.set_level(logging.ERROR, logger="opspilot")
+    with _capture_opspilot_formatted_logs() as output:
+        result = middleware.wrap_tool_call(req, boom)
+    rendered = output.getvalue()
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert result.tool_call_id == "c1"
+    assert result.name == "resolve_k8s_target_from_alert"
+    assert _TOOL_SECRET_SENTINEL in result.content
+    owned = [
+        rec
+        for rec in caplog.records
+        if rec.name == "opspilot"
+        and rec.levelno == logging.ERROR
+        and rec.exc_info
+        and rec.msg == "event=agent_tool_failed failed_stage=tool_call error_type=%s tool_name=%s"
+    ]
+    assert len(owned) == 1
+    rec = owned[0]
+    assert rec.args == ("TypeError", "resolve_k8s_target_from_alert")
+    message = rec.getMessage()
+    assert "failed_stage=tool_call" in message
+    assert "error_type=TypeError" in message
+    assert "tool_name=resolve_k8s_target_from_alert" in message
+    assert rec.exc_info[0] is SafeLogException
+    assert rec.exc_info[1] is not original
+    assert rec.exc_info[2] is original.__traceback__
+    assert str(rec.exc_info[1]) == "TypeError"
+    assert str(original) == f"cannot pickle '_thread.lock' object {_TOOL_SECRET_SENTINEL}"
+    frame_names = [frame.name for frame in traceback.extract_tb(rec.exc_info[2])]
+    assert "boom" in frame_names
+    assert _TOOL_SECRET_SENTINEL not in message
+    assert "Traceback" in rendered
+    assert "boom" in rendered
+    assert _TOOL_SECRET_SENTINEL not in rendered
+    traceback_errors = [r for r in caplog.records if r.name == "opspilot" and r.levelno >= logging.ERROR and r.exc_info]
+    assert traceback_errors == owned
 
 
 def test_dynamic_tool_visibility_exposes_step_tools_plus_always_on_fs():
@@ -481,7 +551,67 @@ async def test_planner_catalog_prepends_k8s_namespace_lookup_hint():
     prompt = "\n".join(str(message.content) for message in llm.messages)
     assert "缺 namespace" in prompt or "反查" in prompt
     assert "diagnose_kubernetes_pod_issues" in prompt
-    assert plan.steps[0].tools[0] == "resolve_k8s_target_from_alert"
+    assert "禁止用 list_kubernetes_pods" in prompt
+    assert "namespace 留空" not in prompt
+    assert "只需规划 resolve_k8s_target_from_alert" not in prompt
+    assert "不要只规划反查就结束" in prompt
+    assert plan.steps[0].tools == ["resolve_k8s_target_from_alert"]
+
+
+@pytest.mark.asyncio
+async def test_planner_task_prompt_includes_agent_system_prompt():
+    tools = [
+        _tool("resolve_k8s_target_from_alert", "从告警解析目标"),
+        _tool("diagnose_kubernetes_pod_issues", "诊断 Pod"),
+        _tool("get_kubernetes_pod_logs", "查日志"),
+    ]
+
+    class FakeLLM:
+        def __init__(self):
+            self.messages = None
+
+        async def ainvoke(self, messages, config=None):
+            self.messages = messages
+            return AIMessage(
+                content=json.dumps(
+                    {
+                        "goal": "复盘告警",
+                        "steps": [
+                            {"objective": "反查命名空间", "tools": ["resolve_k8s_target_from_alert"]},
+                            {"objective": "取证诊断", "tools": ["diagnose_kubernetes_pod_issues", "get_kubernetes_pod_logs"]},
+                        ],
+                    },
+                    ensure_ascii=False,
+                )
+            )
+
+    llm = FakeLLM()
+    plan = await ToolExecutionPlanner(llm).plan(
+        "告警：Unhealthy（kubernetes，minikube，kube-scheduler-minikube）",
+        tools,
+        agent_system_prompt=("你是 Kubernetes 集群 RCA 助手。目标是证据闭环。" "单次任务：解析告警 → 有界反查 → 仅对象仍在时按需取证 → 写报告。" "【附件生成强制规则】这段模板不应进入规划器任务说明。"),
+    )
+    prompt = "\n".join(str(message.content) for message in llm.messages)
+    assert "助手任务说明" in prompt
+    assert "有界反查" in prompt
+    assert "按需取证" in prompt
+    assert "规划须对齐「助手任务说明」" in prompt
+    assert "附件生成强制规则" not in prompt
+    assert [step.tools for step in plan.steps] == [
+        ["resolve_k8s_target_from_alert"],
+        ["diagnose_kubernetes_pod_issues", "get_kubernetes_pod_logs"],
+    ]
+
+
+def test_agent_task_brief_strips_attachment_rule_and_truncates():
+    from apps.opspilot.metis.llm.agent.tool_execution_planner import _agent_task_brief
+
+    brief = _agent_task_brief("角色说明：取证后写报告\n【附件生成强制规则】这段是模板")
+    assert "取证后写报告" in brief
+    assert "附件生成强制规则" not in brief
+    truncated = _agent_task_brief("目标" + ("取证" * 2000), limit=40)
+    assert len(truncated) <= 41
+    assert truncated.endswith("…")
 
 
 @pytest.mark.asyncio
@@ -698,6 +828,31 @@ def test_classify_tool_failure_kind_separates_auth_from_retryable():
     assert unrecoverable_skill_result_hint('{"ok":false,"error":{"code":6,"message":"Cannot reach"}}') is None
 
 
+def test_resolve_planned_execution_compact_limits_scales_with_working_budget():
+    from apps.opspilot.metis.llm.agent.tool_execution_planner import (
+        planned_execution_compact_limits_for_request,
+        resolve_planned_execution_compact_limits,
+    )
+
+    assert resolve_planned_execution_compact_limits() == (1500, 1000)
+    assert resolve_planned_execution_compact_limits(input_working_tokens=None) == (1500, 1000)
+    assert resolve_planned_execution_compact_limits(input_working_tokens=0) == (1500, 1000)
+    assert resolve_planned_execution_compact_limits(input_working_tokens=6800) == (1500, 1000)
+
+    tool_chars, ai_chars = resolve_planned_execution_compact_limits(input_working_tokens=186_000)
+    assert tool_chars == 37_200
+    assert ai_chars == 27_352
+    assert tool_chars > 1500
+    assert ai_chars > 1000
+
+    request = SimpleNamespace(
+        extra_config={"input_working_tokens": 186_000},
+        message_trim_config={"max_single_message_tokens": 37_200},
+    )
+    assert planned_execution_compact_limits_for_request(request) == (37_200, 27_352)
+    assert planned_execution_compact_limits_for_request(SimpleNamespace(extra_config={})) == (1500, 1000)
+
+
 def test_compact_planned_execution_messages_truncates_tool_and_ai_text():
     from langchain_core.messages import AIMessage, ToolMessage
 
@@ -842,6 +997,53 @@ def test_enforce_k8s_namespace_lookup_first_prepends_resolve_step():
     )
     assert [step.tools for step in fixed_mid.steps] == [
         ["current_time"],
+        ["resolve_k8s_target_from_alert"],
+        ["diagnose_kubernetes_pod_issues"],
+    ]
+
+
+def test_enforce_k8s_namespace_lookup_strips_cluster_wide_scans():
+    from apps.opspilot.metis.llm.agent.tool_execution_planner import ToolExecutionPlan, ToolExecutionStep, enforce_k8s_namespace_lookup_first
+
+    packed = ToolExecutionPlan(
+        goal="RCA",
+        steps=[
+            ToolExecutionStep(
+                objective="定位 Pod",
+                tools=["resolve_k8s_target_from_alert", "list_kubernetes_pods", "list_kubernetes_events"],
+            )
+        ],
+    )
+    fixed_packed = enforce_k8s_namespace_lookup_first(
+        packed,
+        {
+            "resolve_k8s_target_from_alert",
+            "list_kubernetes_pods",
+            "list_kubernetes_events",
+            "diagnose_kubernetes_pod_issues",
+        },
+        max_steps=4,
+    )
+    assert [step.tools for step in fixed_packed.steps] == [["resolve_k8s_target_from_alert"]]
+
+    scanned = ToolExecutionPlan(
+        goal="RCA",
+        steps=[
+            ToolExecutionStep(objective="扫全集群", tools=["list_kubernetes_pods", "list_kubernetes_events"]),
+            ToolExecutionStep(objective="诊断 Pod", tools=["diagnose_kubernetes_pod_issues"]),
+        ],
+    )
+    fixed_scanned = enforce_k8s_namespace_lookup_first(
+        scanned,
+        {
+            "resolve_k8s_target_from_alert",
+            "list_kubernetes_pods",
+            "list_kubernetes_events",
+            "diagnose_kubernetes_pod_issues",
+        },
+        max_steps=4,
+    )
+    assert [step.tools for step in fixed_scanned.steps] == [
         ["resolve_k8s_target_from_alert"],
         ["diagnose_kubernetes_pod_issues"],
     ]

--- a/server/apps/opspilot/tests/test_k8s_instance_scope.py
+++ b/server/apps/opspilot/tests/test_k8s_instance_scope.py
@@ -412,3 +412,214 @@ def test_list_pods_fanout_uses_scan_wrapper(mocker):
     assert "conn refused" in by_cluster["bk-lite-k3s"]["error"]
     assert by_cluster["onedc_k8s_cluster"]["items"][0]["name"] == "nacos-0"
     assert set(seen) == {"bk-lite-k3s", "onedc_k8s_cluster"}
+
+
+def _assert_requires_instance_name(payload):
+    assert "请指定 instance_name" in payload["error"]
+
+
+def test_restart_pod_multi_requires_instance_name():
+    from apps.opspilot.metis.llm.tools.kubernetes.remediation import restart_pod
+
+    config, _ = _multi_config()
+    out = json.loads(restart_pod.invoke({"pod_name": "p", "namespace": "default", "wait_for_ready": False}, config=config))
+    _assert_requires_instance_name(out)
+
+
+def test_scale_deployment_multi_requires_instance_name():
+    from apps.opspilot.metis.llm.tools.kubernetes.remediation import scale_deployment
+
+    config, _ = _multi_config()
+    out = json.loads(scale_deployment.invoke({"deployment_name": "d", "namespace": "default", "replicas": 2}, config=config))
+    _assert_requires_instance_name(out)
+
+
+def test_batch_restart_pods_multi_requires_instance_name():
+    from apps.opspilot.metis.llm.tools.kubernetes.batch_operations import batch_restart_pods
+
+    config, _ = _multi_config()
+    out = json.loads(batch_restart_pods.invoke({"namespace": "default", "pod_names": ["p"]}, config=config))
+    _assert_requires_instance_name(out)
+
+
+def test_diagnose_pending_pod_issues_multi_requires_instance_name():
+    from apps.opspilot.metis.llm.tools.kubernetes.diagnostics_advanced import diagnose_pending_pod_issues
+
+    config, _ = _multi_config()
+    out = json.loads(diagnose_pending_pod_issues.invoke({"pod_name": "p", "namespace": "default"}, config=config))
+    _assert_requires_instance_name(out)
+
+
+def test_restart_pod_explicit_instance_binds_only_target(mocker):
+    from kubernetes.client import ApiException
+
+    from apps.opspilot.metis.llm.tools.kubernetes import remediation as r
+
+    config, _ = _multi_config()
+    seen = []
+
+    def _prep(cfg):
+        seen.append(cfg["configurable"]["instance_name"])
+
+    mocker.patch.object(r, "prepare_context", side_effect=_prep)
+    core = mocker.MagicMock()
+    mocker.patch.object(r.client, "CoreV1Api", return_value=core)
+    core.read_namespaced_pod.side_effect = ApiException(status=404)
+
+    out = json.loads(
+        r.restart_pod.invoke(
+            {"pod_name": "p", "namespace": "default", "wait_for_ready": False, "instance_name": "onedc_k8s_cluster"},
+            config=config,
+        )
+    )
+    assert "Pod不存在" in out["error"]
+    assert seen == ["onedc_k8s_cluster"]
+
+
+def test_scale_deployment_explicit_instance_binds_only_target(mocker):
+    from kubernetes.client import ApiException
+
+    from apps.opspilot.metis.llm.tools.kubernetes import remediation as r
+
+    config, _ = _multi_config()
+    seen = []
+
+    def _prep(cfg):
+        seen.append(cfg["configurable"]["instance_name"])
+
+    mocker.patch.object(r, "prepare_context", side_effect=_prep)
+    apps = mocker.MagicMock()
+    mocker.patch.object(r.client, "AppsV1Api", return_value=apps)
+    apps.read_namespaced_deployment.side_effect = ApiException(status=404)
+    apps.read_namespaced_stateful_set.side_effect = ApiException(status=404)
+
+    out = json.loads(
+        r.scale_deployment.invoke(
+            {"deployment_name": "d", "namespace": "default", "replicas": 2, "instance_name": "onedc_k8s_cluster"},
+            config=config,
+        )
+    )
+    assert seen == ["onedc_k8s_cluster"]
+    assert out.get("error") or out.get("success") is False
+
+
+def test_batch_restart_pods_explicit_instance_binds_only_target(mocker):
+    from apps.opspilot.metis.llm.tools.kubernetes import batch_operations as b
+
+    config, _ = _multi_config()
+    seen = []
+
+    def _prep(cfg):
+        seen.append(cfg["configurable"]["instance_name"])
+
+    mocker.patch.object(b, "prepare_context", side_effect=_prep)
+    core = mocker.MagicMock()
+    mocker.patch.object(b.client, "CoreV1Api", return_value=core)
+    core.read_namespaced_pod.side_effect = Exception("missing")
+
+    out = json.loads(
+        b.batch_restart_pods.invoke(
+            {"namespace": "default", "pod_names": ["p"], "instance_name": "onedc_k8s_cluster"},
+            config=config,
+        )
+    )
+    assert seen == ["onedc_k8s_cluster"]
+    assert "error" in out or "failed_pods" in out
+
+
+def test_diagnose_pending_explicit_instance_binds_only_target(mocker):
+    from kubernetes.client import ApiException
+
+    from apps.opspilot.metis.llm.tools.kubernetes import diagnostics_advanced as da
+
+    config, _ = _multi_config()
+    seen = []
+
+    def _prep(cfg):
+        seen.append(cfg["configurable"]["instance_name"])
+
+    mocker.patch.object(da, "prepare_context", side_effect=_prep)
+    core = mocker.MagicMock()
+    mocker.patch.object(da.client, "CoreV1Api", return_value=core)
+    core.read_namespaced_pod.side_effect = ApiException(status=404)
+
+    out = json.loads(
+        da.diagnose_pending_pod_issues.invoke(
+            {"pod_name": "p", "namespace": "default", "instance_name": "onedc_k8s_cluster"},
+            config=config,
+        )
+    )
+    assert "Pod不存在" in out["error"]
+    assert seen == ["onedc_k8s_cluster"]
+
+
+def test_list_events_fanout_uses_scan_wrapper(mocker):
+    from apps.opspilot.metis.llm.tools.kubernetes import resources as res
+
+    config, _ = _multi_config()
+    seen = []
+
+    def _fake(namespace, bound_config):
+        seen.append(bound_config["configurable"]["instance_name"])
+        if bound_config["configurable"]["instance_name"] == "bk-lite-k3s":
+            raise RuntimeError("conn refused")
+        return json.dumps([{"type": "Warning", "reason": "BackOff"}])
+
+    mocker.patch.object(res, "_list_kubernetes_events_on_instance", side_effect=_fake)
+    out = json.loads(res.list_kubernetes_events.invoke({}, config=config))
+    assert out["mode"] == "multi_instance"
+    by_cluster = {item["cluster"]: item for item in out["instances"]}
+    assert "conn refused" in by_cluster["bk-lite-k3s"]["error"]
+    assert by_cluster["onedc_k8s_cluster"]["items"][0]["reason"] == "BackOff"
+    assert set(seen) == {"bk-lite-k3s", "onedc_k8s_cluster"}
+
+
+def test_cleanup_failed_pods_multi_requires_instance_name():
+    from apps.opspilot.metis.llm.tools.kubernetes.batch_operations import cleanup_failed_pods
+
+    config, _ = _multi_config()
+    out = json.loads(cleanup_failed_pods.invoke({}, config=config))
+    _assert_requires_instance_name(out)
+
+
+def test_rollback_and_wait_and_delete_multi_require_instance_name():
+    from apps.opspilot.metis.llm.tools.kubernetes.remediation import delete_kubernetes_resource, rollback_deployment, wait_for_pod_ready
+
+    config, _ = _multi_config()
+    _assert_requires_instance_name(json.loads(rollback_deployment.invoke({"deployment_name": "d", "namespace": "ns"}, config=config)))
+    _assert_requires_instance_name(json.loads(wait_for_pod_ready.invoke({"pod_name": "p", "namespace": "ns"}, config=config)))
+    _assert_requires_instance_name(
+        json.loads(delete_kubernetes_resource.invoke({"resource_type": "pod", "resource_name": "p", "namespace": "ns"}, config=config))
+    )
+
+
+def test_pending_trace_scaling_compare_multi_require_instance_name():
+    from apps.opspilot.metis.llm.tools.kubernetes.optimization import check_scaling_capacity, compare_deployment_revisions
+    from apps.opspilot.metis.llm.tools.kubernetes.tracing import trace_service_chain
+
+    config, _ = _multi_config()
+    _assert_requires_instance_name(json.loads(trace_service_chain.invoke({"service_name": "svc", "namespace": "ns"}, config=config)))
+    _assert_requires_instance_name(json.loads(check_scaling_capacity.invoke({"namespace": "ns", "replicas": 2}, config=config)))
+    _assert_requires_instance_name(
+        json.loads(compare_deployment_revisions.invoke({"deployment_name": "d", "namespace": "ns", "revision1": 1, "revision2": 2}, config=config))
+    )
+
+
+def test_list_deployments_fanout_uses_scan_wrapper(mocker):
+    from apps.opspilot.metis.llm.tools.kubernetes import resources as res
+
+    config, _ = _multi_config()
+    seen = []
+
+    def _fake(namespace, limit, offset, bound_config):
+        seen.append(bound_config["configurable"]["instance_name"])
+        return json.dumps(
+            {"items": [{"name": bound_config["configurable"]["instance_name"]}], "total": 1, "returned": 1, "offset": 0, "has_more": False}
+        )
+
+    mocker.patch.object(res, "_list_kubernetes_deployments_on_instance", side_effect=_fake)
+    out = json.loads(res.list_kubernetes_deployments.invoke({}, config=config))
+    assert out["mode"] == "multi_instance"
+    by_cluster = {item["cluster"]: item for item in out["instances"]}
+    assert by_cluster["bk-lite-k3s"]["items"][0]["name"] == "bk-lite-k3s"
+    assert set(seen) == {"bk-lite-k3s", "onedc_k8s_cluster"}

--- a/server/apps/opspilot/tests/test_k8s_instance_scope.py
+++ b/server/apps/opspilot/tests/test_k8s_instance_scope.py
@@ -1,0 +1,414 @@
+"""多实例路由辅助与 resolve/定点/扫描行为单测。不连真实集群。"""
+
+import io
+import json
+import logging
+import pickle
+import threading
+import traceback
+from contextlib import contextmanager
+
+import pydantic.root_model  # noqa
+import yaml
+
+from apps.core.logger import SafeLogException, opspilot_logger
+from apps.opspilot.metis.llm.tools.kubernetes.instance_scope import bind_instance_config, point_instance_error, route_alert_cluster, run_scan_tool
+
+_LOOKUP_NAMESPACES = "apps.opspilot.metis.llm.tools.kubernetes.data_collection._lookup_namespaces_by_resource_name"
+_LOOKUP_SECRET_SENTINEL = "kc-secret-hunter2-not-for-logs"
+
+
+@contextmanager
+def _capture_opspilot_formatted_logs():
+    output = io.StringIO()
+    handler = logging.StreamHandler(output)
+    handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+    opspilot_logger.addHandler(handler)
+    try:
+        yield output
+    finally:
+        opspilot_logger.removeHandler(handler)
+
+
+def _multi_config(names=("bk-lite-k3s", "onedc_k8s_cluster")):
+    instances = [{"id": f"i{i}", "name": name, "kubeconfig_data": f"kc-{name}"} for i, name in enumerate(names, start=1)]
+    return {"configurable": {"kubernetes_instances": instances}}, instances
+
+
+class TestRouteAlertCluster:
+    def test_multi_match_by_display_name(self):
+        config, _ = _multi_config()
+        bound, extra = route_alert_cluster("onedc_k8s_cluster", config)
+        assert extra["instance_name"] == "onedc_k8s_cluster"
+        assert bound["configurable"]["instance_name"] == "onedc_k8s_cluster"
+        assert "route_error" not in extra
+
+    def test_bind_skips_unpicklable_runtime_objects(self):
+        config, _ = _multi_config(names=("minikube", "other"))
+        config["configurable"]["browser_step_callback"] = threading.Lock()
+        config["configurable"]["graph_request"] = threading.Lock()
+        config["configurable"]["token_usage_accumulator"] = threading.Lock()
+
+        bound, extra = route_alert_cluster("minikube", config)
+        assert extra["instance_name"] == "minikube"
+        assert bound["configurable"]["instance_name"] == "minikube"
+        assert "browser_step_callback" not in bound["configurable"]
+        pickle.dumps(bound)
+
+        rebound = bind_instance_config(config, config["configurable"]["kubernetes_instances"][0])
+        pickle.dumps(rebound)
+
+    def test_multi_match_by_kubeconfig_cluster(self):
+        kubeconfig = yaml.safe_dump({"clusters": [{"name": "onedc_k8s_cluster"}]})
+        config = {
+            "configurable": {
+                "kubernetes_instances": [
+                    {"id": "i1", "name": "bk-lite-k3s", "kubeconfig_data": "kc-a"},
+                    {"id": "i2", "name": "prod-display", "kubeconfig_data": kubeconfig},
+                ]
+            }
+        }
+        bound, extra = route_alert_cluster("onedc_k8s_cluster", config)
+        assert extra["instance_name"] == "prod-display"
+        assert bound["configurable"]["instance_id"] == "i2"
+
+    def test_multi_unbound_closes(self):
+        config, _ = _multi_config()
+        bound, extra = route_alert_cluster("ghost-cluster", config)
+        assert bound is None
+        assert "未绑定实例" in extra["route_error"]
+        assert "bk-lite-k3s" in extra["route_error"]
+
+    def test_multi_missing_cluster_closes(self):
+        config, _ = _multi_config()
+        bound, extra = route_alert_cluster(None, config)
+        assert bound is None
+        assert "未提供集群标识" in extra["route_error"]
+
+    def test_single_mismatch_hint(self):
+        config = {"configurable": {"kubernetes_instances": [{"id": "i1", "name": "bk-lite-k3s", "kubeconfig_data": "kc"}]}}
+        bound, extra = route_alert_cluster("onedc_k8s_cluster", config)
+        assert bound is not None
+        assert extra["instance_name"] == "bk-lite-k3s"
+        assert "cluster_mismatch" in extra
+
+    def test_single_match_no_mismatch(self):
+        config = {"configurable": {"kubernetes_instances": [{"id": "i1", "name": "onedc_k8s_cluster", "kubeconfig_data": "kc"}]}}
+        bound, extra = route_alert_cluster("onedc_k8s_cluster", config)
+        assert extra["instance_name"] == "onedc_k8s_cluster"
+        assert "cluster_mismatch" not in extra
+
+    def test_no_instances_passthrough(self):
+        bound, extra = route_alert_cluster("onedc_k8s_cluster", {"configurable": {}})
+        assert extra == {}
+        assert bound == {"configurable": {}}
+
+
+class TestPointInstanceError:
+    def test_multi_requires_name(self):
+        config, _ = _multi_config()
+        err = json.loads(point_instance_error(config))
+        assert "请指定 instance_name" in err["error"]
+        assert "onedc_k8s_cluster" in err["instance_names"]
+
+    def test_single_ok(self):
+        config = {"configurable": {"kubernetes_instances": [{"id": "i1", "name": "only", "kubeconfig_data": "kc"}]}}
+        assert point_instance_error(config) is None
+
+    def test_already_bound_ok(self):
+        config, _ = _multi_config()
+        config["configurable"]["instance_name"] = "bk-lite-k3s"
+        assert point_instance_error(config) is None
+
+
+class TestRunScanTool:
+    def test_single_passthrough_list(self):
+        out = json.loads(run_scan_tool({"configurable": {}}, None, lambda _cfg: json.dumps([{"name": "p"}])))
+        assert out == [{"name": "p"}]
+
+    def test_fanout_aggregates_and_skips_error(self):
+        config, _ = _multi_config()
+
+        def _run(bound):
+            name = bound["configurable"]["instance_name"]
+            if name == "bk-lite-k3s":
+                return json.dumps([{"name": "a"}])
+            return json.dumps({"error": "kubeconfig 无效"})
+
+        out = json.loads(run_scan_tool(config, None, _run))
+        assert out["mode"] == "multi_instance"
+        by_cluster = {item["cluster"]: item for item in out["instances"]}
+        assert by_cluster["bk-lite-k3s"]["items"] == [{"name": "a"}]
+        assert by_cluster["onedc_k8s_cluster"]["error"] == "kubeconfig 无效"
+
+    def test_explicit_instance_no_fanout(self):
+        config, _ = _multi_config()
+        seen = []
+
+        def _run(bound):
+            seen.append(bound["configurable"]["instance_name"])
+            return json.dumps([{"name": "p"}])
+
+        out = json.loads(run_scan_tool(config, "onedc_k8s_cluster", _run))
+        assert out == [{"name": "p"}]
+        assert seen == ["onedc_k8s_cluster"]
+
+    def test_already_bound_no_fanout(self):
+        config, _ = _multi_config()
+        config["configurable"]["instance_name"] = "bk-lite-k3s"
+        seen = []
+
+        def _run(bound):
+            seen.append(bound["configurable"].get("instance_name"))
+            return json.dumps([{"name": "p"}])
+
+        out = json.loads(run_scan_tool(config, None, _run))
+        assert out == [{"name": "p"}]
+        assert seen == ["bk-lite-k3s"]
+
+
+def test_resolve_routes_to_matched_instance_and_looks_up(mocker):
+    from apps.opspilot.metis.llm.tools.kubernetes.data_collection import resolve_k8s_target_from_alert
+
+    config, _ = _multi_config()
+    mocker.patch("apps.opspilot.metis.llm.tools.kubernetes.data_collection._cluster_config_error", return_value=None)
+    mocker.patch(
+        _LOOKUP_NAMESPACES,
+        return_value=([{"name": "nacos-0", "namespace": "nacos"}], [], None),
+    )
+
+    payload = json.loads(
+        resolve_k8s_target_from_alert.invoke(
+            {"normalized_alert": "告警：Unhealthy（kubernetes，onedc_k8s_cluster，nacos-0） 检测到异常\n内容：Readiness probe failed"},
+            config=config,
+        )
+    )
+    assert payload["resolved"] is True
+    assert payload["instance_name"] == "onedc_k8s_cluster"
+    assert payload["namespace"] == "nacos"
+    assert payload["pod_name"] == "nacos-0"
+
+
+def test_resolve_survives_runtime_locks_in_configurable(mocker):
+    from apps.opspilot.metis.llm.tools.kubernetes.data_collection import resolve_k8s_target_from_alert
+
+    config, _ = _multi_config(names=("minikube", "other"))
+    config["configurable"]["browser_step_callback"] = threading.Lock()
+    config["configurable"]["graph_request"] = threading.Lock()
+    mocker.patch("apps.opspilot.metis.llm.tools.kubernetes.data_collection._cluster_config_error", return_value=None)
+    lookup = mocker.patch(_LOOKUP_NAMESPACES)
+    list_pods = mocker.patch("apps.opspilot.metis.llm.tools.kubernetes.resources.list_kubernetes_pods")
+
+    payload = json.loads(
+        resolve_k8s_target_from_alert.invoke(
+            {"normalized_alert": ("告警：Unhealthy（kubernetes，minikube，kube-scheduler-minikube） 检测到异常\n" "内容：Liveness probe failed")},
+            config=config,
+        )
+    )
+    assert payload.get("error") != "TypeError"
+    assert "cannot pickle" not in str(payload.get("error") or "")
+    assert payload["resolved"] is True
+    assert payload["instance_name"] == "minikube"
+    assert payload["namespace"] == "kube-system"
+    assert payload["namespace_lookup"] == "control_plane_convention"
+    lookup.assert_not_called()
+    list_pods.invoke.assert_not_called()
+
+
+def test_resolve_model_object_name_json_routes_to_minikube(mocker):
+    from apps.opspilot.metis.llm.tools.kubernetes.data_collection import resolve_k8s_target_from_alert
+
+    config, _ = _multi_config(names=("bk-lite-k3s", "minikube"))
+    mocker.patch("apps.opspilot.metis.llm.tools.kubernetes.data_collection._cluster_config_error", return_value=None)
+    lookup = mocker.patch(_LOOKUP_NAMESPACES)
+    list_pods = mocker.patch("apps.opspilot.metis.llm.tools.kubernetes.resources.list_kubernetes_pods")
+
+    payload = json.loads(
+        resolve_k8s_target_from_alert.invoke(
+            {
+                "normalized_alert": json.dumps(
+                    {
+                        "alert_name": "Unhealthy",
+                        "cluster": "minikube",
+                        "object_name": "kube-scheduler-minikube",
+                        "probe_type": "Liveness",
+                        "error": "TLS handshake timeout",
+                    },
+                    ensure_ascii=False,
+                )
+            },
+            config=config,
+        )
+    )
+    assert payload.get("missing_data") != ["resource_type_or_name"]
+    assert payload["resource_type"] == "pod"
+    assert payload["pod_name"] == "kube-scheduler-minikube"
+    assert payload["instance_name"] == "minikube"
+    assert payload["namespace"] == "kube-system"
+    assert payload["namespace_lookup"] == "control_plane_convention"
+    assert payload["resolved"] is True
+    lookup.assert_not_called()
+    list_pods.invoke.assert_not_called()
+
+
+def test_resolve_static_pod_name_without_kind_routes_to_minikube(mocker):
+    from apps.opspilot.metis.llm.tools.kubernetes.data_collection import resolve_k8s_target_from_alert
+
+    config, _ = _multi_config(names=("bk-lite-k3s", "minikube"))
+    mocker.patch("apps.opspilot.metis.llm.tools.kubernetes.data_collection._cluster_config_error", return_value=None)
+    lookup = mocker.patch(_LOOKUP_NAMESPACES)
+    list_pods = mocker.patch("apps.opspilot.metis.llm.tools.kubernetes.resources.list_kubernetes_pods")
+
+    payload = json.loads(
+        resolve_k8s_target_from_alert.invoke(
+            {"normalized_alert": {"name": "kube-scheduler-minikube", "cluster": "minikube"}},
+            config=config,
+        )
+    )
+    assert payload.get("missing_data") != ["resource_type_or_name"]
+    assert payload["resource_type"] == "pod"
+    assert payload["pod_name"] == "kube-scheduler-minikube"
+    assert payload["instance_name"] == "minikube"
+    assert payload["namespace"] == "kube-system"
+    assert payload["namespace_lookup"] == "control_plane_convention"
+    assert payload["resolved"] is True
+    lookup.assert_not_called()
+    list_pods.invoke.assert_not_called()
+
+
+def test_resolve_event_json_does_not_treat_monitor_service_as_k8s_service(mocker):
+    from apps.opspilot.metis.llm.tools.kubernetes.data_collection import resolve_k8s_target_from_alert
+
+    config, _ = _multi_config(names=("bk-lite-k3s", "minikube"))
+    mocker.patch("apps.opspilot.metis.llm.tools.kubernetes.data_collection._cluster_config_error", return_value=None)
+    payload = json.loads(
+        resolve_k8s_target_from_alert.invoke(
+            {
+                "normalized_alert": {
+                    "item": "Unhealthy",
+                    "service": "kubernetes",
+                    "location": "minikube",
+                    "resource_name": "kube-scheduler-minikube",
+                    "labels": {
+                        "kind": "Pod",
+                        "name": "kube-scheduler-minikube",
+                        "namespace": "kube-system",
+                        "cluster_name": "minikube",
+                    },
+                    "tags": {"cluster": "minikube", "namespace": "kube-system", "kind": "Pod"},
+                }
+            },
+            config=config,
+        )
+    )
+    assert payload["resource_type"] == "pod"
+    assert payload.get("service_name") in (None, "", [])
+    assert payload["instance_name"] == "minikube"
+    assert payload["cluster"] == "minikube"
+    assert payload["namespace"] == "kube-system"
+    assert payload["resolved"] is True
+    assert payload.get("error") is None
+
+
+def test_resolve_lookup_failure_logs_once(mocker, caplog):
+    from apps.opspilot.metis.llm.tools.kubernetes.data_collection import resolve_k8s_target_from_alert
+
+    config, _ = _multi_config(names=("minikube-log", "other-log"))
+    mocker.patch("apps.opspilot.metis.llm.tools.kubernetes.data_collection._cluster_config_error", return_value=None)
+    lookup_error = RuntimeError(f"conn refused {_LOOKUP_SECRET_SENTINEL}")
+    mocker.patch(_LOOKUP_NAMESPACES, side_effect=lookup_error)
+    caplog.set_level(logging.INFO, logger="opspilot")
+
+    with _capture_opspilot_formatted_logs() as output:
+        payload = json.loads(
+            resolve_k8s_target_from_alert.invoke(
+                {"normalized_alert": {"labels": {"cluster": "minikube-log", "pod": "log-probe-pod"}}},
+                config=config,
+            )
+        )
+    rendered = output.getvalue()
+    assert payload["resolved"] is False
+    assert _LOOKUP_SECRET_SENTINEL in payload["error"]
+    owned = [
+        rec
+        for rec in caplog.records
+        if rec.name == "opspilot"
+        and rec.levelno >= logging.ERROR
+        and rec.exc_info
+        and rec.msg == "event=k8s_alert_resolve_failed failed_stage=%s error_type=%s instance_name=%s"
+    ]
+    assert len(owned) == 1
+    rec = owned[0]
+    assert rec.args == ("namespace_lookup", "RuntimeError", "minikube-log")
+    message = rec.getMessage()
+    assert "failed_stage=namespace_lookup" in message
+    assert "error_type=RuntimeError" in message
+    assert "instance_name=minikube-log" in message
+    assert rec.exc_info[0] is SafeLogException
+    assert rec.exc_info[1] is not lookup_error
+    assert rec.exc_info[2] is lookup_error.__traceback__
+    assert str(rec.exc_info[1]) == "RuntimeError"
+    assert str(lookup_error) == f"conn refused {_LOOKUP_SECRET_SENTINEL}"
+    frame_names = [frame.name for frame in traceback.extract_tb(rec.exc_info[2])]
+    assert "resolve_k8s_target_from_alert" in frame_names
+    assert "kubeconfig" not in message.lower()
+    assert _LOOKUP_SECRET_SENTINEL not in message
+    assert "Traceback" in rendered
+    assert "resolve_k8s_target_from_alert" in rendered
+    assert _LOOKUP_SECRET_SENTINEL not in rendered
+    traceback_errors = [r for r in caplog.records if r.name == "opspilot" and r.levelno >= logging.ERROR and r.exc_info]
+    assert traceback_errors == owned
+
+
+def test_resolve_unbound_cluster_is_conclusive():
+    from apps.opspilot.metis.llm.tools.kubernetes.data_collection import resolve_k8s_target_from_alert
+
+    config, _ = _multi_config()
+    payload = json.loads(
+        resolve_k8s_target_from_alert.invoke(
+            {"normalized_alert": {"title": "Unhealthy（kubernetes，ghost，nacos-0）", "labels": {"cluster": "ghost", "pod": "nacos-0"}}},
+            config=config,
+        )
+    )
+    assert payload["resolved"] is False
+    assert payload["conclusive"] is True
+    assert "未绑定实例" in payload["error"]
+
+
+def test_resolve_multi_without_cluster_is_conclusive():
+    from apps.opspilot.metis.llm.tools.kubernetes.data_collection import resolve_k8s_target_from_alert
+
+    config, _ = _multi_config()
+    payload = json.loads(resolve_k8s_target_from_alert.invoke({"normalized_alert": {"labels": {"pod": "nacos-0"}}}, config=config))
+    assert payload["resolved"] is False
+    assert payload["conclusive"] is True
+    assert "未提供集群标识" in payload["error"]
+
+
+def test_diagnose_multi_requires_instance_name():
+    from apps.opspilot.metis.llm.tools.kubernetes.diagnostics import diagnose_kubernetes_pod_issues
+
+    config, _ = _multi_config()
+    out = json.loads(diagnose_kubernetes_pod_issues.invoke({"namespace": "nacos", "pod_name": "nacos-0"}, config=config))
+    assert "请指定 instance_name" in out["error"]
+
+
+def test_list_pods_fanout_uses_scan_wrapper(mocker):
+    from apps.opspilot.metis.llm.tools.kubernetes import resources as res
+
+    config, _ = _multi_config()
+    seen = []
+
+    def _fake(namespace, bound_config):
+        seen.append(bound_config["configurable"]["instance_name"])
+        if bound_config["configurable"]["instance_name"] == "bk-lite-k3s":
+            raise RuntimeError("conn refused")
+        return json.dumps([{"name": "nacos-0", "namespace": "nacos"}])
+
+    mocker.patch.object(res, "_list_kubernetes_pods_on_instance", side_effect=_fake)
+    out = json.loads(res.list_kubernetes_pods.invoke({}, config=config))
+    assert out["mode"] == "multi_instance"
+    by_cluster = {item["cluster"]: item for item in out["instances"]}
+    assert "conn refused" in by_cluster["bk-lite-k3s"]["error"]
+    assert by_cluster["onedc_k8s_cluster"]["items"][0]["name"] == "nacos-0"
+    assert set(seen) == {"bk-lite-k3s", "onedc_k8s_cluster"}

--- a/server/apps/opspilot/tests/test_kubernetes_data_collection_tools.py
+++ b/server/apps/opspilot/tests/test_kubernetes_data_collection_tools.py
@@ -1066,6 +1066,8 @@ def test_infer_kube_system_namespace_for_control_plane_static_pods():
     assert _infer_kube_system_namespace("kube-proxy-minikube") == "kube-system"
     assert _infer_kube_system_namespace("nacos-0") is None
     assert _infer_kube_system_namespace("kube-scheduler-minikube", "deployment") is None
+    assert _infer_kube_system_namespace("kube-proxy-exporter") is None
+    assert _infer_kube_system_namespace("kube-proxy-metrics") is None
 
 
 def test_lookup_namespaces_by_resource_name_uses_name_field_selector(mocker):
@@ -1087,6 +1089,29 @@ def test_lookup_namespaces_by_resource_name_uses_name_field_selector(mocker):
     assert events == []
     core.list_pod_for_all_namespaces.assert_called_once_with(field_selector="metadata.name=nacos-0")
     core.list_event_for_all_namespaces.assert_not_called()
+
+
+def test_lookup_namespaces_accepts_dns1123_subdomain_and_rejects_invalid(mocker):
+    from types import SimpleNamespace
+
+    from apps.opspilot.metis.llm.tools.kubernetes import data_collection as dc
+
+    mocker.patch.object(dc, "prepare_context")
+    core = mocker.MagicMock()
+    mocker.patch.object(dc.client, "CoreV1Api", return_value=core)
+    core.list_pod_for_all_namespaces.return_value = SimpleNamespace(items=[])
+    core.list_event_for_all_namespaces.return_value = SimpleNamespace(items=[])
+
+    pods, events, error = dc._lookup_namespaces_by_resource_name("kube-scheduler-node.example.com", {})
+    assert error is None
+    assert pods == []
+    core.list_pod_for_all_namespaces.assert_called_once_with(field_selector="metadata.name=kube-scheduler-node.example.com")
+
+    pods, events, error = dc._lookup_namespaces_by_resource_name("NOT VALID!!", {})
+    assert pods == []
+    assert events == []
+    assert "DNS-1123" in error
+    assert core.list_pod_for_all_namespaces.call_count == 1
 
 
 def test_lookup_namespaces_by_resource_name_falls_back_to_events(mocker):

--- a/server/apps/opspilot/tests/test_kubernetes_data_collection_tools.py
+++ b/server/apps/opspilot/tests/test_kubernetes_data_collection_tools.py
@@ -818,6 +818,14 @@ NACOS_READINESS_ALERT_TEXT = (
     "负责人:：devil"
 )
 
+_LOOKUP_NAMESPACES = "apps.opspilot.metis.llm.tools.kubernetes.data_collection._lookup_namespaces_by_resource_name"
+
+
+def _patch_namespace_lookup(pods, events=None, error=None):
+    from unittest.mock import patch
+
+    return patch(_LOOKUP_NAMESPACES, return_value=(pods, events or [], error))
+
 
 def test_normalize_alert_event_builds_stable_schema():
     from apps.opspilot.metis.llm.tools.kubernetes.data_collection import normalize_alert_event
@@ -861,16 +869,9 @@ def test_normalize_alert_event_parses_nacos_notification_text_into_cluster():
 
 
 def test_resolve_k8s_target_from_alert_accepts_nacos_notification_text():
-    from unittest.mock import patch
-
     from apps.opspilot.metis.llm.tools.kubernetes.data_collection import resolve_k8s_target_from_alert
 
-    pods_json = json.dumps([{"name": "nacos-0", "namespace": "nacos", "phase": "Running"}])
-    with patch("apps.opspilot.metis.llm.tools.kubernetes.resources.list_kubernetes_pods") as list_pods, patch(
-        "apps.opspilot.metis.llm.tools.kubernetes.resources.list_kubernetes_events"
-    ) as list_events:
-        list_pods.invoke.return_value = pods_json
-        list_events.invoke.return_value = json.dumps([])
+    with _patch_namespace_lookup([{"name": "nacos-0", "namespace": "nacos"}]):
         payload = json.loads(resolve_k8s_target_from_alert.invoke({"normalized_alert": NACOS_READINESS_ALERT_TEXT}))
 
     assert payload["resolved"] is True
@@ -920,16 +921,9 @@ def test_resolve_k8s_target_from_alert_marks_missing_data_when_unresolved():
 
 
 def test_resolve_k8s_target_from_alert_reads_flattened_pod_name():
-    from unittest.mock import patch
-
     from apps.opspilot.metis.llm.tools.kubernetes.data_collection import resolve_k8s_target_from_alert
 
-    pods_json = json.dumps([{"name": "pod1005", "namespace": "prod", "phase": "Running"}])
-    with patch("apps.opspilot.metis.llm.tools.kubernetes.resources.list_kubernetes_pods") as list_pods, patch(
-        "apps.opspilot.metis.llm.tools.kubernetes.resources.list_kubernetes_events"
-    ) as list_events:
-        list_pods.invoke.return_value = pods_json
-        list_events.invoke.return_value = json.dumps([])
+    with _patch_namespace_lookup([{"name": "pod1005", "namespace": "prod"}]):
         result = resolve_k8s_target_from_alert.invoke(
             {
                 "normalized_alert": {
@@ -948,8 +942,6 @@ def test_resolve_k8s_target_from_alert_reads_flattened_pod_name():
 
 
 def test_resolve_k8s_target_from_alert_reads_flattened_kind_and_name():
-    from unittest.mock import patch
-
     from apps.opspilot.metis.llm.tools.kubernetes.data_collection import resolve_k8s_target_from_alert
 
     alert = {
@@ -961,12 +953,7 @@ def test_resolve_k8s_target_from_alert_reads_flattened_kind_and_name():
         "alert_time": "2026-08-28 10:09:01",
         "namespace": None,
     }
-    pods_json = json.dumps([{"name": "server-69bf94649c-b8szc", "namespace": "bklite", "phase": "Running"}])
-    with patch("apps.opspilot.metis.llm.tools.kubernetes.resources.list_kubernetes_pods") as list_pods, patch(
-        "apps.opspilot.metis.llm.tools.kubernetes.resources.list_kubernetes_events"
-    ) as list_events:
-        list_pods.invoke.return_value = pods_json
-        list_events.invoke.return_value = json.dumps([])
+    with _patch_namespace_lookup([{"name": "server-69bf94649c-b8szc", "namespace": "bklite"}]) as lookup:
         result = resolve_k8s_target_from_alert.invoke({"normalized_alert": alert})
 
     payload = json.loads(result)
@@ -975,12 +962,10 @@ def test_resolve_k8s_target_from_alert_reads_flattened_kind_and_name():
     assert payload["resource_name"] == "server-69bf94649c-b8szc"
     assert payload["pod_name"] == "server-69bf94649c-b8szc"
     assert payload["namespace"] == "bklite"
-    list_pods.invoke.assert_called_once()
+    lookup.assert_called_once()
 
 
 def test_resolve_k8s_target_from_alert_marks_lookup_exhausted_when_pod_gone():
-    from unittest.mock import patch
-
     from apps.opspilot.metis.llm.tools.kubernetes.data_collection import resolve_k8s_target_from_alert
 
     alert = {
@@ -991,11 +976,7 @@ def test_resolve_k8s_target_from_alert_marks_lookup_exhausted_when_pod_gone():
         "detail": "Startup probe failed: connection refused",
     }
     config = {"configurable": {}}
-    with patch("apps.opspilot.metis.llm.tools.kubernetes.resources.list_kubernetes_pods") as list_pods, patch(
-        "apps.opspilot.metis.llm.tools.kubernetes.resources.list_kubernetes_events"
-    ) as list_events:
-        list_pods.invoke.return_value = json.dumps([])
-        list_events.invoke.return_value = json.dumps([])
+    with _patch_namespace_lookup([]) as lookup:
         first = json.loads(resolve_k8s_target_from_alert.invoke({"normalized_alert": alert}, config=config))
         second = json.loads(resolve_k8s_target_from_alert.invoke({"normalized_alert": alert}, config=config))
 
@@ -1006,8 +987,7 @@ def test_resolve_k8s_target_from_alert_marks_lookup_exhausted_when_pod_gone():
     assert first["namespace"] is None
     assert "namespace" in first["missing_data"]
     assert second == first
-    list_pods.invoke.assert_called_once()
-    list_events.invoke.assert_called_once()
+    lookup.assert_called_once()
 
 
 def test_resolve_k8s_target_from_alert_ignores_non_object_title_name():
@@ -1026,7 +1006,7 @@ def test_resolve_k8s_target_from_alert_surfaces_kubeconfig_error():
     from apps.opspilot.metis.llm.tools.kubernetes.data_collection import resolve_k8s_target_from_alert
 
     with patch(
-        "apps.opspilot.metis.llm.tools.kubernetes.utils.prepare_context",
+        "apps.opspilot.metis.llm.tools.kubernetes.data_collection.prepare_context",
         side_effect=Exception("无法加载 Kubernetes 配置: Invalid base64-encoded string. 请检查 kubeconfig 配置内容或集群连接。"),
     ):
         result = resolve_k8s_target_from_alert.invoke(
@@ -1040,15 +1020,9 @@ def test_resolve_k8s_target_from_alert_surfaces_kubeconfig_error():
 
 
 def test_resolve_k8s_target_from_alert_surfaces_lookup_error_payload():
-    from unittest.mock import patch
-
     from apps.opspilot.metis.llm.tools.kubernetes.data_collection import resolve_k8s_target_from_alert
 
-    with patch("apps.opspilot.metis.llm.tools.kubernetes.resources.list_kubernetes_pods") as list_pods, patch(
-        "apps.opspilot.metis.llm.tools.kubernetes.resources.list_kubernetes_events"
-    ) as list_events:
-        list_pods.invoke.return_value = json.dumps({"error": "获取Pod列表失败: (401)\nReason: Unauthorized"})
-        list_events.invoke.return_value = json.dumps([])
+    with _patch_namespace_lookup([], error="获取Pod列表失败: (401)\nReason: Unauthorized"):
         result = resolve_k8s_target_from_alert.invoke({"normalized_alert": {"labels": {"pod": "pod1005"}}})
 
     payload = json.loads(result)
@@ -1057,23 +1031,14 @@ def test_resolve_k8s_target_from_alert_surfaces_lookup_error_payload():
 
 
 def test_resolve_k8s_target_from_alert_looks_up_namespace_via_pods():
-    from unittest.mock import patch
-
     from apps.opspilot.metis.llm.tools.kubernetes.data_collection import resolve_k8s_target_from_alert
 
-    pods_json = json.dumps(
+    with _patch_namespace_lookup(
         [
-            {"name": "server-5b8fb979d7-csdcc", "namespace": "bklite", "phase": "Running"},
-            {"name": "other", "namespace": "default", "phase": "Running"},
+            {"name": "server-5b8fb979d7-csdcc", "namespace": "bklite"},
+            {"name": "other", "namespace": "default"},
         ]
-    )
-    events_json = json.dumps([])
-
-    with patch("apps.opspilot.metis.llm.tools.kubernetes.resources.list_kubernetes_pods") as list_pods, patch(
-        "apps.opspilot.metis.llm.tools.kubernetes.resources.list_kubernetes_events"
-    ) as list_events:
-        list_pods.invoke.return_value = pods_json
-        list_events.invoke.return_value = events_json
+    ) as lookup:
         result = resolve_k8s_target_from_alert.invoke(
             {
                 "normalized_alert": {
@@ -1089,8 +1054,86 @@ def test_resolve_k8s_target_from_alert_looks_up_namespace_via_pods():
     assert payload["namespace"] == "bklite"
     assert payload["pod_name"] == "server-5b8fb979d7-csdcc"
     assert payload["namespace_lookup"] == "pods_or_events"
-    list_pods.invoke.assert_called_once()
-    list_events.invoke.assert_called_once()
+    lookup.assert_called_once()
+
+
+def test_infer_kube_system_namespace_for_control_plane_static_pods():
+    from apps.opspilot.metis.llm.tools.kubernetes.data_collection import _infer_kube_system_namespace
+
+    assert _infer_kube_system_namespace("kube-scheduler-minikube") == "kube-system"
+    assert _infer_kube_system_namespace("kube-apiserver-minikube", "pod") == "kube-system"
+    assert _infer_kube_system_namespace("kube-controller-manager-minikube") == "kube-system"
+    assert _infer_kube_system_namespace("kube-proxy-minikube") == "kube-system"
+    assert _infer_kube_system_namespace("nacos-0") is None
+    assert _infer_kube_system_namespace("kube-scheduler-minikube", "deployment") is None
+
+
+def test_lookup_namespaces_by_resource_name_uses_name_field_selector(mocker):
+    from types import SimpleNamespace
+
+    from apps.opspilot.metis.llm.tools.kubernetes import data_collection as dc
+
+    mocker.patch.object(dc, "prepare_context")
+    core = mocker.MagicMock()
+    mocker.patch.object(dc.client, "CoreV1Api", return_value=core)
+    core.list_pod_for_all_namespaces.return_value = SimpleNamespace(
+        items=[SimpleNamespace(metadata=SimpleNamespace(name="nacos-0", namespace="nacos"))]
+    )
+
+    pods, events, error = dc._lookup_namespaces_by_resource_name("nacos-0", {})
+
+    assert error is None
+    assert pods == [{"name": "nacos-0", "namespace": "nacos"}]
+    assert events == []
+    core.list_pod_for_all_namespaces.assert_called_once_with(field_selector="metadata.name=nacos-0")
+    core.list_event_for_all_namespaces.assert_not_called()
+
+
+def test_lookup_namespaces_by_resource_name_falls_back_to_events(mocker):
+    from types import SimpleNamespace
+
+    from apps.opspilot.metis.llm.tools.kubernetes import data_collection as dc
+
+    mocker.patch.object(dc, "prepare_context")
+    core = mocker.MagicMock()
+    mocker.patch.object(dc.client, "CoreV1Api", return_value=core)
+    core.list_pod_for_all_namespaces.return_value = SimpleNamespace(items=[])
+    core.list_event_for_all_namespaces.return_value = SimpleNamespace(
+        items=[
+            SimpleNamespace(
+                involved_object=SimpleNamespace(kind="Pod", name="nacos-0"),
+                namespace="nacos",
+                metadata=SimpleNamespace(namespace="nacos"),
+            )
+        ]
+    )
+
+    pods, events, error = dc._lookup_namespaces_by_resource_name("nacos-0", {})
+
+    assert error is None
+    assert pods == []
+    assert events == [{"object": "Pod/nacos-0", "namespace": "nacos"}]
+    core.list_event_for_all_namespaces.assert_called_once_with(field_selector="involvedObject.name=nacos-0")
+
+
+def test_resolve_control_plane_pod_skips_cluster_wide_list():
+    from unittest.mock import patch
+
+    from apps.opspilot.metis.llm.tools.kubernetes.data_collection import resolve_k8s_target_from_alert
+
+    with patch("apps.opspilot.metis.llm.tools.kubernetes.resources.list_kubernetes_pods") as list_pods, patch(_LOOKUP_NAMESPACES) as lookup:
+        payload = json.loads(
+            resolve_k8s_target_from_alert.invoke(
+                {"normalized_alert": ("告警：Unhealthy（kubernetes，minikube，kube-scheduler-minikube） 检测到异常\n" "内容：Liveness probe failed")}
+            )
+        )
+
+    assert payload["resolved"] is True
+    assert payload["namespace"] == "kube-system"
+    assert payload["pod_name"] == "kube-scheduler-minikube"
+    assert payload["namespace_lookup"] == "control_plane_convention"
+    lookup.assert_not_called()
+    list_pods.invoke.assert_not_called()
 
 
 def test_apply_namespace_lookup_reports_multiple_candidates():

--- a/server/apps/opspilot/tests/test_tools_k8s_batch_operations_service.py
+++ b/server/apps/opspilot/tests/test_tools_k8s_batch_operations_service.py
@@ -21,19 +21,15 @@ from apps.opspilot.metis.llm.tools.kubernetes import batch_operations as b
 @pytest.fixture
 def core():
     c = MagicMock()
-    with patch.object(b, "prepare_context", return_value=None), \
-         patch.object(b.client, "CoreV1Api", return_value=c):
+    with patch.object(b, "prepare_context", return_value=None), patch.object(b.client, "CoreV1Api", return_value=c):
         yield c
 
 
-def _pod(name="p", ns="default", phase="Running", owner=True, uid="u1",
-         volumes=None, containers=None, reason=None, cstatuses=None):
+def _pod(name="p", ns="default", phase="Running", owner=True, uid="u1", volumes=None, containers=None, reason=None, cstatuses=None):
     owner_refs = [SimpleNamespace(kind="ReplicaSet", name="rs")] if owner else None
     return SimpleNamespace(
-        metadata=SimpleNamespace(name=name, namespace=ns, uid=uid,
-                                 owner_references=owner_refs),
-        status=SimpleNamespace(phase=phase, reason=reason,
-                               container_statuses=cstatuses),
+        metadata=SimpleNamespace(name=name, namespace=ns, uid=uid, owner_references=owner_refs),
+        status=SimpleNamespace(phase=phase, reason=reason, container_statuses=cstatuses),
         spec=SimpleNamespace(volumes=volumes, containers=containers),
     )
 
@@ -88,8 +84,7 @@ class TestBatchRestart:
         owned = _pod(name="owned", owner=True, uid="a")
         orphan = _pod(name="orphan", owner=False, uid="b")
         core.list_namespaced_pod.return_value = _items([owned, orphan])
-        out = json.loads(b.batch_restart_pods.invoke({
-            "namespace": "prod", "label_selector": "app=x", "config": {}}))
+        out = json.loads(b.batch_restart_pods.invoke({"namespace": "prod", "label_selector": "app=x", "config": {}}))
         assert out["total_pods"] == 2
         assert [p["pod_name"] for p in out["restarted_pods"]] == ["owned"]
         assert [p["pod_name"] for p in out["skipped_pods"]] == ["orphan"]
@@ -100,44 +95,43 @@ class TestBatchRestart:
             if name == "gone":
                 raise ApiException(status=404)
             return _pod(name=name, owner=True)
+
         core.read_namespaced_pod.side_effect = read
-        out = json.loads(b.batch_restart_pods.invoke({
-            "namespace": "prod", "pod_names": ["live", "gone"], "config": {}}))
+        out = json.loads(b.batch_restart_pods.invoke({"namespace": "prod", "pod_names": ["live", "gone"], "config": {}}))
         assert out["total_pods"] == 1
         assert out["restarted_pods"][0]["pod_name"] == "live"
 
     def test_no_matching_pods(self, core):
         core.list_namespaced_pod.return_value = _items([])
-        out = json.loads(b.batch_restart_pods.invoke({
-            "namespace": "prod", "label_selector": "app=none", "config": {}}))
+        out = json.loads(b.batch_restart_pods.invoke({"namespace": "prod", "label_selector": "app=none", "config": {}}))
         assert out["message"] == "没有找到匹配的Pod"
 
     def test_delete_failure_recorded(self, core):
         core.list_namespaced_pod.return_value = _items([_pod(owner=True)])
         core.delete_namespaced_pod.side_effect = ApiException(status=500)
-        out = json.loads(b.batch_restart_pods.invoke({
-            "namespace": "prod", "label_selector": "a=b", "config": {}}))
+        out = json.loads(b.batch_restart_pods.invoke({"namespace": "prod", "label_selector": "a=b", "config": {}}))
         assert len(out["failed_pods"]) == 1
 
     def test_wait_for_ready(self, core):
         pod = _pod(name="w", owner=True, uid="old")
         core.list_namespaced_pod.return_value = _items([pod])
-        new_pod = _pod(name="w", owner=True, uid="new",
-                       cstatuses=[SimpleNamespace(ready=True)])
+        new_pod = _pod(name="w", owner=True, uid="new", cstatuses=[SimpleNamespace(ready=True)])
         new_pod.status.phase = "Running"
         core.read_namespaced_pod.return_value = new_pod
-        with patch.object(b.time, "sleep", return_value=None), \
-             patch.object(b.time, "time", side_effect=[0, 0, 1]):
-            out = json.loads(b.batch_restart_pods.invoke({
-                "namespace": "prod", "label_selector": "a=b",
-                "wait_for_ready": True, "config": {}}))
+        with patch.object(b.time, "sleep", return_value=None), patch.object(b.time, "time", side_effect=[0, 0, 1]):
+            out = json.loads(b.batch_restart_pods.invoke({"namespace": "prod", "label_selector": "a=b", "wait_for_ready": True, "config": {}}))
         assert out["all_ready"] is True
         assert out["ready_count"] == 1
 
+    def test_string_wait_for_ready_false_skips_wait(self, core):
+        core.list_namespaced_pod.return_value = _items([_pod(owner=True)])
+        out = json.loads(b.batch_restart_pods.func(namespace="prod", label_selector="a=b", wait_for_ready="false", config={}))
+        assert out["wait_for_ready"] is False
+        assert "all_ready" not in out
+
     def test_generic_exception_wrapped(self, core):
         core.list_namespaced_pod.side_effect = RuntimeError("boom")
-        out = json.loads(b.batch_restart_pods.invoke({
-            "namespace": "prod", "label_selector": "a=b", "config": {}}))
+        out = json.loads(b.batch_restart_pods.invoke({"namespace": "prod", "label_selector": "a=b", "config": {}}))
         assert "批量重启失败" in out["error"]
 
 
@@ -145,8 +139,7 @@ class TestBatchRestart:
 class TestFindConfigMapConsumers:
     def test_configmap_not_found(self, core):
         core.read_namespaced_config_map.side_effect = ApiException(status=404)
-        out = json.loads(b.find_configmap_consumers.invoke({
-            "configmap_name": "cm", "namespace": "prod", "config": {}}))
+        out = json.loads(b.find_configmap_consumers.invoke({"configmap_name": "cm", "namespace": "prod", "config": {}}))
         assert out["configmap_exists"] is False
         assert "不存在" in out["message"]
 
@@ -155,20 +148,14 @@ class TestFindConfigMapConsumers:
         # volume + subpath pod
         vol = SimpleNamespace(name="v", config_map=SimpleNamespace(name="cm"))
         vm = SimpleNamespace(name="v", sub_path="x")
-        sub_pod = _pod(name="subp", owner=True,
-                       volumes=[vol], containers=[SimpleNamespace(
-                           volume_mounts=[vm], env=None)])
+        sub_pod = _pod(name="subp", owner=True, volumes=[vol], containers=[SimpleNamespace(volume_mounts=[vm], env=None)])
         # env pod
         ref = SimpleNamespace(config_map_key_ref=SimpleNamespace(name="cm"))
-        env_pod = _pod(name="envp", owner=True, volumes=None,
-                       containers=[SimpleNamespace(
-                           volume_mounts=[], env=[SimpleNamespace(value_from=ref)])])
+        env_pod = _pod(name="envp", owner=True, volumes=None, containers=[SimpleNamespace(volume_mounts=[], env=[SimpleNamespace(value_from=ref)])])
         # unrelated pod
-        other = _pod(name="other", owner=True, volumes=None,
-                     containers=[SimpleNamespace(volume_mounts=[], env=None)])
+        other = _pod(name="other", owner=True, volumes=None, containers=[SimpleNamespace(volume_mounts=[], env=None)])
         core.list_namespaced_pod.return_value = _items([sub_pod, env_pod, other])
-        out = json.loads(b.find_configmap_consumers.invoke({
-            "configmap_name": "cm", "namespace": "prod", "config": {}}))
+        out = json.loads(b.find_configmap_consumers.invoke({"configmap_name": "cm", "namespace": "prod", "config": {}}))
         assert out["total_consumers"] == 2
         names = {c["pod_name"] for c in out["consumers"]}
         assert names == {"subp", "envp"}
@@ -177,11 +164,9 @@ class TestFindConfigMapConsumers:
 
     def test_no_consumers_recommendation(self, core):
         core.read_namespaced_config_map.return_value = SimpleNamespace()
-        pod = _pod(name="x", volumes=None,
-                   containers=[SimpleNamespace(volume_mounts=[], env=None)])
+        pod = _pod(name="x", volumes=None, containers=[SimpleNamespace(volume_mounts=[], env=None)])
         core.list_namespaced_pod.return_value = _items([pod])
-        out = json.loads(b.find_configmap_consumers.invoke({
-            "configmap_name": "cm", "namespace": "prod", "config": {}}))
+        out = json.loads(b.find_configmap_consumers.invoke({"configmap_name": "cm", "namespace": "prod", "config": {}}))
         assert out["total_consumers"] == 0
         assert any("可以安全修改或删除" in r for r in out["recommendations"])
 
@@ -189,18 +174,15 @@ class TestFindConfigMapConsumers:
         core.read_namespaced_config_map.return_value = SimpleNamespace()
         vol = SimpleNamespace(name="v", config_map=SimpleNamespace(name="cm"))
         vm = SimpleNamespace(name="v", sub_path=None)
-        pod = _pod(name="vp", owner=True, volumes=[vol],
-                   containers=[SimpleNamespace(volume_mounts=[vm], env=None)])
+        pod = _pod(name="vp", owner=True, volumes=[vol], containers=[SimpleNamespace(volume_mounts=[vm], env=None)])
         core.list_namespaced_pod.return_value = _items([pod])
-        out = json.loads(b.find_configmap_consumers.invoke({
-            "configmap_name": "cm", "namespace": "prod", "config": {}}))
+        out = json.loads(b.find_configmap_consumers.invoke({"configmap_name": "cm", "namespace": "prod", "config": {}}))
         assert out["consumers"][0]["needs_restart"] is False
         assert any("自动生效" in r for r in out["recommendations"])
 
     def test_exception_wrapped(self, core):
         core.read_namespaced_config_map.side_effect = RuntimeError("boom")
-        out = json.loads(b.find_configmap_consumers.invoke({
-            "configmap_name": "cm", "namespace": "prod", "config": {}}))
+        out = json.loads(b.find_configmap_consumers.invoke({"configmap_name": "cm", "namespace": "prod", "config": {}}))
         assert "查找失败" in out["error"]
 
 
@@ -218,20 +200,17 @@ class TestCleanupFailedPods:
 
     def test_namespace_scoped(self, core):
         core.list_namespaced_pod.return_value = _items([_pod(name="f", phase="Failed")])
-        out = json.loads(b.cleanup_failed_pods.invoke({
-            "namespace": "prod", "config": {}}))
+        out = json.loads(b.cleanup_failed_pods.invoke({"namespace": "prod", "config": {}}))
         core.list_namespaced_pod.assert_called_once_with("prod")
         assert out["namespace"] == "prod"
 
     def test_no_pods_to_clean(self, core):
-        core.list_pod_for_all_namespaces.return_value = _items(
-            [_pod(name="r", phase="Running")])
+        core.list_pod_for_all_namespaces.return_value = _items([_pod(name="r", phase="Running")])
         out = json.loads(b.cleanup_failed_pods.invoke({"config": {}}))
         assert out["message"] == "没有需要清理的Pod"
 
     def test_delete_failure_counted(self, core):
-        core.list_pod_for_all_namespaces.return_value = _items(
-            [_pod(name="f", phase="Failed")])
+        core.list_pod_for_all_namespaces.return_value = _items([_pod(name="f", phase="Failed")])
         core.delete_namespaced_pod.side_effect = ApiException(status=500)
         out = json.loads(b.cleanup_failed_pods.invoke({"config": {}}))
         assert out["total_failed"] == 1

--- a/server/apps/opspilot/tests/test_tools_k8s_diagnostics_advanced_service.py
+++ b/server/apps/opspilot/tests/test_tools_k8s_diagnostics_advanced_service.py
@@ -21,10 +21,9 @@ from apps.opspilot.metis.llm.tools.kubernetes import diagnostics_advanced as da
 @pytest.fixture
 def apis():
     core, net, storage = MagicMock(), MagicMock(), MagicMock()
-    with patch.object(da, "prepare_context", return_value=None), \
-         patch.object(da.client, "CoreV1Api", return_value=core), \
-         patch.object(da.client, "NetworkingV1Api", return_value=net), \
-         patch.object(da.client, "StorageV1Api", return_value=storage):
+    with patch.object(da, "prepare_context", return_value=None), patch.object(da.client, "CoreV1Api", return_value=core), patch.object(
+        da.client, "NetworkingV1Api", return_value=net
+    ), patch.object(da.client, "StorageV1Api", return_value=storage):
         yield core, net, storage
 
 
@@ -32,19 +31,15 @@ def _items(lst):
     return SimpleNamespace(items=lst)
 
 
-def _pod(phase="Pending", conditions=None, containers=None, node_selector=None,
-         tolerations=None, volumes=None, cstatuses=None, uid="self"):
+def _pod(phase="Pending", conditions=None, containers=None, node_selector=None, tolerations=None, volumes=None, cstatuses=None, uid="self"):
     return SimpleNamespace(
         metadata=SimpleNamespace(name="p", namespace="default", uid=uid),
-        status=SimpleNamespace(phase=phase, conditions=conditions,
-                               container_statuses=cstatuses),
-        spec=SimpleNamespace(containers=containers, node_selector=node_selector,
-                             tolerations=tolerations, volumes=volumes),
+        status=SimpleNamespace(phase=phase, conditions=conditions, container_statuses=cstatuses),
+        spec=SimpleNamespace(containers=containers, node_selector=node_selector, tolerations=tolerations, volumes=volumes),
     )
 
 
-def _node(name="n1", cpu="8", mem="16Gi", pods="110", unschedulable=False,
-          labels=None, taints=None):
+def _node(name="n1", cpu="8", mem="16Gi", pods="110", unschedulable=False, labels=None, taints=None):
     return SimpleNamespace(
         metadata=SimpleNamespace(name=name, labels=labels or {}),
         spec=SimpleNamespace(unschedulable=unschedulable, taints=taints),
@@ -56,29 +51,23 @@ class TestDiagnosePending:
     def test_not_pending_early_return(self, apis):
         core, _, _ = apis
         core.read_namespaced_pod.return_value = _pod(phase="Running")
-        out = json.loads(da.diagnose_pending_pod_issues.invoke({
-            "pod_name": "p", "namespace": "default", "config": {}}))
+        out = json.loads(da.diagnose_pending_pod_issues.invoke({"pod_name": "p", "namespace": "default", "config": {}}))
         assert "不是Pending" in out["diagnosis_summary"]
 
     def test_not_found_404(self, apis):
         core, _, _ = apis
         core.read_namespaced_pod.side_effect = ApiException(status=404)
-        out = json.loads(da.diagnose_pending_pod_issues.invoke({
-            "pod_name": "ghost", "namespace": "default", "config": {}}))
+        out = json.loads(da.diagnose_pending_pod_issues.invoke({"pod_name": "ghost", "namespace": "default", "config": {}}))
         assert "Pod不存在" in out["error"]
 
     def test_insufficient_resources(self, apis):
         core, _, _ = apis
-        cond = SimpleNamespace(type="PodScheduled", status="False",
-                               reason="Unschedulable", message="no fit")
-        container = SimpleNamespace(resources=SimpleNamespace(
-            requests={"cpu": "16", "memory": "32Gi"}))
-        core.read_namespaced_pod.return_value = _pod(
-            conditions=[cond], containers=[container])
+        cond = SimpleNamespace(type="PodScheduled", status="False", reason="Unschedulable", message="no fit")
+        container = SimpleNamespace(resources=SimpleNamespace(requests={"cpu": "16", "memory": "32Gi"}))
+        core.read_namespaced_pod.return_value = _pod(conditions=[cond], containers=[container])
         core.list_node.return_value = _items([_node(cpu="2", mem="4Gi")])
         core.list_pod_for_all_namespaces.return_value = _items([])
-        out = json.loads(da.diagnose_pending_pod_issues.invoke({
-            "pod_name": "p", "namespace": "default", "config": {}}))
+        out = json.loads(da.diagnose_pending_pod_issues.invoke({"pod_name": "p", "namespace": "default", "config": {}}))
         cats = [i["category"] for i in out["issues"]]
         assert "scheduling" in cats and "resource" in cats
         assert out["pending_reason"] == "Unschedulable"
@@ -86,12 +75,10 @@ class TestDiagnosePending:
     def test_node_selector_no_match(self, apis):
         core, _, _ = apis
         container = SimpleNamespace(resources=None)
-        core.read_namespaced_pod.return_value = _pod(
-            containers=[container], node_selector={"disktype": "ssd"})
+        core.read_namespaced_pod.return_value = _pod(containers=[container], node_selector={"disktype": "ssd"})
         core.list_node.return_value = _items([_node(labels={"disktype": "hdd"})])
         core.list_pod_for_all_namespaces.return_value = _items([])
-        out = json.loads(da.diagnose_pending_pod_issues.invoke({
-            "pod_name": "p", "namespace": "default", "config": {}}))
+        out = json.loads(da.diagnose_pending_pod_issues.invoke({"pod_name": "p", "namespace": "default", "config": {}}))
         assert any(i["category"] == "affinity" for i in out["issues"])
         assert any("NodeSelector过于严格" in r for r in out["recommendations"])
 
@@ -99,23 +86,18 @@ class TestDiagnosePending:
         core, _, _ = apis
         container = SimpleNamespace(resources=None)
         taint = SimpleNamespace(key="dedicated", value="gpu", effect="NoSchedule")
-        core.read_namespaced_pod.return_value = _pod(
-            containers=[container], tolerations=None)
+        core.read_namespaced_pod.return_value = _pod(containers=[container], tolerations=None)
         core.list_node.return_value = _items([_node(taints=[taint])])
         core.list_pod_for_all_namespaces.return_value = _items([])
-        out = json.loads(da.diagnose_pending_pod_issues.invoke({
-            "pod_name": "p", "namespace": "default", "config": {}}))
+        out = json.loads(da.diagnose_pending_pod_issues.invoke({"pod_name": "p", "namespace": "default", "config": {}}))
         assert any(i["category"] == "taint" for i in out["issues"])
 
     def test_pvc_not_bound_and_missing(self, apis):
         core, _, _ = apis
         container = SimpleNamespace(resources=None)
-        vol_unbound = SimpleNamespace(persistent_volume_claim=SimpleNamespace(
-            claim_name="data"))
-        vol_missing = SimpleNamespace(persistent_volume_claim=SimpleNamespace(
-            claim_name="gone"))
-        core.read_namespaced_pod.return_value = _pod(
-            containers=[container], volumes=[vol_unbound, vol_missing])
+        vol_unbound = SimpleNamespace(persistent_volume_claim=SimpleNamespace(claim_name="data"))
+        vol_missing = SimpleNamespace(persistent_volume_claim=SimpleNamespace(claim_name="gone"))
+        core.read_namespaced_pod.return_value = _pod(containers=[container], volumes=[vol_unbound, vol_missing])
         core.list_node.return_value = _items([_node()])
         core.list_pod_for_all_namespaces.return_value = _items([])
 
@@ -123,9 +105,9 @@ class TestDiagnosePending:
             if name == "data":
                 return SimpleNamespace(status=SimpleNamespace(phase="Pending"))
             raise ApiException(status=404)
+
         core.read_namespaced_persistent_volume_claim.side_effect = read_pvc
-        out = json.loads(da.diagnose_pending_pod_issues.invoke({
-            "pod_name": "p", "namespace": "default", "config": {}}))
+        out = json.loads(da.diagnose_pending_pod_issues.invoke({"pod_name": "p", "namespace": "default", "config": {}}))
         msgs = [i["message"] for i in out["issues"] if i["category"] == "pvc"]
         assert any("PVC未绑定" in m for m in msgs)
         assert any("PVC不存在" in m for m in msgs)
@@ -133,14 +115,11 @@ class TestDiagnosePending:
     def test_image_pull_failure(self, apis):
         core, _, _ = apis
         container = SimpleNamespace(resources=None)
-        cs = SimpleNamespace(name="c", state=SimpleNamespace(
-            waiting=SimpleNamespace(reason="ImagePullBackOff", message="not found")))
-        core.read_namespaced_pod.return_value = _pod(
-            containers=[container], cstatuses=[cs])
+        cs = SimpleNamespace(name="c", state=SimpleNamespace(waiting=SimpleNamespace(reason="ImagePullBackOff", message="not found")))
+        core.read_namespaced_pod.return_value = _pod(containers=[container], cstatuses=[cs])
         core.list_node.return_value = _items([_node()])
         core.list_pod_for_all_namespaces.return_value = _items([])
-        out = json.loads(da.diagnose_pending_pod_issues.invoke({
-            "pod_name": "p", "namespace": "default", "config": {}}))
+        out = json.loads(da.diagnose_pending_pod_issues.invoke({"pod_name": "p", "namespace": "default", "config": {}}))
         assert any(i["category"] == "image" for i in out["issues"])
 
     def test_no_issues_summary(self, apis):
@@ -149,8 +128,7 @@ class TestDiagnosePending:
         core.read_namespaced_pod.return_value = _pod(containers=[container])
         core.list_node.return_value = _items([_node()])
         core.list_pod_for_all_namespaces.return_value = _items([])
-        out = json.loads(da.diagnose_pending_pod_issues.invoke({
-            "pod_name": "p", "namespace": "default", "config": {}}))
+        out = json.loads(da.diagnose_pending_pod_issues.invoke({"pod_name": "p", "namespace": "default", "config": {}}))
         assert "未发现明显问题" in out["diagnosis_summary"]
 
 
@@ -158,8 +136,8 @@ def _np(name, policy_types, pod_selector=None, egress=None, ingress=None):
     return SimpleNamespace(
         metadata=SimpleNamespace(name=name),
         spec=SimpleNamespace(
-            pod_selector=SimpleNamespace(match_labels=pod_selector or {}),
-            policy_types=policy_types, egress=egress, ingress=ingress),
+            pod_selector=SimpleNamespace(match_labels=pod_selector or {}), policy_types=policy_types, egress=egress, ingress=ingress
+        ),
     )
 
 
@@ -167,28 +145,27 @@ class TestNetworkPolicies:
     def test_no_policies(self, apis):
         _, net, _ = apis
         net.list_namespaced_network_policy.return_value = _items([])
-        out = json.loads(da.check_network_policies_blocking.invoke({
-            "source_namespace": "src", "config": {}}))
+        out = json.loads(da.check_network_policies_blocking.invoke({"source_namespace": "src", "config": {}}))
         assert "未配置NetworkPolicy" in out["diagnosis_summary"]
 
     def test_default_deny_egress(self, apis):
         _, net, _ = apis
         np = _np("deny-egress", ["Egress"], egress=None)
         net.list_namespaced_network_policy.return_value = _items([np])
-        out = json.loads(da.check_network_policies_blocking.invoke({
-            "source_namespace": "src", "config": {}}))
+        out = json.loads(da.check_network_policies_blocking.invoke({"source_namespace": "src", "config": {}}))
         assert out["egress_blocked"] is True
         assert "出站Egress" in out["diagnosis_summary"]
 
     def test_default_deny_ingress_target(self, apis):
         _, net, _ = apis
+
         def list_np(ns):
             if ns == "src":
                 return _items([])
             return _items([_np("deny-ingress", ["Ingress"], ingress=None)])
+
         net.list_namespaced_network_policy.side_effect = list_np
-        out = json.loads(da.check_network_policies_blocking.invoke({
-            "source_namespace": "src", "target_namespace": "dst", "config": {}}))
+        out = json.loads(da.check_network_policies_blocking.invoke({"source_namespace": "src", "target_namespace": "dst", "config": {}}))
         assert out["ingress_blocked"] is True
         assert "入站Ingress" in out["diagnosis_summary"]
 
@@ -197,24 +174,21 @@ class TestNetworkPolicies:
         # egress defined -> not blocked
         np = _np("allow", ["Egress"], egress=[SimpleNamespace()])
         net.list_namespaced_network_policy.return_value = _items([np])
-        out = json.loads(da.check_network_policies_blocking.invoke({
-            "source_namespace": "src", "config": {}}))
+        out = json.loads(da.check_network_policies_blocking.invoke({"source_namespace": "src", "config": {}}))
         assert out["egress_blocked"] is False
         assert "未发现明显阻断" in out["diagnosis_summary"]
 
     def test_exception_wrapped(self, apis):
         _, net, _ = apis
         net.list_namespaced_network_policy.side_effect = RuntimeError("boom")
-        out = json.loads(da.check_network_policies_blocking.invoke({
-            "source_namespace": "src", "config": {}}))
+        out = json.loads(da.check_network_policies_blocking.invoke({"source_namespace": "src", "config": {}}))
         assert "检查失败" in out["error"]
 
 
 def _pvc(name="pvc", ns="default", phase="Bound", capacity="10Gi", sc="standard"):
     return SimpleNamespace(
         metadata=SimpleNamespace(name=name, namespace=ns),
-        status=SimpleNamespace(phase=phase,
-                               capacity={"storage": capacity} if capacity else None),
+        status=SimpleNamespace(phase=phase, capacity={"storage": capacity} if capacity else None),
         spec=SimpleNamespace(storage_class_name=sc, access_modes=["ReadWriteOnce"]),
     )
 
@@ -222,21 +196,25 @@ def _pvc(name="pvc", ns="default", phase="Bound", capacity="10Gi", sc="standard"
 class TestPvcCapacity:
     def test_bound_with_mount_mapping(self, apis):
         core, _, _ = apis
-        core.list_persistent_volume_claim_for_all_namespaces.return_value = _items([
-            _pvc(name="data")])
+        core.list_persistent_volume_claim_for_all_namespaces.return_value = _items([_pvc(name="data")])
         vol = SimpleNamespace(persistent_volume_claim=SimpleNamespace(claim_name="data"))
-        pod = SimpleNamespace(
-            metadata=SimpleNamespace(name="webpod", namespace="default"),
-            spec=SimpleNamespace(volumes=[vol]))
+        pod = SimpleNamespace(metadata=SimpleNamespace(name="webpod", namespace="default"), spec=SimpleNamespace(volumes=[vol]))
         core.list_pod_for_all_namespaces.return_value = _items([pod])
         out = json.loads(da.check_pvc_capacity.invoke({"config": {}}))
         assert out["total_pvcs"] == 1
         assert out["pvc_list"][0]["mounted_by"] == ["webpod"]
 
+    def test_string_threshold_is_coerced(self, apis):
+        core, _, _ = apis
+        core.list_persistent_volume_claim_for_all_namespaces.return_value = _items([_pvc(name="data")])
+        core.list_pod_for_all_namespaces.return_value = _items([])
+        out = json.loads(da.check_pvc_capacity.func(threshold_percent="80", config={}))
+        assert "error" not in out
+        assert out["threshold_percent"] == 80
+
     def test_pending_pvc(self, apis):
         core, _, _ = apis
-        core.list_persistent_volume_claim_for_all_namespaces.return_value = _items([
-            _pvc(name="data", phase="Pending")])
+        core.list_persistent_volume_claim_for_all_namespaces.return_value = _items([_pvc(name="data", phase="Pending")])
         core.list_pod_for_all_namespaces.return_value = _items([])
         out = json.loads(da.check_pvc_capacity.invoke({"config": {}}))
         assert len(out["pending_pvcs"]) == 1
@@ -246,8 +224,7 @@ class TestPvcCapacity:
         core, _, _ = apis
         core.list_namespaced_persistent_volume_claim.return_value = _items([_pvc()])
         core.list_namespaced_pod.return_value = _items([])
-        out = json.loads(da.check_pvc_capacity.invoke({
-            "namespace": "prod", "config": {}}))
+        out = json.loads(da.check_pvc_capacity.invoke({"namespace": "prod", "config": {}}))
         core.list_namespaced_persistent_volume_claim.assert_called_once_with("prod")
         assert out["total_pvcs"] == 1
 
@@ -261,7 +238,6 @@ class TestPvcCapacity:
 
     def test_exception_wrapped(self, apis):
         core, _, _ = apis
-        core.list_persistent_volume_claim_for_all_namespaces.side_effect = \
-            RuntimeError("boom")
+        core.list_persistent_volume_claim_for_all_namespaces.side_effect = RuntimeError("boom")
         out = json.loads(da.check_pvc_capacity.invoke({"config": {}}))
         assert "检查失败" in out["error"]

--- a/server/apps/opspilot/tests/test_tools_k8s_diagnostics_service.py
+++ b/server/apps/opspilot/tests/test_tools_k8s_diagnostics_service.py
@@ -204,7 +204,7 @@ class TestHighRestart:
     def test_string_threshold_is_coerced(self, core):
         cs = _cstatus(restart_count=3)
         core.list_pod_for_all_namespaces.return_value = _items([_pod(cstatuses=[cs])])
-        out = json.loads(d.get_high_restart_kubernetes_pods.invoke({"restart_threshold": "3", "config": {}}))
+        out = json.loads(d.get_high_restart_kubernetes_pods.func(restart_threshold="3", config={}))
         assert len(out) == 1
 
     def test_api_exception_wrapped(self, core):

--- a/server/apps/opspilot/tests/test_tools_k8s_exec_service.py
+++ b/server/apps/opspilot/tests/test_tools_k8s_exec_service.py
@@ -60,3 +60,17 @@ class TestExecInPod:
     def test_approval_metadata_required(self):
         meta = e.exec_in_pod.metadata or {}
         assert (meta.get("approval") or {}).get("required") is True
+
+    def test_string_timeout_is_coerced(self, exec_env):
+        _, stream_fn = exec_env
+        out = json.loads(
+            e.exec_in_pod.func(
+                namespace="nacos",
+                pod_name="nacos-0",
+                command=["curl", "-s", "http://127.0.0.1"],
+                timeout="10",
+                config={},
+            )
+        )
+        assert out["success"] is True
+        assert stream_fn.call_args.kwargs["_request_timeout"] == 10

--- a/server/apps/opspilot/tests/test_tools_k8s_optimization_service.py
+++ b/server/apps/opspilot/tests/test_tools_k8s_optimization_service.py
@@ -252,6 +252,24 @@ class TestValidateProbes:
         assert out["http_get"]["path"] is None
         assert out["type"] == "httpGet"
 
+    def test_nonstandard_port_is_json_safe_and_keeps_path(self):
+        probe = SimpleNamespace(
+            http_get=SimpleNamespace(path="/readyz", port=object(), scheme="HTTP", host=None),
+            tcp_socket=None,
+            _exec=SimpleNamespace(command=object()),
+            grpc=None,
+            initial_delay_seconds=5,
+            period_seconds=10,
+            timeout_seconds=1,
+            failure_threshold=3,
+        )
+        out = o._serialize_probe(probe)
+        dumped = json.dumps(out)
+        assert "/readyz" in dumped
+        assert out["http_get"]["path"] == "/readyz"
+        parsed = json.loads(dumped)
+        assert parsed["http_get"]["path"] == "/readyz"
+
     def test_missing_probes_and_bad_delay(self, apis):
         _, apps = apis
         container = _container(liveness=_probe(delay=0), readiness=None)

--- a/server/apps/opspilot/tests/test_tools_k8s_optimization_service.py
+++ b/server/apps/opspilot/tests/test_tools_k8s_optimization_service.py
@@ -3,7 +3,7 @@
 mock prepare_context 与 client.CoreV1Api/AppsV1Api,构造节点/Pod/Deployment/RS。覆盖
 check_scaling_capacity(Ready/unschedulable 过滤、CPU/内存/Pod 不足、仅 Pod 容量分支、
 紧张预警)、check_pod_distribution(单节点单点故障/不均匀/单可用区/StatefulSet 回退/
-都不存在)、validate_probe_configuration(探针缺失/initialDelay=0/评分/404)、
+都不存在)、validate_probe_configuration(探针缺失/initialDelay=0/评分/404、httpGet.path)、
 compare_deployment_revisions(镜像/env/副本差异、revision 缺失)。另测 _get_probe_type。
 不连真实集群。
 """
@@ -98,6 +98,15 @@ class TestScalingCapacity:
         assert out["can_scale"] is False
         assert any("Pod容量不足" in r for r in out["recommendations"])
 
+    def test_string_replicas_are_coerced(self, apis):
+        core, _ = apis
+        core.list_node.return_value = _items([_node("n1", pods="5")])
+        existing = [_pod(name=f"e{i}") for i in range(4)]
+        core.list_pod_for_all_namespaces.return_value = _items(existing)
+        out = json.loads(o.check_scaling_capacity.func(namespace="p", replicas="3", config={}))
+        assert out["can_scale"] is False
+        assert out["requested_replicas"] == 3
+
     def test_exception_wrapped(self, apis):
         core, _ = apis
         core.list_node.side_effect = RuntimeError("boom")
@@ -165,12 +174,18 @@ class TestPodDistribution:
         assert "未找到Deployment或StatefulSet" in out["error"]
 
 
-def _probe(http=True, tcp=False, exec_=False, grpc=False, delay=10, timeout=1):
+def _probe(http=True, tcp=False, exec_=False, grpc=False, delay=10, timeout=1, path="/healthz", port=8080):
+    http_get = None
+    if http:
+        http_get = SimpleNamespace(path=path, port=port, scheme="HTTP", host=None)
+    tcp_socket = SimpleNamespace(port=port, host=None) if tcp else None
+    exec_action = SimpleNamespace(command=["cat", "/tmp/healthy"]) if exec_ else None
+    grpc_action = SimpleNamespace(port=port, service="health") if grpc else None
     return SimpleNamespace(
-        http_get=object() if http else None,
-        tcp_socket=object() if tcp else None,
-        _exec=object() if exec_ else None,
-        grpc=object() if grpc else None,
+        http_get=http_get,
+        tcp_socket=tcp_socket,
+        _exec=exec_action,
+        grpc=grpc_action,
         initial_delay_seconds=delay,
         period_seconds=10,
         timeout_seconds=timeout,
@@ -201,6 +216,41 @@ class TestValidateProbes:
         out = json.loads(o.validate_probe_configuration.invoke({"deployment_name": "d", "namespace": "p", "config": {}}))
         assert out["probe_score"] == "2/2"
         assert out["overall_status"] == "good"
+        liveness = out["containers_analysis"][0]["liveness_probe"]
+        assert liveness["type"] == "httpGet"
+        assert liveness["http_get"]["path"] == "/healthz"
+        assert liveness["http_get"]["port"] == 8080
+        assert liveness["http_get"]["scheme"] == "HTTP"
+
+    def test_tcp_and_exec_endpoints_are_serialized(self, apis):
+        _, apps = apis
+        container = _container(liveness=_probe(http=False, tcp=True, port=9090), readiness=_probe(http=False, exec_=True))
+        apps.read_namespaced_deployment.return_value = SimpleNamespace(
+            spec=SimpleNamespace(template=SimpleNamespace(spec=SimpleNamespace(containers=[container])))
+        )
+        out = json.loads(o.validate_probe_configuration.invoke({"deployment_name": "d", "namespace": "p", "config": {}}))
+        liveness = out["containers_analysis"][0]["liveness_probe"]
+        readiness = out["containers_analysis"][0]["readiness_probe"]
+        assert liveness["type"] == "tcpSocket"
+        assert liveness["tcp_socket"]["port"] == 9090
+        assert liveness["http_get"] is None
+        assert readiness["type"] == "exec"
+        assert readiness["exec_command"] == ["cat", "/tmp/healthy"]
+
+    def test_incomplete_http_get_mock_does_not_raise(self):
+        probe = SimpleNamespace(
+            http_get=object(),
+            tcp_socket=None,
+            _exec=None,
+            grpc=None,
+            initial_delay_seconds=5,
+            period_seconds=10,
+            timeout_seconds=1,
+            failure_threshold=3,
+        )
+        out = o._serialize_probe(probe)
+        assert out["http_get"]["path"] is None
+        assert out["type"] == "httpGet"
 
     def test_missing_probes_and_bad_delay(self, apis):
         _, apps = apis
@@ -274,6 +324,16 @@ class TestCompareRevisions:
         env_diff = next(d for d in out["differences"] if d["field"].endswith("].env"))
         assert "B" in env_diff["added_vars"]
         assert "A" in env_diff["modified_vars"]
+
+    def test_string_revisions_are_coerced(self, apis):
+        _, apps = apis
+        apps.read_namespaced_deployment.return_value = _deploy()
+        rs1 = _rs("rs1", 1, image="img:1", env=None, replicas=2)
+        rs2 = _rs("rs2", 2, image="img:2", env=None, replicas=2)
+        apps.list_namespaced_replica_set.return_value = _items([rs1, rs2])
+        out = json.loads(o.compare_deployment_revisions.func(deployment_name="d", namespace="p", revision1="1", revision2="2", config={}))
+        assert "error" not in out
+        assert out["has_changes"] is True
 
     def test_revision1_missing(self, apis):
         _, apps = apis

--- a/server/apps/opspilot/tests/test_tools_k8s_remediation_service.py
+++ b/server/apps/opspilot/tests/test_tools_k8s_remediation_service.py
@@ -22,9 +22,9 @@ from apps.opspilot.metis.llm.tools.kubernetes import remediation as r
 @pytest.fixture
 def apis():
     core, apps = MagicMock(), MagicMock()
-    with patch.object(r, "prepare_context", return_value=None), \
-         patch.object(r.client, "CoreV1Api", return_value=core), \
-         patch.object(r.client, "AppsV1Api", return_value=apps):
+    with patch.object(r, "prepare_context", return_value=None), patch.object(r.client, "CoreV1Api", return_value=core), patch.object(
+        r.client, "AppsV1Api", return_value=apps
+    ):
         yield core, apps
 
 
@@ -34,8 +34,7 @@ def _pod(uid="u1", phase="Running", ready=None, owner=True, ip="1.2.3.4", node="
     if ready is not None:
         cstatuses = [SimpleNamespace(ready=ready)]
     return SimpleNamespace(
-        metadata=SimpleNamespace(name="p", namespace="default", uid=uid,
-                                 owner_references=owner_refs),
+        metadata=SimpleNamespace(name="p", namespace="default", uid=uid, owner_references=owner_refs),
         status=SimpleNamespace(phase=phase, container_statuses=cstatuses, pod_ip=ip),
         spec=SimpleNamespace(node_name=node),
     )
@@ -45,26 +44,20 @@ class TestRestartPod:
     def test_not_found(self, apis):
         core, _ = apis
         core.read_namespaced_pod.side_effect = ApiException(status=404)
-        out = json.loads(r.restart_pod.invoke({
-            "pod_name": "p", "namespace": "default", "wait_for_ready": False,
-            "config": {}}))
+        out = json.loads(r.restart_pod.invoke({"pod_name": "p", "namespace": "default", "wait_for_ready": False, "config": {}}))
         assert out["success"] is False and "Pod不存在" in out["error"]
 
     def test_delete_failure(self, apis):
         core, _ = apis
         core.read_namespaced_pod.return_value = _pod()
         core.delete_namespaced_pod.side_effect = ApiException(status=500)
-        out = json.loads(r.restart_pod.invoke({
-            "pod_name": "p", "namespace": "default", "wait_for_ready": False,
-            "config": {}}))
+        out = json.loads(r.restart_pod.invoke({"pod_name": "p", "namespace": "default", "wait_for_ready": False, "config": {}}))
         assert "删除Pod失败" in out["error"]
 
     def test_no_wait_success(self, apis):
         core, _ = apis
         core.read_namespaced_pod.return_value = _pod(uid="old")
-        out = json.loads(r.restart_pod.invoke({
-            "pod_name": "p", "namespace": "default", "wait_for_ready": False,
-            "config": {}}))
+        out = json.loads(r.restart_pod.invoke({"pod_name": "p", "namespace": "default", "wait_for_ready": False, "config": {}}))
         assert out["success"] is True
         assert out["old_pod_uid"] == "old"
         assert out["owner_controller"]["kind"] == "ReplicaSet"
@@ -75,23 +68,16 @@ class TestRestartPod:
             _pod(uid="old"),  # initial read
             _pod(uid="new", ready=True),  # poll read
         ]
-        with patch.object(r.time, "sleep", return_value=None), \
-             patch.object(r.time, "time", side_effect=[0, 0, 1]):
-            out = json.loads(r.restart_pod.invoke({
-                "pod_name": "p", "namespace": "default", "wait_for_ready": True,
-                "config": {}}))
+        with patch.object(r.time, "sleep", return_value=None), patch.object(r.time, "time", side_effect=[0, 0, 1]):
+            out = json.loads(r.restart_pod.invoke({"pod_name": "p", "namespace": "default", "wait_for_ready": True, "config": {}}))
         assert out["new_pod_status"] == "ready"
         assert out["new_pod_uid"] == "new"
 
     def test_wait_timeout(self, apis):
         core, _ = apis
-        core.read_namespaced_pod.side_effect = [_pod(uid="old"),
-                                                _pod(uid="old")]  # never replaced
-        with patch.object(r.time, "sleep", return_value=None), \
-             patch.object(r.time, "time", side_effect=[0, 0, 5, 100]):
-            out = json.loads(r.restart_pod.invoke({
-                "pod_name": "p", "namespace": "default", "wait_for_ready": True,
-                "timeout": 3, "config": {}}))
+        core.read_namespaced_pod.side_effect = [_pod(uid="old"), _pod(uid="old")]  # never replaced
+        with patch.object(r.time, "sleep", return_value=None), patch.object(r.time, "time", side_effect=[0, 0, 5, 100]):
+            out = json.loads(r.restart_pod.invoke({"pod_name": "p", "namespace": "default", "wait_for_ready": True, "timeout": 3, "config": {}}))
         assert out["new_pod_status"] == "not_ready"
 
 
@@ -100,23 +86,27 @@ class TestScaleDeployment:
         _, apps = apis
         dep = SimpleNamespace(spec=SimpleNamespace(replicas=1))
         apps.read_namespaced_deployment.return_value = dep
-        out = json.loads(r.scale_deployment.invoke({
-            "deployment_name": "d", "namespace": "default", "replicas": 3,
-            "config": {}}))
+        out = json.loads(r.scale_deployment.invoke({"deployment_name": "d", "namespace": "default", "replicas": 3, "config": {}}))
         assert out["resource_type"] == "Deployment"
         assert out["operation"] == "scale_up"
         assert out["previous_replicas"] == 1
         assert dep.spec.replicas == 3
         apps.patch_namespaced_deployment.assert_called_once()
 
+    def test_string_replicas_are_coerced(self, apis):
+        _, apps = apis
+        dep = SimpleNamespace(spec=SimpleNamespace(replicas=1))
+        apps.read_namespaced_deployment.return_value = dep
+        out = json.loads(r.scale_deployment.func(deployment_name="d", namespace="default", replicas="3", config={}))
+        assert out["operation"] == "scale_up"
+        assert dep.spec.replicas == 3
+
     def test_fallback_to_statefulset(self, apis):
         _, apps = apis
         apps.read_namespaced_deployment.side_effect = ApiException(status=404)
         ss = SimpleNamespace(spec=SimpleNamespace(replicas=5))
         apps.read_namespaced_stateful_set.return_value = ss
-        out = json.loads(r.scale_deployment.invoke({
-            "deployment_name": "d", "namespace": "default", "replicas": 2,
-            "config": {}}))
+        out = json.loads(r.scale_deployment.invoke({"deployment_name": "d", "namespace": "default", "replicas": 2, "config": {}}))
         assert out["resource_type"] == "StatefulSet"
         assert out["operation"] == "scale_down"
         apps.patch_namespaced_stateful_set.assert_called_once()
@@ -125,9 +115,7 @@ class TestScaleDeployment:
         _, apps = apis
         apps.read_namespaced_deployment.side_effect = ApiException(status=404)
         apps.read_namespaced_stateful_set.side_effect = ApiException(status=404)
-        out = json.loads(r.scale_deployment.invoke({
-            "deployment_name": "d", "namespace": "default", "replicas": 2,
-            "config": {}}))
+        out = json.loads(r.scale_deployment.invoke({"deployment_name": "d", "namespace": "default", "replicas": 2, "config": {}}))
         assert "未找到Deployment或StatefulSet" in out["error"]
 
 
@@ -147,11 +135,9 @@ def _rs(name, revision, image="img:1"):
     container = SimpleNamespace(image=image)
     return SimpleNamespace(
         metadata=SimpleNamespace(
-            name=name, annotations={"deployment.kubernetes.io/revision": str(revision)},
-            creation_timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc)),
-        spec=SimpleNamespace(replicas=2,
-                             template=SimpleNamespace(spec=SimpleNamespace(
-                                 containers=[container]))),
+            name=name, annotations={"deployment.kubernetes.io/revision": str(revision)}, creation_timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc)
+        ),
+        spec=SimpleNamespace(replicas=2, template=SimpleNamespace(spec=SimpleNamespace(containers=[container]))),
         status=SimpleNamespace(ready_replicas=2),
     )
 
@@ -160,10 +146,8 @@ class TestRevisionHistory:
     def test_history_sorted(self, apis):
         _, apps = apis
         apps.read_namespaced_deployment.return_value = _deployment("3")
-        apps.list_namespaced_replica_set.return_value = SimpleNamespace(
-            items=[_rs("rs1", 1), _rs("rs3", 3), _rs("rs2", 2)])
-        out = json.loads(r.get_deployment_revision_history.invoke({
-            "deployment_name": "d", "namespace": "default", "config": {}}))
+        apps.list_namespaced_replica_set.return_value = SimpleNamespace(items=[_rs("rs1", 1), _rs("rs3", 3), _rs("rs2", 2)])
+        out = json.loads(r.get_deployment_revision_history.invoke({"deployment_name": "d", "namespace": "default", "config": {}}))
         assert out["total_revisions"] == 3
         assert [rv["revision"] for rv in out["revisions"]] == [3, 2, 1]
         assert out["current_revision"] == 3
@@ -171,8 +155,7 @@ class TestRevisionHistory:
     def test_not_found(self, apis):
         _, apps = apis
         apps.read_namespaced_deployment.side_effect = ApiException(status=404)
-        out = json.loads(r.get_deployment_revision_history.invoke({
-            "deployment_name": "d", "namespace": "default", "config": {}}))
+        out = json.loads(r.get_deployment_revision_history.invoke({"deployment_name": "d", "namespace": "default", "config": {}}))
         assert "Deployment不存在" in out["error"]
 
 
@@ -181,10 +164,8 @@ class TestRollback:
         _, apps = apis
         dep = _deployment("3")
         apps.read_namespaced_deployment.return_value = dep
-        apps.list_namespaced_replica_set.return_value = SimpleNamespace(
-            items=[_rs("rs3", 3, "img:3"), _rs("rs2", 2, "img:2")])
-        out = json.loads(r.rollback_deployment.invoke({
-            "deployment_name": "d", "namespace": "default", "config": {}}))
+        apps.list_namespaced_replica_set.return_value = SimpleNamespace(items=[_rs("rs3", 3, "img:3"), _rs("rs2", 2, "img:2")])
+        out = json.loads(r.rollback_deployment.invoke({"deployment_name": "d", "namespace": "default", "config": {}}))
         assert out["success"] is True
         assert out["target_revision"] == 2  # previous = second highest
         assert out["target_image"] == "img:2"
@@ -196,80 +177,68 @@ class TestRollback:
         # 触发 UnboundLocalError,被外层捕获包装为 "回滚失败"。即指定版本回滚永远失败。
         _, apps = apis
         apps.read_namespaced_deployment.return_value = _deployment("3")
-        apps.list_namespaced_replica_set.return_value = SimpleNamespace(
-            items=[_rs("rs1", 1, "img:1"), _rs("rs3", 3, "img:3")])
-        out = json.loads(r.rollback_deployment.invoke({
-            "deployment_name": "d", "namespace": "default", "revision": 1,
-            "config": {}}))
+        apps.list_namespaced_replica_set.return_value = SimpleNamespace(items=[_rs("rs1", 1, "img:1"), _rs("rs3", 3, "img:3")])
+        out = json.loads(r.rollback_deployment.invoke({"deployment_name": "d", "namespace": "default", "revision": 1, "config": {}}))
         assert out["success"] is False
         assert "replica_sets" in out["error"]
 
     def test_no_history_to_rollback(self, apis):
         _, apps = apis
         apps.read_namespaced_deployment.return_value = _deployment("1")
-        apps.list_namespaced_replica_set.return_value = SimpleNamespace(
-            items=[_rs("rs1", 1)])
-        out = json.loads(r.rollback_deployment.invoke({
-            "deployment_name": "d", "namespace": "default", "config": {}}))
+        apps.list_namespaced_replica_set.return_value = SimpleNamespace(items=[_rs("rs1", 1)])
+        out = json.loads(r.rollback_deployment.invoke({"deployment_name": "d", "namespace": "default", "config": {}}))
         assert "没有可回滚的历史版本" in out["error"]
 
     def test_target_revision_missing_also_hits_unbound_bug(self, apis):
         # 同上:显式 revision 路径在到达 "未找到revision" 校验前即因 replica_sets 未绑定失败。
         _, apps = apis
         apps.read_namespaced_deployment.return_value = _deployment("3")
-        apps.list_namespaced_replica_set.return_value = SimpleNamespace(
-            items=[_rs("rs3", 3)])
-        out = json.loads(r.rollback_deployment.invoke({
-            "deployment_name": "d", "namespace": "default", "revision": 99,
-            "config": {}}))
+        apps.list_namespaced_replica_set.return_value = SimpleNamespace(items=[_rs("rs3", 3)])
+        out = json.loads(r.rollback_deployment.invoke({"deployment_name": "d", "namespace": "default", "revision": 99, "config": {}}))
         assert out["success"] is False
         assert "replica_sets" in out["error"]
 
     def test_deployment_not_found(self, apis):
         _, apps = apis
         apps.read_namespaced_deployment.side_effect = ApiException(status=404)
-        out = json.loads(r.rollback_deployment.invoke({
-            "deployment_name": "d", "namespace": "default", "config": {}}))
+        out = json.loads(r.rollback_deployment.invoke({"deployment_name": "d", "namespace": "default", "config": {}}))
         assert "Deployment不存在" in out["error"]
 
 
 class TestDeleteResource:
-    @pytest.mark.parametrize("rtype,api_attr", [
-        ("pod", "delete_namespaced_pod"),
-        ("service", "delete_namespaced_service"),
-        ("configmap", "delete_namespaced_config_map"),
-        ("secret", "delete_namespaced_secret"),
-    ])
+    @pytest.mark.parametrize(
+        "rtype,api_attr",
+        [
+            ("pod", "delete_namespaced_pod"),
+            ("service", "delete_namespaced_service"),
+            ("configmap", "delete_namespaced_config_map"),
+            ("secret", "delete_namespaced_secret"),
+        ],
+    )
     def test_delete_core_types(self, apis, rtype, api_attr):
         core, _ = apis
-        out = json.loads(r.delete_kubernetes_resource.invoke({
-            "resource_type": rtype, "resource_name": "x", "namespace": "default",
-            "config": {}}))
+        out = json.loads(r.delete_kubernetes_resource.invoke({"resource_type": rtype, "resource_name": "x", "namespace": "default", "config": {}}))
         assert out["success"] is True
         assert out["resource_type"] == rtype
         getattr(core, api_attr).assert_called_once()
 
     def test_delete_deployment(self, apis):
         _, apps = apis
-        out = json.loads(r.delete_kubernetes_resource.invoke({
-            "resource_type": "deployment", "resource_name": "d",
-            "namespace": "default", "config": {}}))
+        out = json.loads(
+            r.delete_kubernetes_resource.invoke({"resource_type": "deployment", "resource_name": "d", "namespace": "default", "config": {}})
+        )
         assert out["success"] is True
         apps.delete_namespaced_deployment.assert_called_once()
 
     def test_unsupported_type(self, apis):
-        out = json.loads(r.delete_kubernetes_resource.invoke({
-            "resource_type": "widget", "resource_name": "x", "namespace": "default",
-            "config": {}}))
+        out = json.loads(r.delete_kubernetes_resource.invoke({"resource_type": "widget", "resource_name": "x", "namespace": "default", "config": {}}))
         assert out["success"] is False
         assert "不支持的资源类型" in out["error"]
 
     def test_delete_404(self, apis):
         core, _ = apis
         core.delete_namespaced_pod.side_effect = ApiException(status=404)
-        out = json.loads(r.delete_kubernetes_resource.invoke({
-            "resource_type": "pod", "resource_name": "x", "namespace": "default",
-            "config": {}}))
+        out = json.loads(r.delete_kubernetes_resource.invoke({"resource_type": "pod", "resource_name": "x", "namespace": "default", "config": {}}))
         assert "资源不存在" in out["error"]
 
 
@@ -277,10 +246,8 @@ class TestWaitForPodReady:
     def test_ready(self, apis):
         core, _ = apis
         core.read_namespaced_pod.return_value = _pod(phase="Running", ready=True)
-        with patch.object(r.time, "sleep", return_value=None), \
-             patch.object(r.time, "time", side_effect=[0, 0, 1]):
-            out = json.loads(r.wait_for_pod_ready.invoke({
-                "pod_name": "p", "namespace": "default", "config": {}}))
+        with patch.object(r.time, "sleep", return_value=None), patch.object(r.time, "time", side_effect=[0, 0, 1]):
+            out = json.loads(r.wait_for_pod_ready.invoke({"pod_name": "p", "namespace": "default", "config": {}}))
         assert out["status"] == "ready"
         assert out["pod_ip"] == "1.2.3.4"
 
@@ -288,23 +255,26 @@ class TestWaitForPodReady:
         core, _ = apis
         core.read_namespaced_pod.return_value = _pod(phase="Failed")
         with patch.object(r.time, "time", side_effect=[0, 0, 1]):
-            out = json.loads(r.wait_for_pod_ready.invoke({
-                "pod_name": "p", "namespace": "default", "config": {}}))
+            out = json.loads(r.wait_for_pod_ready.invoke({"pod_name": "p", "namespace": "default", "config": {}}))
         assert out["status"] == "Failed"
 
     def test_not_found(self, apis):
         core, _ = apis
         core.read_namespaced_pod.side_effect = ApiException(status=404)
         with patch.object(r.time, "time", side_effect=[0, 0, 1]):
-            out = json.loads(r.wait_for_pod_ready.invoke({
-                "pod_name": "p", "namespace": "default", "config": {}}))
+            out = json.loads(r.wait_for_pod_ready.invoke({"pod_name": "p", "namespace": "default", "config": {}}))
         assert "Pod不存在" in out["error"]
 
     def test_timeout(self, apis):
         core, _ = apis
         core.read_namespaced_pod.return_value = _pod(phase="Pending")
-        with patch.object(r.time, "sleep", return_value=None), \
-             patch.object(r.time, "time", side_effect=[0, 0, 5, 100]):
-            out = json.loads(r.wait_for_pod_ready.invoke({
-                "pod_name": "p", "namespace": "default", "timeout": 3, "config": {}}))
+        with patch.object(r.time, "sleep", return_value=None), patch.object(r.time, "time", side_effect=[0, 0, 5, 100]):
+            out = json.loads(r.wait_for_pod_ready.invoke({"pod_name": "p", "namespace": "default", "timeout": 3, "config": {}}))
+        assert out["status"] == "timeout"
+
+    def test_string_timeout_is_coerced(self, apis):
+        core, _ = apis
+        core.read_namespaced_pod.return_value = _pod(phase="Pending")
+        with patch.object(r.time, "sleep", return_value=None), patch.object(r.time, "time", side_effect=[0, 0, 5, 100]):
+            out = json.loads(r.wait_for_pod_ready.func(pod_name="p", namespace="default", timeout="3", config={}))
         assert out["status"] == "timeout"

--- a/server/apps/opspilot/tests/test_tools_k8s_resources_ext_service.py
+++ b/server/apps/opspilot/tests/test_tools_k8s_resources_ext_service.py
@@ -97,6 +97,15 @@ class TestListDeployments:
         assert "禁止" in out.get("_next_step_hint", "")
         assert "analyze_deployment_configurations" in out["_next_step_hint"]
 
+    def test_string_limit_and_offset_are_coerced(self, apis):
+        _, apps, _ = apis
+        deps = [self._dep(f"d{i}") for i in range(5)]
+        apps.list_deployment_for_all_namespaces.return_value = SimpleNamespace(items=deps)
+        out = json.loads(res.list_kubernetes_deployments.func(limit="2", offset="1", config={}))
+        assert out["returned"] == 2
+        assert out["offset"] == 1
+        assert out["items"][0]["name"] == "d1"
+
     def test_namespaced_and_limit_clamped(self, apis):
         _, apps, _ = apis
         apps.list_namespaced_deployment.return_value = SimpleNamespace(items=[self._dep("d", ready=None)])
@@ -235,6 +244,13 @@ class TestPreviousPodLogs:
         _, kwargs = core.read_namespaced_pod_log.call_args
         assert kwargs["previous"] is True
         assert kwargs["container"] == "app"
+
+    def test_string_lines_and_tail_are_coerced(self, apis):
+        core, _, _ = apis
+        core.read_namespaced_pod.return_value = self._pod([SimpleNamespace(name="app")])
+        core.read_namespaced_pod_log.return_value = "l1\nl2\nl3"
+        out = res.get_kubernetes_previous_pod_logs.func(namespace="ns", pod_name="p1", lines="2", tail="false", config={})
+        assert out == "l1\nl2"
 
     def test_empty_previous_logs(self, apis):
         core, _, _ = apis

--- a/server/apps/opspilot/tests/test_tools_k8s_resources_service.py
+++ b/server/apps/opspilot/tests/test_tools_k8s_resources_service.py
@@ -41,9 +41,7 @@ class TestGetKubernetesNamespaces:
         fake_core.list_namespace.return_value = SimpleNamespace(items=[ns])
 
         out = json.loads(res.get_kubernetes_namespaces.invoke({"config": {}}))
-        assert out == [
-            {"name": "default", "status": "Active", "creation_time": None, "labels": {"k": "v"}, "annotations": {}}
-        ]
+        assert out == [{"name": "default", "status": "Active", "creation_time": None, "labels": {"k": "v"}, "annotations": {}}]
 
     def test_exception_returns_error_json(self, fake_core):
         fake_core.list_namespace.side_effect = RuntimeError("boom")
@@ -69,9 +67,7 @@ class TestListKubernetesPods:
         assert out[0]["phase"] == "Running"
         assert out[0]["ip"] == "1.2.3.4"
         assert out[0]["node"] == "node-1"
-        assert out[0]["containers"][0] == {
-            "name": "app", "ready": True, "restart_count": 2, "image": "img:1", "state": "running"
-        }
+        assert out[0]["containers"][0] == {"name": "app", "ready": True, "restart_count": 2, "image": "img:1", "state": "running"}
         fake_core.list_namespaced_pod.assert_called_once_with("default")
 
     def test_all_namespaces_when_none(self, fake_core):
@@ -120,15 +116,19 @@ class TestGetKubernetesPodLogs:
     def test_head_mode_truncates(self, fake_core):
         fake_core.read_namespaced_pod.return_value = self._pod_with_containers(["only"])
         fake_core.read_namespaced_pod_log.return_value = "l1\nl2\nl3\nl4"
-        out = res.get_kubernetes_pod_logs.invoke(
-            {"namespace": "ns", "pod_name": "p", "lines": 2, "tail": False, "config": {}}
-        )
+        out = res.get_kubernetes_pod_logs.invoke({"namespace": "ns", "pod_name": "p", "lines": 2, "tail": False, "config": {}})
         assert out == "l1\nl2"
+
+    def test_string_lines_and_tail_are_coerced(self, fake_core):
+        fake_core.read_namespaced_pod.return_value = self._pod_with_containers(["only"])
+        fake_core.read_namespaced_pod_log.return_value = "l1\nl2\nl3\nl4"
+        out = res.get_kubernetes_pod_logs.func(namespace="ns", pod_name="p", lines="2", tail="false", config={})
+        assert out == "l1\nl2"
+        _, kwargs = fake_core.read_namespaced_pod_log.call_args
+        assert kwargs["tail_lines"] is None
 
     def test_container_creating_message(self, fake_core):
         fake_core.read_namespaced_pod.return_value = self._pod_with_containers(["only"])
         fake_core.read_namespaced_pod_log.side_effect = ApiException(status=400, reason="ContainerCreating")
-        out = res.get_kubernetes_pod_logs.invoke(
-            {"namespace": "ns", "pod_name": "p", "container": "only", "config": {}}
-        )
+        out = res.get_kubernetes_pod_logs.invoke({"namespace": "ns", "pod_name": "p", "container": "only", "config": {}})
         assert "正在创建中" in out

--- a/server/apps/opspilot/tests/test_tools_k8s_tracing_service.py
+++ b/server/apps/opspilot/tests/test_tools_k8s_tracing_service.py
@@ -27,9 +27,9 @@ OLD = NOW - timedelta(hours=48)
 @pytest.fixture
 def apis():
     core, net = MagicMock(), MagicMock()
-    with patch.object(t, "prepare_context", return_value=None), \
-         patch.object(t.client, "CoreV1Api", return_value=core), \
-         patch.object(t.client, "NetworkingV1Api", return_value=net):
+    with patch.object(t, "prepare_context", return_value=None), patch.object(t.client, "CoreV1Api", return_value=core), patch.object(
+        t.client, "NetworkingV1Api", return_value=net
+    ):
         yield core, net
 
 
@@ -39,8 +39,7 @@ def _items(lst):
 
 def _svc(selector=None, type_="ClusterIP"):
     port = SimpleNamespace(name="http", port=80, target_port=8080, protocol="TCP")
-    return SimpleNamespace(spec=SimpleNamespace(
-        type=type_, cluster_ip="10.0.0.1", ports=[port], selector=selector))
+    return SimpleNamespace(spec=SimpleNamespace(type=type_, cluster_ip="10.0.0.1", ports=[port], selector=selector))
 
 
 def _addr(ip, kind="Pod", name="p"):
@@ -63,8 +62,7 @@ class TestTraceServiceChain:
     def test_service_not_found(self, apis):
         core, _ = apis
         core.read_namespaced_service.side_effect = ApiException(status=404)
-        out = json.loads(t.trace_service_chain.invoke({
-            "service_name": "svc", "namespace": "default", "config": {}}))
+        out = json.loads(t.trace_service_chain.invoke({"service_name": "svc", "namespace": "default", "config": {}}))
         assert out["chain"]["service"]["exists"] is False
         assert any(i["severity"] == "critical" for i in out["issues"])
 
@@ -73,8 +71,7 @@ class TestTraceServiceChain:
         core.read_namespaced_service.return_value = _svc(selector=None)
         core.read_namespaced_endpoints.return_value = SimpleNamespace(subsets=None)
         net.list_namespaced_ingress.return_value = _items([])
-        out = json.loads(t.trace_service_chain.invoke({
-            "service_name": "svc", "namespace": "default", "config": {}}))
+        out = json.loads(t.trace_service_chain.invoke({"service_name": "svc", "namespace": "default", "config": {}}))
         assert any("没有配置selector" in i["message"] for i in out["issues"])
 
     def test_healthy_full_chain(self, apis):
@@ -82,25 +79,20 @@ class TestTraceServiceChain:
         core.read_namespaced_service.return_value = _svc(selector={"app": "x"})
         subset = SimpleNamespace(addresses=[_addr("1.1.1.1")], not_ready_addresses=None)
         core.read_namespaced_endpoints.return_value = SimpleNamespace(subsets=[subset])
-        core.list_namespaced_pod.return_value = _items([
-            _pod(cstatuses=[_cstatus(ready=True)])])
+        core.list_namespaced_pod.return_value = _items([_pod(cstatuses=[_cstatus(ready=True)])])
         net.list_namespaced_ingress.return_value = _items([])
-        out = json.loads(t.trace_service_chain.invoke({
-            "service_name": "svc", "namespace": "default", "config": {}}))
+        out = json.loads(t.trace_service_chain.invoke({"service_name": "svc", "namespace": "default", "config": {}}))
         assert out["health_status"] == "healthy"
         assert out["chain"]["endpoints"]["ready_count"] == 1
 
     def test_no_ready_endpoints_and_unready_pod(self, apis):
         core, net = apis
         core.read_namespaced_service.return_value = _svc(selector={"app": "x"})
-        subset = SimpleNamespace(addresses=None,
-                                 not_ready_addresses=[_addr("2.2.2.2")])
+        subset = SimpleNamespace(addresses=None, not_ready_addresses=[_addr("2.2.2.2")])
         core.read_namespaced_endpoints.return_value = SimpleNamespace(subsets=[subset])
-        core.list_namespaced_pod.return_value = _items([
-            _pod(phase="Pending", cstatuses=[_cstatus(ready=False)])])
+        core.list_namespaced_pod.return_value = _items([_pod(phase="Pending", cstatuses=[_cstatus(ready=False)])])
         net.list_namespaced_ingress.return_value = _items([])
-        out = json.loads(t.trace_service_chain.invoke({
-            "service_name": "svc", "namespace": "default", "config": {}}))
+        out = json.loads(t.trace_service_chain.invoke({"service_name": "svc", "namespace": "default", "config": {}}))
         assert out["health_status"] == "critical"
         msgs = [i["message"] for i in out["issues"]]
         assert any("没有就绪的Endpoint" in m for m in msgs)
@@ -111,17 +103,12 @@ class TestTraceServiceChain:
         core.read_namespaced_service.return_value = _svc(selector={"app": "x"})
         subset = SimpleNamespace(addresses=[_addr("1.1.1.1")], not_ready_addresses=None)
         core.read_namespaced_endpoints.return_value = SimpleNamespace(subsets=[subset])
-        core.list_namespaced_pod.return_value = _items([
-            _pod(cstatuses=[_cstatus(ready=True)])])
-        path = SimpleNamespace(path="/", path_type="Prefix", backend=SimpleNamespace(
-            service=SimpleNamespace(name="svc")))
-        rule = SimpleNamespace(host="example.com",
-                               http=SimpleNamespace(paths=[path]))
-        ingress = SimpleNamespace(metadata=SimpleNamespace(name="ing"),
-                                  spec=SimpleNamespace(rules=[rule]))
+        core.list_namespaced_pod.return_value = _items([_pod(cstatuses=[_cstatus(ready=True)])])
+        path = SimpleNamespace(path="/", path_type="Prefix", backend=SimpleNamespace(service=SimpleNamespace(name="svc")))
+        rule = SimpleNamespace(host="example.com", http=SimpleNamespace(paths=[path]))
+        ingress = SimpleNamespace(metadata=SimpleNamespace(name="ing"), spec=SimpleNamespace(rules=[rule]))
         net.list_namespaced_ingress.return_value = _items([ingress])
-        out = json.loads(t.trace_service_chain.invoke({
-            "service_name": "svc", "namespace": "default", "config": {}}))
+        out = json.loads(t.trace_service_chain.invoke({"service_name": "svc", "namespace": "default", "config": {}}))
         assert out["chain"]["ingress"]["exists"] is True
         assert out["chain"]["ingress"]["ingresses"][0]["host"] == "example.com"
 
@@ -130,54 +117,86 @@ class TestEventsTimeline:
     def test_time_filter_and_summary(self, apis):
         core, _ = apis
         recent = SimpleNamespace(
-            type="Warning", reason="BackOff", message="m", count=2,
-            last_timestamp=RECENT, first_timestamp=RECENT,
+            type="Warning",
+            reason="BackOff",
+            message="m",
+            count=2,
+            last_timestamp=RECENT,
+            first_timestamp=RECENT,
             metadata=SimpleNamespace(creation_timestamp=RECENT),
-            source=SimpleNamespace(component="kubelet"))
+            source=SimpleNamespace(component="kubelet"),
+        )
         old = SimpleNamespace(
-            type="Normal", reason="Pulled", message="m", count=1,
-            last_timestamp=OLD, first_timestamp=OLD,
+            type="Normal",
+            reason="Pulled",
+            message="m",
+            count=1,
+            last_timestamp=OLD,
+            first_timestamp=OLD,
             metadata=SimpleNamespace(creation_timestamp=OLD),
-            source=SimpleNamespace(component="kubelet"))
+            source=SimpleNamespace(component="kubelet"),
+        )
         core.list_namespaced_event.return_value = _items([recent, old])
-        out = json.loads(t.get_resource_events_timeline.invoke({
-            "resource_type": "Pod", "resource_name": "p", "namespace": "default",
-            "hours": 24, "config": {}}))
+        out = json.loads(
+            t.get_resource_events_timeline.invoke({"resource_type": "Pod", "resource_name": "p", "namespace": "default", "hours": 24, "config": {}})
+        )
         assert out["total_events"] == 1  # old event filtered out
         assert out["event_summary"]["Warning"] == 2
+
+    def test_hours_string_is_coerced(self, apis):
+        core, _ = apis
+        recent = SimpleNamespace(
+            type="Warning",
+            reason="BackOff",
+            message="m",
+            count=1,
+            last_timestamp=RECENT,
+            first_timestamp=RECENT,
+            metadata=SimpleNamespace(creation_timestamp=RECENT),
+            source=SimpleNamespace(component="kubelet"),
+        )
+        old = SimpleNamespace(
+            type="Normal",
+            reason="Pulled",
+            message="m",
+            count=1,
+            last_timestamp=OLD,
+            first_timestamp=OLD,
+            metadata=SimpleNamespace(creation_timestamp=OLD),
+            source=SimpleNamespace(component="kubelet"),
+        )
+        core.list_namespaced_event.return_value = _items([recent, old])
+        out = json.loads(t.get_resource_events_timeline.func(resource_type="Pod", resource_name="p", namespace="default", hours="24", config={}))
+        assert "error" not in out
+        assert out["total_events"] == 1
+        assert out["time_range_hours"] == 24
 
     def test_api_exception(self, apis):
         core, _ = apis
         core.list_namespaced_event.side_effect = ApiException(status=500)
-        out = json.loads(t.get_resource_events_timeline.invoke({
-            "resource_type": "Pod", "resource_name": "p", "namespace": "default",
-            "config": {}}))
+        out = json.loads(t.get_resource_events_timeline.invoke({"resource_type": "Pod", "resource_name": "p", "namespace": "default", "config": {}}))
         assert "获取事件时间线失败" in out["error"]
 
 
 def _term(reason="Error", exit_code=1, msg="m"):
-    return SimpleNamespace(reason=reason, exit_code=exit_code, message=msg,
-                           started_at=RECENT, finished_at=RECENT)
+    return SimpleNamespace(reason=reason, exit_code=exit_code, message=msg, started_at=RECENT, finished_at=RECENT)
 
 
-def _restart_cstatus(name="c", restarts=5, waiting=None, terminated=None,
-                     running=None, last_term=None):
+def _restart_cstatus(name="c", restarts=5, waiting=None, terminated=None, running=None, last_term=None):
     state = SimpleNamespace(waiting=waiting, terminated=terminated, running=running)
     last_state = SimpleNamespace(terminated=last_term) if last_term else None
-    return SimpleNamespace(name=name, restart_count=restarts, state=state,
-                           last_state=last_state)
+    return SimpleNamespace(name=name, restart_count=restarts, state=state, last_state=last_state)
 
 
 class TestRestartPattern:
     def test_oom_exit_137(self, apis):
         core, _ = apis
-        cs = _restart_cstatus(restarts=5, waiting=SimpleNamespace(
-            reason="CrashLoopBackOff", message="back"),
-            last_term=_term(reason="OOMKilled", exit_code=137))
+        cs = _restart_cstatus(
+            restarts=5, waiting=SimpleNamespace(reason="CrashLoopBackOff", message="back"), last_term=_term(reason="OOMKilled", exit_code=137)
+        )
         pod = _pod(cstatuses=[cs])
         core.list_pod_for_all_namespaces.return_value = _items([pod])
-        core.list_namespaced_event.return_value = _items([
-            SimpleNamespace(reason="BackOff", message="m", count=3)])
+        core.list_namespaced_event.return_value = _items([SimpleNamespace(reason="BackOff", message="m", count=3)])
         out = json.loads(t.analyze_pod_restart_pattern.invoke({"config": {}}))
         a = out["analysis"][0]
         assert a["restart_count"] == 5
@@ -187,9 +206,9 @@ class TestRestartPattern:
 
     def test_sigterm_143(self, apis):
         core, _ = apis
-        cs = _restart_cstatus(restarts=4, terminated=SimpleNamespace(
-            reason="Completed", exit_code=143, message="m"),
-            last_term=_term(reason="Completed", exit_code=143))
+        cs = _restart_cstatus(
+            restarts=4, terminated=SimpleNamespace(reason="Completed", exit_code=143, message="m"), last_term=_term(reason="Completed", exit_code=143)
+        )
         core.list_pod_for_all_namespaces.return_value = _items([_pod(cstatuses=[cs])])
         core.list_namespaced_event.return_value = _items([])
         out = json.loads(t.analyze_pod_restart_pattern.invoke({"config": {}}))
@@ -199,8 +218,7 @@ class TestRestartPattern:
         core, _ = apis
         cs = _restart_cstatus(restarts=1)
         core.list_pod_for_all_namespaces.return_value = _items([_pod(cstatuses=[cs])])
-        out = json.loads(t.analyze_pod_restart_pattern.invoke({
-            "min_restarts": 3, "config": {}}))
+        out = json.loads(t.analyze_pod_restart_pattern.invoke({"min_restarts": 3, "config": {}}))
         assert out["total_problematic_containers"] == 0
 
     def test_string_threshold_is_coerced(self, apis):
@@ -208,21 +226,17 @@ class TestRestartPattern:
         cs = _restart_cstatus(restarts=3, last_term=_term(exit_code=1))
         core.list_pod_for_all_namespaces.return_value = _items([_pod(cstatuses=[cs])])
         core.list_namespaced_event.return_value = _items([])
-        out = json.loads(t.analyze_pod_restart_pattern.invoke({
-            "min_restarts": "3", "config": {}}))
+        out = json.loads(t.analyze_pod_restart_pattern.func(min_restarts="3", config={}))
         assert out["analysis"][0]["restart_count"] == 3
 
     def test_namespace_scoped_and_sorted(self, apis):
         core, _ = apis
-        cs_low = _restart_cstatus(name="low", restarts=3,
-                                  last_term=_term(exit_code=1))
-        cs_high = _restart_cstatus(name="high", restarts=12,
-                                   last_term=_term(exit_code=1))
+        cs_low = _restart_cstatus(name="low", restarts=3, last_term=_term(exit_code=1))
+        cs_high = _restart_cstatus(name="high", restarts=12, last_term=_term(exit_code=1))
         pod = _pod(cstatuses=[cs_low, cs_high])
         core.list_namespaced_pod.return_value = _items([pod])
         core.list_namespaced_event.return_value = _items([])
-        out = json.loads(t.analyze_pod_restart_pattern.invoke({
-            "namespace": "prod", "config": {}}))
+        out = json.loads(t.analyze_pod_restart_pattern.invoke({"namespace": "prod", "config": {}}))
         core.list_namespaced_pod.assert_called_once_with("prod")
         # sorted desc by restart_count
         assert out["analysis"][0]["restart_count"] == 12
@@ -239,22 +253,27 @@ class TestCheckOOM:
     def test_oom_events_and_pods(self, apis):
         core, _ = apis
         ev = SimpleNamespace(
-            reason="OOMKilling", message="oom", count=2,
-            last_timestamp=RECENT, first_timestamp=RECENT,
+            reason="OOMKilling",
+            message="oom",
+            count=2,
+            last_timestamp=RECENT,
+            first_timestamp=RECENT,
             metadata=SimpleNamespace(namespace="default", creation_timestamp=RECENT),
-            involved_object=SimpleNamespace(name="p"))
+            involved_object=SimpleNamespace(name="p"),
+        )
         core.list_event_for_all_namespaces.return_value = _items([ev])
-        spec_container = SimpleNamespace(name="c", resources=SimpleNamespace(
-            limits={"memory": "256Mi"}, requests={"memory": "128Mi"}))
-        cs = SimpleNamespace(name="c", restart_count=3,
-                             last_state=SimpleNamespace(terminated=SimpleNamespace(
-                                 reason="OOMKilled", finished_at=RECENT, exit_code=137)))
+        spec_container = SimpleNamespace(name="c", resources=SimpleNamespace(limits={"memory": "256Mi"}, requests={"memory": "128Mi"}))
+        cs = SimpleNamespace(
+            name="c", restart_count=3, last_state=SimpleNamespace(terminated=SimpleNamespace(reason="OOMKilled", finished_at=RECENT, exit_code=137))
+        )
         pod = SimpleNamespace(
             metadata=SimpleNamespace(name="p", namespace="default"),
             status=SimpleNamespace(container_statuses=[cs]),
-            spec=SimpleNamespace(containers=[spec_container]))
+            spec=SimpleNamespace(containers=[spec_container]),
+        )
         core.list_pod_for_all_namespaces.return_value = _items([pod])
-        out = json.loads(t.check_oom_events.invoke({"config": {}}))
+        out = json.loads(t.check_oom_events.func(hours="24", config={}))
+        assert "error" not in out
         assert out["total_oom_events"] == 1
         assert out["total_oom_pods"] == 1
         assert out["oom_pods"][0]["memory_limit"] == "256Mi"
@@ -264,8 +283,7 @@ class TestCheckOOM:
         core, _ = apis
         core.list_namespaced_event.return_value = _items([])
         core.list_namespaced_pod.return_value = _items([])
-        out = json.loads(t.check_oom_events.invoke({
-            "namespace": "prod", "config": {}}))
+        out = json.loads(t.check_oom_events.invoke({"namespace": "prod", "config": {}}))
         core.list_namespaced_event.assert_called_once_with("prod")
         assert out["namespace"] == "prod"
         assert out["total_oom_events"] == 0

--- a/server/apps/opspilot/tests/test_tools_k8s_utils_pure.py
+++ b/server/apps/opspilot/tests/test_tools_k8s_utils_pure.py
@@ -151,6 +151,13 @@ class TestCoerceInt:
         assert k8s.coerce_int(0, 24, lo=1, hi=168) == 1
         assert k8s.coerce_int(999, 24, lo=1, hi=168) == 168
 
+    def test_non_finite_and_overflow_use_default(self):
+        assert k8s.coerce_int("inf", 24) == 24
+        assert k8s.coerce_int("1e309", 24) == 24
+        assert k8s.coerce_int("nan", 24) == 24
+        with pytest.raises(ValueError):
+            k8s.coerce_int("inf")
+
 
 class TestCoerceBool:
     def test_false_strings(self):

--- a/server/apps/opspilot/tests/test_tools_k8s_utils_pure.py
+++ b/server/apps/opspilot/tests/test_tools_k8s_utils_pure.py
@@ -23,7 +23,7 @@ class TestFormatBytes:
         assert k8s.format_bytes(5 * 1024 * 1024) == "5.0 MiB"
 
     def test_gib_rounding(self):
-        assert k8s.format_bytes(int(2.5 * 1024 ** 3)) == "2.5 GiB"
+        assert k8s.format_bytes(int(2.5 * 1024**3)) == "2.5 GiB"
 
 
 class TestParseResourceQuantity:
@@ -35,10 +35,10 @@ class TestParseResourceQuantity:
         assert k8s.parse_resource_quantity("100m") == 0.1
 
     def test_memory_gi(self):
-        assert k8s.parse_resource_quantity("1Gi") == 1024 ** 3
+        assert k8s.parse_resource_quantity("1Gi") == 1024**3
 
     def test_memory_mi(self):
-        assert k8s.parse_resource_quantity("500Mi") == 500 * 1024 ** 2
+        assert k8s.parse_resource_quantity("500Mi") == 500 * 1024**2
 
     def test_decimal_si_k(self):
         assert k8s.parse_resource_quantity("2K") == 2000
@@ -126,3 +126,39 @@ class TestRepresentStrNoFold:
         out = k8s._preprocess_kubeconfig(yaml.safe_dump(cfg))
         # 长 token 应被双引号包裹,且 yaml 可往返解析
         assert yaml.safe_load(out)["users"][0]["user"]["token"] == long_val
+
+
+class TestCoerceInt:
+    def test_string_and_float_string(self):
+        assert k8s.coerce_int("24", 1) == 24
+        assert k8s.coerce_int("24.9", 1) == 24
+        assert k8s.coerce_int(24, 1) == 24
+
+    def test_none_and_blank_use_default(self):
+        assert k8s.coerce_int(None, 24) == 24
+        assert k8s.coerce_int("", 24) == 24
+
+    def test_allow_none(self):
+        assert k8s.coerce_int(None, allow_none=True) is None
+        assert k8s.coerce_int("", allow_none=True) is None
+
+    def test_invalid_falls_back_or_raises(self):
+        assert k8s.coerce_int("abc", 24) == 24
+        with pytest.raises(ValueError):
+            k8s.coerce_int("abc")
+
+    def test_clamps_bounds(self):
+        assert k8s.coerce_int(0, 24, lo=1, hi=168) == 1
+        assert k8s.coerce_int(999, 24, lo=1, hi=168) == 168
+
+
+class TestCoerceBool:
+    def test_false_strings(self):
+        assert k8s.coerce_bool("false", True) is False
+        assert k8s.coerce_bool("0", True) is False
+        assert k8s.coerce_bool(False, True) is False
+
+    def test_true_strings_and_default(self):
+        assert k8s.coerce_bool("true", False) is True
+        assert k8s.coerce_bool(None, True) is True
+        assert k8s.coerce_bool("maybe", True) is True


### PR DESCRIPTION
模型常把数字编成字符串导致时间窗计算 TypeError；探针校验只报是否配置。统一 coerce 数值/布尔，序列化 httpGet.path，并收口多实例定点与告警 namespace 反查。