### PR TITLE
fix(monitor): 退役原始 PromQL 查询入口

### DIFF
--- a/docs/design-docs/monitor-module-architecture-analysis.md
+++ b/docs/design-docs/monitor-module-architecture-analysis.md
@@ -79,7 +79,7 @@ VictoriaMetrics
 |---|---|---|---|
 | Catalog | 对象类型、对象、插件、指标、配置/UI 模板 | `models/plugin.py`、`models/monitor_metrics.py`、`management/services/plugin_migrate.py` | 监控能力定义、版本和兼容信息 |
 | Onboarding | 实例接入、参数校验、预检、配置渲染、下发与对账 | `services/node_mgmt.py`、`services/collect_detect.py`、`utils/plugin_controller.py` | 期望采集状态、接入操作状态 |
-| Observation | 指标查询、实例发现、插件在线状态、搜索与视图 | `services/monitor_instance.py`、`services/effective_plugins.py`、`utils/victoriametrics_api.py` | 观测状态的投影，不拥有原始时序事实 |
+| Observation | 受控指标查询、实例发现、插件在线状态、搜索与视图 | `services/authorized_metric_query.py`、`services/dashboard_query_capabilities.py`、`services/monitor_instance.py`、`services/effective_plugins.py`、`utils/victoriametrics_api.py` | 观测状态的投影与查询授权，不拥有原始时序事实 |
 | Policy Engine | 策略、调度、扫描、聚合、基线和无数据检测 | `views/monitor_policy.py`、`tasks/services/policy_scan/` | 策略定义、扫描游标与基线 |
 | Alerting | 事件、告警状态机、原始数据、指标快照 | `models/monitor_policy.py`、`tasks/services/policy_scan/event_alert_manager.py` | 事件和告警的业务事实 |
 | Delivery | 通知渠道、告警中心投影、失败补偿 | `services/alert_lifecycle_notify.py`、`tasks/monitor_policy.py` | 投递记录、重试和对账状态 |
@@ -234,6 +234,13 @@ status / organization_hint
 - 标签到实例身份的转换；
 - 缓存和批量查询；
 - 错误分类、降级与可观测性。
+
+当前页面查询已先收敛到 `AuthorizedMetricQueryService`：调用方只能提交指标 ID 或仓库生成的
+看板能力 ID，服务端在访问 VictoriaMetrics 前完成团队实例权限、监控对象绑定、模板参数和
+动态维度校验。`dashboard_query_capabilities.py` 作为内置看板查询允许列表，将浏览器提交的
+原始 PromQL 改为服务端模板渲染；旧 REST `query`、`query_range` 入口已退役。该服务是统一
+`MetricQueryPort` 的现有应用接缝，后续查询预算、缓存和错误分类应继续在此边界收敛，而不是
+重新向 HTTP 或消息调用方暴露原始查询语言。
 
 例如当前有效插件状态会按插件逐个发起 VM 查询，见 [effective_plugins.py:71](../../server/apps/monitor/services/effective_plugins.py#L71)。对象或插件数量增长时，这类“业务循环内调用指标后端”的实现需要被查询预算和批量规划约束。
 

--- a/server/apps/monitor/services/authorized_metric_query.py
+++ b/server/apps/monitor/services/authorized_metric_query.py
@@ -3,7 +3,8 @@ from dataclasses import dataclass
 
 from apps.core.utils.permission_utils import get_permission_rules, permission_filter
 from apps.monitor.constants.permission import PermissionConstants
-from apps.monitor.models import Metric, MonitorInstance
+from apps.monitor.models import Metric, MonitorInstance, MonitorObject
+from apps.monitor.services.metric_query_contract import AuthorizedMetricQueryError, build_instance_matchers, escape_metric_label_value
 from apps.monitor.services.metrics import Metrics
 from apps.monitor.utils.dimension import parse_instance_id
 
@@ -17,15 +18,9 @@ ALLOWED_AGGREGATIONS = {
 ALLOWED_FILTER_OPERATORS = {"=", "!=", "=~", "!~"}
 
 
-class AuthorizedMetricQueryError(ValueError):
-    def __init__(self, message: str, *, code: str):
-        super().__init__(message)
-        self.code = code
-
-
 @dataclass(frozen=True)
 class AuthorizedMetricQuery:
-    metric: Metric
+    metric: Metric | None
     instance_ids: tuple[str, ...]
     query: str
     start: int
@@ -34,10 +29,6 @@ class AuthorizedMetricQuery:
     detect_gaps: bool
     collection_interval: int | None
     card_budget: bool
-
-
-def _escape_label_value(value) -> str:
-    return str(value).replace("\\", "\\\\").replace('"', '\\"')
 
 
 def _metric_instance_id_keys(metric: Metric) -> list[str]:
@@ -49,31 +40,6 @@ def _metric_instance_id_keys(metric: Metric) -> list[str]:
             code="metric_instance_keys_missing",
         )
     return normalized
-
-
-def _instance_matchers(instance_ids: tuple[str, ...], keys: list[str]) -> list[str]:
-    values_by_key = {key: set() for key in keys}
-    for instance_id in instance_ids:
-        values = parse_instance_id(instance_id)
-        if len(values) < len(keys):
-            raise AuthorizedMetricQueryError(
-                "监控实例标识与指标契约不匹配",
-                code="instance_identity_invalid",
-            )
-        for index, key in enumerate(keys):
-            value = values[index]
-            if value in (None, ""):
-                raise AuthorizedMetricQueryError(
-                    "监控实例标识与指标契约不匹配",
-                    code="instance_identity_invalid",
-                )
-            values_by_key[key].add(str(value))
-
-    matchers = []
-    for key, values in values_by_key.items():
-        escaped_values = [_escape_label_value(re.escape(value)) for value in sorted(values)]
-        matchers.append(f'{key}=~"{"|".join(escaped_values)}"')
-    return matchers
 
 
 def _allowed_dimensions(metric: Metric) -> set[str]:
@@ -108,11 +74,11 @@ def _filter_matchers(metric: Metric, filters) -> list[str]:
             raise AuthorizedMetricQueryError("筛选操作符不受支持", code="filter_operator_invalid")
         if value in (None, ""):
             raise AuthorizedMetricQueryError("筛选值不能为空", code="filter_value_invalid")
-        matchers.append(f'{label}{operator}"{_escape_label_value(value)}"')
+        matchers.append(f'{label}{operator}"{escape_metric_label_value(value)}"')
     return matchers
 
 
-def _build_query(metric: Metric, instance_ids: tuple[str, ...], filters, aggregation) -> str:
+def _render_metric_query(metric: Metric, matchers: list[str], aggregation) -> str:
     template = metric.query or ""
     if "__$labels__" not in template:
         raise AuthorizedMetricQueryError(
@@ -120,9 +86,6 @@ def _build_query(metric: Metric, instance_ids: tuple[str, ...], filters, aggrega
             code="metric_template_not_scoped",
         )
 
-    instance_keys = _metric_instance_id_keys(metric)
-    matchers = _instance_matchers(instance_ids, instance_keys)
-    matchers.extend(_filter_matchers(metric, filters))
     query = template.replace("__$labels__", ", ".join(matchers))
 
     aggregation_name = str(aggregation or "AVG").upper()
@@ -130,8 +93,16 @@ def _build_query(metric: Metric, instance_ids: tuple[str, ...], filters, aggrega
         raise AuthorizedMetricQueryError("汇聚方式不受支持", code="aggregation_invalid")
     aggregation_func = ALLOWED_AGGREGATIONS[aggregation_name]
     if aggregation_func:
+        instance_keys = _metric_instance_id_keys(metric)
         query = f'{aggregation_func}({query}) by ({", ".join(instance_keys)})'
     return query
+
+
+def _build_query(metric: Metric, instance_ids: tuple[str, ...], filters, aggregation) -> str:
+    instance_keys = _metric_instance_id_keys(metric)
+    matchers = build_instance_matchers(instance_ids, instance_keys)
+    matchers.extend(_filter_matchers(metric, filters))
+    return _render_metric_query(metric, matchers, aggregation)
 
 
 def _normalize_bool(value, *, field: str) -> bool:
@@ -150,28 +121,9 @@ class AuthorizedMetricQueryService:
         self.current_team = current_team
         self.include_children = include_children
 
-    def _prepare(self, payload: dict) -> AuthorizedMetricQuery:
-        if not isinstance(payload, dict):
-            raise AuthorizedMetricQueryError("请求体必须是对象", code="payload_invalid")
-        if self.user is None or self.current_team in (None, ""):
-            raise AuthorizedMetricQueryError(
-                "缺少用户或组织信息",
-                code="query_identity_required",
-            )
-        if "query" in payload:
-            raise AuthorizedMetricQueryError(
-                "受控查询不接受原始 PromQL",
-                code="raw_query_not_allowed",
-            )
-
-        monitor_object_id = payload.get("monitor_object_id")
-        metric_id = payload.get("metric_id")
-        raw_instance_ids = payload.get("instance_ids")
-        if monitor_object_id in (None, "") or metric_id in (None, ""):
-            raise AuthorizedMetricQueryError(
-                "monitor_object_id 和 metric_id 不能为空",
-                code="metric_context_required",
-            )
+    def _authorize_instances(self, monitor_object_id, raw_instance_ids) -> tuple[MonitorObject, tuple[str, ...]]:
+        if monitor_object_id in (None, ""):
+            raise AuthorizedMetricQueryError("monitor_object_id 不能为空", code="metric_context_required")
         if not isinstance(raw_instance_ids, list) or not raw_instance_ids:
             raise AuthorizedMetricQueryError(
                 "instance_ids 不能为空",
@@ -185,11 +137,11 @@ class AuthorizedMetricQueryService:
                 code="instance_ids_required",
             )
 
-        metric = Metric.objects.select_related("monitor_object").filter(id=metric_id, monitor_object_id=monitor_object_id).first()
-        if metric is None:
+        monitor_object = MonitorObject.objects.filter(id=monitor_object_id).first()
+        if monitor_object is None:
             raise AuthorizedMetricQueryError(
-                "监控对象或指标不存在",
-                code="metric_not_found",
+                "监控对象不存在",
+                code="monitor_object_not_found",
             )
 
         if getattr(self.user, "is_superuser", False):
@@ -220,6 +172,72 @@ class AuthorizedMetricQueryService:
             raise AuthorizedMetricQueryError(
                 "无权访问所选监控实例",
                 code="monitor_instance_forbidden",
+            )
+        return monitor_object, instance_ids
+
+    def _authorize_host_process_scope(self, monitor_object_id, scope) -> tuple[MonitorObject, tuple[str, ...], list[str]]:
+        if not isinstance(scope, dict) or scope.get("type") != "host_process":
+            raise AuthorizedMetricQueryError("查询作用域无效", code="query_scope_invalid")
+        process_object = MonitorObject.objects.filter(id=monitor_object_id, name="Process").first()
+        if process_object is None:
+            raise AuthorizedMetricQueryError("进程查询对象无效", code="query_scope_invalid")
+        host_object, host_instance_ids = self._authorize_instances(
+            scope.get("host_monitor_object_id"),
+            [scope.get("host_instance_id")],
+        )
+        if host_object.name != "Host" or len(host_instance_ids) != 1:
+            raise AuthorizedMetricQueryError("主机查询作用域无效", code="query_scope_invalid")
+
+        host_values = parse_instance_id(host_instance_ids[0])
+        if not host_values or host_values[0] in (None, ""):
+            raise AuthorizedMetricQueryError("主机实例标识无效", code="query_scope_invalid")
+        matchers = [f'instance_id=~"{escape_metric_label_value(re.escape(str(host_values[0])))}"']
+
+        raw_names = scope.get("process_names") or []
+        if not isinstance(raw_names, list) or len(raw_names) > 100:
+            raise AuthorizedMetricQueryError("进程筛选范围无效", code="query_scope_invalid")
+        process_names = sorted({str(name).strip() for name in raw_names if str(name).strip()})
+        if any(len(name) > 200 for name in process_names):
+            raise AuthorizedMetricQueryError("进程筛选范围无效", code="query_scope_invalid")
+        if process_names:
+            values = "|".join(escape_metric_label_value(re.escape(name)) for name in process_names)
+            matchers.append(f'process_name=~"{values}"')
+        return process_object, host_instance_ids, matchers
+
+    def _prepare(self, payload: dict) -> AuthorizedMetricQuery:
+        if not isinstance(payload, dict):
+            raise AuthorizedMetricQueryError("请求体必须是对象", code="payload_invalid")
+        if self.user is None or self.current_team in (None, ""):
+            raise AuthorizedMetricQueryError(
+                "缺少用户或组织信息",
+                code="query_identity_required",
+            )
+        if "query" in payload:
+            raise AuthorizedMetricQueryError(
+                "受控查询不接受原始 PromQL",
+                code="raw_query_not_allowed",
+            )
+
+        monitor_object_id = payload.get("monitor_object_id")
+        metric_id = payload.get("metric_id")
+        capability_id = str(payload.get("capability_id") or "").strip()
+        if (metric_id in (None, "")) == (not capability_id):
+            raise AuthorizedMetricQueryError(
+                "metric_id 与 capability_id 必须且只能提供一个",
+                code="metric_context_required",
+            )
+        scope_matchers = None
+        if payload.get("scope") is not None:
+            if capability_id:
+                raise AuthorizedMetricQueryError("查询能力不接受自定义作用域", code="query_scope_invalid")
+            monitor_object, instance_ids, scope_matchers = self._authorize_host_process_scope(
+                monitor_object_id,
+                payload.get("scope"),
+            )
+        else:
+            monitor_object, instance_ids = self._authorize_instances(
+                monitor_object_id,
+                payload.get("instance_ids"),
             )
 
         try:
@@ -259,15 +277,53 @@ class AuthorizedMetricQueryService:
         else:
             collection_interval = None
 
+        metric = None
+        if capability_id:
+            if payload.get("filters") not in (None, [], "") or payload.get("aggregation") not in (None, ""):
+                raise AuthorizedMetricQueryError(
+                    "仪表盘查询能力不接受自定义筛选或汇聚",
+                    code="capability_params_invalid",
+                )
+            from apps.monitor.services.dashboard_query_capabilities import build_dashboard_query
+
+            query = build_dashboard_query(
+                capability_id=capability_id,
+                monitor_object=monitor_object,
+                instance_ids=instance_ids,
+                start=start,
+                end=end,
+                params=payload.get("capability_params"),
+            )
+        else:
+            metric = (
+                Metric.objects.select_related("monitor_object")
+                .filter(
+                    id=metric_id,
+                    monitor_object_id=monitor_object.id,
+                )
+                .first()
+            )
+            if metric is None:
+                raise AuthorizedMetricQueryError(
+                    "监控对象或指标不存在",
+                    code="metric_not_found",
+                )
+            if scope_matchers is not None:
+                if payload.get("filters") not in (None, [], ""):
+                    raise AuthorizedMetricQueryError("进程查询不接受额外筛选", code="query_scope_invalid")
+                query = _render_metric_query(metric, scope_matchers, payload.get("aggregation"))
+            else:
+                query = _build_query(
+                    metric,
+                    instance_ids,
+                    payload.get("filters"),
+                    payload.get("aggregation"),
+                )
+
         return AuthorizedMetricQuery(
             metric=metric,
             instance_ids=instance_ids,
-            query=_build_query(
-                metric,
-                instance_ids,
-                payload.get("filters"),
-                payload.get("aggregation"),
-            ),
+            query=query,
             start=start,
             end=end,
             step=step,

--- a/server/apps/monitor/services/dashboard_query_capabilities.py
+++ b/server/apps/monitor/services/dashboard_query_capabilities.py
@@ -1,0 +1,159 @@
+import json
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+from apps.monitor.models import MonitorObject
+
+from .metric_query_contract import AuthorizedMetricQueryError, build_instance_matchers, escape_metric_label_value
+
+CAPABILITY_MANIFEST = Path(__file__).resolve().parent.parent / "support-files" / "dashboard_query_capabilities.json"
+MAX_CAPABILITY_TEMPLATE_LENGTH = 20_000
+MAX_KAFKA_DIMENSIONS = 10
+MAX_KAFKA_DIMENSION_VALUE_LENGTH = 256
+
+
+def dashboard_query_capability_id(template: str) -> str:
+    value = 2166136261
+    for byte in template.encode("utf-8"):
+        value ^= byte
+        value = (value * 16777619) & 0xFFFFFFFF
+    return f"dashboard:v1:{value:08x}"
+
+
+def _query_window(start: int, end: int) -> str:
+    seconds = max(1, round((end - start) / 1000))
+    for divisor, suffix in ((86400, "d"), (3600, "h"), (60, "m")):
+        if seconds % divisor == 0:
+            return f"{seconds // divisor}{suffix}"
+    return f"{seconds}s"
+
+
+@dataclass(frozen=True)
+class DashboardQueryCapability:
+    id: str
+    object_names: frozenset[str]
+    template: str
+
+
+@lru_cache(maxsize=1)
+def load_dashboard_query_capabilities() -> dict[str, DashboardQueryCapability]:
+    payload = json.loads(CAPABILITY_MANIFEST.read_text(encoding="utf-8"))
+    if payload.get("version") != 1 or not isinstance(payload.get("capabilities"), list):
+        raise RuntimeError("invalid dashboard query capability manifest")
+
+    capabilities = {}
+    for item in payload["capabilities"]:
+        capability_id = str(item.get("id") or "")
+        template = str(item.get("template") or "")
+        object_names = item.get("object_names")
+        selectors = re.findall(r"\{([^{}]*)\}", template)
+        if (
+            not capability_id
+            or not template
+            or len(template) > MAX_CAPABILITY_TEMPLATE_LENGTH
+            or "__$labels__" not in template
+            or not selectors
+            or any("__$labels__" not in selector for selector in selectors)
+            or not isinstance(object_names, list)
+            or not object_names
+            or dashboard_query_capability_id(template) != capability_id
+            or capability_id in capabilities
+        ):
+            raise RuntimeError(f"invalid dashboard query capability: {capability_id or '-'}")
+        normalized_object_names = frozenset(str(name).strip() for name in object_names if str(name).strip())
+        if not normalized_object_names:
+            raise RuntimeError(f"invalid dashboard query capability: {capability_id}")
+        capabilities[capability_id] = DashboardQueryCapability(
+            id=capability_id,
+            object_names=normalized_object_names,
+            template=template,
+        )
+    return capabilities
+
+
+def _normalize_kafka_dimensions(value) -> list[dict[str, str]]:
+    if not isinstance(value, list) or not value or len(value) > MAX_KAFKA_DIMENSIONS:
+        raise AuthorizedMetricQueryError(
+            "Kafka 查询维度数量无效",
+            code="capability_params_invalid",
+        )
+    normalized = []
+    for item in value:
+        if not isinstance(item, dict):
+            raise AuthorizedMetricQueryError("Kafka 查询维度无效", code="capability_params_invalid")
+        dimension = {
+            "consumer_group": str(item.get("consumer_group") or "").strip(),
+            "topic": str(item.get("topic") or "").strip(),
+            "partition": str(item.get("partition") or "").strip(),
+        }
+        if not dimension["topic"] or not dimension["partition"]:
+            raise AuthorizedMetricQueryError("Kafka 查询维度无效", code="capability_params_invalid")
+        if any(len(value) > MAX_KAFKA_DIMENSION_VALUE_LENGTH for value in dimension.values()):
+            raise AuthorizedMetricQueryError("Kafka 查询维度过长", code="capability_params_invalid")
+        normalized.append(dimension)
+    return normalized
+
+
+def _build_kafka_dimension_query(capability_id: str, params, instance_matchers: list[str]) -> str:
+    definitions = {
+        "dashboard:dynamic:kafka:current-offset": ("kafka_consumergroup_current_offset_gauge", True),
+        "dashboard:dynamic:kafka:oldest-offset": ("kafka_topic_partition_oldest_offset_gauge", False),
+        "dashboard:dynamic:kafka:lag-history": ("kafka_consumergroup_lag_gauge", True),
+    }
+    definition = definitions.get(capability_id)
+    if not definition:
+        raise AuthorizedMetricQueryError("查询能力不存在", code="capability_not_found")
+    if not isinstance(params, dict):
+        raise AuthorizedMetricQueryError("Kafka 查询参数无效", code="capability_params_invalid")
+    metric_name, with_consumer_group = definition
+    dimensions = _normalize_kafka_dimensions(params.get("dimensions"))
+    selectors = []
+    for item in dimensions:
+        labels = [
+            *instance_matchers,
+            f'topic="{escape_metric_label_value(item["topic"])}"',
+            f'partition="{escape_metric_label_value(item["partition"])}"',
+        ]
+        if with_consumer_group:
+            if not item["consumer_group"]:
+                raise AuthorizedMetricQueryError("Kafka 查询维度无效", code="capability_params_invalid")
+            labels.append(f'consumergroup="{escape_metric_label_value(item["consumer_group"])}"')
+        selectors.append(f'{metric_name}{{{",".join(labels)}}}')
+    return f'max by (consumergroup, topic, partition) ({" or ".join(selectors)})'
+
+
+def build_dashboard_query(
+    *,
+    capability_id: str,
+    monitor_object: MonitorObject,
+    instance_ids: tuple[str, ...],
+    start: int,
+    end: int,
+    params=None,
+) -> str:
+    instance_keys = [str(key).strip() for key in monitor_object.instance_id_keys or [] if str(key).strip()]
+    if not instance_keys:
+        raise AuthorizedMetricQueryError(
+            "监控对象缺少实例标识契约",
+            code="metric_instance_keys_missing",
+        )
+    matchers = build_instance_matchers(instance_ids, instance_keys)
+
+    if capability_id.startswith("dashboard:dynamic:kafka:"):
+        if monitor_object.name != "Kafka":
+            raise AuthorizedMetricQueryError("查询能力与监控对象不匹配", code="capability_object_mismatch")
+        return _build_kafka_dimension_query(capability_id, params, matchers)
+
+    capability = load_dashboard_query_capabilities().get(capability_id)
+    if not capability:
+        raise AuthorizedMetricQueryError("查询能力不存在", code="capability_not_found")
+    if monitor_object.name not in capability.object_names:
+        raise AuthorizedMetricQueryError("查询能力与监控对象不匹配", code="capability_object_mismatch")
+
+    query = capability.template.replace("__$labels__", ", ".join(matchers))
+    query = query.replace("__$window__", _query_window(start, end))
+    if "__$" in query:
+        raise AuthorizedMetricQueryError("查询能力参数不完整", code="capability_template_invalid")
+    return query

--- a/server/apps/monitor/services/metric_query_contract.py
+++ b/server/apps/monitor/services/metric_query_contract.py
@@ -1,0 +1,38 @@
+import re
+
+from apps.monitor.utils.dimension import parse_instance_id
+
+
+class AuthorizedMetricQueryError(ValueError):
+    def __init__(self, message: str, *, code: str):
+        super().__init__(message)
+        self.code = code
+
+
+def escape_metric_label_value(value) -> str:
+    return str(value).replace("\\", "\\\\").replace('"', '\\"')
+
+
+def build_instance_matchers(instance_ids: tuple[str, ...], keys: list[str]) -> list[str]:
+    values_by_key = {key: set() for key in keys}
+    for instance_id in instance_ids:
+        values = parse_instance_id(instance_id)
+        if len(values) < len(keys):
+            raise AuthorizedMetricQueryError(
+                "监控实例标识与指标契约不匹配",
+                code="instance_identity_invalid",
+            )
+        for index, key in enumerate(keys):
+            value = values[index]
+            if value in (None, ""):
+                raise AuthorizedMetricQueryError(
+                    "监控实例标识与指标契约不匹配",
+                    code="instance_identity_invalid",
+                )
+            values_by_key[key].add(str(value))
+
+    matchers = []
+    for key, values in values_by_key.items():
+        escaped_values = [escape_metric_label_value(re.escape(value)) for value in sorted(values)]
+        matchers.append(f'{key}=~"{"|".join(escaped_values)}"')
+    return matchers

--- a/server/apps/monitor/support-files/dashboard_query_capabilities.json
+++ b/server/apps/monitor/support-files/dashboard_query_capabilities.json
@@ -1,0 +1,5909 @@
+{
+  "version": 1,
+  "capabilities": [
+    {
+      "id": "dashboard:v1:0037a371",
+      "object_names": [
+        "Docker"
+      ],
+      "template": "sum(rate(docker_container_blkio_io_service_bytes_recursive_read{__$labels__}[__$window__])) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:0045f512",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_threads_connected{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:004ae763",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "win_ad_DS_Directory_Writes_persec{instance_type=\"active_directory\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:006e18b1",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "mongodb_active_reads{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:0089b8fa",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "rate(tomcat_connector_error_count{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:00974148",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "cpu_usage_user{instance_type=\"k3s\",cpu=\"cpu-total\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:00a8c54f",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "win_ad_LDAP_Writes_persec{instance_type=\"active_directory\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:00b65b22",
+      "object_names": [
+        "Loadbalance"
+      ],
+      "template": "sum(sflow_packets{instance_type='loadbalance', collect_type='sflow', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:01fe2d05",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "win_ad_DRA_Inbound_Full_Sync_Objects_Remaining{instance_type=\"active_directory\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:020ca5e3",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_connection_errors_max_connections{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:02375761",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_threads_cached{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:023ea113",
+      "object_names": [
+        "Minio"
+      ],
+      "template": "min by (instance_id) (minio_cluster_erasure_set_online_drives_count_gauge{__$labels__}) or min by (instance_id) (minio_cluster_health_erasure_set_online_drives_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:0262696a",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "mongodb_connections_available{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:026784a7",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "sum without (db) (rate(postgresql_temp_files{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:033abc0d",
+      "object_names": [
+        "InfluxDB"
+      ],
+      "template": "sum by (instance_id) (rate(influxdb_httpd_writeReq{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:03c7ef3b",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "win_ad_DS_Directory_Searches_persec{instance_type=\"active_directory\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:0444c91a",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_threads_running{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:04522f87",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "clamp_min(rabbitmq_node_mem_limit{__$labels__} - rabbitmq_node_mem_used{__$labels__}, 0)"
+    },
+    {
+      "id": "dashboard:v1:04757891",
+      "object_names": [
+        "SGLang"
+      ],
+      "template": "clamp_max(100 * avg(sglang:token_usage_gauge{__$labels__}), 100)"
+    },
+    {
+      "id": "dashboard:v1:04c2972d",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_open_tables{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:05108083",
+      "object_names": [
+        "Minio"
+      ],
+      "template": "max by (instance_id) (minio_system_drive_perc_util_gauge{__$labels__}) or max by (instance_id) (minio_node_drive_perc_util_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:05195e7e",
+      "object_names": [
+        "InfluxDB"
+      ],
+      "template": "sum by (instance_id) (rate(influxdb_httpd_authFail{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:053a1b6a",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_connection_errors_max_connections{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:05d94de9",
+      "object_names": [
+        "Kafka"
+      ],
+      "template": "min(kafka_up_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:061331f1",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "sum(rate(interface_ifInDiscards{__$labels__}[__$window__])) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:064d7f70",
+      "object_names": [
+        "Consul"
+      ],
+      "template": "clamp_max(100 * sum by (instance_id) (consul_health_checks_passing{__$labels__}) / clamp_min(count by (instance_id) (consul_health_checks_status{__$labels__}), 1), 100)"
+    },
+    {
+      "id": "dashboard:v1:065a8dde",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "100 * sum(prometheus_remote_write_kube_deployment_status_replicas_available{instance_type=\"k8s\",__$labels__}) / clamp_min(sum(prometheus_remote_write_kube_deployment_spec_replicas{instance_type=\"k8s\",__$labels__}),1)"
+    },
+    {
+      "id": "dashboard:v1:069588ce",
+      "object_names": [
+        "ElasticSearch"
+      ],
+      "template": "rate(elasticsearch_http_total_opened{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:077cf7a3",
+      "object_names": [
+        "Ping"
+      ],
+      "template": "max(ping_maximum_response_ms{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:0793542d",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "count(prometheus_remote_write_kube_deployment_status_replicas_unavailable{instance_type=\"k3s\",__$labels__} > 0)"
+    },
+    {
+      "id": "dashboard:v1:07aee933",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "100 * (rate(tomcat_connector_error_count{__$labels__}[__$window__]) / clamp_min(rate(tomcat_connector_request_count{__$labels__}[__$window__]), 1))"
+    },
+    {
+      "id": "dashboard:v1:08002511",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "sum without (db) (rate(postgresql_buffers_backend{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:0815012b",
+      "object_names": [
+        "Firewall"
+      ],
+      "template": "topk(10, avg_over_time((sum(sflow_bytes{instance_type='firewall', collect_type='sflow', __$labels__}) by (instance_id, header_protocol))[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:087b531e",
+      "object_names": [
+        "Apache"
+      ],
+      "template": "100 * (apache_BusyWorkers{__$labels__} / clamp_min(apache_BusyWorkers{__$labels__} + apache_IdleWorkers{__$labels__}, 1))"
+    },
+    {
+      "id": "dashboard:v1:08a35d8a",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "rate(tomcat_connector_bytes_sent{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:08ba0691",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "sum(prometheus_remote_write_kube_pod_container_resource_requests{instance_type=\"k3s\",resource=\"memory\", __$labels__})"
+    },
+    {
+      "id": "dashboard:v1:08c9e584",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_innodb_row_lock_waits{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:0924f764",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "rate(sqlserver_performance_value{counter=\"SQL Re-Compilations/sec\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:0959407a",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "count(prometheus_remote_write_kube_statefulset_status_replicas_ready{instance_type=\"k3s\",__$labels__} < prometheus_remote_write_kube_statefulset_replicas{instance_type=\"k3s\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:09624949",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "http_response_response_time{instance_type=\"exchange\", endpoint=\"owa\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:09c23589",
+      "object_names": [
+        "Kafka"
+      ],
+      "template": "count({instance_type='kafka', collect_type='exporter', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:0a50a530",
+      "object_names": [
+        "LlamaServer"
+      ],
+      "template": "avg(llamacpp:predicted_tokens_seconds_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:0a6a83ef",
+      "object_names": [
+        "Website"
+      ],
+      "template": "avg(http_response_result_code{__$labels__} == bool 3) * 100"
+    },
+    {
+      "id": "dashboard:v1:0a94e627",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "win_ad_DS_Threads_in_Use{instance_type=\"active_directory\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:0aa8340c",
+      "object_names": [
+        "nginx"
+      ],
+      "template": "rate(nginx_handled{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:0bad41f3",
+      "object_names": [
+        "TCPPort"
+      ],
+      "template": "avg(net_response_result_code{__$labels__} != bool 0) * 100"
+    },
+    {
+      "id": "dashboard:v1:0bb78e7f",
+      "object_names": [
+        "Haproxy"
+      ],
+      "template": "sum by (instance_id) (rate(haproxy_chkfail{svname=\"BACKEND\",__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:0cae881a",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "rate(mongodb_commands{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:0d432287",
+      "object_names": [
+        "Host"
+      ],
+      "template": "cpu_usage_system{cpu=\"cpu-total\", instance_type=\"os\", __$labels__} or cpu_usage_system_total_gauge{instance_type=\"os\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:0d71ccab",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "rate(sqlserver_requests_cpu_time_ms{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:0e200c97",
+      "object_names": [
+        "Node"
+      ],
+      "template": "count(prometheus_remote_write_kube_node_info{instance_type='k8s', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:0e274631",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_aborted_clients{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:0e4c81d6",
+      "object_names": [
+        "ActiveMQ"
+      ],
+      "template": "activemq_topics_dequeue_count{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:0e5e5527",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "sum(irate(prometheus_remote_write_container_cpu_usage_seconds_total{instance_type=\"k3s\", __$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:0f02a9f8",
+      "object_names": [
+        "Loadbalance"
+      ],
+      "template": "avg(sflow_frame_length{instance_type='loadbalance', collect_type='sflow', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:0f04a10a",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "sum without (db) (rate(postgresql_maxwritten_clean{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:0f0f3650",
+      "object_names": [
+        "JVM"
+      ],
+      "template": "jvm_threads_daemon_count_value{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:0f59d99a",
+      "object_names": [
+        "Zookeeper"
+      ],
+      "template": "zookeeper_approximate_data_size{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:0f827925",
+      "object_names": [
+        "JVM"
+      ],
+      "template": "jvm_os_memory_physical_total_value{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:0f880d93",
+      "object_names": [
+        "Node"
+      ],
+      "template": "rate(prometheus_remote_write_diskio_reads{instance_type=\"k8s\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:1093db4a",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "rate(diskio_reads{instance_type=\"k3s\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:109ba2d5",
+      "object_names": [
+        "Pod"
+      ],
+      "template": "100 * ( sum(irate(prometheus_remote_write_container_cpu_usage_seconds_total{instance_type=\"k8s\",__$labels__}[__$window__])) by (instance_id,pod) / on(instance_id,pod) sum(prometheus_remote_write_kube_pod_container_resource_limits{instance_type=\"k8s\", resource=\"cpu\",__$labels__}) by (instance_id,pod) )"
+    },
+    {
+      "id": "dashboard:v1:113f8935",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "topk(5, sum by (pod) (increase(prometheus_remote_write_kube_pod_container_status_restarts_total{instance_type=\"k3s\",__$labels__}[1h])))"
+    },
+    {
+      "id": "dashboard:v1:1182a607",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "max(device_memory_usage{__$labels__}) by (instance_id) or avg(device_memory_usage{__$labels__}) by (instance_id) or (sum(device_memory_used{__$labels__}) by (instance_id) / (sum(device_memory_used{__$labels__}) by (instance_id) + sum(device_memory_free{__$labels__}) by (instance_id)) * 100) or (sum(device_memory_used{__$labels__}) by (instance_id) / sum(device_memory_total{__$labels__}) by (instance_id) * 100) or ((sum(device_memory_total{__$labels__}) by (instance_id) - sum(device_memory_free{__$labels__}) by (instance_id)) / sum(device_memory_total{__$labels__}) by (instance_id) * 100)"
+    },
+    {
+      "id": "dashboard:v1:11eabfbd",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "sum by (instance_id) (sqlserver_volume_space_available_space_bytes{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:124d5e0e",
+      "object_names": [
+        "Docker"
+      ],
+      "template": "sum(rate(docker_container_blkio_io_service_bytes_recursive_write{__$labels__}[__$window__])) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:12a0fa17",
+      "object_names": [
+        "Node"
+      ],
+      "template": "prometheus_remote_write_cpu_usage_iowait{instance_type=\"k8s\",cpu=\"cpu-total\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:12a5f7de",
+      "object_names": [
+        "LlamaServer"
+      ],
+      "template": "sum(rate(llamacpp:tokens_predicted_total_counter{__$labels__}[5m])) / sum(rate(llamacpp:n_decode_total_counter{__$labels__}[5m]))"
+    },
+    {
+      "id": "dashboard:v1:12b28502",
+      "object_names": [
+        "Ping"
+      ],
+      "template": "count({instance_type='ping', collect_type='ping', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:1301a9bd",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "mem_buffered{instance_type=\"k3s\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:13365ed8",
+      "object_names": [
+        "Process"
+      ],
+      "template": "sum(procstat_memory_usage{instance_type=\"process\", __$labels__}) by (instance_id, process_name)"
+    },
+    {
+      "id": "dashboard:v1:139b9cb0",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "max by (instance_id) (mysql_variables_super_read_only{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:13b556c4",
+      "object_names": [
+        "Loadbalance"
+      ],
+      "template": "avg(device_memory_usage{__$labels__}) by (instance_id) or (sum(device_memory_used{__$labels__}) by (instance_id) / sum(device_memory_total{__$labels__}) by (instance_id) * 100) or ((sum(device_memory_total{__$labels__}) by (instance_id) - sum(device_memory_free{__$labels__}) by (instance_id)) / sum(device_memory_total{__$labels__}) by (instance_id) * 100)"
+    },
+    {
+      "id": "dashboard:v1:13d2b6bb",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "max by (instance_id, node, device) (disk_used_percent{instance_type=\"k3s\", __$labels__})"
+    },
+    {
+      "id": "dashboard:v1:13eac1e4",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "clamp_max(100 * max by (instance_id) (mysql_open_files{__$labels__}) / on(instance_id) clamp_min(max by (instance_id) (mysql_variables_open_files_limit{__$labels__}), 1), 100)"
+    },
+    {
+      "id": "dashboard:v1:1402c33b",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "mem_shared{instance_type=\"k3s\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:145e9382",
+      "object_names": [
+        "TCPPort"
+      ],
+      "template": "avg(net_response_result_code{__$labels__} == bool 1) * 100"
+    },
+    {
+      "id": "dashboard:v1:14683557",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "rate(mongodb_page_faults{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:14f738cf",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "max by (instance_id) (mysql_process_list_threads_sending_data{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:150958a1",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "count(count(prometheus_remote_write_kube_pod_info{instance_type=\"k3s\",__$labels__}) by (namespace))"
+    },
+    {
+      "id": "dashboard:v1:164ec0ca",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "sum without (db) (rate(postgresql_tup_deleted{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:16cc42ec",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "sum without (db) (rate(postgresql_tup_returned{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:16e207b6",
+      "object_names": [
+        "ElasticSearch"
+      ],
+      "template": "100 * elasticsearch_cluster_health_active_primary_shards{__$labels__} / clamp_min(elasticsearch_cluster_health_active_primary_shards{__$labels__} + elasticsearch_cluster_health_unassigned_shards{__$labels__}, 1)"
+    },
+    {
+      "id": "dashboard:v1:16ecd72d",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "rate(net_packets_sent{instance_type=\"k3s\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:17108b30",
+      "object_names": [
+        "SGLang"
+      ],
+      "template": "sum(rate(sglang:generation_tokens_total_counter{__$labels__}[5m]))"
+    },
+    {
+      "id": "dashboard:v1:17193cd8",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "topk(8, sum by (db) (rate(postgresql_xact_rollback{__$labels__}[__$window__])))"
+    },
+    {
+      "id": "dashboard:v1:176eb56c",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "histogram_quantile(0.99, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:e2e_request_latency_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:e2e_request_latency_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:e2e_request_latency_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
+    },
+    {
+      "id": "dashboard:v1:178128bc",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "win_exchange_availability_Availability_Requests_(sec){instance_type=\"exchange\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:17b5e898",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "sum without (database) (rate(sqlserver_database_io_writes{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:17c23836",
+      "object_names": [
+        "Consul"
+      ],
+      "template": "count({instance_type='consul', collect_type='middleware', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:17eafa6c",
+      "object_names": [
+        "ElasticSearch"
+      ],
+      "template": "topk(8, max by (node_name) (elasticsearch_process_cpu_percent{__$labels__}))"
+    },
+    {
+      "id": "dashboard:v1:17f3483b",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "tomcat_jvm_memory_max{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:184929b2",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "clamp_max(100 * max by (instance_id) (mongodb_wtcache_current_bytes{__$labels__}) / on(instance_id) clamp_min(max by (instance_id) (mongodb_wtcache_max_bytes_configured{__$labels__}), 1), 100)"
+    },
+    {
+      "id": "dashboard:v1:1851f1d7",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "win_ad_DRA_Pending_Replication_Operations{instance_type=\"active_directory\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:18caab92",
+      "object_names": [
+        "Apache"
+      ],
+      "template": "apache_Load1{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:190c0e9b",
+      "object_names": [
+        "Access",
+        "ConsoleServer",
+        "Firewall",
+        "Loadbalance",
+        "NetworkService",
+        "Router",
+        "Switch",
+        "Transmission",
+        "VoiceGateway",
+        "Wireless"
+      ],
+      "template": "(sum(rate(interface_ifHCOutOctets{__$labels__}[__$window__])) by (instance_id)) or (sum(rate(interface_ifOutOctets{__$labels__}[__$window__])) by (instance_id))"
+    },
+    {
+      "id": "dashboard:v1:19336c2b",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "count(prometheus_remote_write_kube_pod_container_status_waiting_reason{instance_type=\"k3s\",reason=\"CrashLoopBackOff\",__$labels__} > 0)"
+    },
+    {
+      "id": "dashboard:v1:19ad1449",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "rate(rabbitmq_overview_messages_published{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:19ad740d",
+      "object_names": [
+        "Minio"
+      ],
+      "template": "min by (instance_id) (minio_cluster_erasure_set_overall_health_gauge{__$labels__}) or min by (instance_id) (minio_cluster_health_erasure_set_status_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:1a1c8bea",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "count(prometheus_remote_write_kube_node_info{instance_type=\"k3s\",__$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:1a2695ec",
+      "object_names": [
+        "Etcd"
+      ],
+      "template": "max by (instance_id) (etcd_server_proposals_pending_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:1a8564b8",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "count(prometheus_remote_write_kube_deployment_spec_replicas{instance_type=\"k8s\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:1adbf7f6",
+      "object_names": [
+        "Haproxy"
+      ],
+      "template": "avg by (instance_id) (haproxy_ttime{svname=\"BACKEND\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:1b087ed9",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_max_used_connections{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:1b1e3bf3",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "100 - avg(prometheus_remote_write_cpu_usage_idle{instance_type=\"k8s\",cpu=\"cpu-total\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:1b363a55",
+      "object_names": [
+        "Docker"
+      ],
+      "template": "topk(8, max by (container_name) (docker_container_mem_usage_percent{__$labels__}))"
+    },
+    {
+      "id": "dashboard:v1:1befba65",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "sum by (instance_id) (sqlserver_volume_space_used_space_bytes{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:1c073cc6",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "count({instance_type='postgres', collect_type='database', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:1c23b5bf",
+      "object_names": [
+        "SGLang"
+      ],
+      "template": "histogram_quantile(0.50, sum by (instance_id, le) (label_replace(rate({__name__=~\"sglang:time_to_first_token_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"sglang:time_to_first_token_seconds_(.+)\") or label_replace(rate({__name__=\"sglang:time_to_first_token_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
+    },
+    {
+      "id": "dashboard:v1:1c5cafe5",
+      "object_names": [
+        "Router"
+      ],
+      "template": "avg(label_value(netflow_in_bytes{instance_type='router', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:1d07bfdf",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_variables_max_connections{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:1d131c0f",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "sum by (instance_id) (vllm:num_requests_waiting_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:1d14844f",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "max by (instance_id) (oracledb_sga_total_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:1d398f0b",
+      "object_names": [
+        "Loadbalance"
+      ],
+      "template": "topk(10, avg_over_time((sum(sflow_bytes{instance_type='loadbalance', collect_type='sflow', __$labels__}) by (instance_id, header_protocol))[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:1d4d9955",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "histogram_quantile(0.50, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_generation_tokens_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_generation_tokens_(.+)\") or label_replace(rate({__name__=\"vllm:request_generation_tokens_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
+    },
+    {
+      "id": "dashboard:v1:1d7d03af",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "mongodb_open_connections{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:1ddc55cf",
+      "object_names": [
+        "Etcd"
+      ],
+      "template": "clamp_min(etcd_server_quota_backend_bytes_gauge{__$labels__} - etcd_mvcc_db_total_size_in_bytes_gauge{__$labels__}, 0)"
+    },
+    {
+      "id": "dashboard:v1:1df7f3ac",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "max by (instance_id) (oracledb_wait_time_commit_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:1e07292d",
+      "object_names": [
+        "Kafka"
+      ],
+      "template": "sum(kafka_exporter_lag_anomalies_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:1e582047",
+      "object_names": [
+        "TCPPort"
+      ],
+      "template": "avg(net_response_result_code{__$labels__} == bool 0) * 100"
+    },
+    {
+      "id": "dashboard:v1:1e65c4ce",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "mongodb_wtcache_current_bytes{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:1e81601b",
+      "object_names": [
+        "SGLang"
+      ],
+      "template": "histogram_quantile(0.90, sum by (instance_id, le) (label_replace(rate({__name__=~\"sglang:time_to_first_token_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"sglang:time_to_first_token_seconds_(.+)\") or label_replace(rate({__name__=\"sglang:time_to_first_token_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
+    },
+    {
+      "id": "dashboard:v1:1ea69a2a",
+      "object_names": [
+        "Zookeeper"
+      ],
+      "template": "count({instance_type='zookeeper', collect_type='middleware', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:1ed84440",
+      "object_names": [
+        "Loadbalance"
+      ],
+      "template": "count({instance_type='loadbalance', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:1ee5774a",
+      "object_names": [
+        "Etcd"
+      ],
+      "template": "sum by (instance_id) (rate(etcd_server_proposals_failed_total_counter{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:1f79c86d",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "rate(mongodb_net_in_bytes_count{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:20114010",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "histogram_quantile(0.95, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:inter_token_latency_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:inter_token_latency_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:inter_token_latency_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
+    },
+    {
+      "id": "dashboard:v1:206eb9f4",
+      "object_names": [
+        "LlamaServer"
+      ],
+      "template": "sum(rate(llamacpp:tokens_predicted_total_counter{__$labels__}[5m]))"
+    },
+    {
+      "id": "dashboard:v1:20aed6f8",
+      "object_names": [
+        "ElasticSearch"
+      ],
+      "template": "topk(8, max by (node_name) (elasticsearch_jvm_mem_heap_used_percent{__$labels__}))"
+    },
+    {
+      "id": "dashboard:v1:20b8344b",
+      "object_names": [
+        "Access",
+        "ConsoleServer",
+        "Firewall",
+        "Loadbalance",
+        "NetworkService",
+        "Router",
+        "Switch",
+        "Transmission",
+        "VoiceGateway",
+        "Wireless"
+      ],
+      "template": "(sum(rate(interface_ifHCInOctets{__$labels__}[__$window__])) by (instance_id)) or (sum(rate(interface_ifInOctets{__$labels__}[__$window__])) by (instance_id))"
+    },
+    {
+      "id": "dashboard:v1:20cc0d1b",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "max by (instance_id) (mysql_variables_log_bin{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:20f32b60",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "count(prometheus_remote_write_kube_node_info{instance_type=\"k8s\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:2116e4a1",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "win_exchange_adaccess_LDAP_Timeout_Errors_persec{instance_type=\"exchange\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:22082839",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "rate(sqlserver_performance_value{counter=\"Lock Waits/sec\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:22596b8e",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "histogram_quantile(0.95, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_queue_time_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_queue_time_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:request_queue_time_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
+    },
+    {
+      "id": "dashboard:v1:229a3849",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "rate(sqlserver_waitstats_resource_wait_ms{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:22c1d86d",
+      "object_names": [
+        "K3SPod"
+      ],
+      "template": "max by (instance_id, pod) ((prometheus_remote_write_kube_pod_status_phase{instance_type=\"k3s\",phase=\"Pending\",__$labels__} == 1) * 0 or (prometheus_remote_write_kube_pod_status_phase{instance_type=\"k3s\",phase=\"Running\",__$labels__} == 1) * 1 or (prometheus_remote_write_kube_pod_status_phase{instance_type=\"k3s\",phase=\"Succeeded\",__$labels__} == 1) * 2 or (prometheus_remote_write_kube_pod_status_phase{instance_type=\"k3s\",phase=\"Failed\",__$labels__} == 1) * 3 or (prometheus_remote_write_kube_pod_status_phase{instance_type=\"k3s\",phase=\"Unknown\",__$labels__} == 1) * 4)"
+    },
+    {
+      "id": "dashboard:v1:24588819",
+      "object_names": [
+        "Website"
+      ],
+      "template": "avg(http_response_result_code{__$labels__} == bool 5) * 100"
+    },
+    {
+      "id": "dashboard:v1:25277dde",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "100 * (1 - rate(mysql_key_reads{__$labels__}[__$window__]) / clamp_min(rate(mysql_key_read_requests{__$labels__}[__$window__]), 1e-6))"
+    },
+    {
+      "id": "dashboard:v1:252bc3de",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "100 * sum(prometheus_remote_write_kube_statefulset_status_replicas_ready{instance_type=\"k8s\",__$labels__}) / clamp_min(sum(prometheus_remote_write_kube_statefulset_replicas{instance_type=\"k8s\",__$labels__}),1)"
+    },
+    {
+      "id": "dashboard:v1:2573d10b",
+      "object_names": [
+        "Zookeeper"
+      ],
+      "template": "zookeeper_fsync_threshold_exceed_count{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:25a62668",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "max by (instance_id, node, device) (disk_inodes_used_percent{instance_type=\"k3s\", __$labels__})"
+    },
+    {
+      "id": "dashboard:v1:26885db1",
+      "object_names": [
+        "Redis"
+      ],
+      "template": "rate(redis_rejected_connections{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:26929806",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "topk(5, sum by (pod) (rate(prometheus_remote_write_container_cpu_usage_seconds_total{instance_type=\"k8s\",__$labels__}[__$window__])))"
+    },
+    {
+      "id": "dashboard:v1:26bc2dc3",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "rate(mongodb_latency_commands{__$labels__}[__$window__])/clamp_min(rate(mongodb_latency_commands_count{__$labels__}[__$window__]), 1e-6) / 1e6"
+    },
+    {
+      "id": "dashboard:v1:26e0c938",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "tomcat_jvm_memorypool_used{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:2709e481",
+      "object_names": [
+        "ElasticSearch"
+      ],
+      "template": "elasticsearch_fs_data_0_available_in_bytes{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:2728c633",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "tomcat_connector_error_count{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:2773683b",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "rabbitmq_overview_messages_ready{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:27cd3350",
+      "object_names": [
+        "Apache"
+      ],
+      "template": "count({instance_type='apache', collect_type='middleware', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:2819fa77",
+      "object_names": [
+        "SGLang"
+      ],
+      "template": "clamp_max(100 * avg(sglang:cache_hit_rate_gauge{__$labels__}), 100)"
+    },
+    {
+      "id": "dashboard:v1:2900961d",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "sum(prometheus_remote_write_kube_pod_status_phase{instance_type=\"k3s\",__$labels__}) by (phase)"
+    },
+    {
+      "id": "dashboard:v1:29134c84",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "win_exchange_activesync_Requests_persec{instance_type=\"exchange\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:291e728e",
+      "object_names": [
+        "Node"
+      ],
+      "template": "prometheus_remote_write_diskio_io_util{instance_type=\"k8s\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:293d2165",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "sum without (db) (rate(postgresql_xact_commit{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:29def2cf",
+      "object_names": [
+        "Router"
+      ],
+      "template": "sum(sflow_bytes{instance_type='router', collect_type='sflow', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:29faf6bc",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "net_response_response_time{instance_type=\"active_directory\", endpoint=\"ldap\", __$labels__} * 1000"
+    },
+    {
+      "id": "dashboard:v1:2a729ce3",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "http_response_result_code{instance_type=\"exchange\", endpoint=\"ews\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:2b101c51",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_variables_tmp_table_size{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:2b20a6e8",
+      "object_names": [
+        "K3SPod"
+      ],
+      "template": "sum by (instance_id,pod,device) ( rate(prometheus_remote_write_container_fs_writes_total{instance_type=\"k3s\",__$labels__}[__$window__]) )"
+    },
+    {
+      "id": "dashboard:v1:2b409bd1",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "win_exchange_transport_queues_Retry_Mailbox_Delivery_Queue_Length{instance_type=\"exchange\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:2b416071",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "max by (instance_id) (clamp_min(oracledb_resource_current_utilization_gauge{__$labels__} / clamp_min(oracledb_resource_limit_value_gauge{__$labels__}, 1) * 100, 0))"
+    },
+    {
+      "id": "dashboard:v1:2b5109cb",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_variables_table_open_cache{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:2beb4c8f",
+      "object_names": [
+        "Pod"
+      ],
+      "template": "sum by (instance_id,pod) ( rate(prometheus_remote_write_container_network_receive_bytes_total{instance_type=\"k8s\",__$labels__}[__$window__]) )"
+    },
+    {
+      "id": "dashboard:v1:2d0e5ee1",
+      "object_names": [
+        "InfluxDB"
+      ],
+      "template": "sum by (instance_id) (influxdb_database_numSeries{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:2d1acd27",
+      "object_names": [
+        "Redis"
+      ],
+      "template": "rate(redis_keyspace_misses{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:2de6fb29",
+      "object_names": [
+        "JVM"
+      ],
+      "template": "jvm_os_memory_physical_free_value{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:2e04f0e5",
+      "object_names": [
+        "Host"
+      ],
+      "template": "clamp_min(100 - cpu_usage_idle{cpu=\"cpu-total\", instance_type=\"os\", __$labels__} - cpu_usage_user{cpu=\"cpu-total\", instance_type=\"os\", __$labels__} - cpu_usage_system{cpu=\"cpu-total\", instance_type=\"os\", __$labels__} - cpu_usage_iowait{cpu=\"cpu-total\", instance_type=\"os\", __$labels__}, 0) or clamp_min(host_cpu_usage_percent_gauge{instance_type=\"os\", __$labels__} - cpu_usage_user_total_gauge{instance_type=\"os\", __$labels__} - cpu_usage_system_total_gauge{instance_type=\"os\", __$labels__} - cpu_usage_iowait_total_gauge{instance_type=\"os\", __$labels__}, 0)"
+    },
+    {
+      "id": "dashboard:v1:2e4f8a61",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_com_insert{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:2e5c747b",
+      "object_names": [
+        "K3SPod"
+      ],
+      "template": "count(prometheus_remote_write_kube_pod_info{instance_type='k3s', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:2e88f1e5",
+      "object_names": [
+        "ElasticSearch"
+      ],
+      "template": "elasticsearch_cluster_health_active_primary_shards{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:2fc2832b",
+      "object_names": [
+        "InfluxDB"
+      ],
+      "template": "count({instance_type='influxdb', collect_type='database', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:30203ebb",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "histogram_quantile(0.95, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_decode_time_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_decode_time_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:request_decode_time_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
+    },
+    {
+      "id": "dashboard:v1:304100e9",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "max by (instance_id) (mysql_slave_slave_io_running_int{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:3051fbde",
+      "object_names": [
+        "Docker"
+      ],
+      "template": "sum(docker_container_status_restart_count{__$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:309c32ee",
+      "object_names": [
+        "LlamaServer"
+      ],
+      "template": "sum(llamacpp:requests_deferred_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:309da43c",
+      "object_names": [
+        "Etcd"
+      ],
+      "template": "count({instance_type='etcd', collect_type='bkpull', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:310452d5",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "count({instance_type='mongodb', collect_type='database', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:3142769f",
+      "object_names": [
+        "TCPPort"
+      ],
+      "template": "max(net_response_response_time{__$labels__}) * 1000"
+    },
+    {
+      "id": "dashboard:v1:3191f945",
+      "object_names": [
+        "Minio"
+      ],
+      "template": "max by (instance_id) (minio_cluster_health_capacity_usable_free_bytes_gauge{__$labels__}) or max by (instance_id) (minio_cluster_capacity_usable_free_bytes_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:31e81656",
+      "object_names": [
+        "Node"
+      ],
+      "template": "rate(prometheus_remote_write_net_packets_recv{instance_type=\"k8s\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:31fafe6c",
+      "object_names": [
+        "Minio"
+      ],
+      "template": "clamp_min(100 * (1 - minio_cluster_health_capacity_usable_free_bytes_gauge{__$labels__} / clamp_min(minio_cluster_health_capacity_usable_total_bytes_gauge{__$labels__}, 1)), 0) or clamp_min(100 * (1 - minio_cluster_capacity_usable_free_bytes_gauge{__$labels__} / clamp_min(minio_cluster_capacity_usable_total_bytes_gauge{__$labels__}, 1)), 0)"
+    },
+    {
+      "id": "dashboard:v1:32353bb7",
+      "object_names": [
+        "Kafka"
+      ],
+      "template": "max by (instance_id) (kafka_brokers_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:3238f5d0",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "win_exchange_owa_Requests_persec{instance_type=\"exchange\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:327d67a5",
+      "object_names": [
+        "Haproxy"
+      ],
+      "template": "avg by (instance_id) (haproxy_ctime{svname=\"BACKEND\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:32fb7fd4",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "mongodb_wtcache_max_bytes_configured{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:332bc477",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "sum(prometheus_remote_write_container_memory_working_set_bytes{instance_type=\"k8s\", __$labels__})"
+    },
+    {
+      "id": "dashboard:v1:3365f98a",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "tomcat_connector_processing_time{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:34cac749",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "topk(5, sum by (pod) (rate(prometheus_remote_write_container_cpu_usage_seconds_total{instance_type=\"k3s\",__$labels__}[5m])))"
+    },
+    {
+      "id": "dashboard:v1:350832a9",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_bytes_received{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:3517bce0",
+      "object_names": [
+        "InfluxDB"
+      ],
+      "template": "sum by (instance_id) (rate(influxdb_httpd_pointsWrittenDropped{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:35497dc1",
+      "object_names": [
+        "LlamaServer"
+      ],
+      "template": "sum(llamacpp:prompt_tokens_total_counter{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:357a3767",
+      "object_names": [
+        "Zookeeper"
+      ],
+      "template": "zookeeper_znode_count{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:35fca49b",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_variables_innodb_buffer_pool_size{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:363e3caf",
+      "object_names": [
+        "Loadbalance",
+        "Router",
+        "Switch"
+      ],
+      "template": "max(device_psu_state{__$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:36951148",
+      "object_names": [
+        "Website"
+      ],
+      "template": "max by (instance_id) (http_response_response_time{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:36bd5c14",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "rate(mongodb_queries{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:374e2122",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "max(device_voltage_volts{__$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:374fb8f1",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "count(prometheus_remote_write_kube_node_info{instance_type=\"k8s\",__$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:3759c104",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "rabbitmq_node_fd_used{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:376e1423",
+      "object_names": [
+        "TCPPort"
+      ],
+      "template": "avg(net_response_result_code{__$labels__} == bool 4) * 100"
+    },
+    {
+      "id": "dashboard:v1:37748413",
+      "object_names": [
+        "Redis"
+      ],
+      "template": "redis_mem_fragmentation_ratio{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:3792cfdc",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "rate(sqlserver_performance_value{counter=\"Checkpoint pages/sec\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:37b62004",
+      "object_names": [
+        "Loadbalance"
+      ],
+      "template": "avg(sflow_sampling_rate{instance_type='loadbalance', collect_type='sflow', __$labels__}) by (instance_id) or avg(label_value(sflow_bytes{instance_type='loadbalance', collect_type='sflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:37bca60e",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "win_ad_DRA_Outbound_Bytes_Total_persec{instance_type=\"active_directory\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:382abf2c",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "max by (instance_id, node, device) (disk_free{instance_type=\"k3s\", __$labels__})"
+    },
+    {
+      "id": "dashboard:v1:3895943d",
+      "object_names": [
+        "Zookeeper"
+      ],
+      "template": "zookeeper_version{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:38b588d0",
+      "object_names": [
+        "Minio"
+      ],
+      "template": "sum by (instance_id) (rate(minio_api_requests_5xx_errors_total_counter{__$labels__}[__$window__])) or sum by (instance_id) (rate(minio_s3_requests_5xx_errors_total_counter{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:39218e88",
+      "object_names": [
+        "Zookeeper"
+      ],
+      "template": "zookeeper_outstanding_requests{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:394cf2e3",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "win_ad_LDAP_Bind_Time{instance_type=\"active_directory\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:39a36fd6",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "sum(sflow_packets{instance_type='switch', collect_type='sflow', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:39d6449f",
+      "object_names": [
+        "Pod"
+      ],
+      "template": "100 * ( sum(prometheus_remote_write_container_memory_working_set_bytes{instance_type=\"k8s\",__$labels__}) by (instance_id,pod) / on(instance_id,pod) sum(prometheus_remote_write_kube_pod_container_resource_limits{instance_type=\"k8s\", resource=\"memory\",__$labels__}) by (instance_id,pod) )"
+    },
+    {
+      "id": "dashboard:v1:3af524ce",
+      "object_names": [
+        "Apache"
+      ],
+      "template": "rate(apache_TotalAccesses{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:3b106fc3",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "rate(rabbitmq_overview_messages_delivered{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:3b29c4b0",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "sum without (db) (rate(postgresql_xact_rollback{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:3ba3b6f6",
+      "object_names": [
+        "Haproxy"
+      ],
+      "template": "sum by (instance_id) (rate(haproxy_econ{svname=\"BACKEND\",__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:3bdb7dad",
+      "object_names": [
+        "Zookeeper"
+      ],
+      "template": "zookeeper_num_alive_connections{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:3c7b682f",
+      "object_names": [
+        "JVM"
+      ],
+      "template": "jvm_os_memory_swap_free_value{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:3c82d3ed",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_aborted_connects{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:3d1d54f4",
+      "object_names": [
+        "Etcd"
+      ],
+      "template": "sum by (instance_id) (rate(etcd_server_heartbeat_send_failures_total_counter{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:3d4e82d8",
+      "object_names": [
+        "Etcd"
+      ],
+      "template": "sum by (instance_id) (rate(etcd_server_leader_changes_seen_total_counter{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:3df1b876",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "max(device_fan_speed{__$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:3e17a1a1",
+      "object_names": [
+        "Zookeeper"
+      ],
+      "template": "zookeeper_ephemerals_count{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:3e25d5af",
+      "object_names": [
+        "Host"
+      ],
+      "template": "system_load1{instance_type=\"os\", __$labels__} or system_load1_gauge{instance_type=\"os\", __$labels__} or host_cpu_load_1m_gauge{instance_type=\"os\", __$labels__} or system_load1_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:3ed547e5",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "rate(sqlserver_requests_logical_reads{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:3eda3797",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "rate(net_packets_recv{instance_type=\"k3s\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:3f98dbb9",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "count(prometheus_remote_write_kube_deployment_spec_replicas{instance_type=\"k3s\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:3fa6cef8",
+      "object_names": [
+        "Node"
+      ],
+      "template": "prometheus_remote_write_mem_buffered{instance_type=\"k8s\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:3fb9c103",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "max by (instance_id) (oracledb_pga_used_percent_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:3fe1e356",
+      "object_names": [
+        "Node"
+      ],
+      "template": "100 - avg by (instance_id, node) (prometheus_remote_write_cpu_usage_idle{instance_type=\"k8s\", cpu=\"cpu-total\", __$labels__})"
+    },
+    {
+      "id": "dashboard:v1:401f455f",
+      "object_names": [
+        "Haproxy"
+      ],
+      "template": "avg by (instance_id) (haproxy_qtime{svname=\"BACKEND\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:4097c55a",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "topk(8, sum by (database_name) (sqlserver_database_io_write_latency_ms{__$labels__}))"
+    },
+    {
+      "id": "dashboard:v1:40cf764b",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "sum without (db) (rate(postgresql_deadlocks{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:4107353d",
+      "object_names": [
+        "Firewall"
+      ],
+      "template": "firewall_vpn_tunnels{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:419611c4",
+      "object_names": [
+        "Pod"
+      ],
+      "template": "max by (instance_id, pod) ((prometheus_remote_write_kube_pod_status_phase{instance_type=\"k8s\",phase=\"Pending\",__$labels__} == 1) * 0 or (prometheus_remote_write_kube_pod_status_phase{instance_type=\"k8s\",phase=\"Running\",__$labels__} == 1) * 1 or (prometheus_remote_write_kube_pod_status_phase{instance_type=\"k8s\",phase=\"Succeeded\",__$labels__} == 1) * 2 or (prometheus_remote_write_kube_pod_status_phase{instance_type=\"k8s\",phase=\"Failed\",__$labels__} == 1) * 3 or (prometheus_remote_write_kube_pod_status_phase{instance_type=\"k8s\",phase=\"Unknown\",__$labels__} == 1) * 4)"
+    },
+    {
+      "id": "dashboard:v1:41aa9f7e",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_innodb_buffer_pool_reads{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:41f1de7e",
+      "object_names": [
+        "Haproxy"
+      ],
+      "template": "sum by (instance_id) (rate(haproxy_hrsp_5xx{svname=\"BACKEND\",__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:425a56b0",
+      "object_names": [
+        "SGLang"
+      ],
+      "template": "histogram_quantile(0.50, sum by (instance_id, le) (label_replace(rate({__name__=~\"sglang:e2e_request_latency_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"sglang:e2e_request_latency_seconds_(.+)\") or label_replace(rate({__name__=\"sglang:e2e_request_latency_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
+    },
+    {
+      "id": "dashboard:v1:42e2a318",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "max by (instance_id) (mysql_variables_read_only{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:43024617",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_table_open_cache_misses{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:4319e339",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "rabbitmq_node_run_queue{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:43a22b11",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "count(prometheus_remote_write_kube_node_info{instance_type=\"k3s\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:44a4f6ed",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "max by (instance_id) (oracledb_wait_time_system_io_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:44ef8f64",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "sum(prometheus_remote_write_kube_node_status_allocatable{instance_type=\"k8s\",resource=\"cpu\", __$labels__})"
+    },
+    {
+      "id": "dashboard:v1:45083898",
+      "object_names": [
+        "Process"
+      ],
+      "template": "((floor(((avg(clamp_max(net_response_result_code{instance_type=\"process\", __$labels__}, 1) == bool 0) by (instance_id, process_name)) or process_port_alive{instance_type=\"process\", __$labels__})) + ceil(((avg(clamp_max(net_response_result_code{instance_type=\"process\", __$labels__}, 1) == bool 0) by (instance_id, process_name)) or process_port_alive{instance_type=\"process\", __$labels__}))) / 2)"
+    },
+    {
+      "id": "dashboard:v1:45252c58",
+      "object_names": [
+        "Loadbalance",
+        "Router",
+        "Switch"
+      ],
+      "template": "max(device_fan_state{__$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:456d99c5",
+      "object_names": [
+        "Apache"
+      ],
+      "template": "apache_scboard_waiting{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:45a1d079",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "rate(rabbitmq_node_mnesia_disk_tx_count{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:46271e39",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "win_exchange_adaccess_LDAP_Read_Time{instance_type=\"exchange\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:469730f4",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "mongodb_connections_current{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:46d0f9ce",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "100 * sum(prometheus_remote_write_kube_deployment_status_replicas_available{instance_type=\"k3s\",__$labels__}) / clamp_min(sum(prometheus_remote_write_kube_deployment_spec_replicas{instance_type=\"k3s\",__$labels__}),1)"
+    },
+    {
+      "id": "dashboard:v1:46e96889",
+      "object_names": [
+        "Redis"
+      ],
+      "template": "rate(redis_keyspace_hits{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:472656c9",
+      "object_names": [
+        "Zookeeper"
+      ],
+      "template": "clamp_min(zookeeper_max_file_descriptor_count{__$labels__} - zookeeper_open_file_descriptor_count{__$labels__}, 0)"
+    },
+    {
+      "id": "dashboard:v1:47306783",
+      "object_names": [
+        "ActiveMQ"
+      ],
+      "template": "rate(activemq_topics_enqueue_count{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:474fc672",
+      "object_names": [
+        "Firewall"
+      ],
+      "template": "sum(netflow_in_bytes{instance_type='firewall', collect_type='netflow', __$labels__} * label_value(netflow_in_bytes{instance_type='firewall', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id) / sum(netflow_in_packets{instance_type='firewall', collect_type='netflow', __$labels__} * label_value(netflow_in_packets{instance_type='firewall', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:476af534",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "sum by (instance_id) (rate(vllm:prompt_tokens_total_counter{__$labels__}[5m])) * 60"
+    },
+    {
+      "id": "dashboard:v1:48694644",
+      "object_names": [
+        "SGLang"
+      ],
+      "template": "sum(rate(sglang:prompt_tokens_total_counter{__$labels__}[5m]))"
+    },
+    {
+      "id": "dashboard:v1:48989c3a",
+      "object_names": [
+        "Firewall"
+      ],
+      "template": "count({instance_type='firewall', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:48a9356c",
+      "object_names": [
+        "Pod"
+      ],
+      "template": "sum by (instance_id,pod,device) ( rate(prometheus_remote_write_container_fs_reads_total{instance_type=\"k8s\",__$labels__}[__$window__]) )"
+    },
+    {
+      "id": "dashboard:v1:48ed8ca4",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "sum(sflow_bytes{instance_type='switch', collect_type='sflow', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:4913c929",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_innodb_row_lock_time_avg{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:491856b5",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "histogram_quantile(0.90, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_prompt_tokens_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_prompt_tokens_(.+)\") or label_replace(rate({__name__=\"vllm:request_prompt_tokens_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
+    },
+    {
+      "id": "dashboard:v1:4925b8e9",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "system_load1{instance_type=\"k3s\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:492fc6fa",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "100 * rate(mysql_table_open_cache_hits{__$labels__}[__$window__]) / clamp_min(rate(mysql_table_open_cache_hits{__$labels__}[__$window__]) + rate(mysql_table_open_cache_misses{__$labels__}[__$window__]), 1e-6)"
+    },
+    {
+      "id": "dashboard:v1:49387988",
+      "object_names": [
+        "Docker"
+      ],
+      "template": "max(docker_container_mem_usage{__$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:496eb865",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_com_update{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:49dbe520",
+      "object_names": [
+        "ElasticSearch"
+      ],
+      "template": "elasticsearch_jvm_mem_heap_used_percent{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:4ac00cb9",
+      "object_names": [
+        "Minio"
+      ],
+      "template": "sum by (instance_id) (rate(minio_api_requests_traffic_sent_bytes_counter{__$labels__}[__$window__])) or sum by (instance_id) (rate(minio_s3_traffic_sent_bytes_counter{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:4ad46230",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "max by (instance_id) (oracledb_sga_used_percent_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:4ad88e6f",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "win_ad_DRA_Inbound_Bytes_Total_persec{instance_type=\"active_directory\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:4ae2cd32",
+      "object_names": [
+        "TCPPort"
+      ],
+      "template": "count({instance_type='tcp', collect_type='tcp', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:4b36d818",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_aborted_connects{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:4ba559b5",
+      "object_names": [
+        "Haproxy"
+      ],
+      "template": "sum by (instance_id) (rate(haproxy_wredis{svname=\"BACKEND\",__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:4c14ad42",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "win_ad_ATQ_Outstanding_Queued_Requests{instance_type=\"active_directory\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:4c6c3c5d",
+      "object_names": [
+        "nginx"
+      ],
+      "template": "rate(nginx_accepts{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:4d3788b9",
+      "object_names": [
+        "InfluxDB"
+      ],
+      "template": "max by (instance_id) (influxdb_runtime_HeapAlloc{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:4d3aca94",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "mem_cached{instance_type=\"k3s\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:4db325ac",
+      "object_names": [
+        "K3SPod"
+      ],
+      "template": "prometheus_remote_write_kube_pod_container_status_restarts_total{instance_type=\"k3s\",__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:4dbf9ddb",
+      "object_names": [
+        "Redis"
+      ],
+      "template": "rate(redis_expired_keys{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:4df58d02",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "rate(sqlserver_requests_wait_time_ms{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:4e8928b2",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_slow_queries{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:4eaf2b98",
+      "object_names": [
+        "Minio"
+      ],
+      "template": "max by (instance_id) (minio_cluster_erasure_set_overall_health_gauge{__$labels__}) or max by (instance_id) (minio_cluster_health_status_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:4f5a2773",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "sum(prometheus_remote_write_kube_node_status_allocatable{instance_type=\"k8s\",resource=\"memory\", __$labels__})"
+    },
+    {
+      "id": "dashboard:v1:4ff9c403",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "win_exchange_transport_queues_Poison_Queue_Length{instance_type=\"exchange\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:501b0278",
+      "object_names": [
+        "ElasticSearch"
+      ],
+      "template": "elasticsearch_process_cpu_percent{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:504c2598",
+      "object_names": [
+        "Node"
+      ],
+      "template": "topk(5, sum by (pod) (rate(prometheus_remote_write_container_cpu_usage_seconds_total{instance_type=\"k8s\",__$labels__}[5m])))"
+    },
+    {
+      "id": "dashboard:v1:50d24874",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "sqlserver_performance_value{counter=\"Target Server Memory (KB)\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:50f2b03f",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "win_ad_LDAP_Searches_persec{instance_type=\"active_directory\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:512ffba4",
+      "object_names": [
+        "Ping"
+      ],
+      "template": "clamp_max(100 - avg(ping_percent_packet_loss{__$labels__}), 100)"
+    },
+    {
+      "id": "dashboard:v1:51dee34b",
+      "object_names": [
+        "JVM"
+      ],
+      "template": "jvm_memory_usage_committed_value{type=\"Heap\",__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:51f56db8",
+      "object_names": [
+        "Docker"
+      ],
+      "template": "topk(8, max by (container_name) (docker_container_cpu_usage_percent{__$labels__}))"
+    },
+    {
+      "id": "dashboard:v1:5251c26a",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "avg(label_value(netflow_in_bytes{instance_type='switch', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:525575db",
+      "object_names": [
+        "Loadbalance",
+        "Switch"
+      ],
+      "template": "sum(device_memory_used{__$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:5265677e",
+      "object_names": [
+        "Consul"
+      ],
+      "template": "sum by (instance_id) (consul_health_checks_critical{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:52d678dd",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "clamp_max(100 * max by (instance_id) (mysql_threads_connected{__$labels__}) / on(instance_id) clamp_min(max by (instance_id) (mysql_variables_max_connections{__$labels__}), 1), 100)"
+    },
+    {
+      "id": "dashboard:v1:52e18755",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "rate(diskio_read_bytes{instance_type=\"k3s\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:52e3e537",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_questions{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:5356f91a",
+      "object_names": [
+        "Host"
+      ],
+      "template": "sum by (instance_id) (rate(net_err_out{instance_type=\"os\", __$labels__}[__$window__]) or rate(net_err_out_gauge{instance_type=\"os\", __$labels__}[__$window__]) or rate(net_err_out_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:544d4c36",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "rate(diskio_read_time{instance_type=\"k3s\", __$labels__}[__$window__]) / clamp_min(rate(diskio_reads{instance_type=\"k3s\", __$labels__}[__$window__]), 1e-9)"
+    },
+    {
+      "id": "dashboard:v1:54beea06",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "mongodb_wtcache_tracked_dirty_bytes{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:54cfc6f2",
+      "object_names": [
+        "ActiveMQ"
+      ],
+      "template": "count({instance_type='activemq', collect_type='middleware', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:55833b43",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "topk(8, sum by (db) (postgresql_numbackends{__$labels__}))"
+    },
+    {
+      "id": "dashboard:v1:55933392",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "rabbitmq_node_proc_used{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:55a2c1c3",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "mongodb_queued_writes{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:55bf5f9b",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "histogram_quantile(0.95, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_prefill_time_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_prefill_time_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:request_prefill_time_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
+    },
+    {
+      "id": "dashboard:v1:566ff64c",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "sum by (queue, vhost) (rabbitmq_queue_messages_ready{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:567b19e4",
+      "object_names": [
+        "Host"
+      ],
+      "template": "sum by (instance_id) (rate(net_bytes_recv{instance_type=\"os\", __$labels__}[__$window__]) or rate(net_bytes_recv_gauge{instance_type=\"os\", __$labels__}[__$window__]) or rate(net_bytes_recv_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:56aac697",
+      "object_names": [
+        "Pod"
+      ],
+      "template": "sum by (instance_id,pod,device) ( rate(prometheus_remote_write_container_fs_writes_total{instance_type=\"k8s\",__$labels__}[__$window__]) )"
+    },
+    {
+      "id": "dashboard:v1:56e84f9a",
+      "object_names": [
+        "Loadbalance"
+      ],
+      "template": "sum(netflow_in_bytes{instance_type='loadbalance', collect_type='netflow', __$labels__} * label_value(netflow_in_bytes{instance_type='loadbalance', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id) / sum(netflow_in_packets{instance_type='loadbalance', collect_type='netflow', __$labels__} * label_value(netflow_in_packets{instance_type='loadbalance', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:570ef25f",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "100 * rate(mysql_created_tmp_disk_tables{__$labels__}[__$window__]) / clamp_min(rate(mysql_created_tmp_tables{__$labels__}[__$window__]), 1e-6)"
+    },
+    {
+      "id": "dashboard:v1:5714ba03",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "sum by (instance_id) (rate(oracledb_activity_parse_count_total_gauge{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:5764f10c",
+      "object_names": [
+        "Kafka"
+      ],
+      "template": "count((kafka_consumergroup_lag_gauge{__$labels__} == -1) unless on(instance_id, consumergroup, topic, partition) (kafka_consumergroup_lag_anomaly_gauge{__$labels__} == 1)) or on() vector(0)"
+    },
+    {
+      "id": "dashboard:v1:57d70761",
+      "object_names": [
+        "Etcd"
+      ],
+      "template": "clamp_min((etcd_mvcc_db_total_size_in_bytes_gauge{__$labels__} - etcd_mvcc_db_total_size_in_use_in_bytes_gauge{__$labels__}) / clamp_min(etcd_mvcc_db_total_size_in_bytes_gauge{__$labels__}, 1) * 100, 0)"
+    },
+    {
+      "id": "dashboard:v1:585d46ef",
+      "object_names": [
+        "Node"
+      ],
+      "template": "max by (instance_id, node, device) (prometheus_remote_write_disk_inodes_used_percent{instance_type=\"k8s\", __$labels__})"
+    },
+    {
+      "id": "dashboard:v1:58a0aecb",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "net_response_response_time{instance_type=\"active_directory\", endpoint=\"ldaps\", __$labels__} * 1000"
+    },
+    {
+      "id": "dashboard:v1:59661395",
+      "object_names": [
+        "nginx"
+      ],
+      "template": "clamp_max(100 * (nginx_reading{__$labels__} + nginx_writing{__$labels__}) / clamp_min(nginx_active{__$labels__}, 1), 100)"
+    },
+    {
+      "id": "dashboard:v1:59a1c2ee",
+      "object_names": [
+        "Etcd"
+      ],
+      "template": "sum by (instance_id) (rate(etcd_mvcc_delete_total_counter{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:59ae969c",
+      "object_names": [
+        "Firewall"
+      ],
+      "template": "firewall_active_sessions{__$labels__} or firewall_current_connections{__$labels__} or firewall_active_connections{__$labels__} or firewall_tcp_connections{__$labels__} or firewall_pf_states{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:5a55e526",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "100 * (rabbitmq_overview_messages_unacked{__$labels__} / clamp_min(rabbitmq_overview_messages{__$labels__}, 1))"
+    },
+    {
+      "id": "dashboard:v1:5a7f4ae8",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "topk(5, prometheus_remote_write_mem_used_percent{instance_type=\"k8s\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:5aa4e079",
+      "object_names": [
+        "Docker"
+      ],
+      "template": "sum(rate(docker_container_net_rx_bytes{__$labels__}[__$window__])) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:5ac524f2",
+      "object_names": [
+        "Host"
+      ],
+      "template": "mem_used_percent{instance_type=\"os\", __$labels__} or host_mem_used_percent_gauge{instance_type=\"os\", __$labels__} or mem_used_percent_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:5addc434",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "count(count(prometheus_remote_write_kube_pod_info{instance_type=\"k8s\",__$labels__}) by (namespace))"
+    },
+    {
+      "id": "dashboard:v1:5b09f228",
+      "object_names": [
+        "Minio"
+      ],
+      "template": "sum by (instance_id) (minio_api_requests_incoming_total_gauge{__$labels__}) or sum by (instance_id) (minio_s3_requests_incoming_total_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:5b208122",
+      "object_names": [
+        "Etcd"
+      ],
+      "template": "sum by (instance_id) (rate(etcd_server_proposals_committed_total_gauge{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:5b25c2be",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "sum(rate(interface_ifOutDiscards{__$labels__}[__$window__])) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:5b32db72",
+      "object_names": [
+        "ElasticSearch"
+      ],
+      "template": "elasticsearch_process_open_file_descriptors{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:5b47bda9",
+      "object_names": [
+        "Etcd"
+      ],
+      "template": "max by (instance_id) (etcd_server_has_leader_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:5b7942fa",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "net_response_result_code{instance_type=\"active_directory\", endpoint=\"ldaps\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:5c738e40",
+      "object_names": [
+        "Node"
+      ],
+      "template": "rate(prometheus_remote_write_net_packets_sent{instance_type=\"k8s\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:5ca86c45",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "win_ad_ATQ_Estimated_Queue_Delay{instance_type=\"active_directory\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:5d3088b5",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "tomcat_connector_max_threads{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:5da4cdb8",
+      "object_names": [
+        "Ping"
+      ],
+      "template": "avg(ping_result_code{__$labels__} == bool 0) * 100"
+    },
+    {
+      "id": "dashboard:v1:5dc11471",
+      "object_names": [
+        "K3SPod"
+      ],
+      "template": "100 * ( sum(irate(prometheus_remote_write_container_cpu_usage_seconds_total{instance_type=\"k3s\",__$labels__}[__$window__])) by (instance_id,pod) / on(instance_id,pod) sum(prometheus_remote_write_kube_pod_container_resource_limits{instance_type=\"k3s\", resource=\"cpu\",__$labels__}) by (instance_id,pod) )"
+    },
+    {
+      "id": "dashboard:v1:5ddfa051",
+      "object_names": [
+        "Minio"
+      ],
+      "template": "max by (instance_id) (minio_cluster_health_drives_online_count_gauge{__$labels__}) or max by (instance_id) (minio_cluster_drive_online_total_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:5e21aa00",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "histogram_quantile(0.99, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_generation_tokens_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_generation_tokens_(.+)\") or label_replace(rate({__name__=\"vllm:request_generation_tokens_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
+    },
+    {
+      "id": "dashboard:v1:5e25cc9f",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "rabbitmq_overview_queues{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:5e44d3f7",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "count(prometheus_remote_write_kube_daemonset_status_number_unavailable{instance_type=\"k8s\",__$labels__} > 0)"
+    },
+    {
+      "id": "dashboard:v1:5f29a022",
+      "object_names": [
+        "Zookeeper"
+      ],
+      "template": "rate(zookeeper_fsync_threshold_exceed_count{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:5f41b916",
+      "object_names": [
+        "nginx"
+      ],
+      "template": "nginx_waiting{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:5f7e5563",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "tomcat_connector_bytes_sent{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:5fce1502",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "avg(sflow_sampling_rate{instance_type='switch', collect_type='sflow', __$labels__}) by (instance_id) or avg(label_value(sflow_bytes{instance_type='switch', collect_type='sflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:60a33134",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "rate(sqlserver_performance_value{counter=\"Number of Deadlocks/sec\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:6188de37",
+      "object_names": [
+        "Router"
+      ],
+      "template": "avg(device_memory_usage{__$labels__}) by (instance_id) or ((sum(device_memory_total{__$labels__}) by (instance_id) - sum(device_memory_free{__$labels__}) by (instance_id)) / sum(device_memory_total{__$labels__}) by (instance_id) * 100)"
+    },
+    {
+      "id": "dashboard:v1:619c6393",
+      "object_names": [
+        "Process"
+      ],
+      "template": "sum(procstat_num_threads{instance_type=\"process\", __$labels__}) by (instance_id, process_name)"
+    },
+    {
+      "id": "dashboard:v1:61afb2c8",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "rate(sqlserver_performance_value{counter=~\"Batch Requests/sec\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:6206d346",
+      "object_names": [
+        "Haproxy"
+      ],
+      "template": "sum by (instance_id) (haproxy_rate{svname=\"FRONTEND\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:62ad801a",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "count({instance_type='active_directory', collect_type='host', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:62f232d7",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_innodb_buffer_pool_pages_total{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:63181e12",
+      "object_names": [
+        "Router"
+      ],
+      "template": "avg(sflow_sampling_rate{instance_type='router', collect_type='sflow', __$labels__}) by (instance_id) or avg(label_value(sflow_bytes{instance_type='router', collect_type='sflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:631fe3c5",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "win_ad_DS_Notify_Queue_Size{instance_type=\"active_directory\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:638cb2dc",
+      "object_names": [
+        "JVM"
+      ],
+      "template": "sum(rate(jvm_gc_collectioncount_value{__$labels__}[__$window__])) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:6391a9df",
+      "object_names": [
+        "Redis"
+      ],
+      "template": "clamp_min(max by (instance_id) (redis_maxmemory{__$labels__}) - max by (instance_id) (redis_used_memory{__$labels__}), 0)"
+    },
+    {
+      "id": "dashboard:v1:63ba018a",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "sum(netflow_in_bytes{instance_type='switch', collect_type='netflow', __$labels__} * label_value(netflow_in_bytes{instance_type='switch', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id) / sum(netflow_in_packets{instance_type='switch', collect_type='netflow', __$labels__} * label_value(netflow_in_packets{instance_type='switch', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:63e55517",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "max by (instance_id) (oracledb_tablespace_used_percent_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:6416f65b",
+      "object_names": [
+        "SGLang"
+      ],
+      "template": "sum(sglang:gen_throughput_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:64264f55",
+      "object_names": [
+        "Kafka"
+      ],
+      "template": "topk(10, max by (consumergroup, topic, partition) (kafka_consumergroup_lag_gauge{__$labels__} >= 0))"
+    },
+    {
+      "id": "dashboard:v1:659002f9",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "sqlserver_schedulers_active_workers_count{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:6592d907",
+      "object_names": [
+        "Haproxy"
+      ],
+      "template": "sum by (instance_id) (rate(haproxy_chkdown{svname=\"BACKEND\",__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:65ad0fda",
+      "object_names": [
+        "Node"
+      ],
+      "template": "prometheus_remote_write_mem_shared{instance_type=\"k8s\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:65ffa41a",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "sqlserver_server_properties_uptime{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:666aa1e6",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "rabbitmq_node_sockets_used{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:671c14e8",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "rabbitmq_overview_connections{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:676f96b8",
+      "object_names": [
+        "LlamaServer"
+      ],
+      "template": "clamp_max(100 * avg(llamacpp:kv_cache_usage_ratio_gauge{__$labels__}), 100)"
+    },
+    {
+      "id": "dashboard:v1:67c75e59",
+      "object_names": [
+        "Loadbalance"
+      ],
+      "template": "topk(10, avg_over_time((sum(sflow_bytes{instance_type='loadbalance', collect_type='sflow', __$labels__}) by (instance_id, src_ip, src_port, dst_ip, header_protocol, dst_port))[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:67e2282d",
+      "object_names": [
+        "Redis"
+      ],
+      "template": "redis_used_memory{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:6970bbf2",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "count({instance_type='switch', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:698da4f4",
+      "object_names": [
+        "SGLang"
+      ],
+      "template": "sum(rate(sglang:time_to_first_token_seconds_sum{__$labels__}[5m])) / sum(rate(sglang:time_to_first_token_seconds_count{__$labels__}[5m]))"
+    },
+    {
+      "id": "dashboard:v1:69b8d97c",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "sum(irate(prometheus_remote_write_container_cpu_usage_seconds_total{instance_type=\"k8s\", __$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:6a65eff6",
+      "object_names": [
+        "Apache"
+      ],
+      "template": "apache_ParentServerConfigGeneration{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:6b68ac0a",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "win_ad_DS_Directory_Reads_persec{instance_type=\"active_directory\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:6b8ec769",
+      "object_names": [
+        "JVM"
+      ],
+      "template": "sum(jvm_memorypool_usage_committed_value{__$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:6baa43bf",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "mongodb_uptime_ns{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:6bab9127",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "win_ad_LDAP_New_Connections_persec{instance_type=\"active_directory\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:6bc43be2",
+      "object_names": [
+        "Firewall"
+      ],
+      "template": "sum(sflow_packets{instance_type='firewall', collect_type='sflow', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:6bd52764",
+      "object_names": [
+        "Zookeeper"
+      ],
+      "template": "clamp_max(100 * (zookeeper_open_file_descriptor_count{__$labels__} / clamp_min(zookeeper_max_file_descriptor_count{__$labels__}, 1)), 100)"
+    },
+    {
+      "id": "dashboard:v1:6cb43331",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "sqlserver_performance_value{counter=\"Total Server Memory (KB)\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:6cd18340",
+      "object_names": [
+        "Redis"
+      ],
+      "template": "count({instance_type='redis', collect_type='database', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:6d074c64",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "count(prometheus_remote_write_kube_pod_info{instance_type=\"k3s\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:6ddc8a0f",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "mongodb_resident_megabytes{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:6e098331",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "sum by (queue, vhost) (rabbitmq_queue_consumers{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:6e4f44cc",
+      "object_names": [
+        "Firewall"
+      ],
+      "template": "topk(10, avg_over_time((sum(netflow_in_bytes{instance_type='firewall', collect_type='netflow', __$labels__} * label_value(netflow_in_bytes{instance_type='firewall', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id, protocol))[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:6e7177c6",
+      "object_names": [
+        "Firewall"
+      ],
+      "template": "avg(sflow_sampling_rate{instance_type='firewall', collect_type='sflow', __$labels__}) by (instance_id) or avg(label_value(sflow_bytes{instance_type='firewall', collect_type='sflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:6ed4a7e1",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "rate(net_bytes_recv{instance_type=\"k3s\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:6f135964",
+      "object_names": [
+        "Consul"
+      ],
+      "template": "max by (instance_id) (consul_health_checks_status{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:6f15906e",
+      "object_names": [
+        "Docker"
+      ],
+      "template": "docker_n_containers_stopped{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:6f23278e",
+      "object_names": [
+        "Zookeeper"
+      ],
+      "template": "zookeeper_min_latency{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:6f244f83",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_com_delete{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:6f403a8a",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "win_ad_DRA_Pending_Replication_Synchronizations{instance_type=\"active_directory\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:6f47c73f",
+      "object_names": [
+        "Loadbalance"
+      ],
+      "template": "sum(netflow_in_bytes{instance_type='loadbalance', collect_type='netflow', __$labels__} * label_value(netflow_in_bytes{instance_type='loadbalance', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:70750b39",
+      "object_names": [
+        "Etcd"
+      ],
+      "template": "1000 * histogram_quantile(0.99, sum(rate((label_replace({__name__=~\"etcd_disk_backend_commit_duration_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"etcd_disk_backend_commit_duration_seconds_(.+)\"))[5m:]) or label_replace(rate(etcd_disk_backend_commit_duration_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+    },
+    {
+      "id": "dashboard:v1:707b5adf",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "topk(10, avg_over_time((sum(sflow_bytes{instance_type='switch', collect_type='sflow', __$labels__}) by (instance_id, header_protocol))[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:70ffc291",
+      "object_names": [
+        "ElasticSearch"
+      ],
+      "template": "elasticsearch_cluster_health_unassigned_shards{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:712226d0",
+      "object_names": [
+        "Node"
+      ],
+      "template": "rate(prometheus_remote_write_diskio_read_bytes{instance_type=\"k8s\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:7172dcbe",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "sum without (db) (rate(postgresql_checkpoints_timed{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:71800475",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "rabbitmq_overview_messages_unacked{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:72c3c696",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "cpu_usage_system{instance_type=\"k3s\",cpu=\"cpu-total\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:731f0f39",
+      "object_names": [
+        "K3SCluster",
+        "K3SNode"
+      ],
+      "template": "topk(5, sum by (pod) (prometheus_remote_write_container_memory_working_set_bytes{instance_type=\"k3s\",__$labels__}))"
+    },
+    {
+      "id": "dashboard:v1:73aa4208",
+      "object_names": [
+        "Node"
+      ],
+      "template": "rate(prometheus_remote_write_diskio_writes{instance_type=\"k8s\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:73b0ad8d",
+      "object_names": [
+        "Etcd"
+      ],
+      "template": "max by (instance_id) (etcd_debugging_mvcc_keys_total_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:73eac485",
+      "object_names": [
+        "SGLang"
+      ],
+      "template": "histogram_quantile(0.99, sum by (instance_id, le) (label_replace(rate({__name__=~\"sglang:e2e_request_latency_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"sglang:e2e_request_latency_seconds_(.+)\") or label_replace(rate({__name__=\"sglang:e2e_request_latency_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
+    },
+    {
+      "id": "dashboard:v1:74481caa",
+      "object_names": [
+        "Kafka"
+      ],
+      "template": "sum(kafka_topic_partitions_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:74da13d2",
+      "object_names": [
+        "Docker"
+      ],
+      "template": "clamp_max(100 * (docker_n_containers_stopped{__$labels__} / clamp_min(docker_n_containers{__$labels__}, 1)), 100)"
+    },
+    {
+      "id": "dashboard:v1:76ff4618",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "win_exchange_http_proxy_Average_Authentication_Latency{instance_type=\"exchange\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:77a5c5ef",
+      "object_names": [
+        "Haproxy"
+      ],
+      "template": "sum by (instance_id) (rate(haproxy_hrsp_4xx{svname=\"BACKEND\",__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:78470004",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "avg without (database) (avg_over_time(sqlserver_database_io_read_latency_ms{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:7852cb47",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "max by (instance_id) (mysql_process_list_threads_waiting_for_lock{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:789b57a4",
+      "object_names": [
+        "Loadbalance"
+      ],
+      "template": "topk(10, avg_over_time((sum(netflow_in_bytes{instance_type='loadbalance', collect_type='netflow', __$labels__} * label_value(netflow_in_bytes{instance_type='loadbalance', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id, protocol))[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:78ca9d67",
+      "object_names": [
+        "ActiveMQ"
+      ],
+      "template": "rate(activemq_topics_dequeue_count{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:78eef267",
+      "object_names": [
+        "ElasticSearch"
+      ],
+      "template": "elasticsearch_http_current_open{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:799bc026",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "clamp_min(tomcat_connector_max_threads{__$labels__} - tomcat_connector_current_threads_busy{__$labels__}, 0)"
+    },
+    {
+      "id": "dashboard:v1:79a395dc",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "sqlserver_performance_value{counter=\"Memory Grants Pending\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:7a11ebe7",
+      "object_names": [
+        "Process"
+      ],
+      "template": "clamp_max(count(procstat_cpu_usage{instance_type=\"process\", __$labels__}) by (instance_id, process_name), 1)"
+    },
+    {
+      "id": "dashboard:v1:7a3d067c",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "sum by (instance_id) (sqlserver_volume_space_total_space_bytes{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:7a69506b",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "count(prometheus_remote_write_kube_daemonset_status_desired_number_scheduled{instance_type=\"k8s\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:7a7d8c48",
+      "object_names": [
+        "Access"
+      ],
+      "template": "count({instance_type='access', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:7b994982",
+      "object_names": [
+        "Router"
+      ],
+      "template": "sum(netflow_in_bytes{instance_type='router', collect_type='netflow', __$labels__} * label_value(netflow_in_bytes{instance_type='router', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id) / sum(netflow_in_packets{instance_type='router', collect_type='netflow', __$labels__} * label_value(netflow_in_packets{instance_type='router', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:7bdc6dac",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "100 * (rabbitmq_node_mem_used{__$labels__} / clamp_min(rabbitmq_node_mem_limit{__$labels__}, 1))"
+    },
+    {
+      "id": "dashboard:v1:7be7f413",
+      "object_names": [
+        "Host"
+      ],
+      "template": "processes_zombies{instance_type=\"os\", __$labels__} or processes_zombies_gauge{instance_type=\"os\", __$labels__} or processes_zombies_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:7be92b55",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "min((device_optical_tx_power{__$labels__} != -10000 != -2147483648) / 100) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:7c7235e5",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "win_exchange_workload_ActiveTasks{instance_type=\"exchange\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:7cbd0452",
+      "object_names": [
+        "Node"
+      ],
+      "template": "prometheus_remote_write_mem_available{instance_type=\"k8s\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:7ccbdb68",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "avg_over_time(sqlserver_cpu_system_idle_cpu{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:7ced90db",
+      "object_names": [
+        "Haproxy"
+      ],
+      "template": "sum by (instance_id) (haproxy_req_rate{svname=\"FRONTEND\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:7d6fd449",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "sqlserver_waitstats_waiting_tasks_count{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:7d8dad5a",
+      "object_names": [
+        "Pod"
+      ],
+      "template": "sum by (instance_id,pod) ( rate(prometheus_remote_write_container_network_transmit_bytes_total{instance_type=\"k8s\",__$labels__}[__$window__]) )"
+    },
+    {
+      "id": "dashboard:v1:7dfe1458",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "sum without (db) (rate(postgresql_blks_read{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:7e4ca59b",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "tomcat_connector_current_thread_count{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:7fe1cae9",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "count({instance_type='mysql', collect_type='database', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:7ff082fe",
+      "object_names": [
+        "Transmission"
+      ],
+      "template": "count({instance_type='transmission', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:7ff96566",
+      "object_names": [
+        "Router"
+      ],
+      "template": "topk(10, avg_over_time((sum(sflow_bytes{instance_type='router', collect_type='sflow', __$labels__}) by (instance_id, header_protocol))[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:80289fe3",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_variables_open_files_limit{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:80452508",
+      "object_names": [
+        "Router"
+      ],
+      "template": "topk(10, avg_over_time((sum(sflow_bytes{instance_type='router', collect_type='sflow', __$labels__}) by (instance_id, src_ip, src_port, dst_ip, header_protocol, dst_port))[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:8056a87d",
+      "object_names": [
+        "nginx"
+      ],
+      "template": "nginx_active{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:80bd1482",
+      "object_names": [
+        "Cluster",
+        "Node"
+      ],
+      "template": "topk(5, sum by (pod) (prometheus_remote_write_container_memory_working_set_bytes{instance_type=\"k8s\",__$labels__}))"
+    },
+    {
+      "id": "dashboard:v1:80e28994",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "sqlserver_performance_value{counter=\"Page life expectancy\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:80f550dc",
+      "object_names": [
+        "Redis"
+      ],
+      "template": "redis_uptime{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:813f0944",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "max by (instance_id) (oracledb_wait_time_concurrency_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:814210e1",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "clamp_max(100 * max by (instance_id) (vllm:kv_cache_usage_perc_gauge{__$labels__}), 100)"
+    },
+    {
+      "id": "dashboard:v1:815547b2",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "cpu_usage_iowait{instance_type=\"k3s\",cpu=\"cpu-total\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:817522ba",
+      "object_names": [
+        "Access",
+        "ConsoleServer",
+        "Firewall",
+        "Loadbalance",
+        "NetworkService",
+        "Router",
+        "Switch",
+        "Transmission",
+        "VoiceGateway",
+        "Wireless"
+      ],
+      "template": "sum(snmp_uptime{__$labels__} / 100) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:8190568d",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "rate(diskio_writes{instance_type=\"k3s\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:81ca8185",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "win_exchange_mapihttp_Active_User_Count{instance_type=\"exchange\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:81eab703",
+      "object_names": [
+        "Host"
+      ],
+      "template": "system_load15{instance_type=\"os\", __$labels__} or system_load15_gauge{instance_type=\"os\", __$labels__} or host_cpu_load_15m_gauge{instance_type=\"os\", __$labels__} or system_load15_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:81fabd58",
+      "object_names": [
+        "Firewall"
+      ],
+      "template": "sum(sflow_bytes{instance_type='firewall', collect_type='sflow', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:821a6e6f",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "histogram_quantile(0.95, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:time_to_first_token_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:time_to_first_token_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:time_to_first_token_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
+    },
+    {
+      "id": "dashboard:v1:82826b79",
+      "object_names": [
+        "Firewall"
+      ],
+      "template": "topk(10, avg_over_time((sum(sflow_bytes{instance_type='firewall', collect_type='sflow', __$labels__}) by (instance_id, src_ip, src_port, dst_ip, header_protocol, dst_port))[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:839d52b6",
+      "object_names": [
+        "Apache"
+      ],
+      "template": "apache_scboard_sending{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:83b2c4ae",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "count(prometheus_remote_write_kube_daemonset_status_number_unavailable{instance_type=\"k3s\",__$labels__} > 0)"
+    },
+    {
+      "id": "dashboard:v1:83e89d25",
+      "object_names": [
+        "Haproxy"
+      ],
+      "template": "sum by (instance_id) (rate(haproxy_bout{svname=\"FRONTEND\",__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:8420b1dc",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_innodb_buffer_pool_read_requests{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:84332c24",
+      "object_names": [
+        "ActiveMQ"
+      ],
+      "template": "rate(activemq_topics_enqueue_count{__$labels__}[__$window__]) - rate(activemq_topics_dequeue_count{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:856f14b7",
+      "object_names": [
+        "Docker"
+      ],
+      "template": "sum(rate(docker_container_net_tx_bytes{__$labels__}[__$window__])) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:85f876de",
+      "object_names": [
+        "Apache"
+      ],
+      "template": "apache_BytesPerSec{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:860ae6e6",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_bytes_sent{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:8612e1d4",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "topk(10, avg_over_time((sum(netflow_in_bytes{instance_type='switch', collect_type='netflow', __$labels__} * label_value(netflow_in_bytes{instance_type='switch', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id, protocol))[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:8676b063",
+      "object_names": [
+        "Apache"
+      ],
+      "template": "apache_BusyWorkers{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:868978ec",
+      "object_names": [
+        "Ping"
+      ],
+      "template": "avg(ping_percent_packet_loss{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:86a6f5df",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "sum(prometheus_remote_write_kube_pod_container_resource_requests{instance_type=\"k8s\",resource=\"cpu\", __$labels__})"
+    },
+    {
+      "id": "dashboard:v1:86ad41c0",
+      "object_names": [
+        "Minio"
+      ],
+      "template": "sum by (instance_id) (rate(minio_api_requests_rejected_auth_total_counter{__$labels__}[__$window__])) or sum by (instance_id) (rate(minio_s3_requests_rejected_auth_total_counter{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:87a1a5a2",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "100 * sum(any(prometheus_remote_write_disk_used{instance_type=\"k8s\",__$labels__}) by (instance_id, device)) / sum(any(prometheus_remote_write_disk_total{instance_type=\"k8s\",__$labels__}) by (instance_id, device))"
+    },
+    {
+      "id": "dashboard:v1:8894f1eb",
+      "object_names": [
+        "Host"
+      ],
+      "template": "cpu_usage_iowait{cpu=\"cpu-total\", instance_type=\"os\", __$labels__} or cpu_usage_iowait_total_gauge{instance_type=\"os\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:889da5be",
+      "object_names": [
+        "Apache"
+      ],
+      "template": "apache_Load5{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:88eb6a67",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "rate(tomcat_connector_request_count{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:88f44f9f",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "100 - avg by (instance_id, node) (cpu_usage_idle{instance_type=\"k3s\", cpu=\"cpu-total\", __$labels__})"
+    },
+    {
+      "id": "dashboard:v1:8929d4f1",
+      "object_names": [
+        "Router"
+      ],
+      "template": "sum(sflow_packets{instance_type='router', collect_type='sflow', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:893451e4",
+      "object_names": [
+        "Minio"
+      ],
+      "template": "max by (instance_id) (minio_cluster_health_nodes_online_count_gauge{__$labels__}) or max by (instance_id) (minio_cluster_nodes_online_total_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:8944e468",
+      "object_names": [
+        "LlamaServer"
+      ],
+      "template": "sum(rate(llamacpp:prompt_tokens_total_counter{__$labels__}[5m]))"
+    },
+    {
+      "id": "dashboard:v1:899ecacc",
+      "object_names": [
+        "SGLang"
+      ],
+      "template": "histogram_quantile(0.90, sum by (instance_id, le) (label_replace(rate({__name__=~\"sglang:e2e_request_latency_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"sglang:e2e_request_latency_seconds_(.+)\") or label_replace(rate({__name__=\"sglang:e2e_request_latency_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
+    },
+    {
+      "id": "dashboard:v1:89c73029",
+      "object_names": [
+        "Website"
+      ],
+      "template": "count((http_response_http_response_code{__$labels__} >= 200) and (http_response_http_response_code{__$labels__} < 300)) or on() vector(0)"
+    },
+    {
+      "id": "dashboard:v1:89e2d8b9",
+      "object_names": [
+        "LlamaServer"
+      ],
+      "template": "sum(llamacpp:tokens_predicted_total_counter{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:8a6739f8",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_queries{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:8ab7d7ad",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "rate(sqlserver_waitstats_signal_wait_time_ms{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:8ae3b991",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "rabbitmq_node_mem_limit{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:8af954fa",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "sum by (instance_id) (rate(oracledb_activity_execute_count_gauge{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:8bf22e36",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "rabbitmq_node_disk_free{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:8c3fa8da",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "count(prometheus_remote_write_kube_pod_container_status_waiting_reason{instance_type=\"k8s\",reason=\"CrashLoopBackOff\",__$labels__} > 0)"
+    },
+    {
+      "id": "dashboard:v1:8c433504",
+      "object_names": [
+        "Etcd"
+      ],
+      "template": "sum by (instance_id) (rate(etcd_mvcc_put_total_counter{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:8c4812fc",
+      "object_names": [
+        "nginx"
+      ],
+      "template": "rate(nginx_requests{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:8c84605b",
+      "object_names": [
+        "Node"
+      ],
+      "template": "max by (instance_id, node, device) (prometheus_remote_write_disk_free{instance_type=\"k8s\", __$labels__})"
+    },
+    {
+      "id": "dashboard:v1:8cf1f894",
+      "object_names": [
+        "JVM"
+      ],
+      "template": "jvm_memory_usage_used_value{type=\"Heap\",__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:8ebd3e28",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "sqlserver_memory_clerks_size_kb{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:8ef05738",
+      "object_names": [
+        "TCPPort"
+      ],
+      "template": "avg(net_response_result_code{__$labels__} == bool 3) * 100"
+    },
+    {
+      "id": "dashboard:v1:904bf908",
+      "object_names": [
+        "ElasticSearch"
+      ],
+      "template": "elasticsearch_thread_pool_search_queue{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:905e2c1c",
+      "object_names": [
+        "Router"
+      ],
+      "template": "topk(10, avg_over_time((sum(netflow_in_bytes{instance_type='router', collect_type='netflow', __$labels__} * label_value(netflow_in_bytes{instance_type='router', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id, protocol))[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:912f3ab2",
+      "object_names": [
+        "Docker"
+      ],
+      "template": "count({instance_type='docker', collect_type='docker', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:915ccf13",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "min((device_optical_rx_power{__$labels__} != -10000 != -2147483648) / 100) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:91755901",
+      "object_names": [
+        "Firewall",
+        "Loadbalance",
+        "Router"
+      ],
+      "template": "avg(device_cpu_usage{__$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:91ab6422",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "win_exchange_workload_QueuedTasks{instance_type=\"exchange\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:91c1ff43",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "max by (instance_id) (oracledb_uptime_seconds_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:91de146a",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "win_ad_LDAP_Successful_Binds_persec{instance_type=\"active_directory\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:92b77ed7",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "sqlserver_performance_value{counter=\"User Connections\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:92e02e90",
+      "object_names": [
+        "nginx"
+      ],
+      "template": "count({instance_type='nginx', collect_type='middleware', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:92fb39c9",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "sqlserver_performance_value{counter=\"Memory Grants Outstanding\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:92ff6295",
+      "object_names": [
+        "K3SPod"
+      ],
+      "template": "sum by (instance_id,pod) ( rate(prometheus_remote_write_container_network_transmit_bytes_total{instance_type=\"k3s\",__$labels__}[__$window__]) )"
+    },
+    {
+      "id": "dashboard:v1:9348d0a5",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_variables_max_heap_table_size{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:9366617e",
+      "object_names": [
+        "Redis"
+      ],
+      "template": "clamp_max(100 * max by (instance_id) (redis_used_memory{__$labels__}) / on(instance_id) clamp_min(max by (instance_id) (redis_maxmemory{__$labels__}), 1), 100)"
+    },
+    {
+      "id": "dashboard:v1:93d0324a",
+      "object_names": [
+        "Node"
+      ],
+      "template": "rate(prometheus_remote_write_diskio_read_time{instance_type=\"k8s\", __$labels__}[__$window__]) / clamp_min(rate(prometheus_remote_write_diskio_reads{instance_type=\"k8s\", __$labels__}[__$window__]), 1e-9)"
+    },
+    {
+      "id": "dashboard:v1:94707d0f",
+      "object_names": [
+        "Router"
+      ],
+      "template": "sum(netflow_in_bytes{instance_type='router', collect_type='netflow', __$labels__} * label_value(netflow_in_bytes{instance_type='router', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:94a981c7",
+      "object_names": [
+        "Router"
+      ],
+      "template": "avg(sflow_frame_length{instance_type='router', collect_type='sflow', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:94c4755f",
+      "object_names": [
+        "Apache"
+      ],
+      "template": "apache_ReqPerSec{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:95163e11",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "tomcat_jvm_memorypool_committed{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:9563d407",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "rate(rabbitmq_overview_messages_acked{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:95743d57",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "win_ad_LDAP_Client_Sessions{instance_type=\"active_directory\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:95a3cdb8",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "sum without (db) (rate(postgresql_buffers_alloc{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:960d17a0",
+      "object_names": [
+        "Loadbalance"
+      ],
+      "template": "sum(sflow_bytes{instance_type='loadbalance', collect_type='sflow', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:964fc05a",
+      "object_names": [
+        "Router"
+      ],
+      "template": "topk(10, avg_over_time((sum(netflow_in_bytes{instance_type='router', collect_type='netflow', __$labels__} * label_value(netflow_in_bytes{instance_type='router', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id, src, src_port, dst, protocol, dst_port))[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:969bb3f3",
+      "object_names": [
+        "Haproxy"
+      ],
+      "template": "sum by (instance_id) (haproxy_qcur{svname=\"BACKEND\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:96af52ae",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "tomcat_connector_current_threads_busy{__$labels__} / clamp_min(tomcat_connector_max_threads{__$labels__}, 1) * 100"
+    },
+    {
+      "id": "dashboard:v1:9734fe9b",
+      "object_names": [
+        "Minio"
+      ],
+      "template": "max by (instance_id) (minio_system_memory_used_perc_gauge{__$labels__}) or max by (instance_id) (minio_node_mem_used_perc_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:9788b1ef",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "sum by (instance_id) (rate(oracledb_activity_user_commits_gauge{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:98078440",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "100 * sum by (instance_id) (sqlserver_volume_space_used_space_bytes{__$labels__}) / clamp_min(sum by (instance_id) (sqlserver_volume_space_total_space_bytes{__$labels__}), 1)"
+    },
+    {
+      "id": "dashboard:v1:98235ada",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "count(prometheus_remote_write_kube_node_info{instance_type='k3s', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:983cd0a8",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "rate(diskio_write_bytes{instance_type=\"k3s\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:986cf93c",
+      "object_names": [
+        "ElasticSearch"
+      ],
+      "template": "count({instance_type='elasticsearch', collect_type='database', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:98f119bb",
+      "object_names": [
+        "Etcd"
+      ],
+      "template": "max by (instance_id) (etcd_server_is_leader_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:9921c6cc",
+      "object_names": [
+        "Haproxy"
+      ],
+      "template": "sum by (instance_id) (rate(haproxy_bin{svname=\"FRONTEND\",__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:993d2382",
+      "object_names": [
+        "LlamaServer"
+      ],
+      "template": "sum(llamacpp:requests_processing_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:99fd0614",
+      "object_names": [
+        "Zookeeper"
+      ],
+      "template": "zookeeper_max_file_descriptor_count{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:99fe4b6a",
+      "object_names": [
+        "SGLang"
+      ],
+      "template": "sum(sglang:num_queue_reqs_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:9a2946ac",
+      "object_names": [
+        "Node"
+      ],
+      "template": "rate(prometheus_remote_write_net_bytes_recv{instance_type=\"k8s\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:9aae68cb",
+      "object_names": [
+        "Docker"
+      ],
+      "template": "sum(rate(docker_container_net_tx_errors{__$labels__}[__$window__])) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:9ad0f351",
+      "object_names": [
+        "JVM"
+      ],
+      "template": "jvm_threads_peak_count_value{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:9aed688b",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "tomcat_jvm_memory_total{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:9b4a39e8",
+      "object_names": [
+        "Redis"
+      ],
+      "template": "rate(redis_total_net_input_bytes{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:9b9e334f",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "count({instance_type='vllm', collect_type='bkpull', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:9c005642",
+      "object_names": [
+        "Loadbalance"
+      ],
+      "template": "topk(10, avg_over_time((sum(netflow_in_bytes{instance_type='loadbalance', collect_type='netflow', __$labels__} * label_value(netflow_in_bytes{instance_type='loadbalance', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id, src, src_port, dst, protocol, dst_port))[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:9c4a4a93",
+      "object_names": [
+        "JVM"
+      ],
+      "template": "max(1 - jmx_scrape_error_gauge{instance_type='jvm', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:9c73b761",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "histogram_quantile(0.90, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_generation_tokens_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_generation_tokens_(.+)\") or label_replace(rate({__name__=\"vllm:request_generation_tokens_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
+    },
+    {
+      "id": "dashboard:v1:9d78c2c3",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "topk(8, sum by (db) (rate(postgresql_temp_files{__$labels__}[__$window__])))"
+    },
+    {
+      "id": "dashboard:v1:9da847fa",
+      "object_names": [
+        "Host"
+      ],
+      "template": "sum by (instance_id) (rate(net_bytes_sent{instance_type=\"os\", __$labels__}[__$window__]) or rate(net_bytes_sent_gauge{instance_type=\"os\", __$labels__}[__$window__]) or rate(net_bytes_sent_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:9dcfda8c",
+      "object_names": [
+        "Ping"
+      ],
+      "template": "avg(ping_average_response_ms{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:9dd8e800",
+      "object_names": [
+        "LlamaServer"
+      ],
+      "template": "sum(rate(llamacpp:n_decode_total_counter{__$labels__}[5m]))"
+    },
+    {
+      "id": "dashboard:v1:9df94b8f",
+      "object_names": [
+        "LlamaServer"
+      ],
+      "template": "avg(llamacpp:n_busy_slots_per_decode_counter{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:9e51c113",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "clamp_min(rate(mysql_created_tmp_tables{__$labels__}[__$window__]) - rate(mysql_created_tmp_disk_tables{__$labels__}[__$window__]), 0)"
+    },
+    {
+      "id": "dashboard:v1:9ed2014d",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "topk(5, sum by (container_label_io_kubernetes_pod_namespace) (prometheus_remote_write_container_memory_working_set_bytes{instance_type=\"k8s\",__$labels__}))"
+    },
+    {
+      "id": "dashboard:v1:9ef6dee8",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_connection_errors_select{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:9f68dff6",
+      "object_names": [
+        "Consul"
+      ],
+      "template": "sum by (instance_id) (consul_health_checks_passing{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:9f883202",
+      "object_names": [
+        "Node"
+      ],
+      "template": "rate(prometheus_remote_write_net_bytes_sent{instance_type=\"k8s\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:9f9b304e",
+      "object_names": [
+        "Etcd"
+      ],
+      "template": "clamp_min(etcd_mvcc_db_total_size_in_bytes_gauge{__$labels__} / clamp_min(etcd_server_quota_backend_bytes_gauge{__$labels__}, 1) * 100, 0)"
+    },
+    {
+      "id": "dashboard:v1:9fd59461",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_connection_errors_peer_address{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:a049174f",
+      "object_names": [
+        "Website"
+      ],
+      "template": "avg by (instance_id) ((sum without (result) (count_over_time(http_response_result_type{result=\"success\",__$labels__}[__$window__])) or sum without (result) (count_over_time(http_response_result_type{__$labels__}[__$window__])) * 0) / sum without (result) (count_over_time(http_response_result_type{__$labels__}[__$window__])) * 100)"
+    },
+    {
+      "id": "dashboard:v1:a06486a6",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "topk(8, clamp_min(oracledb_resource_current_utilization_gauge{__$labels__} / clamp_min(oracledb_resource_limit_value_gauge{__$labels__}, 1) * 100, 0))"
+    },
+    {
+      "id": "dashboard:v1:a09d704d",
+      "object_names": [
+        "ElasticSearch"
+      ],
+      "template": "bottomk(8, min by (node_name) (elasticsearch_fs_data_0_available_in_bytes{__$labels__}))"
+    },
+    {
+      "id": "dashboard:v1:a0e33d66",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "rabbitmq_node_uptime{__$labels__} / 1000"
+    },
+    {
+      "id": "dashboard:v1:a10e2bf8",
+      "object_names": [
+        "Docker"
+      ],
+      "template": "docker_n_containers{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:a12d44b0",
+      "object_names": [
+        "Host"
+      ],
+      "template": "mem_available{instance_type=\"os\", __$labels__} or host_mem_available_bytes_gauge{instance_type=\"os\", __$labels__} or mem_available_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:a154369f",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "win_exchange_transport_queues_Unreachable_Queue_Length{instance_type=\"exchange\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:a18d6065",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "topk(5, sum by (namespace) (prometheus_remote_write_container_memory_working_set_bytes{instance_type=\"k3s\",__$labels__}))"
+    },
+    {
+      "id": "dashboard:v1:a2270f9a",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "sum by (instance_id) (rate(vllm:request_generation_tokens_sum{__$labels__}[5m])) / sum by (instance_id) (rate(vllm:request_generation_tokens_count{__$labels__}[5m]))"
+    },
+    {
+      "id": "dashboard:v1:a248718b",
+      "object_names": [
+        "Redis"
+      ],
+      "template": "rate(redis_total_commands_processed{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:a3e5982c",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "avg(sflow_frame_length{instance_type='switch', collect_type='sflow', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:a41346dd",
+      "object_names": [
+        "InfluxDB"
+      ],
+      "template": "sum by (instance_id) (rate(influxdb_httpd_serverError{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:a4719240",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "mongodb_queued_reads{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:a488e69e",
+      "object_names": [
+        "Website"
+      ],
+      "template": "count(http_response_http_response_code{__$labels__} >= 500) or on() vector(0)"
+    },
+    {
+      "id": "dashboard:v1:a5122dbd",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "topk(5, mem_used_percent{instance_type=\"k3s\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:a528b80e",
+      "object_names": [
+        "Wireless"
+      ],
+      "template": "count({instance_type='wireless', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:a59f6ef0",
+      "object_names": [
+        "Zookeeper"
+      ],
+      "template": "zookeeper_max_latency{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:a5c1faa5",
+      "object_names": [
+        "Host"
+      ],
+      "template": "sum by (instance_id) (rate(diskio_read_bytes{instance_type=\"os\", __$labels__}[__$window__]) or rate(diskio_read_bytes_total_gauge{instance_type=\"os\", __$labels__}[__$window__]) or rate(diskio_read_bytes_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:a6041c1a",
+      "object_names": [
+        "Firewall"
+      ],
+      "template": "avg(label_value(netflow_in_bytes{instance_type='firewall', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:a6227059",
+      "object_names": [
+        "Kafka"
+      ],
+      "template": "sum(kafka_topic_partition_under_replicated_partition_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:a6650fec",
+      "object_names": [
+        "LlamaServer"
+      ],
+      "template": "avg(llamacpp:prompt_tokens_seconds_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:a6eee9fe",
+      "object_names": [
+        "LlamaServer"
+      ],
+      "template": "count({instance_type='llamaserver', collect_type='bkpull', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:a7075f48",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "sum by (instance_id) (rate(vllm:request_success_total_counter{__$labels__}[5m]))"
+    },
+    {
+      "id": "dashboard:v1:a7724867",
+      "object_names": [
+        "Firewall"
+      ],
+      "template": "sum(netflow_in_bytes{instance_type='firewall', collect_type='netflow', __$labels__} * label_value(netflow_in_bytes{instance_type='firewall', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:a7dd6a09",
+      "object_names": [
+        "Redis"
+      ],
+      "template": "redis_keyspace_hitrate{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:a875359b",
+      "object_names": [
+        "JVM"
+      ],
+      "template": "jvm_memory_usage_max_value{type=\"Heap\",__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:a882998a",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "tomcat_connector_current_threads_busy{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:a8a18ae7",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "max by (instance_id) (oracledb_wait_time_user_io_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:a8acccfb",
+      "object_names": [
+        "Redis"
+      ],
+      "template": "rate(redis_total_net_output_bytes{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:a8d9ee58",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "sum(prometheus_remote_write_kube_node_status_allocatable{instance_type=\"k3s\",resource=\"memory\", __$labels__})"
+    },
+    {
+      "id": "dashboard:v1:a8e56348",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "max by (instance_id) (oracledb_up_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:a9a7f076",
+      "object_names": [
+        "SGLang"
+      ],
+      "template": "histogram_quantile(0.99, sum by (instance_id, le) (label_replace(rate({__name__=~\"sglang:time_to_first_token_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"sglang:time_to_first_token_seconds_(.+)\") or label_replace(rate({__name__=\"sglang:time_to_first_token_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
+    },
+    {
+      "id": "dashboard:v1:aa39e9d2",
+      "object_names": [
+        "Loadbalance",
+        "Router",
+        "Switch"
+      ],
+      "template": "max(device_temperature_celsius{__$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:aa57f8ad",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "topk(10, avg_over_time((sum(sflow_bytes{instance_type='switch', collect_type='sflow', __$labels__}) by (instance_id, src_ip, src_port, dst_ip, header_protocol, dst_port))[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:ab0b93c6",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "tomcat_connector_request_count{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:aba2982b",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "avg without (database) (avg_over_time(sqlserver_database_io_write_latency_ms{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:ad73cb81",
+      "object_names": [
+        "Minio"
+      ],
+      "template": "max by (instance_id) (minio_cluster_health_capacity_usable_total_bytes_gauge{__$labels__}) or max by (instance_id) (minio_cluster_capacity_usable_total_bytes_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:af0b870f",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "sum without (db) (rate(postgresql_buffers_checkpoint{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:af670539",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "histogram_quantile(0.50, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_prompt_tokens_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_prompt_tokens_(.+)\") or label_replace(rate({__name__=\"vllm:request_prompt_tokens_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
+    },
+    {
+      "id": "dashboard:v1:b02322b9",
+      "object_names": [
+        "Haproxy"
+      ],
+      "template": "sum by (instance_id) (rate(haproxy_wretr{svname=\"BACKEND\",__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:b073d379",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "topk(8, sum by (database_name) (sqlserver_database_io_read_latency_ms{__$labels__}))"
+    },
+    {
+      "id": "dashboard:v1:b077058c",
+      "object_names": [
+        "Host"
+      ],
+      "template": "processes_blocked{instance_type=\"os\", __$labels__} or processes_blocked_gauge{instance_type=\"os\", __$labels__} or processes_blocked_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:b0f68307",
+      "object_names": [
+        "Pod"
+      ],
+      "template": "prometheus_remote_write_kube_pod_container_status_restarts_total{instance_type=\"k8s\",__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:b116c6b3",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_innodb_data_reads{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:b13b4b2d",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "rate(mongodb_latency_reads{__$labels__}[__$window__])/clamp_min(rate(mongodb_latency_reads_count{__$labels__}[__$window__]), 1e-6) / 1e6"
+    },
+    {
+      "id": "dashboard:v1:b13c4b22",
+      "object_names": [
+        "Redis"
+      ],
+      "template": "redis_clients{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:b17a67db",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "mem_available{instance_type=\"k3s\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:b1aec893",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "win_exchange_transport_queues_Active_Mailbox_Delivery_Queue_Length{instance_type=\"exchange\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:b2594972",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "topk(10, avg_over_time((sum(netflow_in_bytes{instance_type='switch', collect_type='netflow', __$labels__} * label_value(netflow_in_bytes{instance_type='switch', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id, src, src_port, dst, protocol, dst_port))[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:b2c4fcc7",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "sum by (instance_id) (vllm:num_requests_running_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:b2f14009",
+      "object_names": [
+        "Minio"
+      ],
+      "template": "sum by (instance_id) (rate(minio_api_requests_traffic_received_bytes_counter{__$labels__}[__$window__])) or sum by (instance_id) (rate(minio_s3_traffic_received_bytes_counter{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:b348ab8d",
+      "object_names": [
+        "Haproxy"
+      ],
+      "template": "sum by (instance_id) (max by (instance_id, pxname) (haproxy_bck{svname=\"BACKEND\",__$labels__}))"
+    },
+    {
+      "id": "dashboard:v1:b46758f1",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "count(prometheus_remote_write_kube_statefulset_replicas{instance_type=\"k8s\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:b48271b6",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "100 - avg(cpu_usage_idle{instance_type=\"k3s\",cpu=\"cpu-total\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:b48936f6",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "clamp_max(100 * max by (instance_id) (mongodb_wtcache_tracked_dirty_bytes{__$labels__}) / on(instance_id) clamp_min(max by (instance_id) (mongodb_wtcache_current_bytes{__$labels__}), 1), 100)"
+    },
+    {
+      "id": "dashboard:v1:b4ad06b2",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_com_select{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:b5430b18",
+      "object_names": [
+        "Minio"
+      ],
+      "template": "sum by (instance_id) (minio_api_requests_waiting_total_gauge{__$labels__}) or sum by (instance_id) (minio_s3_requests_waiting_total_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:b572dc14",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "max by (instance_id) (mysql_variables_log_slave_updates{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:b5875894",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "topk(5, sum by (pod) (increase(prometheus_remote_write_kube_pod_container_status_restarts_total{instance_type=\"k8s\",__$labels__}[1h])))"
+    },
+    {
+      "id": "dashboard:v1:b63b1822",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "sum without (db) (rate(postgresql_conflicts{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:b642c087",
+      "object_names": [
+        "Active Directory"
+      ],
+      "template": "net_response_result_code{instance_type=\"active_directory\", endpoint=\"ldap\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:b64bad2b",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "sqlserver_performance_value{counter=\"Buffer cache hit ratio\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:b67b981e",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "100 * sum(prometheus_remote_write_kube_statefulset_status_replicas_ready{instance_type=\"k3s\",__$labels__}) / clamp_min(sum(prometheus_remote_write_kube_statefulset_replicas{instance_type=\"k3s\",__$labels__}),1)"
+    },
+    {
+      "id": "dashboard:v1:b6c1e647",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "http_response_result_code{instance_type=\"exchange\", endpoint=\"owa\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:b6e15ea2",
+      "object_names": [
+        "ElasticSearch"
+      ],
+      "template": "rate(elasticsearch_breakers_fielddata_tripped{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:b77acc29",
+      "object_names": [
+        "Node"
+      ],
+      "template": "prometheus_remote_write_cpu_usage_user{instance_type=\"k8s\",cpu=\"cpu-total\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:b78b89b7",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "sum by (queue, vhost) (rabbitmq_queue_messages_unack{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:b798f830",
+      "object_names": [
+        "Docker"
+      ],
+      "template": "docker_n_containers_running{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:b79eba57",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "sum without (db) (postgresql_numbackends{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:b7de8bcd",
+      "object_names": [
+        "Website"
+      ],
+      "template": "count((http_response_http_response_code{__$labels__} >= 400) and (http_response_http_response_code{__$labels__} < 500)) or on() vector(0)"
+    },
+    {
+      "id": "dashboard:v1:b7e87dd2",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "sum(prometheus_remote_write_kube_pod_status_phase{instance_type=\"k8s\",__$labels__}) by (phase)"
+    },
+    {
+      "id": "dashboard:v1:b8277ee6",
+      "object_names": [
+        "Host"
+      ],
+      "template": "(100 - cpu_usage_idle{cpu=\"cpu-total\", instance_type=\"os\", __$labels__}) or host_cpu_usage_percent_gauge{instance_type=\"os\", __$labels__} or cpu_usage_total_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:b8440293",
+      "object_names": [
+        "Zookeeper"
+      ],
+      "template": "rate(zookeeper_packets_received{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:b8d124d3",
+      "object_names": [
+        "Process"
+      ],
+      "template": "sum(procstat_cpu_usage{instance_type=\"process\", __$labels__}) by (instance_id, process_name)"
+    },
+    {
+      "id": "dashboard:v1:b998e908",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "rate(sqlserver_performance_value{counter=\"Log Flushes/sec\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:b9e65408",
+      "object_names": [
+        "Minio"
+      ],
+      "template": "count({instance_type='minio', collect_type='bkpull', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:ba189b8e",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_created_tmp_disk_tables{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:ba3493b0",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "sum by (instance_id) (rate(oracledb_activity_user_rollbacks_gauge{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:ba92b79a",
+      "object_names": [
+        "Website"
+      ],
+      "template": "avg by (instance_id) (http_response_response_time{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:baac1e13",
+      "object_names": [
+        "ElasticSearch"
+      ],
+      "template": "elasticsearch_thread_pool_write_queue{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:bada0b67",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "rabbitmq_overview_messages{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:bbeaba49",
+      "object_names": [
+        "VoiceGateway"
+      ],
+      "template": "count({instance_type='voice_gateway', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:bc042569",
+      "object_names": [
+        "Haproxy"
+      ],
+      "template": "sum by (instance_id) (haproxy_scur{svname=\"FRONTEND\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:bc9ca465",
+      "object_names": [
+        "Node"
+      ],
+      "template": "rate(prometheus_remote_write_diskio_write_bytes{instance_type=\"k8s\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:bd2bc914",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "max by (instance_id) (mysql_process_list_threads_executing{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:bd8b7c1f",
+      "object_names": [
+        "nginx"
+      ],
+      "template": "nginx_reading{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:bdaa98fe",
+      "object_names": [
+        "NetworkService"
+      ],
+      "template": "count({instance_type='network_service', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:bdfac005",
+      "object_names": [
+        "Etcd"
+      ],
+      "template": "sum by (instance_id) (rate(etcd_server_proposals_applied_total_gauge{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:be564564",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_aborted_clients{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:be7c4985",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "rabbitmq_node_mem_used{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:bee49d3d",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "count({instance_type='exchange', collect_type='host', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:bf60e8eb",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_connection_errors_tcpwrap{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:bf77d601",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "max by (instance_id) (oracledb_wait_time_application_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:bf981470",
+      "object_names": [
+        "JVM"
+      ],
+      "template": "sum(jvm_memorypool_usage_used_value{__$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:c02f2273",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "tomcat_connector_max_time{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:c1a856cc",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "rate(mongodb_net_out_bytes_count{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:c1dd6762",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "sum(increase(prometheus_remote_write_kube_pod_container_status_restarts_total{instance_type=\"k3s\",__$labels__}[1h]))"
+    },
+    {
+      "id": "dashboard:v1:c1eda24a",
+      "object_names": [
+        "Firewall"
+      ],
+      "template": "topk(10, avg_over_time((sum(netflow_in_bytes{instance_type='firewall', collect_type='netflow', __$labels__} * label_value(netflow_in_bytes{instance_type='firewall', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id, src, src_port, dst, protocol, dst_port))[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:c2057010",
+      "object_names": [
+        "Firewall"
+      ],
+      "template": "avg(sflow_frame_length{instance_type='firewall', collect_type='sflow', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:c22d3340",
+      "object_names": [
+        "Apache"
+      ],
+      "template": "apache_IdleWorkers{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:c29c1921",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "100 * sum without (db) (rate(postgresql_blks_hit{__$labels__}[__$window__])) / clamp_min(sum without (db) (rate(postgresql_blks_hit{__$labels__}[__$window__])) + sum without (db) (rate(postgresql_blks_read{__$labels__}[__$window__])), 1e-6)"
+    },
+    {
+      "id": "dashboard:v1:c2b34c42",
+      "object_names": [
+        "ActiveMQ"
+      ],
+      "template": "activemq_topics_consumer_count{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:c2ce98fb",
+      "object_names": [
+        "Ping"
+      ],
+      "template": "min(ping_minimum_response_ms{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:c2e57aaf",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "max(device_cpu_usage{__$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:c3434181",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "win_exchange_http_proxy_Outstanding_Proxy_Requests{instance_type=\"exchange\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:c3622228",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "count(prometheus_remote_write_kube_statefulset_status_replicas_ready{instance_type=\"k8s\",__$labels__} < prometheus_remote_write_kube_statefulset_replicas{instance_type=\"k8s\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:c386e57b",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "sqlserver_schedulers_runnable_tasks_count{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:c48e0e04",
+      "object_names": [
+        "Apache"
+      ],
+      "template": "apache_scboard_reading{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:c5376398",
+      "object_names": [
+        "InfluxDB"
+      ],
+      "template": "sum by (instance_id) (rate(influxdb_httpd_pointsWrittenFail{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:c5469d6e",
+      "object_names": [
+        "SGLang"
+      ],
+      "template": "sum(sglang:num_running_reqs_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:c618d67b",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "sum without (db) (rate(postgresql_temp_bytes{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:c63a0dbc",
+      "object_names": [
+        "Process"
+      ],
+      "template": "count({instance_type='process', collect_type='host', __$labels__}) by (instance_id, process_name)"
+    },
+    {
+      "id": "dashboard:v1:c6a51d16",
+      "object_names": [
+        "Zookeeper"
+      ],
+      "template": "zookeeper_avg_latency{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:c6d61d56",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "count(prometheus_remote_write_kube_daemonset_status_desired_number_scheduled{instance_type=\"k3s\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:c6e6bea0",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "histogram_quantile(0.95, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:e2e_request_latency_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:e2e_request_latency_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:e2e_request_latency_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
+    },
+    {
+      "id": "dashboard:v1:c7796ccc",
+      "object_names": [
+        "Docker"
+      ],
+      "template": "clamp_min(sum(increase(docker_container_status_restart_count{__$labels__}[__$window__])) by (instance_id), 0)"
+    },
+    {
+      "id": "dashboard:v1:c7be1493",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "count({instance_type='oracle', collect_type='exporter', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:c8337aec",
+      "object_names": [
+        "InfluxDB"
+      ],
+      "template": "sum by (instance_id) (rate(influxdb_httpd_queryReq{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:c839dbcb",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "rate(net_bytes_sent{instance_type=\"k3s\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:c8740b52",
+      "object_names": [
+        "JVM"
+      ],
+      "template": "sum(jvm_bufferpool_totalcapacity_value{__$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:c894425b",
+      "object_names": [
+        "Kafka"
+      ],
+      "template": "max(kafka_consumergroup_lag_gauge{__$labels__} >= 0)"
+    },
+    {
+      "id": "dashboard:v1:c8c92fa5",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "sum(prometheus_remote_write_kube_node_status_condition{instance_type=\"k3s\",condition=\"Ready\",status=\"true\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:c8cbcbb2",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "mongodb_tcmalloc_current_allocated_bytes{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:c8df5215",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "count(prometheus_remote_write_kube_pod_info{instance_type=\"k8s\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:c92ea4db",
+      "object_names": [
+        "Loadbalance"
+      ],
+      "template": "sum(netflow_in_packets{instance_type='loadbalance', collect_type='netflow', __$labels__} * label_value(netflow_in_packets{instance_type='loadbalance', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:c94bbaff",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_key_reads{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:c96e3801",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "topk(8, sum by (database_name) (rate(sqlserver_database_io_reads{__$labels__}[__$window__]) + rate(sqlserver_database_io_writes{__$labels__}[__$window__])))"
+    },
+    {
+      "id": "dashboard:v1:c9768d55",
+      "object_names": [
+        "ConsoleServer"
+      ],
+      "template": "count({instance_type='console_server', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:ca17f83c",
+      "object_names": [
+        "SGLang"
+      ],
+      "template": "count({instance_type='sglang', collect_type='bkpull', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:ca5b5e26",
+      "object_names": [
+        "Loadbalance"
+      ],
+      "template": "lb_current_connections{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:ca6877cb",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "sum(netflow_in_packets{instance_type='switch', collect_type='netflow', __$labels__} * label_value(netflow_in_packets{instance_type='switch', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:ca6b18de",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "mem_swap_free{instance_type=\"k3s\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:ca9e04e7",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "avg_over_time(sqlserver_cpu_sqlserver_process_cpu{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:cb17c657",
+      "object_names": [
+        "Node"
+      ],
+      "template": "prometheus_remote_write_mem_swap_free{instance_type=\"k8s\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:cc33995b",
+      "object_names": [
+        "Kafka"
+      ],
+      "template": "count(count by (topic) (kafka_topic_partitions_gauge{__$labels__}))"
+    },
+    {
+      "id": "dashboard:v1:ccce066f",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "win_exchange_autodiscover_Requests_persec{instance_type=\"exchange\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:cd4ce4d6",
+      "object_names": [
+        "nginx"
+      ],
+      "template": "100 * rate(nginx_handled{__$labels__}[__$window__]) / clamp_min(rate(nginx_accepts{__$labels__}[__$window__]), 1e-6)"
+    },
+    {
+      "id": "dashboard:v1:cd77ff86",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "max by (instance_id) (oracledb_process_count_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:cdc0d60f",
+      "object_names": [
+        "Host"
+      ],
+      "template": "cpu_usage_user{cpu=\"cpu-total\", instance_type=\"os\", __$labels__} or cpu_usage_user_total_gauge{instance_type=\"os\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:cdc1f188",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "count(prometheus_remote_write_kube_deployment_status_replicas_unavailable{instance_type=\"k8s\",__$labels__} > 0)"
+    },
+    {
+      "id": "dashboard:v1:cdca87b2",
+      "object_names": [
+        "Zookeeper"
+      ],
+      "template": "zookeeper_open_file_descriptor_count{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:cdf7218a",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "count({instance_type='tomcat', collect_type='middleware', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:ce2dce26",
+      "object_names": [
+        "Website"
+      ],
+      "template": "avg(http_response_result_code{__$labels__} == bool 6) * 100"
+    },
+    {
+      "id": "dashboard:v1:ce385139",
+      "object_names": [
+        "Host"
+      ],
+      "template": "sum by (instance_id) (rate(net_err_in{instance_type=\"os\", __$labels__}[__$window__]) or rate(net_err_in_gauge{instance_type=\"os\", __$labels__}[__$window__]) or rate(net_err_in_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:ce4260d5",
+      "object_names": [
+        "Ping"
+      ],
+      "template": "avg(ping_result_code{__$labels__} == bool 1) * 100"
+    },
+    {
+      "id": "dashboard:v1:ce9653ec",
+      "object_names": [
+        "Zookeeper"
+      ],
+      "template": "rate(zookeeper_packets_sent{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:ced590f9",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "sum(increase(prometheus_remote_write_kube_pod_container_status_restarts_total{instance_type=\"k8s\",__$labels__}[1h]))"
+    },
+    {
+      "id": "dashboard:v1:cee2b79c",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "sum(prometheus_remote_write_container_memory_working_set_bytes{instance_type=\"k3s\", __$labels__})"
+    },
+    {
+      "id": "dashboard:v1:cee53735",
+      "object_names": [
+        "Haproxy"
+      ],
+      "template": "sum by (instance_id) (rate(haproxy_hrsp_2xx{svname=\"BACKEND\",__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:cefe9d3a",
+      "object_names": [
+        "Etcd"
+      ],
+      "template": "clamp_min(etcd_server_proposals_committed_total_gauge{__$labels__} - etcd_server_proposals_applied_total_gauge{__$labels__}, 0)"
+    },
+    {
+      "id": "dashboard:v1:cf03dff7",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "100 * mysql_innodb_buffer_pool_pages_dirty{__$labels__} / clamp_min(mysql_innodb_buffer_pool_pages_total{__$labels__}, 1)"
+    },
+    {
+      "id": "dashboard:v1:cf85f24a",
+      "object_names": [
+        "Docker"
+      ],
+      "template": "max(docker_container_mem_usage_percent{__$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:d0052796",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "sum without (db) (rate(postgresql_tup_fetched{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:d01a4fc2",
+      "object_names": [
+        "Apache"
+      ],
+      "template": "apache_scboard_open{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:d0204325",
+      "object_names": [
+        "Haproxy"
+      ],
+      "template": "sum by (instance_id) (max by (instance_id, pxname) (haproxy_act{svname=\"BACKEND\",__$labels__}))"
+    },
+    {
+      "id": "dashboard:v1:d0767d7b",
+      "object_names": [
+        "Router"
+      ],
+      "template": "sum(netflow_in_packets{instance_type='router', collect_type='netflow', __$labels__} * label_value(netflow_in_packets{instance_type='router', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:d0aad3a1",
+      "object_names": [
+        "Consul"
+      ],
+      "template": "count by (instance_id) (consul_health_checks_status{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:d0edd9ad",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "topk(8, max by (tablespace) (oracledb_tablespace_used_percent_gauge{__$labels__}))"
+    },
+    {
+      "id": "dashboard:v1:d123314d",
+      "object_names": [
+        "Docker"
+      ],
+      "template": "sum(rate(docker_container_net_rx_errors{__$labels__}[__$window__])) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:d165d4e8",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "count({instance_type='rabbitmq', collect_type='middleware', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:d1c61df1",
+      "object_names": [
+        "TCPPort"
+      ],
+      "template": "avg(net_response_response_time{__$labels__}) * 1000"
+    },
+    {
+      "id": "dashboard:v1:d2a98c20",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "sqlserver_performance_value{counter=\"Processes blocked\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:d306372b",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "max by (instance_id) (mysql_slave_slave_sql_running_int{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:d33dffa8",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "sum by (queue, vhost) (rabbitmq_queue_messages{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:d3677097",
+      "object_names": [
+        "Redis"
+      ],
+      "template": "redis_blocked_clients{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:d4412920",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "rate(mongodb_inserts{__$labels__}[__$window__]) + rate(mongodb_updates{__$labels__}[__$window__]) + rate(mongodb_deletes{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:d498582e",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "mongodb_cursor_timed_out_count{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:d5eb0490",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "100 * sum(any(disk_used{instance_type=\"k3s\",__$labels__}) by (instance_id, device)) / sum(any(disk_total{instance_type=\"k3s\",__$labels__}) by (instance_id, device))"
+    },
+    {
+      "id": "dashboard:v1:d6273c80",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "histogram_quantile(0.99, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:request_prompt_tokens_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:request_prompt_tokens_(.+)\") or label_replace(rate({__name__=\"vllm:request_prompt_tokens_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
+    },
+    {
+      "id": "dashboard:v1:d6c3e36d",
+      "object_names": [
+        "Consul"
+      ],
+      "template": "sum by (instance_id) (consul_health_checks_warning{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:d6c7cfce",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "sum by (instance_id) (rate(vllm:request_prompt_tokens_sum{__$labels__}[5m])) / sum by (instance_id) (rate(vllm:request_prompt_tokens_count{__$labels__}[5m]))"
+    },
+    {
+      "id": "dashboard:v1:d7af4c8b",
+      "object_names": [
+        "JVM"
+      ],
+      "template": "jvm_threads_count_value{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:d7b283c5",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_uptime{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:d7efb00d",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "sum(prometheus_remote_write_kube_node_status_allocatable{instance_type=\"k3s\",resource=\"cpu\", __$labels__})"
+    },
+    {
+      "id": "dashboard:v1:d80d6ad7",
+      "object_names": [
+        "Website"
+      ],
+      "template": "count((http_response_http_response_code{__$labels__} >= 300) and (http_response_http_response_code{__$labels__} < 400)) or on() vector(0)"
+    },
+    {
+      "id": "dashboard:v1:d83bc0b2",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "max by (instance_id) (mysql_process_list_threads_idle{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:d9291be5",
+      "object_names": [
+        "Haproxy"
+      ],
+      "template": "count({instance_type='haproxy', collect_type='middleware', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:d953be20",
+      "object_names": [
+        "Website"
+      ],
+      "template": "avg(http_response_result_code{__$labels__} == bool 0) * 100"
+    },
+    {
+      "id": "dashboard:v1:d96300e3",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_innodb_buffer_pool_pages_free{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:d9f3bf90",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "sum by (instance_id) (rate(vllm:generation_tokens_total_counter{__$labels__}[5m])) * 60"
+    },
+    {
+      "id": "dashboard:v1:d9f714ff",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "sum without (db) (rate(postgresql_tup_inserted{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:da4fbaac",
+      "object_names": [
+        "Node"
+      ],
+      "template": "prometheus_remote_write_system_load1{instance_type=\"k8s\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:da7250f1",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "topk(5, sum by (pod) (rate(prometheus_remote_write_container_cpu_usage_seconds_total{instance_type=\"k3s\",__$labels__}[__$window__])))"
+    },
+    {
+      "id": "dashboard:v1:dc244186",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "rate(sqlserver_performance_value{counter=\"SQL Compilations/sec\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:dc6a9693",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "win_exchange_transport_queues_Submission_Queue_Length{instance_type=\"exchange\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:dcbef466",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "100 * sum(prometheus_remote_write_kube_daemonset_status_number_available{instance_type=\"k8s\",__$labels__}) / clamp_min(sum(prometheus_remote_write_kube_daemonset_status_desired_number_scheduled{instance_type=\"k8s\",__$labels__}),1)"
+    },
+    {
+      "id": "dashboard:v1:dcc35767",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "sum(netflow_in_bytes{instance_type='switch', collect_type='netflow', __$labels__} * label_value(netflow_in_bytes{instance_type='switch', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:dcc56336",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_innodb_data_fsyncs{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:dd6153a4",
+      "object_names": [
+        "VLLM"
+      ],
+      "template": "histogram_quantile(0.99, sum by (instance_id, le) (label_replace(rate({__name__=~\"vllm:inter_token_latency_seconds_[0-9.]+\", __$labels__}[5m]) keep_metric_names, \"le\", \"$1\", \"__name__\", \"vllm:inter_token_latency_seconds_(.+)\") or label_replace(rate({__name__=\"vllm:inter_token_latency_seconds_+Inf\", __$labels__}[5m]) keep_metric_names, \"le\", \"+Inf\", \"__name__\", \".*\")))"
+    },
+    {
+      "id": "dashboard:v1:dd965d0d",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "sum without (db) (rate(postgresql_checkpoints_req{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:dda9ff8d",
+      "object_names": [
+        "Process"
+      ],
+      "template": "sum(procstat_num_fds{instance_type=\"process\", __$labels__}) by (instance_id, process_name)"
+    },
+    {
+      "id": "dashboard:v1:ddc94289",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "mem_used_percent{instance_type=\"k3s\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:ddc94eaa",
+      "object_names": [
+        "ActiveMQ"
+      ],
+      "template": "activemq_topics_enqueue_count{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:de94efc7",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_connection_errors_internal{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:df2dee47",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "100 * (mysql_innodb_buffer_pool_pages_total{__$labels__} - mysql_innodb_buffer_pool_pages_free{__$labels__}) / clamp_min(mysql_innodb_buffer_pool_pages_total{__$labels__}, 1)"
+    },
+    {
+      "id": "dashboard:v1:df2e1668",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "clamp_max(100 * ((tomcat_jvm_memory_total{__$labels__} - tomcat_jvm_memory_free{__$labels__}) / clamp_min(tomcat_jvm_memory_max{__$labels__}, 1)), 100)"
+    },
+    {
+      "id": "dashboard:v1:df33cb51",
+      "object_names": [
+        "Node"
+      ],
+      "template": "prometheus_remote_write_mem_cached{instance_type=\"k8s\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:df5177cc",
+      "object_names": [
+        "Node"
+      ],
+      "template": "max by (instance_id, node, device) (prometheus_remote_write_disk_used_percent{instance_type=\"k8s\", __$labels__})"
+    },
+    {
+      "id": "dashboard:v1:df7dcc0d",
+      "object_names": [
+        "ElasticSearch"
+      ],
+      "template": "rate(elasticsearch_breakers_request_tripped{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:dfdd50bc",
+      "object_names": [
+        "Website"
+      ],
+      "template": "avg(http_response_result_code{__$labels__} == bool 4) * 100"
+    },
+    {
+      "id": "dashboard:v1:dffe275a",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "rate(sqlserver_waitstats_wait_time_ms{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:e0f2c374",
+      "object_names": [
+        "Zookeeper"
+      ],
+      "template": "zookeeper_watch_count{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:e120fc41",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_key_read_requests{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:e14af78e",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "max by (instance_id) (oracledb_pga_total_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:e14c8eef",
+      "object_names": [
+        "K3SPod"
+      ],
+      "template": "100 * ( sum(prometheus_remote_write_container_memory_working_set_bytes{instance_type=\"k3s\",__$labels__}) by (instance_id,pod) / on(instance_id,pod) sum(prometheus_remote_write_kube_pod_container_resource_limits{instance_type=\"k3s\", resource=\"memory\",__$labels__}) by (instance_id,pod) )"
+    },
+    {
+      "id": "dashboard:v1:e1ec97a8",
+      "object_names": [
+        "Node"
+      ],
+      "template": "rate(prometheus_remote_write_diskio_write_time{instance_type=\"k8s\", __$labels__}[__$window__]) / clamp_min(rate(prometheus_remote_write_diskio_writes{instance_type=\"k8s\", __$labels__}[__$window__]), 1e-9)"
+    },
+    {
+      "id": "dashboard:v1:e1fe4307",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "tomcat_jvm_memory_free{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:e26d7682",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "sum(prometheus_remote_write_kube_pod_container_resource_requests{instance_type=\"k3s\",resource=\"cpu\", __$labels__})"
+    },
+    {
+      "id": "dashboard:v1:e294dd67",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "rabbitmq_node_running{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:e2d426cd",
+      "object_names": [
+        "Apache"
+      ],
+      "template": "apache_Load15{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:e30739bd",
+      "object_names": [
+        "Website"
+      ],
+      "template": "avg(http_response_result_code{__$labels__} == bool 1) * 100"
+    },
+    {
+      "id": "dashboard:v1:e3130a02",
+      "object_names": [
+        "Ping"
+      ],
+      "template": "avg(ping_result_code{__$labels__} == bool 2) * 100"
+    },
+    {
+      "id": "dashboard:v1:e39095be",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "rate(sqlserver_requests_total_elapsed_time_ms{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:e397a535",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "tomcat_jvm_memorypool_max{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:e3c85242",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "mongodb_vsize_megabytes{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:e47a12b1",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "sum(rate(interface_ifInErrors{__$labels__}[__$window__])) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:e4e0cd2a",
+      "object_names": [
+        "Host"
+      ],
+      "template": "max by (instance_id) (disk_used_percent{instance_type=\"os\", __$labels__} or host_disk_used_percent_gauge{instance_type=\"os\", __$labels__} or disk_used_percent_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__})"
+    },
+    {
+      "id": "dashboard:v1:e54bf04a",
+      "object_names": [
+        "Website"
+      ],
+      "template": "avg(http_response_result_code{__$labels__} == bool 2) * 100"
+    },
+    {
+      "id": "dashboard:v1:e5c19424",
+      "object_names": [
+        "Host"
+      ],
+      "template": "sum by (instance_id) (rate(diskio_write_bytes{instance_type=\"os\", __$labels__}[__$window__]) or rate(diskio_write_bytes_total_gauge{instance_type=\"os\", __$labels__}[__$window__]) or rate(diskio_write_bytes_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:e5e98cdd",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "http_response_response_time{instance_type=\"exchange\", endpoint=\"ews\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:e61b30e3",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "rabbitmq_overview_channels{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:e657f024",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "max by (instance_id) (mysql_slave_seconds_behind_master{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:e674aafc",
+      "object_names": [
+        "Haproxy"
+      ],
+      "template": "sum by (instance_id) (rate(haproxy_eresp{svname=\"BACKEND\",__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:e6e75664",
+      "object_names": [
+        "RabbitMQ"
+      ],
+      "template": "rabbitmq_overview_consumers{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:e766f12a",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "sum(device_memory_free{__$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:e823e064",
+      "object_names": [
+        "Host"
+      ],
+      "template": "count({instance_type='os', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:e869394b",
+      "object_names": [
+        "K3SPod"
+      ],
+      "template": "sum by (instance_id,pod,device) ( rate(prometheus_remote_write_container_fs_reads_total{instance_type=\"k3s\",__$labels__}[__$window__]) )"
+    },
+    {
+      "id": "dashboard:v1:e8a018f4",
+      "object_names": [
+        "Node"
+      ],
+      "template": "prometheus_remote_write_mem_used_percent{instance_type=\"k8s\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:e8e89e26",
+      "object_names": [
+        "JVM"
+      ],
+      "template": "jvm_threads_total_started_count_value{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:e98587f7",
+      "object_names": [
+        "Website"
+      ],
+      "template": "clamp_max(100 - avg by (instance_id) ((sum without (result) (count_over_time(http_response_result_type{result=\"success\",__$labels__}[__$window__])) or sum without (result) (count_over_time(http_response_result_type{__$labels__}[__$window__])) * 0) / sum without (result) (count_over_time(http_response_result_type{__$labels__}[__$window__])) * 100), 100)"
+    },
+    {
+      "id": "dashboard:v1:e9ab711a",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_created_tmp_tables{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:eaf95d21",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "max by (instance_id) (oracledb_wait_time_network_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:eb236167",
+      "object_names": [
+        "JVM"
+      ],
+      "template": "100 * sum(rate(jvm_gc_collectiontime_seconds_value{__$labels__}[__$window__])) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:eb9f427b",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "sum without (database) (rate(sqlserver_database_io_reads{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:ebd96df2",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "100 * sum(prometheus_remote_write_mem_used{instance_type=\"k8s\",__$labels__}) / sum(prometheus_remote_write_mem_total{instance_type=\"k8s\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:ec2e434f",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "win_exchange_owa_Current_Unique_Users{instance_type=\"exchange\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:ec5e12e6",
+      "object_names": [
+        "SGLang"
+      ],
+      "template": "sum(rate(sglang:e2e_request_latency_seconds_sum{__$labels__}[5m])) / sum(rate(sglang:e2e_request_latency_seconds_count{__$labels__}[5m]))"
+    },
+    {
+      "id": "dashboard:v1:ec9c95b9",
+      "object_names": [
+        "Firewall"
+      ],
+      "template": "firewall_session_utilization{__$labels__} or (firewall_active_sessions{__$labels__} / firewall_max_sessions{__$labels__} * 100) or (firewall_current_connections{__$labels__} / firewall_max_connections{__$labels__} * 100)"
+    },
+    {
+      "id": "dashboard:v1:ecd2bdad",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_innodb_buffer_pool_pages_dirty{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:ecdc8109",
+      "object_names": [
+        "Website"
+      ],
+      "template": "count(http_response_result_type{instance_type='web', collect_type='web', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:ed9e1237",
+      "object_names": [
+        "Oracle"
+      ],
+      "template": "sum by (instance_id) (oracledb_sessions_value_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:ef9da161",
+      "object_names": [
+        "InfluxDB"
+      ],
+      "template": "sum by (instance_id) (rate(influxdb_httpd_clientError{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:efa783e7",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "count({instance_type='mssql', collect_type='database', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:f09555af",
+      "object_names": [
+        "Host"
+      ],
+      "template": "system_load5{instance_type=\"os\", __$labels__} or system_load5_gauge{instance_type=\"os\", __$labels__} or host_cpu_load_5m_gauge{instance_type=\"os\", __$labels__} or system_load5_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:f09fb174",
+      "object_names": [
+        "nginx"
+      ],
+      "template": "clamp_max(100 * nginx_waiting{__$labels__} / clamp_min(nginx_active{__$labels__}, 1), 100)"
+    },
+    {
+      "id": "dashboard:v1:f0c5ff13",
+      "object_names": [
+        "Apache"
+      ],
+      "template": "apache_ServerUptimeSeconds{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:f0eb2c1d",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "mongodb_assert_user{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:f14a6f66",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "100 * (1 - rate(mysql_innodb_buffer_pool_reads{__$labels__}[__$window__]) / clamp_min(rate(mysql_innodb_buffer_pool_read_requests{__$labels__}[__$window__]), 1e-6))"
+    },
+    {
+      "id": "dashboard:v1:f16c4a64",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "sum(prometheus_remote_write_kube_node_status_condition{instance_type=\"k8s\",condition=\"Ready\",status=\"true\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:f1d6e75b",
+      "object_names": [
+        "Apache"
+      ],
+      "template": "rate(apache_scboard_open{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:f1efd5cd",
+      "object_names": [
+        "Host"
+      ],
+      "template": "topk(8, max by (path, device) (disk_used_percent{instance_type=\"os\", __$labels__} or host_disk_used_percent_gauge{instance_type=\"os\", __$labels__} or disk_used_percent_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}))"
+    },
+    {
+      "id": "dashboard:v1:f20b0627",
+      "object_names": [
+        "Exchange"
+      ],
+      "template": "win_exchange_http_proxy_Proxy_Requests_persec{instance_type=\"exchange\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:f279bc8e",
+      "object_names": [
+        "Pod"
+      ],
+      "template": "count(prometheus_remote_write_kube_pod_info{instance_type='k8s', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:f2b4d061",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_opened_tables{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:f30f80e5",
+      "object_names": [
+        "ElasticSearch"
+      ],
+      "template": "rate(elasticsearch_jvm_gc_collectors_young_collection_time_in_millis{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:f31399ac",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "sum without (db) (rate(postgresql_tup_updated{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:f3b7fb69",
+      "object_names": [
+        "Etcd"
+      ],
+      "template": "sum by (instance_id) (etcd_network_active_peers_gauge{__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:f3c5dfc0",
+      "object_names": [
+        "JVM"
+      ],
+      "template": "sum(jvm_bufferpool_memoryused_value{__$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:f43753eb",
+      "object_names": [
+        "Etcd"
+      ],
+      "template": "1000 * histogram_quantile(0.99, sum(rate((label_replace({__name__=~\"etcd_disk_wal_fsync_duration_seconds_[0-9.]+\", __$labels__}, \"le\", \"$1\", \"__name__\", \"etcd_disk_wal_fsync_duration_seconds_(.+)\"))[5m:]) or label_replace(rate(etcd_disk_wal_fsync_duration_seconds_count{__$labels__}[5m]), \"le\", \"+Inf\", \"__name__\", \".*\")) by (instance_id, le))"
+    },
+    {
+      "id": "dashboard:v1:f4a484a8",
+      "object_names": [
+        "Loadbalance"
+      ],
+      "template": "avg(label_value(netflow_in_bytes{instance_type='loadbalance', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:f4c00da5",
+      "object_names": [
+        "ActiveMQ"
+      ],
+      "template": "activemq_topics_size{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:f5384728",
+      "object_names": [
+        "Haproxy"
+      ],
+      "template": "avg by (instance_id) (haproxy_rtime{svname=\"BACKEND\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:f55b7e5b",
+      "object_names": [
+        "Postgres"
+      ],
+      "template": "sum without (db) (rate(postgresql_blks_hit{__$labels__}[__$window__]))"
+    },
+    {
+      "id": "dashboard:v1:f56ba1ca",
+      "object_names": [
+        "Switch"
+      ],
+      "template": "sum(rate(interface_ifOutErrors{__$labels__}[__$window__])) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:f59dc18d",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_innodb_os_log_fsyncs{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:f5a6dffa",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "rate(diskio_write_time{instance_type=\"k3s\", __$labels__}[__$window__]) / clamp_min(rate(diskio_writes{instance_type=\"k3s\", __$labels__}[__$window__]), 1e-9)"
+    },
+    {
+      "id": "dashboard:v1:f5c4dae3",
+      "object_names": [
+        "nginx"
+      ],
+      "template": "nginx_writing{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:f62099bd",
+      "object_names": [
+        "TCPPort"
+      ],
+      "template": "min(net_response_response_time{__$labels__}) * 1000"
+    },
+    {
+      "id": "dashboard:v1:f63c0b05",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "mysql_open_files{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:f68a5120",
+      "object_names": [
+        "Mongodb"
+      ],
+      "template": "mongodb_active_writes{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:f6b69804",
+      "object_names": [
+        "Apache"
+      ],
+      "template": "apache_CacheCurrentEntries{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:f6edc87c",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "100 * sum(prometheus_remote_write_kube_daemonset_status_number_available{instance_type=\"k3s\",__$labels__}) / clamp_min(sum(prometheus_remote_write_kube_daemonset_status_desired_number_scheduled{instance_type=\"k3s\",__$labels__}),1)"
+    },
+    {
+      "id": "dashboard:v1:f73d2940",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "count(prometheus_remote_write_kube_statefulset_replicas{instance_type=\"k3s\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:f790d549",
+      "object_names": [
+        "Router"
+      ],
+      "template": "count({instance_type='router', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:f8f30032",
+      "object_names": [
+        "Node"
+      ],
+      "template": "prometheus_remote_write_kube_node_status_condition{instance_type=\"k8s\",condition=\"Ready\",status=\"true\",__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:f91d9edf",
+      "object_names": [
+        "Docker"
+      ],
+      "template": "max(docker_container_cpu_usage_percent{__$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:f91ec80b",
+      "object_names": [
+        "Firewall"
+      ],
+      "template": "sum(netflow_in_packets{instance_type='firewall', collect_type='netflow', __$labels__} * label_value(netflow_in_packets{instance_type='firewall', collect_type='netflow', __$labels__}, \"effective_sampling_rate\")) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:f9276881",
+      "object_names": [
+        "Firewall"
+      ],
+      "template": "avg(device_memory_usage{__$labels__}) by (instance_id) or ((sum(device_memory_total{__$labels__}) by (instance_id) - sum(device_memory_free{__$labels__}) by (instance_id)) / sum(device_memory_total{__$labels__}) by (instance_id) * 100) or (sum(device_memory_used{__$labels__}) by (instance_id) / sum(device_memory_total{__$labels__}) by (instance_id) * 100) or (sum(device_memory_used{__$labels__}) by (instance_id) / (sum(device_memory_used{__$labels__}) by (instance_id) + sum(device_memory_free{__$labels__}) by (instance_id)) * 100)"
+    },
+    {
+      "id": "dashboard:v1:f9d16f6f",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "diskio_io_util{instance_type=\"k3s\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:f9e3628a",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "100 * sum(mem_used{instance_type=\"k3s\",__$labels__}) / sum(mem_total{instance_type=\"k3s\",__$labels__})"
+    },
+    {
+      "id": "dashboard:v1:fa3bc5c0",
+      "object_names": [
+        "JVM"
+      ],
+      "template": "100 * jvm_memory_usage_used_value{type=\"Heap\",__$labels__} / clamp_min(jvm_memory_usage_max_value{type=\"Heap\",__$labels__}, 1)"
+    },
+    {
+      "id": "dashboard:v1:fa7e6599",
+      "object_names": [
+        "K3SNode"
+      ],
+      "template": "prometheus_remote_write_kube_node_status_condition{instance_type=\"k3s\",condition=\"Ready\",status=\"true\",__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:facf0f4b",
+      "object_names": [
+        "Node"
+      ],
+      "template": "prometheus_remote_write_cpu_usage_system{instance_type=\"k8s\",cpu=\"cpu-total\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:fb3b1828",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "tomcat_connector_bytes_received{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:fd17a5d0",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "rate(mysql_innodb_data_writes{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:fd499a32",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "rate(sqlserver_performance_value{counter=\"Lazy writes/sec\", __$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:fd4c2c0a",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "sum(prometheus_remote_write_kube_pod_container_resource_requests{instance_type=\"k8s\",resource=\"memory\", __$labels__})"
+    },
+    {
+      "id": "dashboard:v1:fd52d6ea",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "sqlserver_performance_value{counter=\"Free Space in tempdb (KB)\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:fe0b89f4",
+      "object_names": [
+        "ElasticSearch"
+      ],
+      "template": "elasticsearch_cluster_health_status_code{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:fe286723",
+      "object_names": [
+        "Process"
+      ],
+      "template": "sum(procstat_memory_rss{instance_type=\"process\", __$labels__}) by (instance_id, process_name)"
+    },
+    {
+      "id": "dashboard:v1:fed85ec2",
+      "object_names": [
+        "Redis"
+      ],
+      "template": "rate(redis_evicted_keys{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:fefb2221",
+      "object_names": [
+        "Redis"
+      ],
+      "template": "redis_maxmemory{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:ff57711c",
+      "object_names": [
+        "Mysql"
+      ],
+      "template": "clamp_max(100 * max by (instance_id) (mysql_open_tables{__$labels__}) / on(instance_id) clamp_min(max by (instance_id) (mysql_variables_table_open_cache{__$labels__}), 1), 100)"
+    },
+    {
+      "id": "dashboard:v1:ff5b7254",
+      "object_names": [
+        "Host"
+      ],
+      "template": "system_uptime{instance_type=\"os\", __$labels__} or system_uptime_gauge{instance_type=\"os\", __$labels__} or system_uptime_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:ff8dea55",
+      "object_names": [
+        "TCPPort"
+      ],
+      "template": "avg(net_response_result_code{__$labels__} == bool 2) * 100"
+    },
+    {
+      "id": "dashboard:v1:ffbf3f1d",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "sqlserver_performance_value{counter=\"Version Store Size (KB)\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:fff61030",
+      "object_names": [
+        "K3SPod"
+      ],
+      "template": "sum by (instance_id,pod) ( rate(prometheus_remote_write_container_network_receive_bytes_total{instance_type=\"k3s\",__$labels__}[__$window__]) )"
+    }
+  ]
+}

--- a/server/apps/monitor/tests/test_authorized_metric_query_service.py
+++ b/server/apps/monitor/tests/test_authorized_metric_query_service.py
@@ -92,6 +92,93 @@ def test_range_query_uses_server_metric_template_and_authorized_instances(mocker
     )
 
 
+def test_range_query_forwards_gap_detection_and_card_budget(mocker):
+    monitor_object, metric, allowed, _ = _build_metric_contract()
+    service = _service(mocker, allowed)
+    vm_query = mocker.patch(
+        "apps.monitor.services.authorized_metric_query.Metrics.get_metrics_range",
+        return_value={"status": "success", "data": {"result": []}},
+    )
+
+    service.query_range(
+        {
+            "monitor_object_id": monitor_object.id,
+            "metric_id": metric.id,
+            "instance_ids": [allowed.id],
+            "start": 1000,
+            "end": 61000,
+            "step": "60s",
+            "detect_gaps": True,
+            "collection_interval": 60,
+            "card_budget": True,
+        }
+    )
+
+    assert vm_query.call_args.kwargs == {
+        "detect_gaps": True,
+        "collection_interval_seconds": 60,
+        "card_budget": True,
+    }
+
+
+def test_host_process_scope_authorizes_parent_host_and_builds_process_matchers(mocker):
+    host_object = MonitorObject.objects.create(
+        name="Host",
+        level="base",
+        instance_id_keys=["instance_id"],
+    )
+    process_object = MonitorObject.objects.create(
+        name="Process",
+        level="derivative",
+        parent=host_object,
+        instance_id_keys=["instance_id", "process_name"],
+    )
+    plugin = MonitorPlugin.objects.create(name="ProcessPlugin")
+    group = MetricGroup.objects.create(
+        monitor_object=process_object,
+        monitor_plugin=plugin,
+        name="ProcessGroup",
+    )
+    metric = Metric.objects.create(
+        monitor_object=process_object,
+        monitor_plugin=plugin,
+        metric_group=group,
+        name="process_cpu",
+        query="process_cpu{__$labels__}",
+        instance_id_keys=["instance_id", "process_name"],
+    )
+    host = MonitorInstance.objects.create(
+        id="('host-a',)",
+        name="host-a",
+        monitor_object=host_object,
+    )
+    service = _service(mocker, host)
+    vm_query = mocker.patch(
+        "apps.monitor.services.authorized_metric_query.Metrics.get_metrics_range",
+        return_value={"status": "success", "data": {"result": []}},
+    )
+
+    service.query_range(
+        {
+            "monitor_object_id": process_object.id,
+            "metric_id": metric.id,
+            "scope": {
+                "type": "host_process",
+                "host_monitor_object_id": host_object.id,
+                "host_instance_id": host.id,
+                "process_names": ["nginx", "postgres"],
+            },
+            "start": 1000,
+            "end": 61000,
+            "step": "60s",
+        }
+    )
+
+    query = vm_query.call_args.args[0]
+    assert 'instance_id=~"host\\\\-a"' in query
+    assert 'process_name=~"nginx|postgres"' in query
+
+
 def test_mixed_authorized_and_denied_instances_fail_before_vm_query(mocker):
     monitor_object, metric, allowed, denied = _build_metric_contract()
     service = _service(mocker, allowed)

--- a/server/apps/monitor/tests/test_authorized_metric_query_view.py
+++ b/server/apps/monitor/tests/test_authorized_metric_query_view.py
@@ -1,11 +1,11 @@
 import json
 
 import pytest
-from django.urls import Resolver404, resolve
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from apps.core.exceptions.base_app_exception import UnauthorizedException
 from apps.monitor.models import Metric, MetricGroup, MonitorInstance, MonitorObject, MonitorPlugin
+from apps.monitor.services.metrics import MetricsQueryBudgetExceeded
 from apps.monitor.views.metrics_instance import MetricsInstanceViewSet
 
 pytestmark = pytest.mark.django_db
@@ -159,7 +159,55 @@ def test_authorized_range_view_executes_registered_dashboard_capability(authenti
     assert 'instance_id=~"allowed\\\\-view\\\\-host"' in query
 
 
-@pytest.mark.parametrize("action", ["query", "query_range"])
-def test_raw_promql_rest_actions_are_not_registered(action):
-    with pytest.raises(Resolver404):
-        resolve(f"/api/v1/monitor/api/metrics_instance/{action}/")
+def test_raw_promql_rest_actions_are_not_registered():
+    action_paths = {action.url_path for action in MetricsInstanceViewSet.get_extra_actions()}
+    assert "query" not in action_paths
+    assert "query_range" not in action_paths
+    assert "query_by_metric" in action_paths
+    assert "query_by_metric_range" in action_paths
+
+
+def test_authorized_range_view_returns_structured_422_for_budget_error(authenticated_user, mocker):
+    monitor_object, metric, allowed, _ = _setup_query_contract()
+    mocker.patch(
+        "apps.monitor.services.authorized_metric_query.get_permission_rules",
+        return_value={"data": "permission"},
+    )
+    mocker.patch(
+        "apps.monitor.services.authorized_metric_query.permission_filter",
+        side_effect=lambda model, permission, **kwargs: model.objects.filter(id=allowed.id),
+    )
+    error = MetricsQueryBudgetExceeded(
+        data={
+            "code": "MONITOR_RANGE_QUERY_BUDGET_EXCEEDED",
+            "reason": "points_per_series",
+            "limits": {"points_per_series": 10000},
+            "actual": {"points_per_series": 20000},
+        }
+    )
+    mocker.patch(
+        "apps.monitor.services.authorized_metric_query.Metrics.get_metrics_range",
+        side_effect=error,
+    )
+    view = MetricsInstanceViewSet.as_view({"post": "query_by_metric_range"})
+
+    response = view(
+        _request(
+            authenticated_user,
+            {
+                "monitor_object_id": monitor_object.id,
+                "metric_id": metric.id,
+                "instance_ids": [allowed.id],
+                "start": 1000,
+                "end": 61000,
+                "step": "60s",
+            },
+        )
+    )
+
+    assert response.status_code == 422
+    assert json.loads(response.content) == {
+        "data": error.data,
+        "result": False,
+        "message": error.message,
+    }

--- a/server/apps/monitor/tests/test_authorized_metric_query_view.py
+++ b/server/apps/monitor/tests/test_authorized_metric_query_view.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+from django.urls import Resolver404, resolve
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from apps.core.exceptions.base_app_exception import UnauthorizedException
@@ -10,9 +11,9 @@ from apps.monitor.views.metrics_instance import MetricsInstanceViewSet
 pytestmark = pytest.mark.django_db
 
 
-def _setup_query_contract():
+def _setup_query_contract(*, object_name="AuthorizedViewObject"):
     monitor_object = MonitorObject.objects.create(
-        name="AuthorizedViewObject",
+        name=object_name,
         level="base",
         instance_id_keys=["instance_id"],
     )
@@ -119,3 +120,46 @@ def test_authorized_range_view_rejects_mixed_scope_without_vm_call(authenticated
         )
 
     vm_query.assert_not_called()
+
+
+def test_authorized_range_view_executes_registered_dashboard_capability(authenticated_user, mocker):
+    monitor_object, _, allowed, _ = _setup_query_contract(object_name="Website")
+    mocker.patch(
+        "apps.monitor.services.authorized_metric_query.get_permission_rules",
+        return_value={"data": "permission"},
+    )
+    mocker.patch(
+        "apps.monitor.services.authorized_metric_query.permission_filter",
+        side_effect=lambda model, permission, **kwargs: model.objects.filter(id=allowed.id),
+    )
+    vm_query = mocker.patch(
+        "apps.monitor.services.authorized_metric_query.Metrics.get_metrics_range",
+        return_value={"status": "success", "data": {"result": []}},
+    )
+    view = MetricsInstanceViewSet.as_view({"post": "query_by_metric_range"})
+
+    response = view(
+        _request(
+            authenticated_user,
+            {
+                "monitor_object_id": monitor_object.id,
+                "capability_id": "dashboard:v1:0a6a83ef",
+                "instance_ids": [allowed.id],
+                "start": 1000,
+                "end": 61000,
+                "step": "60s",
+            },
+        )
+    )
+
+    assert response.status_code == 200
+    assert json.loads(response.content)["result"] is True
+    query = vm_query.call_args.args[0]
+    assert "http_response_result_code" in query
+    assert 'instance_id=~"allowed\\\\-view\\\\-host"' in query
+
+
+@pytest.mark.parametrize("action", ["query", "query_range"])
+def test_raw_promql_rest_actions_are_not_registered(action):
+    with pytest.raises(Resolver404):
+        resolve(f"/api/v1/monitor/api/metrics_instance/{action}/")

--- a/server/apps/monitor/tests/test_dashboard_query_capabilities.py
+++ b/server/apps/monitor/tests/test_dashboard_query_capabilities.py
@@ -1,0 +1,168 @@
+from types import SimpleNamespace
+
+import pytest
+
+from apps.monitor.models import MonitorInstance, MonitorObject
+from apps.monitor.services.authorized_metric_query import AuthorizedMetricQueryError, AuthorizedMetricQueryService
+from apps.monitor.services.dashboard_query_capabilities import build_dashboard_query, dashboard_query_capability_id, load_dashboard_query_capabilities
+from apps.monitor.views.metrics_instance import MetricsInstanceViewSet
+
+
+def _object(name="Website"):
+    return MonitorObject(name=name, instance_id_keys=["instance_id"])
+
+
+def test_manifest_is_complete_and_content_addressed():
+    capabilities = load_dashboard_query_capabilities()
+
+    assert len(capabilities) >= 800
+    assert all(capability.id == dashboard_query_capability_id(capability.template) for capability in capabilities.values())
+
+
+def test_static_capability_injects_authorized_instance_and_server_window():
+    capability = next(
+        item for item in load_dashboard_query_capabilities().values() if "Website" in item.object_names and "__$window__" in item.template
+    )
+
+    query = build_dashboard_query(
+        capability_id=capability.id,
+        monitor_object=_object(),
+        instance_ids=("('website-a',)",),
+        start=0,
+        end=3_600_000,
+    )
+
+    assert "__$" not in query
+    assert 'instance_id=~"website\\\\-a"' in query
+    assert "[1h]" in query
+
+
+def test_capability_is_bound_to_monitor_object():
+    capability = next(item for item in load_dashboard_query_capabilities().values() if "Website" in item.object_names)
+
+    with pytest.raises(AuthorizedMetricQueryError, match="查询能力与监控对象不匹配"):
+        build_dashboard_query(
+            capability_id=capability.id,
+            monitor_object=_object("Host"),
+            instance_ids=("('host-a',)",),
+            start=0,
+            end=60_000,
+        )
+
+
+def test_unknown_capability_is_rejected():
+    with pytest.raises(AuthorizedMetricQueryError, match="查询能力不存在"):
+        build_dashboard_query(
+            capability_id="dashboard:v1:ffffffff",
+            monitor_object=_object(),
+            instance_ids=("('website-a',)",),
+            start=0,
+            end=60_000,
+        )
+
+
+def test_dynamic_kafka_capability_escapes_dimensions_and_keeps_instance_scope():
+    query = build_dashboard_query(
+        capability_id="dashboard:dynamic:kafka:current-offset",
+        monitor_object=_object("Kafka"),
+        instance_ids=("('kafka-a',)",),
+        start=0,
+        end=60_000,
+        params={
+            "dimensions": [
+                {
+                    "consumer_group": 'group"a',
+                    "topic": "orders",
+                    "partition": "0",
+                }
+            ]
+        },
+    )
+
+    assert 'instance_id=~"kafka\\\\-a"' in query
+    assert 'consumergroup="group\\"a"' in query
+    assert 'topic="orders"' in query
+
+
+@pytest.mark.parametrize(
+    "params",
+    ["dimensions", {"dimensions": [{"consumer_group": "group-a", "topic": "x" * 257, "partition": "0"}]}],
+)
+def test_dynamic_kafka_capability_rejects_unbounded_params(params):
+    with pytest.raises(AuthorizedMetricQueryError, match="Kafka 查询"):
+        build_dashboard_query(
+            capability_id="dashboard:dynamic:kafka:current-offset",
+            monitor_object=_object("Kafka"),
+            instance_ids=("('kafka-a',)",),
+            start=0,
+            end=60_000,
+            params=params,
+        )
+
+
+def test_raw_promql_rest_actions_are_removed():
+    assert not hasattr(MetricsInstanceViewSet, "get_metrics")
+    assert not hasattr(MetricsInstanceViewSet, "get_metrics_range")
+
+
+@pytest.mark.django_db
+def test_authorized_service_executes_registered_capability(mocker):
+    monitor_object = MonitorObject.objects.create(name="Website", instance_id_keys=["instance_id"])
+    instance = MonitorInstance.objects.create(
+        id="('website-a',)",
+        name="website-a",
+        monitor_object=monitor_object,
+    )
+    capability = next(item for item in load_dashboard_query_capabilities().values() if "Website" in item.object_names)
+    vm_query = mocker.patch(
+        "apps.monitor.services.authorized_metric_query.Metrics.get_metrics_range",
+        return_value={"status": "success", "data": {"result": []}},
+    )
+
+    result = AuthorizedMetricQueryService(
+        user=SimpleNamespace(is_superuser=True),
+        current_team=1,
+        include_children=False,
+    ).query_range(
+        {
+            "monitor_object_id": monitor_object.id,
+            "capability_id": capability.id,
+            "instance_ids": [instance.id],
+            "start": 0,
+            "end": 60_000,
+            "step": "60s",
+        }
+    )
+
+    assert result["status"] == "success"
+    assert "__$" not in vm_query.call_args.args[0]
+
+
+@pytest.mark.django_db
+def test_capability_object_mismatch_stops_before_vm(mocker):
+    monitor_object = MonitorObject.objects.create(name="Host", instance_id_keys=["instance_id"])
+    instance = MonitorInstance.objects.create(
+        id="('host-a',)",
+        name="host-a",
+        monitor_object=monitor_object,
+    )
+    capability = next(item for item in load_dashboard_query_capabilities().values() if "Website" in item.object_names)
+    vm_query = mocker.patch("apps.monitor.services.authorized_metric_query.Metrics.get_metrics_range")
+
+    with pytest.raises(AuthorizedMetricQueryError, match="查询能力与监控对象不匹配"):
+        AuthorizedMetricQueryService(
+            user=SimpleNamespace(is_superuser=True),
+            current_team=1,
+            include_children=False,
+        ).query_range(
+            {
+                "monitor_object_id": monitor_object.id,
+                "capability_id": capability.id,
+                "instance_ids": [instance.id],
+                "start": 0,
+                "end": 60_000,
+                "step": "60s",
+            }
+        )
+
+    vm_query.assert_not_called()

--- a/server/apps/monitor/tests/test_metrics_gap_detection.py
+++ b/server/apps/monitor/tests/test_metrics_gap_detection.py
@@ -1,10 +1,6 @@
-import json
-from types import SimpleNamespace
-
 import pytest
 
 from apps.monitor.services.metrics import Metrics, MetricsQueryBudgetExceeded
-from apps.monitor.views.metrics_instance import MetricsInstanceViewSet
 
 pytestmark = pytest.mark.unit
 
@@ -118,39 +114,6 @@ def test_fill_missing_points_rejects_excessive_grid_before_dataframe_allocation(
 
     assert raised.value.data["reason"] == "total_points"
     assert data[0]["values"] == [[0, "1"]]
-
-
-def test_metrics_range_view_returns_structured_422_for_budget_error(monkeypatch):
-    error = MetricsQueryBudgetExceeded(
-        data={
-            "code": "MONITOR_RANGE_QUERY_BUDGET_EXCEEDED",
-            "reason": "points_per_series",
-            "limits": {"points_per_series": 10000},
-            "actual": {"points_per_series": 20000},
-        }
-    )
-    monkeypatch.setattr(
-        "apps.monitor.views.metrics_instance.MetricsService.get_metrics_range",
-        lambda *args, **kwargs: (_ for _ in ()).throw(error),
-    )
-
-    response = MetricsInstanceViewSet().get_metrics_range(
-        SimpleNamespace(
-            GET={
-                "query": "cpu_usage",
-                "start": "0",
-                "end": "1200000",
-                "step": "60s",
-            }
-        )
-    )
-
-    assert response.status_code == 422
-    assert json.loads(response.content) == {
-        "data": error.data,
-        "result": False,
-        "message": "指标范围查询超过服务端预算，请缩短时间范围、减少实例或增大查询步长",
-    }
 
 
 def test_card_budget_clamps_step_before_shared_hard_budget(monkeypatch):
@@ -681,62 +644,3 @@ def test_get_metrics_range_detects_one_minute_gaps_for_thirty_day_window(monkeyp
             ],
         },
     ]
-
-
-def test_metrics_range_view_passes_gap_detection_query_params(monkeypatch):
-    captured = {}
-
-    def fake_get_metrics_range(
-        query,
-        start,
-        end,
-        step,
-        detect_gaps=False,
-        collection_interval_seconds=None,
-        card_budget=False,
-    ):
-        captured.update(
-            {
-                "query": query,
-                "start": start,
-                "end": end,
-                "step": step,
-                "detect_gaps": detect_gaps,
-                "collection_interval_seconds": collection_interval_seconds,
-                "card_budget": card_budget,
-            }
-        )
-        return {"status": "success", "data": {"result": []}}
-
-    monkeypatch.setattr(
-        "apps.monitor.views.metrics_instance.MetricsService.get_metrics_range",
-        fake_get_metrics_range,
-    )
-    monkeypatch.setattr(
-        "apps.monitor.views.metrics_instance.WebUtils.response_success",
-        staticmethod(lambda data: data),
-    )
-
-    response = MetricsInstanceViewSet().get_metrics_range(
-        SimpleNamespace(
-            GET={
-                "query": "cpu_usage",
-                "start": "0",
-                "end": "600000",
-                "step": "1h",
-                "detect_gaps": "true",
-                "collection_interval": "60",
-            }
-        )
-    )
-
-    assert response == {"status": "success", "data": {"result": []}}
-    assert captured == {
-        "query": "cpu_usage",
-        "start": "0",
-        "end": "600000",
-        "step": "1h",
-        "detect_gaps": True,
-        "collection_interval_seconds": "60",
-        "card_budget": False,
-    }

--- a/server/apps/monitor/views/metrics_instance.py
+++ b/server/apps/monitor/views/metrics_instance.py
@@ -13,7 +13,6 @@ from apps.monitor.models import MonitorInstance
 from apps.monitor.models.monitor_metrics import Metric
 from apps.monitor.services.authorized_metric_query import AuthorizedMetricQueryError, AuthorizedMetricQueryService
 from apps.monitor.services.metrics import Metrics as MetricsService
-from apps.monitor.services.metrics import MetricsQueryBudgetExceeded
 from apps.monitor.utils.unit_converter import UnitConverter
 
 
@@ -73,122 +72,6 @@ class MetricsInstanceViewSet(viewsets.ViewSet):
                 data = self._apply_unit_conversion(data, source_unit, target_unit)
             elif auto_convert:
                 data = self._apply_unit_conversion(data, source_unit)
-        return WebUtils.response_success(data)
-
-    @action(methods=["get"], detail=False, url_path="query")
-    def get_metrics(self, request):
-        """
-        查询指标信息（即时查询）
-
-        Query Parameters:
-            query (str): PromQL 查询语句
-            time (int): 求值时刻（毫秒时间戳）；未传时回退 end，再回退为 VM 当前时间
-            end (int): 与 time 相同语义的回退参数（毫秒），便于与 range 查询共用 search params
-            source_unit (str): 初始单位（必填），如 'B', 'bytes', 'ms', 's' 等
-            unit (str): 指定目标单位，若提供则直接转换到该单位，不使用自动推荐
-            auto_convert_unit (bool): 是否自动转换单位，默认 True（仅在未指定 unit 时生效）
-        """
-        query = request.GET.get("query")
-        source_unit = request.GET.get("source_unit")
-        target_unit = request.GET.get("unit")
-        auto_convert = request.GET.get("auto_convert_unit", "true").lower() == "true"
-        time_ms = request.GET.get("time")
-        if time_ms is None:
-            time_ms = request.GET.get("end")
-
-        if not query:
-            raise BaseAppException("query is required")
-
-        eval_time_sec = None
-        if time_ms is not None:
-            try:
-                eval_time_sec = int(time_ms) / 1000.0
-            except (TypeError, ValueError):
-                raise BaseAppException("time must be an integer timestamp in milliseconds")
-
-        data = MetricsService.get_metrics(query, time=eval_time_sec)
-
-        if source_unit:
-            if target_unit:
-                data = self._apply_unit_conversion(data, source_unit, target_unit)
-            elif auto_convert:
-                data = self._apply_unit_conversion(data, source_unit)
-
-        return WebUtils.response_success(data)
-
-    @action(methods=["get"], detail=False, url_path="query_range")
-    def get_metrics_range(self, request):
-        """
-        查询指标（范围查询）
-
-        Query Parameters:
-            query (str): PromQL 查询语句
-            start (int): 开始时间戳（毫秒）
-            end (int): 结束时间戳（毫秒）
-            step (str): 查询步长，如 '5m'
-            detect_gaps (bool): 是否检测断点区间，默认 False
-            collection_interval (int): 指标采集间隔（秒），开启 detect_gaps 时使用
-            source_unit (str): 初始单位（必填），如 'B', 'bytes', 'ms', 's' 等
-            unit (str): 指定目标单位，若提供则直接转换到该单位，不使用自动推荐
-            auto_convert_unit (bool): 是否自动转换单位，默认 True（仅在未指定 unit 时生效）
-        """
-        query = request.GET.get("query")
-        start = request.GET.get("start")
-        end = request.GET.get("end")
-        step = request.GET.get("step", "5m")
-        source_unit = request.GET.get("source_unit")
-        target_unit = request.GET.get("unit")
-        auto_convert = request.GET.get("auto_convert_unit", "true").lower() == "true"
-        detect_gaps = request.GET.get("detect_gaps", "false").lower() == "true"
-        collection_interval = request.GET.get("collection_interval")
-        query_budget = request.GET.get("query_budget")
-
-        if not query:
-            raise BaseAppException("query is required")
-
-        if start is None or end is None:
-            raise BaseAppException("start and end are required")
-
-        try:
-            start_int = int(start)
-            end_int = int(end)
-        except (TypeError, ValueError):
-            raise BaseAppException("start and end must be integer timestamps in milliseconds")
-
-        if start_int >= end_int:
-            raise BaseAppException("start must be less than end")
-
-        if not step:
-            raise BaseAppException("step is required")
-
-        try:
-            MetricsService.parse_step_to_seconds(step)
-        except ValueError as e:
-            raise BaseAppException(f"invalid step: {e}")
-
-        try:
-            data = MetricsService.get_metrics_range(
-                query,
-                start,
-                end,
-                step,
-                detect_gaps=detect_gaps,
-                collection_interval_seconds=collection_interval,
-                card_budget=query_budget == "card",
-            )
-        except MetricsQueryBudgetExceeded as exc:
-            return WebUtils.response_error(
-                response_data=exc.data,
-                error_message=exc.message,
-                status_code=exc.STATUS_CODE,
-            )
-
-        if source_unit:
-            if target_unit:
-                data = self._apply_unit_conversion(data, source_unit, target_unit)
-            elif auto_convert:
-                data = self._apply_unit_conversion(data, source_unit)
-
         return WebUtils.response_success(data)
 
     @staticmethod

--- a/server/apps/monitor/views/metrics_instance.py
+++ b/server/apps/monitor/views/metrics_instance.py
@@ -13,6 +13,7 @@ from apps.monitor.models import MonitorInstance
 from apps.monitor.models.monitor_metrics import Metric
 from apps.monitor.services.authorized_metric_query import AuthorizedMetricQueryError, AuthorizedMetricQueryService
 from apps.monitor.services.metrics import Metrics as MetricsService
+from apps.monitor.services.metrics import MetricsQueryBudgetExceeded
 from apps.monitor.utils.unit_converter import UnitConverter
 
 
@@ -41,6 +42,12 @@ class MetricsInstanceViewSet(viewsets.ViewSet):
             data = self._authorized_query_service(request).query_range(request.data)
         except AuthorizedMetricQueryError as exc:
             self._raise_authorized_query_error(exc)
+        except MetricsQueryBudgetExceeded as exc:
+            return WebUtils.response_error(
+                response_data=exc.data,
+                error_message=exc.message,
+                status_code=exc.STATUS_CODE,
+            )
 
         source_unit = request.data.get("source_unit")
         target_unit = request.data.get("unit")

--- a/server/apps/operation_analysis/common/datasource_security.py
+++ b/server/apps/operation_analysis/common/datasource_security.py
@@ -6,7 +6,7 @@ LEGACY_RAW_MONITOR_QUERY_ROUTES = frozenset(
         "monitor/mm_query_range",
     }
 )
-LEGACY_RAW_MONITOR_QUERY_ERROR = "该监控裸查询接口已停止新增，仅保留存量数据源兼容"
+LEGACY_RAW_MONITOR_QUERY_ERROR = "该监控裸查询接口已退役，禁止继续使用"
 
 
 def is_legacy_raw_monitor_query(*, source_type: str, rest_api: str) -> bool:

--- a/server/apps/operation_analysis/management/commands/init_builtin_canvases.py
+++ b/server/apps/operation_analysis/management/commands/init_builtin_canvases.py
@@ -20,7 +20,6 @@ from django.core.management import BaseCommand
 from django.db import transaction
 
 from apps.core.logger import operation_analysis_logger as logger
-from apps.operation_analysis.common.datasource_security import LEGACY_RAW_MONITOR_QUERY_ROUTES
 from apps.operation_analysis.common.load_json_data import load_support_json
 from apps.operation_analysis.constants.import_export import YAML_SCHEMA_VERSION
 
@@ -156,8 +155,6 @@ def _collect_retired_builtin_objects(doc, canvas_type_model_map, datasource_mode
         datasource_model.objects.filter(is_build_in=True, build_in_key__isnull=False)
         .exclude(build_in_key="")
         .exclude(build_in_key__in=builtin_keys)
-        # 裸查询路由已停止新装发布，但存量画布仍依赖原数据源主键；迁移完成前不得自动退役。
-        .exclude(source_type="nats", rest_api__in=LEGACY_RAW_MONITOR_QUERY_ROUTES)
         .order_by("pk")
     )
     if lock:

--- a/server/apps/operation_analysis/serializers/datasource_serializers.py
+++ b/server/apps/operation_analysis/serializers/datasource_serializers.py
@@ -221,13 +221,7 @@ class DataSourceAPIModelSerializer(BaseFormatTimeSerializer, AuthSerializer):
             getattr(self.instance, "source_type", DataSourceAPIModel.SOURCE_TYPE_NATS),
         )
         rest_api = attrs.get("rest_api", getattr(self.instance, "rest_api", ""))
-        keeps_existing_legacy_route = bool(
-            self.instance
-            and source_type == self.instance.source_type
-            and rest_api == self.instance.rest_api
-            and is_legacy_raw_monitor_query(source_type=source_type, rest_api=rest_api)
-        )
-        if is_legacy_raw_monitor_query(source_type=source_type, rest_api=rest_api) and not keeps_existing_legacy_route:
+        if is_legacy_raw_monitor_query(source_type=source_type, rest_api=rest_api):
             raise serializers.ValidationError({"rest_api": LEGACY_RAW_MONITOR_QUERY_ERROR})
 
         transform_config = attrs.get(

--- a/server/apps/operation_analysis/services/import_export/import_service.py
+++ b/server/apps/operation_analysis/services/import_export/import_service.py
@@ -368,16 +368,7 @@ class ImportService:
             source_type=ds_item.source_type,
             rest_api=ds_item.rest_api,
         )
-        preserves_existing_legacy_route = bool(
-            existing
-            and is_legacy_raw_monitor_query(
-                source_type=existing.source_type,
-                rest_api=existing.rest_api,
-            )
-            and action in {ConflictAction.SKIP.value, ConflictAction.OVERWRITE.value}
-        )
-        skips_existing_route = bool(existing and action == ConflictAction.SKIP.value)
-        if targets_legacy_route and not (preserves_existing_legacy_route or skips_existing_route):
+        if targets_legacy_route:
             self._record_result(
                 ds_item.key,
                 ObjectType.DATASOURCE.value,

--- a/server/apps/operation_analysis/services/import_export/precheck_service.py
+++ b/server/apps/operation_analysis/services/import_export/precheck_service.py
@@ -400,17 +400,8 @@ class PrecheckService:
 
     @staticmethod
     def check_datasource_security(doc: YAMLDocument) -> list[dict]:
-        """在提交导入前拒绝没有可兼容存量记录的监控裸查询数据源。"""
+        """在提交导入前拒绝所有已退役的监控裸查询数据源。"""
         raw_items = [item for item in doc.datasources if is_legacy_raw_monitor_query(source_type=item.source_type, rest_api=item.rest_api)]
-        if not raw_items:
-            return []
-
-        existing_keys = set(
-            DataSourceAPIModel.objects.filter(
-                name__in={item.name for item in raw_items},
-                rest_api__in={item.rest_api for item in raw_items},
-            ).values_list("name", "rest_api")
-        )
         return [
             {
                 "code": ImportExportErrorCode.YAML_SCHEMA_INVALID,
@@ -419,7 +410,6 @@ class PrecheckService:
                 "object_type": ObjectType.DATASOURCE.value,
             }
             for item in raw_items
-            if (item.name, item.rest_api) not in existing_keys
         ]
 
     @classmethod

--- a/server/apps/operation_analysis/tests/test_datasource_filters_serializers.py
+++ b/server/apps/operation_analysis/tests/test_datasource_filters_serializers.py
@@ -180,7 +180,7 @@ def test_datasource_serializer_rejects_new_raw_monitor_query_routes(authenticate
     )
 
     assert not serializer.is_valid()
-    assert serializer.errors["rest_api"] == ["该监控裸查询接口已停止新增，仅保留存量数据源兼容"]
+    assert serializer.errors["rest_api"] == ["该监控裸查询接口已退役，禁止继续使用"]
 
 
 @pytest.mark.django_db
@@ -195,11 +195,11 @@ def test_datasource_serializer_rejects_raw_monitor_query_with_default_source_typ
     )
 
     assert not serializer.is_valid()
-    assert serializer.errors["rest_api"] == ["该监控裸查询接口已停止新增，仅保留存量数据源兼容"]
+    assert serializer.errors["rest_api"] == ["该监控裸查询接口已退役，禁止继续使用"]
 
 
 @pytest.mark.django_db
-def test_datasource_serializer_preserves_existing_raw_monitor_query_route(authenticated_user):
+def test_datasource_serializer_rejects_existing_raw_monitor_query_route(authenticated_user):
     from apps.operation_analysis.serializers.datasource_serializers import DataSourceAPIModelSerializer
 
     datasource = DataSourceAPIModel.objects.create(
@@ -214,6 +214,28 @@ def test_datasource_serializer_preserves_existing_raw_monitor_query_route(authen
         datasource,
         context={"request": _serializer_request(authenticated_user)},
         data=_nats_datasource_payload(name="历史监控查询", rest_api="monitor/mm_query_range"),
+    )
+
+    assert not serializer.is_valid()
+    assert serializer.errors["rest_api"] == ["该监控裸查询接口已退役，禁止继续使用"]
+
+
+@pytest.mark.django_db
+def test_datasource_serializer_allows_migrating_existing_raw_route(authenticated_user):
+    from apps.operation_analysis.serializers.datasource_serializers import DataSourceAPIModelSerializer
+
+    datasource = DataSourceAPIModel.objects.create(
+        name="历史监控查询",
+        rest_api="monitor/mm_query_range",
+        source_type="nats",
+        groups=[1],
+        created_by="system",
+        updated_by="system",
+    )
+    serializer = DataSourceAPIModelSerializer(
+        datasource,
+        context={"request": _serializer_request(authenticated_user)},
+        data=_nats_datasource_payload(name="历史监控查询", rest_api="monitor/get_host_metric_range"),
     )
 
     assert serializer.is_valid(), serializer.errors

--- a/server/apps/operation_analysis/tests/test_datasource_view.py
+++ b/server/apps/operation_analysis/tests/test_datasource_view.py
@@ -61,11 +61,11 @@ def test_datasource_create_rejects_raw_monitor_query_route(authenticated_user):
 
 @pytest.mark.django_db
 @pytest.mark.integration
-def test_existing_raw_monitor_query_datasource_remains_executable(authenticated_user, monkeypatch):
+def test_existing_raw_monitor_query_datasource_is_not_executable(authenticated_user, monkeypatch):
     authenticated_user.is_superuser = True
     request = _build_request(authenticated_user, data={"query": "up"})
 
-    response, payload, captured = _build_view_response(
+    response, _payload, captured = _build_view_response(
         request,
         monkeypatch,
         {"result": True, "data": [{"name": "up", "value": 1}], "message": ""},
@@ -73,11 +73,9 @@ def test_existing_raw_monitor_query_datasource_remains_executable(authenticated_
         params=[{"name": "query", "type": "string", "value": "", "filterType": "params"}],
     )
 
-    assert response.status_code == status.HTTP_200_OK
-    assert payload["data"]["data"] == [{"name": "up", "value": 1}]
-    assert captured["kwargs"]["namespace"] == "monitor"
-    assert captured["kwargs"]["path"] == "mm_query"
-    assert captured["kwargs"]["params"]["query"] == "up"
+    assert response.status_code == status.HTTP_410_GONE
+    assert response.data["detail"] == LEGACY_RAW_MONITOR_QUERY_ERROR
+    assert captured == {}
 
 
 @pytest.mark.django_db

--- a/server/apps/operation_analysis/tests/test_import_export_auth.py
+++ b/server/apps/operation_analysis/tests/test_import_export_auth.py
@@ -148,9 +148,7 @@ def _permission_rules_for_export(*, dashboard_id: int, datasource_ids: list[int]
 
 @pytest.mark.unit
 def test_export_request_rejects_unbounded_object_id_list():
-    serializer = ExportRequestSerializer(
-        data={"object_type": "dashboard", "object_ids": list(range(1, ExportRequestSerializer.MAX_OBJECT_IDS + 2))}
-    )
+    serializer = ExportRequestSerializer(data={"object_type": "dashboard", "object_ids": list(range(1, ExportRequestSerializer.MAX_OBJECT_IDS + 2))})
 
     assert not serializer.is_valid()
     assert "object_ids" in serializer.errors
@@ -442,10 +440,8 @@ def test_precheck_drops_overwrite_when_user_lacks_overwrite_permission(authentic
 
 
 @pytest.mark.django_db
-def test_backend_precheck_does_not_readd_rename_for_existing_raw_monitor_query(authenticated_user, monkeypatch):
-    authenticated_user.permission = {
-        "ops-analysis": {"data_source-View", "data_source-Add", "data_source-Edit"}
-    }
+def test_backend_precheck_rejects_existing_raw_monitor_query(authenticated_user, monkeypatch):
+    authenticated_user.permission = {"ops-analysis": {"data_source-View", "data_source-Add", "data_source-Edit"}}
     existing = DataSourceAPIModel.objects.create(
         name="legacy-raw-query",
         rest_api="monitor/mm_query",
@@ -472,8 +468,8 @@ def test_backend_precheck_does_not_readd_rename_for_existing_raw_monitor_query(a
     payload = _unwrap_payload(json.loads(response.rendered_content))
 
     assert response.status_code == status.HTTP_200_OK
-    assert payload["valid"] is True
-    assert payload["conflicts"][0]["suggested_actions"] == ["overwrite", "skip"]
+    assert payload["valid"] is False
+    assert payload["errors"][0]["message"] == "该监控裸查询接口已退役，禁止继续使用"
 
 
 @pytest.mark.django_db
@@ -763,9 +759,7 @@ def test_backend_legacy_export_rechecks_root_after_competing_transaction(authent
         with ThreadPoolExecutor(max_workers=1) as executor:
             return executor.submit(execute).result(timeout=5)
 
-    dashboard_id = run_committed(
-        lambda: Dashboard.objects.create(name="permission-race-dashboard", groups=[1], view_sets=[]).id
-    )
+    dashboard_id = run_committed(lambda: Dashboard.objects.create(name="permission-race-dashboard", groups=[1], view_sets=[]).id)
     monkeypatch.setattr(
         "apps.operation_analysis.services.import_export.authorization_service.get_permission_rules",
         lambda user, current_team, app_name, permission_key, include_children=False: {

--- a/server/apps/operation_analysis/tests/test_import_service.py
+++ b/server/apps/operation_analysis/tests/test_import_service.py
@@ -269,7 +269,7 @@ def test_import_rejects_new_raw_monitor_query_datasource(rest_api):
 
     assert result["success"] is False
     assert result["summary"]["failed"] == 1
-    assert result["results"][0]["message"] == "该监控裸查询接口已停止新增，仅保留存量数据源兼容"
+    assert result["results"][0]["message"] == "该监控裸查询接口已退役，禁止继续使用"
     assert not DataSourceAPIModel.objects.filter(name="raw-query").exists()
 
 
@@ -286,7 +286,7 @@ def test_precheck_rejects_new_raw_monitor_query_and_limits_legacy_conflict_actio
     assert precheck["errors"] == [
         {
             "code": "OA_YAML_SCHEMA_INVALID",
-            "message": "该监控裸查询接口已停止新增，仅保留存量数据源兼容",
+            "message": "该监控裸查询接口已退役，禁止继续使用",
             "object_key": "raw::monitor/mm_query",
             "object_type": "datasource",
         }
@@ -301,12 +301,12 @@ def test_precheck_rejects_new_raw_monitor_query_and_limits_legacy_conflict_actio
     )
     legacy_precheck = PrecheckService.precheck(yaml_content)
 
-    assert legacy_precheck["valid"] is True
-    assert legacy_precheck["conflicts"][0]["suggested_actions"] == ["skip", "overwrite"]
+    assert legacy_precheck["valid"] is False
+    assert legacy_precheck["errors"][0]["message"] == "该监控裸查询接口已退役，禁止继续使用"
 
 
 @pytest.mark.django_db
-def test_import_allows_overwriting_existing_raw_monitor_query_datasource():
+def test_import_rejects_overwriting_existing_raw_monitor_query_datasource():
     existing = DataSourceAPIModel.objects.create(
         name="raw-query",
         rest_api="monitor/mm_query_range",
@@ -331,9 +331,9 @@ def test_import_allows_overwriting_existing_raw_monitor_query_datasource():
         conflict_decisions={"raw::monitor/mm_query_range": ConflictAction.OVERWRITE.value},
     ).execute()
 
-    assert result["success"] is True
+    assert result["success"] is False
     existing.refresh_from_db()
-    assert existing.desc == "new"
+    assert existing.desc == "old"
 
 
 @pytest.mark.django_db

--- a/server/apps/operation_analysis/tests/test_init_builtin_canvases.py
+++ b/server/apps/operation_analysis/tests/test_init_builtin_canvases.py
@@ -1168,7 +1168,7 @@ def test_init_builtin_canvases_overwrites_and_prunes_only_builtin_datasources():
         created_by="system",
         updated_by="system",
     )
-    preserved_raw_queries = [
+    retired_raw_queries = [
         DataSourceAPIModel.objects.create(
             name=name,
             rest_api=rest_api,
@@ -1205,7 +1205,7 @@ def test_init_builtin_canvases_overwrites_and_prunes_only_builtin_datasources():
     assert legacy.build_in_key == "告警状态分布::alert/get_alert_status_distribution"
     assert legacy.params != [{"name": "legacy"}]
     assert not DataSourceAPIModel.objects.filter(pk=stale.pk).exists()
-    assert all(DataSourceAPIModel.objects.filter(pk=item.pk).exists() for item in preserved_raw_queries)
+    assert all(not DataSourceAPIModel.objects.filter(pk=item.pk).exists() for item in retired_raw_queries)
     assert DataSourceAPIModel.objects.filter(pk=unknown_legacy_builtin.pk, is_build_in=True).exists()
     assert DataSourceAPIModel.objects.filter(pk=custom.pk, is_build_in=False).exists()
 

--- a/server/apps/operation_analysis/views/datasource_view.py
+++ b/server/apps/operation_analysis/views/datasource_view.py
@@ -17,6 +17,7 @@ from apps.core.utils.time_util import format_rfc3339_utc, parse_rfc3339_utc
 from apps.core.utils.trend_granularity import TREND_GROUP_BY_AUTO_REST_APIS
 from apps.core.utils.viewset_utils import AuthViewSet
 from apps.operation_analysis.common.audit_log import get_response_name, log_ops_analysis_success
+from apps.operation_analysis.common.datasource_security import LEGACY_RAW_MONITOR_QUERY_ERROR, is_legacy_raw_monitor_query
 from apps.operation_analysis.common.datasource_visibility import (
     can_access_datasource_in_org,
     expand_datasource_org_query,
@@ -543,6 +544,9 @@ class DataSourceAPIModelViewSet(AuthViewSet):
                 "数据源不存在或已删除",
                 status.HTTP_404_NOT_FOUND,
             )
+
+        if is_legacy_raw_monitor_query(source_type=instance.source_type, rest_api=instance.rest_api):
+            return _build_error_response(LEGACY_RAW_MONITOR_QUERY_ERROR, status.HTTP_410_GONE)
 
         raw_request = getattr(request, "_request", request)
         render_scoped = getattr(raw_request, "dashboard_report_render_scope", None) is not None

--- a/specs/changes/monitor-controlled-dashboard-query/spec.md
+++ b/specs/changes/monitor-controlled-dashboard-query/spec.md
@@ -1,0 +1,85 @@
+# 监控看板受控查询与原始 PromQL 入口退役
+
+## 状态
+
+- Issue：`#4820`
+- 决策：采用方案 A，迁移现有调用方并删除原始 PromQL REST 入口。
+- 产品约束：不保留“管理员任意执行 PromQL”的兼容能力。
+- 部署介入：不需要新增环境变量、迁移脚本或运维配置。
+
+## 背景
+
+监控 Web 曾将看板内置 PromQL 直接提交到
+`metrics_instance/query`、`metrics_instance/query_range`。后端只负责转发查询，无法从请求中
+可靠推导监控对象、实例范围和当前用户可见实例，因此页面权限与 VictoriaMetrics 查询范围
+可能不一致。
+
+此前 Search、Mobile 和运营分析调用方已经迁移到受控指标查询，NATS/RPC 的原始
+`mm_query`、`mm_query_range` 处理器也已退役。本变更完成剩余 Web 看板迁移并删除 REST
+原始查询入口。
+
+## 行为规格
+
+### 请求契约
+
+- 范围查询与即时查询统一使用既有 POST 入口：
+  `query_by_metric_range`、`query_by_metric`。
+- 请求必须且只能提供 `metric_id` 或 `capability_id` 之一，不能提交 `query`。
+- 请求必须携带 `monitor_object_id` 和非空 `instance_ids`；服务端按当前用户、当前团队及
+  `include_children` 计算实例权限，任一实例越权时整次请求失败且不访问 VictoriaMetrics。
+- `metric_id` 查询只允许使用服务端指标模板，并只接受指标声明过的筛选维度和固定汇聚方式。
+- `capability_id` 查询只允许使用仓库生成的看板能力清单；能力必须与监控对象绑定，且每个
+  PromQL 选择器都必须包含由服务端注入的 `__$labels__` 实例占位符。
+- 服务端根据已授权实例生成标签匹配条件，根据请求时间范围生成 `__$window__`；浏览器不能
+  覆盖模板、实例匹配条件或窗口表达式。
+- Kafka 消费位点等有限动态查询只接受结构化维度参数，最多 10 组；服务端转义标签并生成
+  固定查询形状。
+- 主机详情中的进程视图使用 `host_process` 受控作用域：先校验父级 Host 实例权限，再由
+  服务端生成主机和进程名匹配条件；最多接受 100 个进程名。
+
+### 能力清单
+
+- `web/scripts/generate-monitor-query-capabilities.ts` 从内置看板配置和查询模块生成静态清单。
+- 能力 ID 由模板稳定计算；生成阶段拒绝 ID 冲突，服务端加载阶段重新校验 ID、模板长度、
+  对象绑定和实例占位符。
+- 修改内置看板查询时必须重新生成清单；`--check` 模式用于 CI/评审验证清单没有过期。
+- 清单是查询模板的服务端允许列表，不是用户输入或运行期配置。
+
+### 兼容与退役
+
+- 删除 `MetricsInstanceViewSet` 的 GET `query`、`query_range` action；旧 URL 不提供兼容转发。
+- Web 看板、搜索页和指标视图不再发送原始 PromQL。
+- 不恢复 NATS/RPC 的 `mm_query`、`mm_query_range`，也不保留仓外 NATS 调用兼容。
+- 运营分析中指向上述路由的历史自定义数据源保留记录以便识别，但禁止执行、保留原路由的
+  编辑及再次导入；用户仍可删除记录或将其改为受支持的数据源。历史内置数据源由既有
+  `init_builtin_canvases` 退役流程清理。
+- 历史内置看板保持原图表语义、单位换算、时间步长和缺口检测行为。
+
+## 安全与失败语义
+
+- 普通用户与管理员执行同一实例范围校验流程；超级用户只跳过权限规则过滤，仍必须提交真实
+  监控对象和实例，且不能执行任意 PromQL。
+- 未认证上下文、未知能力、对象不匹配、实例越权、原始 `query`、非法动态维度及非法时间
+  参数均在访问 VictoriaMetrics 前失败。
+- 查询能力不接受客户端自定义筛选或汇聚；需要新查询形状时必须通过仓库代码和能力清单评审。
+- 本变更不记录查询正文、身份凭据或 VictoriaMetrics 响应正文。
+
+## 验收要点
+
+1. 现有 Monitor Web 看板正常加载，浏览器请求体不含 `query`。
+2. 同一能力只能查询当前用户在当前团队可见的目标实例。
+3. 混入任一越权实例时整次请求失败，VictoriaMetrics 调用次数为零。
+4. 能力与监控对象不匹配、能力不存在或能力参数非法时调用次数为零。
+5. Kafka 动态维度中的引号和反斜杠被安全转义，且不能改变查询结构。
+6. 旧 REST `query`、`query_range` action 不再注册。
+7. Web、Mobile、运营分析和 NATS/RPC 中不存在对退役原始入口的调用。
+8. 生成器 `--check`、Web 类型检查、前后端聚焦测试通过。
+
+## 测试接缝
+
+- `AuthorizedMetricQueryService`：指标/能力二选一、原始查询拒绝、实例授权、对象绑定、
+  `host_process` 和查询参数转发。
+- `dashboard_query_capabilities`：清单完整性、模板渲染、Kafka 维度转义和限制。
+- `MetricsInstanceViewSet`：认证上下文、成功响应、越权失败和旧 action 退役。
+- Web 查询参数：能力 ID 稳定、静态及动态请求均不携带原始 PromQL。
+- 静态调用扫描：旧 REST 路径与 `mm_query`、`mm_query_range` 调用归零。

--- a/web/package.json
+++ b/web/package.json
@@ -80,6 +80,7 @@
     "test:monitor-builtin-metric-readonly": "pnpm exec tsx scripts/monitor-builtin-metric-readonly-test.ts",
     "test:monitor-policy-formula-payload": "pnpm exec tsx scripts/monitor-policy-formula-payload-test.ts",
     "test:monitor-query-step": "pnpm exec tsx scripts/monitor-query-step-test.ts",
+    "test:monitor-query-capabilities": "pnpm exec vitest run 'src/app/monitor/dashboards/shared/utils/__tests__/query-capability.test.ts' && pnpm exec tsx scripts/generate-monitor-query-capabilities.ts --check",
     "test:monitor-promql-window": "pnpm exec tsx scripts/monitor-promql-window-test.ts",
     "test:monitor-strategy-aggregation-designer": "pnpm exec tsx scripts/monitor-strategy-aggregation-designer-story-test.ts",
     "test:monitor-alert-detail-snapshot": "pnpm exec tsx scripts/monitor-alert-detail-snapshot-test.ts",

--- a/web/scripts/generate-monitor-query-capabilities.ts
+++ b/web/scripts/generate-monitor-query-capabilities.ts
@@ -1,0 +1,161 @@
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { dashboardQueryCapabilityId } from '../src/app/monitor/dashboards/shared/utils/query-capability';
+import {
+  FLOW_SUPPORTED_OBJECT_NAMES,
+  resolveInstanceTypeFromObjectName,
+  type FlowProtocol,
+} from '../src/app/monitor/dashboards/objects/flow-common/constants';
+import {
+  buildConversationTopQuery,
+  buildFlowCollectionStatusQuery,
+  buildFlowMetricQueries,
+  buildProtocolTopQuery,
+} from '../src/app/monitor/dashboards/objects/flow-common/queries';
+
+interface CapabilityEntry {
+  id: string;
+  object_names: string[];
+  template: string;
+}
+
+const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const objectsRoot = join(webRoot, 'src/app/monitor/dashboards/objects');
+const outputPath = resolve(webRoot, '../server/apps/monitor/support-files/dashboard_query_capabilities.json');
+const sourceFiles: string[] = [];
+const directoryRouteKeys = new Map<string, string>();
+
+const metadataSource = readFileSync(
+  join(webRoot, 'src/app/monitor/dashboards/metadata.ts'),
+  'utf8',
+);
+const objectNameByRoute = new Map<string, string>();
+for (const match of metadataSource.matchAll(
+  /\{\s*key:\s*'([^']+)'[\s\S]*?objectName:\s*'([^']+)'[\s\S]*?\}/g,
+)) {
+  objectNameByRoute.set(match[1], match[2]);
+}
+
+const walk = (directory: string) => {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) walk(path);
+    if (entry.isFile() && (entry.name === 'config.ts' || entry.name === 'queries.ts')) {
+      sourceFiles.push(path);
+    }
+  }
+};
+
+const capabilityMap = new Map<string, { template: string; objectNames: Set<string> }>();
+
+const register = (template: string, objectName: string) => {
+  if (!template.includes('__$labels__')) return;
+  const selectors = Array.from(template.matchAll(/\{([^{}]*)\}/g), (match) => match[1]);
+  if (!selectors.length || selectors.some((selector) => !selector.includes('__$labels__'))) {
+    throw new Error(`unscoped dashboard query template for ${objectName}: ${template}`);
+  }
+  const id = dashboardQueryCapabilityId(template);
+  const existing = capabilityMap.get(id);
+  if (existing && existing.template !== template) {
+    throw new Error(`dashboard query capability collision: ${id}`);
+  }
+  const value = existing || { template, objectNames: new Set<string>() };
+  value.objectNames.add(objectName);
+  capabilityMap.set(id, value);
+};
+
+const collectTemplates = (
+  value: unknown,
+  objectName: string,
+  seen = new Set<unknown>(),
+) => {
+  if (typeof value === 'string') {
+    register(value, objectName);
+    return;
+  }
+  if (!value || typeof value !== 'object' || seen.has(value)) return;
+  seen.add(value);
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectTemplates(item, objectName, seen));
+    return;
+  }
+  Object.values(value).forEach((item) => collectTemplates(item, objectName, seen));
+};
+
+const resolveObjectNameForFile = (file: string) => {
+  const relative = file.slice(objectsRoot.length + 1);
+  const directory = relative.split('/')[0];
+  const routeKey = directoryRouteKeys.get(directory) || directory;
+  return objectNameByRoute.get(routeKey);
+};
+
+const registerStaticModules = async () => {
+  walk(objectsRoot);
+  for (const file of sourceFiles.filter((item) => item.endsWith('/config.ts')).sort()) {
+    const loadedModule = await import(pathToFileURL(file).href);
+    for (const value of Object.values(loadedModule)) {
+      if (!value || typeof value !== 'object') continue;
+      const candidate = value as { routeKey?: unknown };
+      if (typeof candidate.routeKey !== 'string') continue;
+      const relative = file.slice(objectsRoot.length + 1);
+      directoryRouteKeys.set(relative.split('/')[0], candidate.routeKey);
+    }
+  }
+  for (const file of sourceFiles.sort()) {
+    const objectName = resolveObjectNameForFile(file);
+    if (!objectName || file.includes('/flow-common/')) continue;
+    const loadedModule = await import(pathToFileURL(file).href);
+    collectTemplates(loadedModule, objectName);
+  }
+};
+
+const registerFlowCapabilities = () => {
+  const protocols: FlowProtocol[] = ['netflow', 'sflow'];
+  for (const objectName of FLOW_SUPPORTED_OBJECT_NAMES) {
+    const instanceType = resolveInstanceTypeFromObjectName(objectName);
+    if (!instanceType) continue;
+    for (const protocol of protocols) {
+      register(buildFlowCollectionStatusQuery(instanceType, protocol), objectName);
+      register(buildConversationTopQuery(instanceType, protocol), objectName);
+      register(buildProtocolTopQuery(instanceType, protocol), objectName);
+      Object.values(buildFlowMetricQueries(instanceType, protocol)).forEach((template) => {
+        register(template, objectName);
+      });
+    }
+  }
+};
+
+const main = async () => {
+  await registerStaticModules();
+  registerFlowCapabilities();
+
+  const knownObjectNames = new Set(objectNameByRoute.values());
+  const capabilities: CapabilityEntry[] = Array.from(capabilityMap, ([id, value]) => ({
+    id,
+    object_names: Array.from(value.objectNames).sort(),
+    template: value.template,
+  })).sort((left, right) => left.id.localeCompare(right.id));
+
+  capabilities.forEach((item) => {
+    item.object_names.forEach((name) => {
+      if (!knownObjectNames.has(name) && !FLOW_SUPPORTED_OBJECT_NAMES.includes(name as never)) {
+        throw new Error(`unknown monitor object for capability ${item.id}: ${name}`);
+      }
+    });
+  });
+
+  const content = `${JSON.stringify({ version: 1, capabilities }, null, 2)}\n`;
+  if (process.argv.includes('--check')) {
+    if (!existsSync(outputPath) || readFileSync(outputPath, 'utf8') !== content) {
+      throw new Error('monitor dashboard query capability manifest is stale');
+    }
+    process.stdout.write(`verified ${capabilities.length} monitor query capabilities\n`);
+    return;
+  }
+  writeFileSync(outputPath, content, 'utf8');
+  process.stdout.write(`generated ${capabilities.length} monitor query capabilities\n`);
+};
+
+void main();

--- a/web/src/app/monitor/(pages)/view/detail/overview.tsx
+++ b/web/src/app/monitor/(pages)/view/detail/overview.tsx
@@ -24,7 +24,6 @@ import {
 import { useTranslation } from '@/utils/i18n';
 import {
   calculateMetrics,
-  mergeViewQueryKeyValues,
   renderChart,
   getRecentTimeRange
 } from '@/app/monitor/utils/common';
@@ -136,19 +135,15 @@ const Overview: React.FC<ViewDetailProps> = ({
 
   const getParams = (item: MetricItem) => {
     const params: SearchParams = {
-      // 卡片统一用完整 query + 通用序列预算；不再走 per-metric view_query。
-      query: (item.query || '').replace(
-        /__\$labels__/g,
-        mergeViewQueryKeyValues([
-          { keys: item.instance_id_keys || [], values: idValues }
-        ])
-      ),
+      monitor_object_id: monitorObjectId,
+      metric_id: item.id,
+      instance_ids: [String(instanceId)],
       source_unit: item.unit || '',
       // 概览卡按指标声明单位格式化，禁止服务端自动换算（否则 ms/bytes/counts 被缩放过后再按原单位展示）。
       auto_convert_unit: false
     };
     // Overview 指标卡与详情指标 Tab 共用 card budget，避免大基数全量打满。
-    params.query_budget = 'card';
+    params.card_budget = true;
     const recentTimeRange = getRecentTimeRange(timeValues);
     const startTime = recentTimeRange.at(0);
     const endTime = recentTimeRange.at(1);

--- a/web/src/app/monitor/(pages)/view/monitorView.tsx
+++ b/web/src/app/monitor/(pages)/view/monitorView.tsx
@@ -16,10 +16,7 @@ import {
 import { ViewModalProps } from '@/app/monitor/types/view';
 import { SearchParams } from '@/app/monitor/types/search';
 import { useTranslation } from '@/utils/i18n';
-import {
-  mergeViewQueryKeyValues,
-  renderChart,
-} from '@/app/monitor/utils/common';
+import { renderChart } from '@/app/monitor/utils/common';
 import { calculateQueryStep } from '@/app/monitor/utils/queryStep';
 import { attachGapIntervals, buildGapDetectionParams } from '@/app/monitor/utils/gapIntervals';
 import dayjs, { Dayjs } from 'dayjs';
@@ -32,7 +29,6 @@ import {
 } from '@/app/monitor/components/metricSelectOptions';
 import { buildSearchTimeQueryParams } from '@/app/monitor/utils/searchTimeQuery';
 import {
-  buildHostProcessLabelPairs,
   isHostMonitorObject,
   isHostProcessMetricsTab,
   resolveHostProcessMetricsTarget,
@@ -47,7 +43,7 @@ const MonitorView: React.FC<ViewModalProps> = ({
   form = INIT_VIEW_MODAL_FORM,
 }) => {
   const { isLoading } = useApiClient();
-  const { get } = useApiClient();
+  const { post } = useApiClient();
   const { getMetricsGroup, getMonitorMetrics, getMonitorObject, getMonitorPlugin, getInstanceList } =
     useMonitorApi();
   const { t } = useTranslation();
@@ -256,7 +252,6 @@ const MonitorView: React.FC<ViewModalProps> = ({
     return () => {
       active = false;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isProcessMetricsView, processObjectId, hostLogicalId]);
 
   const onTabChange = (val: string) => {
@@ -373,22 +368,23 @@ const MonitorView: React.FC<ViewModalProps> = ({
     setVisibleMetricIds(new Set());
   };
 
-  const getParams = (item: MetricItem, ids: string[]) => {
-    const labelKeys = isHostProcessMetricsTab(activeTab)
-      ? ['instance_id']
-      : item.instance_id_keys || [];
-    const labelPairs = isHostProcessMetricsTab(activeTab)
-      ? buildHostProcessLabelPairs(hostLogicalId || ids[0] || '', processFilterNames)
-      : [{ keys: labelKeys, values: ids }];
+  const getParams = (item: MetricItem) => {
+    const processView = isHostProcessMetricsTab(activeTab);
     const params: SearchParams = {
-      // 卡片统一用完整 query + 通用序列预算；不再走 per-metric view_query。
-      query: (item.query || '').replace(
-        /__\$labels__/g,
-        mergeViewQueryKeyValues(labelPairs)
-      ),
+      monitor_object_id: processView ? processObjectId : monitorObject,
+      metric_id: item.id,
+      instance_ids: processView ? undefined : [String(form.instance_id)],
+      scope: processView
+        ? {
+          type: 'host_process',
+          host_monitor_object_id: monitorObject,
+          host_instance_id: form.instance_id,
+          process_names: processFilterNames,
+        }
+        : undefined,
       source_unit: item.unit || '',
     };
-    params.query_budget = 'card';
+    params.card_budget = true;
     const queryWindow = activeQueryWindowRef.current;
     if (queryWindow) {
       params.start = queryWindow.startMs;
@@ -440,11 +436,12 @@ const MonitorView: React.FC<ViewModalProps> = ({
     activeRequestsRef.current.set(metric.id, abortController);
     let response;
     try {
-      const params = getParams(metric, form?.instance_id_values || []);
-      response = await get(`/monitor/api/metrics_instance/query_range/`, {
+      const params = getParams(metric);
+      response = await post(
+        `/monitor/api/metrics_instance/query_by_metric_range/`,
         params,
-        signal: abortController.signal,
-      });
+        { signal: abortController.signal },
+      );
     } catch (error: any) {
       if (error.name === 'AbortError') {
         return;

--- a/web/src/app/monitor/api/view.ts
+++ b/web/src/app/monitor/api/view.ts
@@ -15,22 +15,18 @@ const useViewApi = () => {
   // 必须用 useCallback 固定引用,否则每次重渲染都生成新函数 → effect 反复触发 → 重复发起查询。
   const getInstanceQuery = useCallback(
     async (
-      params: SearchParams = {
-        query: '',
-      }
+      params: SearchParams
     ) => {
-      return await get(`/monitor/api/metrics_instance/query_range/`, {
-        params,
-      });
+      return await post(`/monitor/api/metrics_instance/query_by_metric_range/`, params);
     },
-    [get]
+    [post]
   );
 
   const getInstanceInstantQuery = useCallback(
-    async (params: SearchParams = { query: '' }) => {
-      return await get(`/monitor/api/metrics_instance/query/`, { params });
+    async (params: SearchParams) => {
+      return await post(`/monitor/api/metrics_instance/query_by_metric/`, params);
     },
-    [get]
+    [post]
   );
 
   const getInstanceSearch = useCallback(

--- a/web/src/app/monitor/components/metric-views/index.tsx
+++ b/web/src/app/monitor/components/metric-views/index.tsx
@@ -18,7 +18,6 @@ import { ViewDetailProps } from '@/app/monitor/types/view';
 import { SearchParams } from '@/app/monitor/types/search';
 import { useTranslation } from '@/utils/i18n';
 import {
-  mergeViewQueryKeyValues,
   renderChart,
   getRecentTimeRange
 } from '@/app/monitor/utils/common';
@@ -33,8 +32,7 @@ import {
   useMetricSelectOptions,
 } from '@/app/monitor/components/metricSelectOptions';
 import { buildSearchTimeQueryParams } from '@/app/monitor/utils/searchTimeQuery';
-import { buildHostProcessLabelPairs,
-  isHostMonitorObject,
+import { isHostMonitorObject,
   isHostProcessMetricsTab,
   resolveHostProcessMetricsTarget,
   resolveProcessNameFromInstance,
@@ -145,7 +143,7 @@ const MetricViews: React.FC<ViewDetailProps> = ({
     getMetricsGroup,
     getInstanceList
   } = useMonitorApi();
-  const { get } = useApiClient();
+  const { post } = useApiClient();
   const { t } = useTranslation();
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   const metricSearchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -284,7 +282,6 @@ const MetricViews: React.FC<ViewDetailProps> = ({
       active = false;
     };
     // getInstanceList 来自 hook，身份不稳定；仅随主机/进程对象/页签变化重载。
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isProcessMetricsView, processObjectId, hostLogicalId]);
 
   useEffect(() => {
@@ -543,21 +540,23 @@ const MetricViews: React.FC<ViewDetailProps> = ({
     setVisibleMetricIds(new Set());
   };
 
-  const getParams = (item: MetricItem, ids: string[]) => {
-    const labelKeys = resolveQueryInstanceIdKeys(item.instance_id_keys || []);
-    const labelPairs = isProcessMetricsView
-      ? buildHostProcessLabelPairs(hostLogicalId || ids[0] || '', processFilterNames)
-      : [{ keys: labelKeys, values: ids }];
+  const getParams = (item: MetricItem) => {
     const params: SearchParams = {
-      // 卡片统一用完整 query + 通用序列预算；不再走 per-metric view_query。
-      query: (item.query || '').replace(
-        /__\$labels__/g,
-        mergeViewQueryKeyValues(labelPairs)
-      ),
+      monitor_object_id: isProcessMetricsView ? processObjectId : monitorObjectId,
+      metric_id: item.id,
+      instance_ids: isProcessMetricsView ? undefined : [String(instanceId)],
+      scope: isProcessMetricsView
+        ? {
+          type: 'host_process',
+          host_monitor_object_id: monitorObjectId,
+          host_instance_id: instanceId,
+          process_names: processFilterNames,
+        }
+        : undefined,
       source_unit: item.unit || ''
     };
-    // 完整明细仍由搜索页查询（不带 query_budget）。
-    params.query_budget = 'card';
+    // 完整明细仍由搜索页查询（不带 card_budget）。
+    params.card_budget = true;
     const recentTimeRange = getRecentTimeRange(activeTimeValues);
     const startTime = recentTimeRange.at(0);
     const endTime = recentTimeRange.at(1);
@@ -609,11 +608,12 @@ const MetricViews: React.FC<ViewDetailProps> = ({
     activeRequestsRef.current.set(metric.id, abortController);
     let response;
     try {
-      const params = getParams(metric, idValues);
-      response = await get(`/monitor/api/metrics_instance/query_range/`, {
+      const params = getParams(metric);
+      response = await post(
+        `/monitor/api/metrics_instance/query_by_metric_range/`,
         params,
-        signal: abortController.signal
-      });
+        { signal: abortController.signal },
+      );
     } catch (error: any) {
       if (error.name === 'AbortError') {
         return;

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
@@ -540,10 +540,20 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
 
   const loadSingleMetric = useCallback(
     (metric: SimpleMetricConfig, tv: TimeValuesProps) =>
-      getInstanceQuery(buildSearchParams(metric.query, metric.unit, idValues, instanceIdKeys, tv, undefined, false, currentInstanceInterval))
+      getInstanceQuery(buildSearchParams(
+        metric.query,
+        metric.unit,
+        idValues,
+        instanceIdKeys,
+        tv,
+        undefined,
+        false,
+        currentInstanceInterval,
+        { monitorObjectId, instanceId },
+      ))
         .then((result) => [metric.name, toMetricSeries(metric, result, instanceId, resolvedInstanceName, idValues, instanceIdKeys)] as const)
         .catch(() => [metric.name, { ...metric, viewData: [], loadState: 'error' as const }] as const),
-    [currentInstanceInterval, getInstanceQuery, idValues, instanceId, instanceIdKeys, resolvedInstanceName]
+    [currentInstanceInterval, getInstanceQuery, idValues, instanceId, instanceIdKeys, monitorObjectId, resolvedInstanceName]
   );
 
   const loadMetrics = useCallback(async (silent = false) => {
@@ -571,7 +581,17 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
           (metric) => loadSingleMetric(metric, frozenTimeValues)
         );
         const collectionStatusPromise: Promise<MetricSeries> = getInstanceQuery(
-          buildSearchParams(config.collectionStatusQuery, 'counts', idValues, instanceIdKeys, frozenTimeValues, undefined, false, currentInstanceInterval)
+          buildSearchParams(
+            config.collectionStatusQuery,
+            'counts',
+            idValues,
+            instanceIdKeys,
+            frozenTimeValues,
+            undefined,
+            false,
+            currentInstanceInterval,
+            { monitorObjectId, instanceId },
+          )
         )
           .then((result) =>
             toMetricSeries(

--- a/web/src/app/monitor/dashboards/objects/docker/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/docker/dashboard.tsx
@@ -60,7 +60,8 @@ export default function DockerDashboardPage() {
           timeValues,
           undefined,
           false,
-          currentInstanceInterval
+          currentInstanceInterval,
+          { monitorObjectId: dashboard.monitorObjectId, instanceId: dashboard.instanceId }
         )
       )
         .then((res: any) => [q.key, topLabelBars(res, q.unit, q.color, q.labelKeys)] as const)
@@ -71,7 +72,6 @@ export default function DockerDashboardPage() {
     return () => {
       active = false;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentInstanceInterval, idValuesKey, timeKey, isDashboardMode, instanceIdKeys, getInstanceQuery, loadTick]);
 
   return (

--- a/web/src/app/monitor/dashboards/objects/elasticsearch/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/elasticsearch/dashboard.tsx
@@ -82,7 +82,10 @@ export default function ElasticsearchDashboardPage() {
     runWithConcurrency(ES_TOP_NODE_QUERIES, TOP_NODE_CONCURRENCY, async (q) =>
       // autoConvert=false:禁用服务端单位自动换算,否则会与前端 formatMetricValue 双重换算
       //(如 bytes 被后端先缩成 GiB,前端再按 bytes 缩放)。见 postgresql / host 同因。
-      getInstanceQuery(buildSearchParams(q.query, q.unit, idValues, instanceIdKeys, timeValues, undefined, false, currentInstanceInterval))
+      getInstanceQuery(buildSearchParams(q.query, q.unit, idValues, instanceIdKeys, timeValues, undefined, false, currentInstanceInterval, {
+        monitorObjectId: dashboard.monitorObjectId,
+        instanceId: dashboard.instanceId,
+      }))
         .then((res: any) => [q.key, topNodeBars(res, q.unit, q.color)] as const)
         .catch(() => [q.key, [] as BarItem[]] as const)
     ).then((entries) => {
@@ -94,7 +97,6 @@ export default function ElasticsearchDashboardPage() {
       active = false;
     };
     // loadTick 随核心盘每次加载(含自动刷新)递增,使 TopN 与核心盘同步刷新。
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentInstanceInterval, idValuesKey, timeKey, isDashboardMode, instanceIdKeys, getInstanceQuery, loadTick]);
 
   return (

--- a/web/src/app/monitor/dashboards/objects/flow-common/conversation-table.tsx
+++ b/web/src/app/monitor/dashboards/objects/flow-common/conversation-table.tsx
@@ -84,6 +84,8 @@ export function FlowConversationTable({
           dashboard.timeValues,
           undefined,
           false,
+          dashboard.currentInstanceInterval,
+          { monitorObjectId: dashboard.monitorObjectId, instanceId: dashboard.instanceId },
         ),
       ).catch(() => null);
 

--- a/web/src/app/monitor/dashboards/objects/flow-common/protocol-breakdown.tsx
+++ b/web/src/app/monitor/dashboards/objects/flow-common/protocol-breakdown.tsx
@@ -77,6 +77,8 @@ export function FlowProtocolBreakdown({
           dashboard.timeValues,
           undefined,
           false,
+          dashboard.currentInstanceInterval,
+          { monitorObjectId: dashboard.monitorObjectId, instanceId: dashboard.instanceId },
         ),
       ).catch(() => null);
 

--- a/web/src/app/monitor/dashboards/objects/host/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/host/dashboard.tsx
@@ -69,7 +69,8 @@ export default function HostDashboardPage() {
           timeValues,
           undefined,
           false,
-          currentInstanceInterval
+          currentInstanceInterval,
+          { monitorObjectId: dashboard.monitorObjectId, instanceId: dashboard.instanceId }
         )
       )
         .then((res: any) => [q.key, topLabelBars(res, q.unit, q.color, q.labelKeys)] as const)
@@ -80,7 +81,6 @@ export default function HostDashboardPage() {
     return () => {
       active = false;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentInstanceInterval, idValuesKey, timeKey, isDashboardMode, instanceIdKeys, getInstanceQuery, loadTick]);
 
   return (

--- a/web/src/app/monitor/dashboards/objects/k3s-cluster/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k3s-cluster/dashboard.tsx
@@ -202,7 +202,17 @@ export default function K3sClusterDashboardPage() {
       const q = QUERIES[key];
       try {
         // 前端按声明单位(bytes/counts/percent)格式化，必须关掉服务端自动换算。
-        const result = await getInstanceQuery(buildSearchParams(q.query, q.unit, idValues, instanceIdKeys, tv, undefined, false, currentInstanceInterval));
+        const result = await getInstanceQuery(buildSearchParams(
+          q.query,
+          q.unit,
+          idValues,
+          instanceIdKeys,
+          tv,
+          undefined,
+          false,
+          currentInstanceInterval,
+          { monitorObjectId, instanceId },
+        ));
         return [key, result] as const;
       } catch {
         return [key, null] as const;
@@ -240,7 +250,6 @@ export default function K3sClusterDashboardPage() {
       return;
     }
     loadAll();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentInstanceInterval, idValuesKey, timeValues, displayMode]);
 
   useEffect(() => {
@@ -254,7 +263,6 @@ export default function K3sClusterDashboardPage() {
     return () => {
       if (timerRef.current) clearInterval(timerRef.current);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [frequence, timeValues, idValuesKey, displayMode]);
 
   // ── 派生数据 ──

--- a/web/src/app/monitor/dashboards/objects/k3s-node/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k3s-node/dashboard.tsx
@@ -15,9 +15,9 @@ import {
 import { RingChartPanel, HorizontalBarPanel } from '../../shared/widgets';
 import { buildSearchParams, parseLegacyParamList, normalizeDisplayText } from '../../shared/utils';
 import { buildTopBars, coresDisplay, bytesDisplay } from '../k3s-cluster/parse';
-import { TOP_N } from '../k3s-cluster/queries';
 import { NODE_DASHBOARD_CONFIG } from './config';
 import styles from './index.module.scss';
+import { K3S_NODE_TOP_POD_CPU, K3S_NODE_TOP_POD_MEM } from './queries';
 
 export default function K3sNodeDashboardPage() {
   const dashboard = useSimpleDashboardData(NODE_DASHBOARD_CONFIG);
@@ -32,29 +32,30 @@ export default function K3sNodeDashboardPage() {
     if (legacy.length > 0) return legacy;
     const normalized = normalizeDisplayText(searchParams.get('instance_id') || '');
     return normalized ? [normalized] : [];
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams]);
   const idValuesKey = idValues.join('|');
 
   const [topPodCpuRaw, setTopPodCpuRaw] = useState<any>(null);
   const [topPodMemRaw, setTopPodMemRaw] = useState<any>(null);
 
-  const NODE_TOP_POD_CPU = `topk(${TOP_N}, sum by (pod) (rate(prometheus_remote_write_container_cpu_usage_seconds_total{instance_type="k3s",__$labels__}[5m])))`;
-  const NODE_TOP_POD_MEM = `topk(${TOP_N}, sum by (pod) (prometheus_remote_write_container_memory_working_set_bytes{instance_type="k3s",__$labels__}))`;
-
   useEffect(() => {
     if (idValues.length === 0) return;
     let active = true;
     const tv: TimeValuesProps = dashboard.timeValues;
-    getInstanceQuery(buildSearchParams(NODE_TOP_POD_CPU, 'none', idValues, instanceIdKeys, tv, undefined, false, dashboard.currentInstanceInterval))
+    getInstanceQuery(buildSearchParams(K3S_NODE_TOP_POD_CPU, 'none', idValues, instanceIdKeys, tv, undefined, false, dashboard.currentInstanceInterval, {
+      monitorObjectId: dashboard.monitorObjectId,
+      instanceId: dashboard.instanceId,
+    }))
       .then((r) => { if (active) setTopPodCpuRaw(r); })
       .catch(() => { if (active) setTopPodCpuRaw(null); });
     // 内存为字节类指标:禁用服务端单位自动换算,否则与前端 bytesDisplay 双重换算(见 k3s-cluster 同因)。
-    getInstanceQuery(buildSearchParams(NODE_TOP_POD_MEM, 'bytes', idValues, instanceIdKeys, tv, undefined, false, dashboard.currentInstanceInterval))
+    getInstanceQuery(buildSearchParams(K3S_NODE_TOP_POD_MEM, 'bytes', idValues, instanceIdKeys, tv, undefined, false, dashboard.currentInstanceInterval, {
+      monitorObjectId: dashboard.monitorObjectId,
+      instanceId: dashboard.instanceId,
+    }))
       .then((r) => { if (active) setTopPodMemRaw(r); })
       .catch(() => { if (active) setTopPodMemRaw(null); });
     return () => { active = false; };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [idValuesKey, dashboard.currentInstanceInterval, dashboard.timeValues]);
 
   const nodeTopPodCpuBars = useMemo(() => buildTopBars(topPodCpuRaw, 'pod', '#9254de', coresDisplay), [topPodCpuRaw]);

--- a/web/src/app/monitor/dashboards/objects/k3s-node/queries.ts
+++ b/web/src/app/monitor/dashboards/objects/k3s-node/queries.ts
@@ -1,0 +1,4 @@
+export const K3S_NODE_TOP_POD_CPU =
+  'topk(5, sum by (pod) (rate(prometheus_remote_write_container_cpu_usage_seconds_total{instance_type="k3s",__$labels__}[5m])))';
+export const K3S_NODE_TOP_POD_MEM =
+  'topk(5, sum by (pod) (prometheus_remote_write_container_memory_working_set_bytes{instance_type="k3s",__$labels__}))';

--- a/web/src/app/monitor/dashboards/objects/k8s-cluster/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k8s-cluster/dashboard.tsx
@@ -202,7 +202,17 @@ export default function K8sClusterDashboardPage() {
       const q = QUERIES[key];
       try {
         // 前端按声明单位(bytes/counts/percent)格式化，必须关掉服务端自动换算。
-        const result = await getInstanceQuery(buildSearchParams(q.query, q.unit, idValues, instanceIdKeys, tv, undefined, false, currentInstanceInterval));
+        const result = await getInstanceQuery(buildSearchParams(
+          q.query,
+          q.unit,
+          idValues,
+          instanceIdKeys,
+          tv,
+          undefined,
+          false,
+          currentInstanceInterval,
+          { monitorObjectId, instanceId },
+        ));
         return [key, result] as const;
       } catch {
         return [key, null] as const;
@@ -240,7 +250,6 @@ export default function K8sClusterDashboardPage() {
       return;
     }
     loadAll();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentInstanceInterval, idValuesKey, timeValues, displayMode]);
 
   useEffect(() => {
@@ -254,7 +263,6 @@ export default function K8sClusterDashboardPage() {
     return () => {
       if (timerRef.current) clearInterval(timerRef.current);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [frequence, timeValues, idValuesKey, displayMode]);
 
   // ── 派生数据 ──

--- a/web/src/app/monitor/dashboards/objects/k8s-node/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k8s-node/dashboard.tsx
@@ -15,9 +15,9 @@ import {
 import { RingChartPanel, HorizontalBarPanel } from '../../shared/widgets';
 import { buildSearchParams, parseLegacyParamList, normalizeDisplayText } from '../../shared/utils';
 import { buildTopBars, coresDisplay, bytesDisplay } from '../k8s-cluster/parse';
-import { TOP_N } from '../k8s-cluster/queries';
 import { NODE_DASHBOARD_CONFIG } from './config';
 import styles from './index.module.scss';
+import { K8S_NODE_TOP_POD_CPU, K8S_NODE_TOP_POD_MEM } from './queries';
 
 export default function K8sNodeDashboardPage() {
   const dashboard = useSimpleDashboardData(NODE_DASHBOARD_CONFIG);
@@ -32,29 +32,30 @@ export default function K8sNodeDashboardPage() {
     if (legacy.length > 0) return legacy;
     const normalized = normalizeDisplayText(searchParams.get('instance_id') || '');
     return normalized ? [normalized] : [];
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams]);
   const idValuesKey = idValues.join('|');
 
   const [topPodCpuRaw, setTopPodCpuRaw] = useState<any>(null);
   const [topPodMemRaw, setTopPodMemRaw] = useState<any>(null);
 
-  const NODE_TOP_POD_CPU = `topk(${TOP_N}, sum by (pod) (rate(prometheus_remote_write_container_cpu_usage_seconds_total{instance_type="k8s",__$labels__}[5m])))`;
-  const NODE_TOP_POD_MEM = `topk(${TOP_N}, sum by (pod) (prometheus_remote_write_container_memory_working_set_bytes{instance_type="k8s",__$labels__}))`;
-
   useEffect(() => {
     if (idValues.length === 0) return;
     let active = true;
     const tv: TimeValuesProps = dashboard.timeValues;
-    getInstanceQuery(buildSearchParams(NODE_TOP_POD_CPU, 'none', idValues, instanceIdKeys, tv, undefined, false, dashboard.currentInstanceInterval))
+    getInstanceQuery(buildSearchParams(K8S_NODE_TOP_POD_CPU, 'none', idValues, instanceIdKeys, tv, undefined, false, dashboard.currentInstanceInterval, {
+      monitorObjectId: dashboard.monitorObjectId,
+      instanceId: dashboard.instanceId,
+    }))
       .then((r) => { if (active) setTopPodCpuRaw(r); })
       .catch(() => { if (active) setTopPodCpuRaw(null); });
     // 内存为字节类指标:禁用服务端单位自动换算,否则与前端 bytesDisplay 双重换算(见 k8s-cluster 同因)。
-    getInstanceQuery(buildSearchParams(NODE_TOP_POD_MEM, 'bytes', idValues, instanceIdKeys, tv, undefined, false, dashboard.currentInstanceInterval))
+    getInstanceQuery(buildSearchParams(K8S_NODE_TOP_POD_MEM, 'bytes', idValues, instanceIdKeys, tv, undefined, false, dashboard.currentInstanceInterval, {
+      monitorObjectId: dashboard.monitorObjectId,
+      instanceId: dashboard.instanceId,
+    }))
       .then((r) => { if (active) setTopPodMemRaw(r); })
       .catch(() => { if (active) setTopPodMemRaw(null); });
     return () => { active = false; };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [idValuesKey, dashboard.currentInstanceInterval, dashboard.timeValues]);
 
   const nodeTopPodCpuBars = useMemo(() => buildTopBars(topPodCpuRaw, 'pod', '#9254de', coresDisplay), [topPodCpuRaw]);

--- a/web/src/app/monitor/dashboards/objects/k8s-node/queries.ts
+++ b/web/src/app/monitor/dashboards/objects/k8s-node/queries.ts
@@ -1,0 +1,4 @@
+export const K8S_NODE_TOP_POD_CPU =
+  'topk(5, sum by (pod) (rate(prometheus_remote_write_container_cpu_usage_seconds_total{instance_type="k8s",__$labels__}[5m])))';
+export const K8S_NODE_TOP_POD_MEM =
+  'topk(5, sum by (pod) (prometheus_remote_write_container_memory_working_set_bytes{instance_type="k8s",__$labels__}))';

--- a/web/src/app/monitor/dashboards/objects/kafka/lag-risk-table.tsx
+++ b/web/src/app/monitor/dashboards/objects/kafka/lag-risk-table.tsx
@@ -6,7 +6,7 @@ import type { TableColumnsType } from 'antd';
 import { useSearchParams } from 'next/navigation';
 import useViewApi from '@/app/monitor/api/view';
 import { DashboardPanel, TrendChartPanel } from '../../shared/widgets';
-import { buildSearchParams, formatMetricValue } from '../../shared/utils';
+import { buildDynamicCapabilitySearchParams, buildSearchParams, formatMetricValue } from '../../shared/utils';
 import { renderChart } from '@/app/monitor/utils/common';
 import { ChartData } from '@/app/monitor/types';
 import { useSimpleDashboardData } from '../common/simple-dashboard-core';
@@ -18,7 +18,7 @@ import {
   type KafkaLagRiskResult,
   type KafkaLagRiskRow,
 } from './parse';
-import { buildKafkaTopNExactQuery, KAFKA_LAG_TOP_QUERY } from './queries';
+import { KAFKA_LAG_TOP_QUERY } from './queries';
 
 interface KafkaLagRiskTableProps {
   dashboard: ReturnType<typeof useSimpleDashboardData>;
@@ -66,7 +66,15 @@ export function KafkaLagRiskTable({ dashboard, styles }: KafkaLagRiskTableProps)
     const load = async () => {
       // instant Top 10 在时间窗终点求值（buildSearchParams.time=end），与趋势 range 对齐；负 Lag 不参与排行。
       const lag = await getInstanceInstantQuery(buildSearchParams(
-        KAFKA_LAG_TOP_QUERY, 'counts', dashboard.idValues, instanceIdKeys, dashboard.timeValues, undefined, false,
+        KAFKA_LAG_TOP_QUERY,
+        'counts',
+        dashboard.idValues,
+        instanceIdKeys,
+        dashboard.timeValues,
+        undefined,
+        false,
+        dashboard.currentInstanceInterval,
+        { monitorObjectId: dashboard.monitorObjectId, instanceId: dashboard.instanceId },
       )).catch(() => null);
       if (!active) return;
       const topRows = parseKafkaLagRiskRows({ lag } as KafkaLagRiskResult);
@@ -79,13 +87,38 @@ export function KafkaLagRiskTable({ dashboard, styles }: KafkaLagRiskTableProps)
       }
       const trendDimensions = dimensions.slice(0, LAG_TREND_SERIES_LIMIT);
       // 只为 Top 10 精确维度请求当前/最早 Offset，不再进行全量范围查询。
-      const currentQuery = buildKafkaTopNExactQuery('kafka_consumergroup_current_offset_gauge', dimensions, true);
-      const oldestQuery = buildKafkaTopNExactQuery('kafka_topic_partition_oldest_offset_gauge', dimensions, false);
-      const historyQuery = buildKafkaTopNExactQuery('kafka_consumergroup_lag_gauge', trendDimensions, true);
+      const capabilityDimensions = (items: typeof dimensions) => items.map((item) => ({
+        consumer_group: item.consumerGroup,
+        topic: item.topic,
+        partition: item.partition,
+      }));
+      const capabilityContext = {
+        monitorObjectId: dashboard.monitorObjectId,
+        instanceId: dashboard.instanceId,
+      };
       setHistoryLoading(true);
-      const currentOffsetPromise = getInstanceInstantQuery(buildSearchParams(currentQuery, 'counts', dashboard.idValues, instanceIdKeys, dashboard.timeValues, undefined, false)).catch(() => null);
-      const oldestOffsetPromise = getInstanceInstantQuery(buildSearchParams(oldestQuery, 'counts', dashboard.idValues, instanceIdKeys, dashboard.timeValues, undefined, false)).catch(() => null);
-      const historyPromise = getInstanceQuery(buildSearchParams(historyQuery, 'counts', dashboard.idValues, instanceIdKeys, dashboard.timeValues, undefined, false, dashboard.currentInstanceInterval)).catch(() => null);
+      const currentOffsetPromise = getInstanceInstantQuery(buildDynamicCapabilitySearchParams({
+        capabilityId: 'dashboard:dynamic:kafka:current-offset',
+        capabilityParams: { dimensions: capabilityDimensions(dimensions) },
+        sourceUnit: 'counts',
+        timeValues: dashboard.timeValues,
+        context: capabilityContext,
+      })).catch(() => null);
+      const oldestOffsetPromise = getInstanceInstantQuery(buildDynamicCapabilitySearchParams({
+        capabilityId: 'dashboard:dynamic:kafka:oldest-offset',
+        capabilityParams: { dimensions: capabilityDimensions(dimensions) },
+        sourceUnit: 'counts',
+        timeValues: dashboard.timeValues,
+        context: capabilityContext,
+      })).catch(() => null);
+      const historyPromise = getInstanceQuery(buildDynamicCapabilitySearchParams({
+        capabilityId: 'dashboard:dynamic:kafka:lag-history',
+        capabilityParams: { dimensions: capabilityDimensions(trendDimensions) },
+        sourceUnit: 'counts',
+        timeValues: dashboard.timeValues,
+        minStepSeconds: dashboard.currentInstanceInterval,
+        context: capabilityContext,
+      })).catch(() => null);
       const [currentOffset, oldestOffset] = await Promise.all([
         currentOffsetPromise,
         oldestOffsetPromise,
@@ -115,7 +148,6 @@ export function KafkaLagRiskTable({ dashboard, styles }: KafkaLagRiskTableProps)
       active = false;
     };
     // 查询需随核心盘的实例、时间和自动刷新周期同步重载。
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dashboard.currentInstanceInterval, dashboard.isDashboardMode, dashboard.loadTick, getInstanceInstantQuery, getInstanceQuery, idValuesKey, instanceIdKeys, timeKey]);
 
   const trendRows = useMemo(

--- a/web/src/app/monitor/dashboards/objects/kafka/queries.ts
+++ b/web/src/app/monitor/dashboards/objects/kafka/queries.ts
@@ -1,28 +1,3 @@
 export const KAFKA_LAG_TOP_N = 10;
 
 export const KAFKA_LAG_TOP_QUERY = `topk(${KAFKA_LAG_TOP_N}, max by (consumergroup, topic, partition) (kafka_consumergroup_lag_gauge{__$labels__} >= 0))`;
-
-const escapeLabelValue = (value: string) => value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-
-export interface KafkaLagDimension {
-  consumerGroup: string;
-  topic: string;
-  partition: string;
-}
-
-export const buildKafkaTopNExactQuery = (
-  metric: string,
-  dimensions: KafkaLagDimension[],
-  withConsumerGroup: boolean,
-) => {
-  if (!dimensions.length) return '';
-  const selectors = dimensions.map(({ consumerGroup, topic, partition }) => {
-    const labels = [
-      `topic="${escapeLabelValue(topic)}"`,
-      `partition="${escapeLabelValue(partition)}"`,
-    ];
-    if (withConsumerGroup) labels.unshift(`consumergroup="${escapeLabelValue(consumerGroup)}"`);
-    return `${metric}{__$labels__,${labels.join(',')}}`;
-  });
-  return `max by (consumergroup, topic, partition) (${selectors.join(' or ')})`;
-};

--- a/web/src/app/monitor/dashboards/objects/mongodb/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mongodb/dashboard.tsx
@@ -236,7 +236,10 @@ export default function MongoDashboardPage() {
       metrics,
       METRIC_QUERY_CONCURRENCY,
       async (metric) =>
-        getInstanceQuery(buildSearchParams(metric.query, metric.unit, idValues, instanceIdKeys, targetTimeValues, undefined, false, currentInstanceInterval))
+        getInstanceQuery(buildSearchParams(metric.query, metric.unit, idValues, instanceIdKeys, targetTimeValues, undefined, false, currentInstanceInterval, {
+          monitorObjectId,
+          instanceId,
+        }))
           .then((result) => [metric.name, toMetricSeries(metric, result, instanceId, resolvedInstanceName, idValues, instanceIdKeys)] as const)
           .catch(() => [metric.name, { ...metric, viewData: [], loadState: 'error' as const }] as const)
     );
@@ -259,7 +262,10 @@ export default function MongoDashboardPage() {
         const summaryResultsPromise = loadMetricGroup(MONGODB_METRIC_GROUPS[0].names, frozenTimeValues);
 
         const collectionStatusPromise: Promise<MetricSeries> = getInstanceQuery(
-          buildSearchParams(MONGODB_COLLECTION_STATUS_QUERY, 'counts', idValues, instanceIdKeys, frozenTimeValues, undefined, false, currentInstanceInterval)
+          buildSearchParams(MONGODB_COLLECTION_STATUS_QUERY, 'counts', idValues, instanceIdKeys, frozenTimeValues, undefined, false, currentInstanceInterval, {
+            monitorObjectId,
+            instanceId,
+          })
         )
           .then((result) =>
             toMetricSeries<MongoMetricConfig>(
@@ -297,7 +303,10 @@ export default function MongoDashboardPage() {
             compareMetrics,
             METRIC_QUERY_CONCURRENCY,
             async (metric) =>
-              getInstanceQuery(buildSearchParams(metric.query, metric.unit, idValues, instanceIdKeys, previousTimeValues, undefined, false, currentInstanceInterval))
+              getInstanceQuery(buildSearchParams(metric.query, metric.unit, idValues, instanceIdKeys, previousTimeValues, undefined, false, currentInstanceInterval, {
+                monitorObjectId,
+                instanceId,
+              }))
                 .then((result) => [metric.name, toMetricSeries(metric, result, instanceId, resolvedInstanceName, idValues, instanceIdKeys)] as const)
                 .catch(() => [metric.name, { ...metric, viewData: [], loadState: 'error' as const }] as const)
           )

--- a/web/src/app/monitor/dashboards/objects/mssql/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mssql/dashboard.tsx
@@ -66,7 +66,10 @@ export default function MssqlDashboardPage() {
     runWithConcurrency(MSSQL_TOP_DB_QUERIES, TOP_DB_CONCURRENCY, async (q) =>
       // autoConvert=false:禁用服务端单位自动换算,否则会与前端 formatMetricValue 双重换算
       //(如 ms 被后端先换成 hour,前端再按 ms 格式化,量级错乱)。见 postgresql 同因。
-      getInstanceQuery(buildSearchParams(q.query, q.unit, idValues, instanceIdKeys, timeValues, undefined, false, currentInstanceInterval))
+      getInstanceQuery(buildSearchParams(q.query, q.unit, idValues, instanceIdKeys, timeValues, undefined, false, currentInstanceInterval, {
+        monitorObjectId: dashboard.monitorObjectId,
+        instanceId: dashboard.instanceId,
+      }))
         .then((res: any) => [q.key, topDbBars(res, q.unit, q.color)] as const)
         .catch(() => [q.key, [] as BarItem[]] as const)
     ).then((entries) => {
@@ -78,7 +81,6 @@ export default function MssqlDashboardPage() {
       active = false;
     };
     // loadTick 随核心盘每次加载(含自动刷新)递增,使 TopN 与核心盘同步刷新。
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentInstanceInterval, idValuesKey, timeKey, isDashboardMode, instanceIdKeys, getInstanceQuery, loadTick]);
 
   return (

--- a/web/src/app/monitor/dashboards/objects/mysql/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mysql/dashboard.tsx
@@ -384,7 +384,10 @@ export default function MysqlDashboardPage() {
       metrics,
       METRIC_QUERY_CONCURRENCY,
       async (metric) =>
-        getInstanceQuery(buildSearchParams(metric.query, metric.unit, idValues, instanceIdKeys, targetTimeValues, undefined, false, currentInstanceInterval))
+        getInstanceQuery(buildSearchParams(metric.query, metric.unit, idValues, instanceIdKeys, targetTimeValues, undefined, false, currentInstanceInterval, {
+          monitorObjectId,
+          instanceId,
+        }))
           .then((result) => [metric.name, toMetricSeries(metric, result, instanceId, resolvedInstanceName, idValues, instanceIdKeys)] as const)
           .catch(() => [metric.name, { ...metric, viewData: [], loadState: 'error' as const }] as const)
     );
@@ -408,7 +411,10 @@ export default function MysqlDashboardPage() {
         );
         const summaryResultsPromise = loadMetricGroup(MYSQL_METRIC_GROUPS[0].names, frozenTimeValues);
 
-        const collectionStatusPromise: Promise<MetricSeries> = getInstanceQuery(buildSearchParams(MYSQL_COLLECTION_STATUS_QUERY, 'counts', idValues, instanceIdKeys, frozenTimeValues, undefined, false, currentInstanceInterval))
+        const collectionStatusPromise: Promise<MetricSeries> = getInstanceQuery(buildSearchParams(MYSQL_COLLECTION_STATUS_QUERY, 'counts', idValues, instanceIdKeys, frozenTimeValues, undefined, false, currentInstanceInterval, {
+          monitorObjectId,
+          instanceId,
+        }))
           .then((result) =>
             toMetricSeries(
               {
@@ -445,7 +451,10 @@ export default function MysqlDashboardPage() {
             compareMetrics,
             METRIC_QUERY_CONCURRENCY,
             async (metric) =>
-              getInstanceQuery(buildSearchParams(metric.query, metric.unit, idValues, instanceIdKeys, previousTimeValues, undefined, false, currentInstanceInterval))
+              getInstanceQuery(buildSearchParams(metric.query, metric.unit, idValues, instanceIdKeys, previousTimeValues, undefined, false, currentInstanceInterval, {
+                monitorObjectId,
+                instanceId,
+              }))
                 .then((result) => [metric.name, toMetricSeries(metric, result, instanceId, resolvedInstanceName, idValues, instanceIdKeys)] as const)
                 .catch(() => [metric.name, { ...metric, viewData: [], loadState: 'error' as const }] as const)
           )

--- a/web/src/app/monitor/dashboards/objects/oracle/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/oracle/dashboard.tsx
@@ -56,7 +56,8 @@ export default function OracleDashboardPage() {
           timeValues,
           undefined,
           false,
-          currentInstanceInterval
+          currentInstanceInterval,
+          { monitorObjectId: dashboard.monitorObjectId, instanceId: dashboard.instanceId }
         )
       )
         .then((res: any) => [q.key, topLabelBars(res, q.unit, q.color, q.labelKeys)] as const)
@@ -67,7 +68,6 @@ export default function OracleDashboardPage() {
     return () => {
       active = false;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentInstanceInterval, idValuesKey, timeKey, isDashboardMode, instanceIdKeys, getInstanceQuery, loadTick]);
 
   const renderChart = (chart: (typeof charts)[number], spanClass: string) =>

--- a/web/src/app/monitor/dashboards/objects/postgresql/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/postgresql/dashboard.tsx
@@ -58,7 +58,10 @@ export default function PostgresqlDashboardPage() {
     runWithConcurrency(PG_TOP_DB_QUERIES, TOP_DB_CONCURRENCY, async (q) =>
       // autoConvert=false:禁用服务端单位自动换算,否则会与前端 formatMetricValue 双重换算
       //(如 counts 被后端先 ÷1000 成 thousand,前端再按 counts 缩放,量级错乱)。见 k8s-node 同因。
-      getInstanceQuery(buildSearchParams(q.query, q.unit, idValues, instanceIdKeys, timeValues, undefined, false, currentInstanceInterval))
+      getInstanceQuery(buildSearchParams(q.query, q.unit, idValues, instanceIdKeys, timeValues, undefined, false, currentInstanceInterval, {
+        monitorObjectId: dashboard.monitorObjectId,
+        instanceId: dashboard.instanceId,
+      }))
         .then((res: any) => [q.key, topDbBars(res, q.unit, q.color)] as const)
         .catch(() => [q.key, [] as BarItem[]] as const)
     ).then((entries) => {
@@ -70,7 +73,6 @@ export default function PostgresqlDashboardPage() {
       active = false;
     };
     // loadTick 随核心盘每次加载(含自动刷新)递增,使 TopN 与核心盘同步刷新。
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentInstanceInterval, idValuesKey, timeKey, isDashboardMode, instanceIdKeys, getInstanceQuery, loadTick]);
 
   return (

--- a/web/src/app/monitor/dashboards/shared/utils/__tests__/query-capability.test.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/__tests__/query-capability.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { dashboardQueryCapabilityId } from '../query-capability';
+import {
+  buildDynamicCapabilitySearchParams,
+  buildSearchParams,
+} from '../search-params';
+
+const context = { monitorObjectId: 7, instanceId: "('host-a',)" };
+const timeValues = { timeRange: [0, 3_600_000], originValue: 0 };
+
+describe('monitor dashboard query capabilities', () => {
+  it('uses a stable content id', () => {
+    expect(dashboardQueryCapabilityId('up{__$labels__}')).toBe('dashboard:v1:41dd110b');
+  });
+
+  it('does not send PromQL for static dashboard queries', () => {
+    const params = buildSearchParams(
+      'rate(cpu_usage{__$labels__}[__$window__])',
+      'percent',
+      ['host-a'],
+      ['instance_id'],
+      timeValues,
+      undefined,
+      false,
+      60,
+      context,
+    );
+
+    expect(params.query).toBeUndefined();
+    expect(params.capability_id).toBe('dashboard:v1:7aef5ba1');
+    expect(params.monitor_object_id).toBe(7);
+    expect(params.instance_ids).toEqual(["('host-a',)"]);
+    expect(params.start).toBe(0);
+    expect(params.end).toBe(3_600_000);
+  });
+
+  it('sends only registered dynamic capability parameters', () => {
+    const params = buildDynamicCapabilitySearchParams({
+      capabilityId: 'dashboard:dynamic:kafka:current-offset',
+      capabilityParams: { dimensions: [{ topic: 'orders', partition: '0' }] },
+      sourceUnit: 'counts',
+      timeValues,
+      context,
+    });
+
+    expect(params.query).toBeUndefined();
+    expect(params.capability_id).toBe('dashboard:dynamic:kafka:current-offset');
+    expect(params.capability_params).toEqual({ dimensions: [{ topic: 'orders', partition: '0' }] });
+  });
+});

--- a/web/src/app/monitor/dashboards/shared/utils/query-capability.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/query-capability.ts
@@ -1,0 +1,8 @@
+export const dashboardQueryCapabilityId = (template: string): string => {
+  let hash = 2166136261;
+  for (const byte of new TextEncoder().encode(template)) {
+    hash ^= byte;
+    hash = Math.imul(hash, 16777619) >>> 0;
+  }
+  return `dashboard:v1:${hash.toString(16).padStart(8, '0')}`;
+};

--- a/web/src/app/monitor/dashboards/shared/utils/search-params.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/search-params.ts
@@ -1,27 +1,69 @@
 import { TimeValuesProps } from '@/app/monitor/types';
 import { SearchParams } from '@/app/monitor/types/search';
-import { getRecentTimeRange, mergeViewQueryKeyValues } from '@/app/monitor/utils/common';
+import { getRecentTimeRange } from '@/app/monitor/utils/common';
 import { buildGapDetectionParams } from '@/app/monitor/utils/gapIntervals';
 import { calculateQueryStep } from '@/app/monitor/utils/queryStep';
-import { resolvePromqlWindow } from './time';
+import type { Key } from 'react';
+import { dashboardQueryCapabilityId } from './query-capability';
+
+interface DashboardQueryContext {
+  monitorObjectId: Key;
+  instanceId: Key;
+}
+
+interface DynamicCapabilityParams {
+  capabilityId: string;
+  capabilityParams: Record<string, unknown>;
+  sourceUnit: string;
+  timeValues: TimeValuesProps;
+  minStepSeconds?: unknown;
+  context: DashboardQueryContext;
+}
+
+const applyTimeRange = (
+  params: SearchParams,
+  timeValues: TimeValuesProps,
+  minStepSeconds?: unknown,
+) => {
+  const recentTimeRange = getRecentTimeRange(timeValues);
+  const startTime = recentTimeRange.at(0);
+  const endTime = recentTimeRange.at(1);
+  if (Number.isFinite(startTime) && Number.isFinite(endTime)) {
+    params.start = startTime;
+    params.end = endTime;
+    params.time = endTime;
+    params.step = calculateQueryStep(params.start, params.end, minStepSeconds);
+  }
+  return buildGapDetectionParams(params, minStepSeconds);
+};
+
+export const buildDynamicCapabilitySearchParams = ({
+  capabilityId,
+  capabilityParams,
+  sourceUnit,
+  timeValues,
+  minStepSeconds,
+  context,
+}: DynamicCapabilityParams): SearchParams => applyTimeRange({
+  capability_id: capabilityId,
+  capability_params: capabilityParams,
+  monitor_object_id: context.monitorObjectId,
+  instance_ids: [String(context.instanceId)],
+  source_unit: sourceUnit,
+  auto_convert_unit: false,
+}, timeValues, minStepSeconds);
 
 export const buildSearchParams = (
   query: string,
   sourceUnit: string,
-  idValues: string[],
-  instanceIdKeys: string[],
+  _idValues: string[],
+  _instanceIdKeys: string[],
   timeValues: TimeValuesProps,
-  rawValueMetrics?: Set<string>,
-  autoConvertUnit?: boolean,
-  minStepSeconds?: unknown
+  rawValueMetrics: Set<string> | undefined,
+  autoConvertUnit: boolean | undefined,
+  minStepSeconds: unknown,
+  context: DashboardQueryContext,
 ): SearchParams => {
-  const effectiveIdValues = idValues.length ? idValues : [''];
-  const labels = mergeViewQueryKeyValues([
-    { keys: instanceIdKeys.length ? instanceIdKeys : ['instance_id'], values: effectiveIdValues }
-  ]);
-  const recentTimeRange = getRecentTimeRange(timeValues);
-  const startTime = recentTimeRange.at(0);
-  const endTime = recentTimeRange.at(1);
   // 仪表盘按声明单位由前端 formatMetricValue。省略 autoConvertUnit 且未传 rawValueMetrics 时默认 false，
   // 避免服务端先缩成 hour/GiB 再按原单位展示。显式 true 仍可用于会读响应 data.unit 的调用方。
   // 传入 rawValueMetrics 时：命中白名单的 query 关闭自动换算，其余仍为 true。
@@ -29,20 +71,12 @@ export const buildSearchParams = (
     ? autoConvertUnit
     : rawValueMetrics ? !Array.from(rawValueMetrics).some((m) => query.includes(m)) : false;
   const params: SearchParams = {
-    query: query
-      .replace(/__\$labels__/g, labels)
-      .replace(/__\$window__/g, resolvePromqlWindow(timeValues)),
+    capability_id: dashboardQueryCapabilityId(query),
+    monitor_object_id: context.monitorObjectId,
+    instance_ids: [String(context.instanceId)],
     source_unit: sourceUnit,
     auto_convert_unit: resolvedAutoConvert
   };
 
-  if (Number.isFinite(startTime) && Number.isFinite(endTime)) {
-    params.start = startTime;
-    params.end = endTime;
-    // instant 查询使用窗口终点求值，与 range 曲线时间窗对齐。
-    params.time = endTime;
-    params.step = calculateQueryStep(params.start, params.end, minStepSeconds);
-  }
-
-  return buildGapDetectionParams(params, minStepSeconds);
+  return applyTimeRange(params, timeValues, minStepSeconds);
 };

--- a/web/src/app/monitor/types/search.ts
+++ b/web/src/app/monitor/types/search.ts
@@ -29,6 +29,14 @@ export interface SearchParams {
   start?: number;
   step?: number;
   query?: string;
+  capability_id?: string;
+  capability_params?: Record<string, unknown>;
+  scope?: {
+    type: 'host_process';
+    host_monitor_object_id: React.Key;
+    host_instance_id: React.Key;
+    process_names?: string[];
+  };
   monitor_object_id?: React.Key;
   metric_id?: React.Key;
   instance_ids?: string[];
@@ -42,7 +50,7 @@ export interface SearchParams {
   auto_convert_unit?: boolean;
   detect_gaps?: boolean;
   collection_interval?: number;
-  query_budget?: 'card';
+  card_budget?: boolean;
 }
 
 export interface QueryGroup {


### PR DESCRIPTION
## 问题

监控查询边界本应同时约束“允许执行什么查询”和“允许查询哪些实例”。剩余 Monitor Web 看板仍把完整 PromQL 发送到 `metrics_instance/query`、`query_range`，后端只能转发，无法可靠绑定当前用户、当前团队、监控对象和实例权限。

OA 还保留了历史 `mm_query`、`mm_query_range` 数据源兼容分支，但对应 NATS handler 已经退役，形成不可用且绕开受控查询边界的假兼容。

Closes #4820

## 根因（设计层）

查询模板、实例授权和 VictoriaMetrics 调用分散在浏览器、REST 与 NATS 适配层：浏览器拥有完整查询语言，服务端缺少统一应用用例；静态看板查询也没有可校验的服务端能力目录。页面权限因此不能成为指标查询的强制前置条件。

## 怎么修的

- 将范围查询和即时查询统一收敛到 `AuthorizedMetricQueryService`，请求必须且只能提供 `metric_id` 或 `capability_id`。
- 服务端先校验用户、团队、监控对象和全部实例权限，再渲染指标模板或看板能力；任一实例越权时不访问 VictoriaMetrics。
- 从内置看板配置生成 838 个受控查询能力，服务端重新校验能力 ID、对象绑定、模板长度及每个选择器的实例占位符。
- Kafka 动态查询只接受最多 10 组有限结构化维度，并限制标签长度、统一转义。
- 主机进程视图通过父级 Host 实例授权生成服务端查询作用域。
- Web 全部改用 POST 受控查询，删除原始 GET `query`、`query_range` action。
- OA 历史裸查询数据源执行返回 410，禁止保留原路由编辑和再次导入；允许删除或人工迁移到受支持数据源，旧内置项复用现有初始化退役流程清理。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        W["Monitor Web 看板\nbuildSearchParams"]
        O["OA 历史数据源\nget_source_data"]
    end

    subgraph A["授权与能力层"]
        V["受控 POST action\nmetrics_instance.py"]
        S["实例授权与请求校验\nAuthorizedMetricQueryService"]
        C["模板能力注册表\ndashboard_query_capabilities.py"]
        R["裸查询退役检查\ndatasource_security.py"]
    end

    VM["VictoriaMetrics\n服务端生成 PromQL"]
    E["400/401，VM 调用为零"]
    G["410 Gone"]

    W --> V --> S --> C --> VM
    S -. "能力、对象或实例非法" .-> E
    O --> R --> G
```

## 影响范围

- Server：Monitor 受控查询服务、能力注册表、原始 REST action；OA 历史裸查询执行/编辑/导入边界。
- Web：监控概览、指标视图、内置对象看板及 Kafka 动态查询。
- Mobile、OA 内置画布、NATS/RPC：确认不再调用原始查询入口。
- 不新增环境变量、运维脚本或人工迁移步骤；不需要部署配置介入。
- 不保留管理员任意执行 PromQL 的能力。

## 验证

- Monitor、NATS 与 OA 跨调用方相关回归：116 passed。
- Kafka 动态参数和 REST 路由聚焦回归：15 passed。
- Web 查询契约：3 passed。
- 看板能力生成一致性：838 项通过。
- Web TypeScript 类型检查通过；本次修改文件 ESLint 通过。
- `pyupgrade`、Black、isort、flake8、迁移检查、依赖检查及 Web pre-commit 全部通过。
- Web、Mobile、OA、NATS/RPC 的旧原始查询调用扫描归零。
- 全仓 Web lint 仍有基线 41 errors / 86 warnings，均不在本次修改文件。

## 三轨门禁

- Standards：pass。仓库规范与本次修改文件静态检查无遗留问题。
- Spec：pass。方案 A、无管理员裸查询、OA 历史数据源禁用及无部署配置介入均已实现。
- Runtime Contract：pass。覆盖授权成功、混入越权实例、对象不匹配、未知能力、原始 PromQL 拒绝、旧路由 404、OA 历史执行 410、Kafka 参数转义与上限。
- 评审得分：93 / 100。
