### PR TITLE
fix(opspilot): Pod 日志支持近 24 小时窗口，并收口分步重启排查口径

### DIFF
--- a/server/apps/opspilot/metis/llm/agent/tool_execution_planner.py
+++ b/server/apps/opspilot/metis/llm/agent/tool_execution_planner.py
@@ -80,6 +80,16 @@ _K8S_NAMESPACE_SCAN_TOOLS = frozenset(
 )
 _K8S_NAMESPACE_LOOKUP_TOOLS = frozenset({_K8S_NAMESPACE_RESOLVE_TOOL})
 
+# 全集群发现类工具返回值已带 namespace；其后按对象取事件/describe 不必再插反查步。
+_K8S_CLUSTER_DISCOVERY_TOOLS = frozenset(
+    {
+        "get_high_restart_kubernetes_pods",
+        "get_failed_kubernetes_pods",
+        "get_pending_kubernetes_pods",
+        "get_not_ready_kubernetes_pods",
+    }
+)
+
 # 调用前通常已需要明确 namespace；若计划包含它们且未先反查，则服务端改写计划。
 _K8S_NAMESPACE_REQUIRED_TOOLS = frozenset(
     {
@@ -515,6 +525,14 @@ def enforce_k8s_namespace_lookup_first(
             first_required_idx = index
             break
     if first_required_idx is None:
+        return ToolExecutionPlan(goal=plan.goal, steps=cleaned)
+
+    prior_tools = {tool for step in cleaned[:first_required_idx] for tool in (step.tools or [])}
+    if prior_tools & _K8S_CLUSTER_DISCOVERY_TOOLS:
+        logger.info(
+            "DeepAgent 规划硬校验：前置发现工具已带 namespace，跳过插入反查 prior_tools=%s",
+            sorted(prior_tools & _K8S_CLUSTER_DISCOVERY_TOOLS),
+        )
         return ToolExecutionPlan(goal=plan.goal, steps=cleaned)
 
     lookup_step = ToolExecutionStep(

--- a/server/apps/opspilot/metis/llm/chain/deepagent_assembly.py
+++ b/server/apps/opspilot/metis/llm/chain/deepagent_assembly.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 from langchain_core.messages import AIMessage
 
+from apps.opspilot.metis.llm.chain.entity import HIDE_PLANNED_STEP_TEXT_KEY
+
 
 class DeepAgentAssemblyMixin:
     """Mixin for ToolsNodes; extracted without behavior change."""
@@ -58,6 +60,7 @@ class DeepAgentAssemblyMixin:
     _MARKDOWN_TABLE_RE = re.compile(r"\|[^\n]+\|\s*\n\s*\|?\s*:?-{3,}", re.MULTILINE)
 
     _STEP_STUB_RE = re.compile(r"^执行结果\s*\d+\s*$")
+    HIDE_PLANNED_STEP_TEXT_KEY = HIDE_PLANNED_STEP_TEXT_KEY
 
     @classmethod
     def _iter_planned_assistant_text(cls, messages):
@@ -93,6 +96,43 @@ class DeepAgentAssemblyMixin:
         if completed_step_count <= 1:
             return True
         return cls._planned_output_has_markdown_table(messages)
+
+    @classmethod
+    def _select_visible_planned_messages(cls, messages, *, summary_ran: bool) -> list:
+        """分步过程只给用户看一份终稿：工具结果保留，正文只留最后一张表或最后一段作答。"""
+        visible: list = []
+        answers: list = []
+        stubs: list = []
+        for message in messages or []:
+            if isinstance(message, AIMessage) and not getattr(message, "tool_calls", None):
+                text = str(getattr(message, "content", "") or "").strip()
+                if not text:
+                    continue
+                if cls._STEP_STUB_RE.match(text):
+                    stubs.append(message)
+                    continue
+                answers.append(message)
+                continue
+            visible.append(message)
+        chosen = None
+        if answers:
+            if summary_ran:
+                chosen = answers[-1]
+            else:
+                table_answers = [item for item in answers if cls._MARKDOWN_TABLE_RE.search(str(item.content or ""))]
+                chosen = (table_answers or answers)[-1]
+        elif stubs:
+            chosen = stubs[-1]
+        if chosen is not None:
+            visible.append(chosen)
+        return visible
+
+    @staticmethod
+    def _set_hide_planned_step_text(graph_request, hidden: bool) -> None:
+        extra = getattr(graph_request, "extra_config", None)
+        if extra is None:
+            graph_request.extra_config = extra = {}
+        extra[HIDE_PLANNED_STEP_TEXT_KEY] = bool(hidden)
 
     @staticmethod
     def _plan_is_skills_only(candidate_plan) -> bool:
@@ -151,8 +191,16 @@ class DeepAgentAssemblyMixin:
         )
 
     @staticmethod
-    def _planned_tool_step_guidance() -> str:
+    def _planned_tool_step_guidance(*, is_last_step: bool = False) -> str:
         """业务工具步：与技能步共用停手契约，但不收掉本步多个计划工具。"""
+        if is_last_step:
+            tail = (
+                "本步给出用户可见的最终答案：只保留一张表，口径必须对齐用户问题。"
+                "用户问今天或某时间窗时，以事件时间线为准；累计 restart_count 不是该时间窗次数，禁止写成「今天重启了 N 次」。"
+                "若与前面累计名单矛盾，只保留时间窗结论，不要再贴口径不同的第二张表。"
+            )
+        else:
+            tail = "本步证据只给后续步骤用，不要输出 Markdown 表或最终结论。" "用户问今天或某时间窗时，禁止把累计 restart_count 写成该时间窗的次数。"
         return (
             "【工具执行】只调用本步骤计划/可见工具。"
             "未计划工具会被拒绝，不要改调其他工具，也不要当作步骤失败去重规划。"
@@ -162,8 +210,7 @@ class DeepAgentAssemblyMixin:
             "401、kubeconfig 无效、连接参数缺失或解密失败时不要改参重试，把错误原样告诉用户并结束本步。"
             "工具抛出 AttributeError/TypeError 等实现异常时不要重试，把错误告诉用户。"
             "403 仅在可换 namespace 或实例时最多改参 1 次，否则把权限错误告诉用户。"
-            "工具成功后用一两句话直接回答用户并结束本步，禁止再写第二份重复说明，"
-            "也不要把同一张表或同一份名单再输出一遍。"
+            f"{tail}"
         )
 
     @staticmethod
@@ -177,6 +224,7 @@ class DeepAgentAssemblyMixin:
         "\n\n【分步工具执行】外部规划器已经拆分任务。"
         "每次只完成当前步骤，只调用当前可见工具；不要自行创建待办、子任务或重复规划。"
         "工具证据足够后立即结束当前步骤。"
+        "给用户只保留一份与问题口径一致的结论；过程步骤不要输出互相矛盾的表。"
         "需要向用户提问时可使用交互工具；"
         "但可用工具查到的定位信息（例如缺 namespace 时先反查 Pod/Events）禁止直接问用户。"
     )
@@ -308,6 +356,8 @@ _plan_is_skills_only = DeepAgentAssemblyMixin._plan_is_skills_only
 _planned_step_already_answered = DeepAgentAssemblyMixin._planned_step_already_answered
 _planned_output_has_markdown_table = DeepAgentAssemblyMixin._planned_output_has_markdown_table
 _should_skip_planned_summary = DeepAgentAssemblyMixin._should_skip_planned_summary
+_select_visible_planned_messages = DeepAgentAssemblyMixin._select_visible_planned_messages
+_set_hide_planned_step_text = DeepAgentAssemblyMixin._set_hide_planned_step_text
 _planned_tool_step_guidance = DeepAgentAssemblyMixin._planned_tool_step_guidance
 _should_use_lightweight_after_empty_plan = DeepAgentAssemblyMixin._should_use_lightweight_after_empty_plan
 _should_use_lightweight_direct_reply = DeepAgentAssemblyMixin._should_use_lightweight_direct_reply

--- a/server/apps/opspilot/metis/llm/chain/entity.py
+++ b/server/apps/opspilot/metis/llm/chain/entity.py
@@ -2,6 +2,9 @@ from typing import Any, Callable, Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
+# 分步执行期间由引擎写入 extra_config：为 True 时 AG-UI 不推步内助手正文。
+HIDE_PLANNED_STEP_TEXT_KEY = "opspilot_hide_planned_step_text"
+
 
 class NormalizedToolCall(BaseModel):
     """规范化后的 tool_call 访问器。

--- a/server/apps/opspilot/metis/llm/chain/graph.py
+++ b/server/apps/opspilot/metis/llm/chain/graph.py
@@ -27,7 +27,7 @@ from langchain_core.messages import AIMessage, ToolMessage
 from langgraph.constants import START
 
 from apps.core.logger import opspilot_logger as logger
-from apps.opspilot.metis.llm.chain.entity import BasicLLMRequest, BasicLLMResponse
+from apps.opspilot.metis.llm.chain.entity import HIDE_PLANNED_STEP_TEXT_KEY, BasicLLMRequest, BasicLLMResponse
 from apps.opspilot.metis.llm.chain.report_renderers import find_unclosed_phantom_tool_call_start, strip_phantom_tool_calls
 from apps.opspilot.metis.llm.common.llm_error_diagnostics import (
     classify_llm_error,
@@ -54,6 +54,12 @@ _DEEPAGENT_BUILTIN_TOOL_NAMES = frozenset(
         "task",
     }
 )
+
+
+def _hide_planned_step_text(request: BasicLLMRequest) -> bool:
+    extra = getattr(request, "extra_config", None) or {}
+    return bool(extra.get(HIDE_PLANNED_STEP_TEXT_KEY))
+
 
 # 纯文本轮开播条件（仅 show_think=True 时启用；与模型无关，不按厂商硬编码）：
 # 1) 连续多个正文 stream chunk 且未见 tool_call，或
@@ -1507,10 +1513,14 @@ class BasicGraph(ABC):
                         pending_turn_text += text_piece
                         turn_plain_text_chunks += 1
                         # show_think=False：禁止提前开播，等 chat_model_end 再裁定（防长旁白泄漏）。
-                        should_go_live = show_think and (
-                            turn_text_live
-                            or turn_plain_text_chunks >= _AGUI_PLAIN_TEXT_LIVE_AFTER_CHUNKS
-                            or len(pending_turn_text) >= _AGUI_PLAIN_TEXT_LIVE_AFTER_CHARS
+                        should_go_live = (
+                            (not _hide_planned_step_text(request))
+                            and show_think
+                            and (
+                                turn_text_live
+                                or turn_plain_text_chunks >= _AGUI_PLAIN_TEXT_LIVE_AFTER_CHUNKS
+                                or len(pending_turn_text) >= _AGUI_PLAIN_TEXT_LIVE_AFTER_CHARS
+                            )
                         )
                         if should_go_live and pending_turn_text:
                             live_events, current_message_id, message_started = self._emit_live_text_delta(
@@ -1558,10 +1568,27 @@ class BasicGraph(ABC):
                     output = event_data.get("output")
                     end_tool_calls = getattr(output, "tool_calls", None) or []
                     turn_has_tools = bool(end_tool_calls) or turn_saw_tool_call_chunks
+                    hide_step_text = _hide_planned_step_text(request)
                     # 有工具：丢弃本轮旁白缓冲，只补工具事件。
                     # 已实时推送：冲掉剩余缓冲并结束消息，禁止再整段重发。
                     # 未实时推送的短纯文本：chat_model_end 一次性发出。
-                    if turn_has_tools:
+                    # 分步执行步内正文：只给后续步骤看，不推给用户。
+                    if hide_step_text and not turn_has_tools:
+                        pending_turn_text = ""
+                        fallback_text = ""
+                        allow_non_streaming_text = False
+                        if message_started and current_message_id is not None:
+                            yield encoder.encode(
+                                TextMessageEndEvent(
+                                    type=EventType.TEXT_MESSAGE_END,
+                                    message_id=current_message_id,
+                                    timestamp=int(time.time() * 1000),
+                                )
+                            )
+                            message_started = False
+                        live_turn_emitted_text = ""
+                        turn_text_live = False
+                    elif turn_has_tools:
                         pending_turn_text = ""
                         fallback_text = ""
                         allow_non_streaming_text = bool(tool_result_seen_since_model_end)
@@ -1625,17 +1652,20 @@ class BasicGraph(ABC):
                         request.max_output_tokens > 0 and isinstance(completion_tokens, int) and completion_tokens >= request.max_output_tokens
                     ):
                         output_truncated = True
-                    chat_model_end_events = self._handle_chat_model_end_event(
-                        event_data,
-                        encoder,
-                        current_message_id,
-                        current_tool_calls,
-                        # 已实时推送过正文时传 True，避免 end 再用 output.content 整段重发。
-                        message_started=turn_text_live,
-                        allow_non_streaming_text=allow_non_streaming_text,
-                        fallback_text=fallback_text,
-                        emitted_text_signatures=emitted_text_signatures,
-                    )
+                    if hide_step_text and not turn_has_tools:
+                        chat_model_end_events = []
+                    else:
+                        chat_model_end_events = self._handle_chat_model_end_event(
+                            event_data,
+                            encoder,
+                            current_message_id,
+                            current_tool_calls,
+                            # 已实时推送过正文时传 True，避免 end 再用 output.content 整段重发。
+                            message_started=turn_text_live,
+                            allow_non_streaming_text=allow_non_streaming_text,
+                            fallback_text=fallback_text,
+                            emitted_text_signatures=emitted_text_signatures,
+                        )
                     # 收集本轮 chat_model_end 实际 emit 的文本指纹(含拆段后的全文),
                     # 后续 on_chain_end 若再 emit 相同内容会基于此集合去重。
                     if _record_emitted_text_signatures(chat_model_end_events, emitted_text_signatures):
@@ -1653,7 +1683,7 @@ class BasicGraph(ABC):
                 elif event_type == "on_chain_end":
                     # add_chat_history_node 结束时 last=上一轮助手，不得当成本轮直答。
                     # 仍回填 ToolMessage（若有），但不 emit 文本。
-                    if str(event.get("name") or "") == "add_chat_history_node":
+                    if str(event.get("name") or "") == "add_chat_history_node" or _hide_planned_step_text(request):
                         chain_events = self._handle_chain_end_tool_results_only(
                             event_data,
                             encoder,

--- a/server/apps/opspilot/metis/llm/chain/node.py
+++ b/server/apps/opspilot/metis/llm/chain/node.py
@@ -2359,6 +2359,7 @@ class ToolsNodes(
             registered_tools = list(tools)
             original_messages = list(state.get("messages") or [])
             collected_output_messages: List[BaseMessage] = []
+            summary_ran = False
             skill_packages = self._resolve_skill_packages(graph_request)
             has_skill_packages = bool(skill_packages)
             # 渐进路径推迟沙箱物化：空计划寒暄不应为技能包付 DeepAgent/FS 税。
@@ -2730,6 +2731,8 @@ class ToolsNodes(
                 agent_state: Dict[str, Any] = {"messages": without_system_messages(original_messages)}
                 replan_count = 0
                 total_steps = len(plan.steps)
+                summary_ran = False
+                self._set_hide_planned_step_text(graph_request, True)
 
                 while pending_steps:
                     step = pending_steps.pop(0)
@@ -2754,7 +2757,8 @@ class ToolsNodes(
                     ):
                         step_guidance = "\n" + self._skill_only_step_guidance(skill_packages)
                     else:
-                        step_guidance = "\n" + self._planned_tool_step_guidance()
+                        is_last_step = not pending_steps
+                        step_guidance = "\n" + self._planned_tool_step_guidance(is_last_step=is_last_step)
                     step_message = _internal_message(
                         f"执行计划当前步骤：{step.objective}\n"
                         f"本步骤计划工具：{', '.join(step.tools) or '无'}。\n"
@@ -3045,6 +3049,7 @@ class ToolsNodes(
                 active_tools.clear()
                 visibility_middleware.include_always_visible = False
                 limit_middleware.enforce_limits = False
+                self._set_hide_planned_step_text(graph_request, False)
                 # 若分析步因上限提前结束，仍要在最终总结前补上修复闭环。
                 await _maybe_run_repair_workflow()
                 completed_text = "\n".join(f"- {step.objective}: {step.result}" for step in completed_steps) or "没有需要执行工具的步骤"
@@ -3076,6 +3081,7 @@ class ToolsNodes(
                         "禁止再输出 Markdown 表格或重复名单；用户若已看过步骤结果，最多补一两句。"
                     )
                 if final_message is not None:
+                    summary_ran = True
                     final_payload = {
                         **agent_state,
                         "messages": list(agent_state.get("messages") or []) + [final_message],
@@ -3125,6 +3131,7 @@ class ToolsNodes(
                         ]
                     }
             finally:
+                self._set_hide_planned_step_text(graph_request, False)
                 # 用完即弃：销毁本次运行的一次性技能沙箱目录
                 # _cleanup_sandbox 内部有 None 守卫,但这里再写一次防御:
                 # sandbox_dir 只在 _build_skill_backend_and_sources 成功返回时
@@ -3135,7 +3142,10 @@ class ToolsNodes(
             # 分步执行路径已单独累积对外消息；其余路径仍从最终 state 截取新增消息。
             final_messages = result.get("messages", [])
             if collected_output_messages:
-                new_messages = collected_output_messages
+                new_messages = self._select_visible_planned_messages(
+                    collected_output_messages,
+                    summary_ran=summary_ran,
+                )
             else:
                 if not final_messages:
                     return {"messages": [AIMessage(content="DeepAgent 未返回任何消息")]}

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/diagnostics.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/diagnostics.py
@@ -323,6 +323,10 @@ def get_high_restart_kubernetes_pods(restart_threshold: int = 5, instance_name=N
     - 提供容器镜像信息，便于定位版本问题
     - 展示Ready状态，判断当前是否正常
 
+    **注意：** restart_count 是容器自创建以来的累计次数，不是今天或指定时间窗内的次数。
+    用户问「今天重启了几次」时，本工具不能当作时间窗答案；必须再用
+    get_resource_events_timeline 等按时间过滤，且不要把累计次数写成「今天重启了 N 次」。
+
     **与analyze_pod_restart_pattern的区别：**
     - 本工具：快速列表，找出"哪些Pod在重启"
     - analyze_pod_restart_pattern：深度分析"为什么重启"（退出码、OOM、事件）

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/resources.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/resources.py
@@ -12,6 +12,13 @@ from apps.core.logger import opspilot_logger as logger
 from apps.opspilot.metis.llm.tools.kubernetes.instance_scope import prepare_point_instance, run_scan_tool
 from apps.opspilot.metis.llm.tools.kubernetes.utils import coerce_bool, coerce_int, prepare_context
 
+_DEFAULT_LOG_HOURS = 24
+_MAX_LOG_HOURS = 168
+
+
+def _pod_log_since_seconds(hours) -> int:
+    return coerce_int(hours, _DEFAULT_LOG_HOURS, lo=1, hi=_MAX_LOG_HOURS) * 3600
+
 
 @tool()
 def get_kubernetes_namespaces(config: RunnableConfig):
@@ -474,7 +481,14 @@ def get_kubernetes_resource_yaml(namespace, resource_type, resource_name, instan
 
 @tool()
 def get_kubernetes_pod_logs(
-    namespace, pod_name, container=None, lines: int = 100, tail: bool = True, instance_name=None, config: RunnableConfig = None
+    namespace,
+    pod_name,
+    container=None,
+    lines: int = 100,
+    tail: bool = True,
+    hours: int = 24,
+    instance_name=None,
+    config: RunnableConfig = None,
 ):
     """
     获取Pod容器日志 - 定位应用程序错误
@@ -500,7 +514,8 @@ def get_kubernetes_pod_logs(
 
     **重要提示：**
     - 本工具只能获取当前运行容器的日志
-    - 如果容器已重启，无法获取上一次的日志（需要--previous参数，暂不支持）
+    - 容器已重启时，上一轮日志用 get_kubernetes_previous_pod_logs
+    - 默认只取近 24 小时，再按 lines 截取；频繁重启先看当天即可
     - 日志默认最多1MB，超大日志会被截断
 
     Args:
@@ -516,6 +531,7 @@ def get_kubernetes_pod_logs(
         tail (bool, optional): True=最后N行，False=开头N行，默认True
             - True: 查看最新日志（推荐）
             - False: 查看启动初期日志
+        hours (int, optional): 时间窗（小时），默认24，对应当天；最大168
         config (RunnableConfig): 工具配置（自动传递）
 
     Returns:
@@ -535,6 +551,7 @@ def get_kubernetes_pod_logs(
     prepare_context(config)
     lines = coerce_int(lines, 100, lo=1, hi=10000)
     tail = coerce_bool(tail, True)
+    since_seconds = _pod_log_since_seconds(hours)
     try:
         core_v1 = client.CoreV1Api()
 
@@ -560,6 +577,7 @@ def get_kubernetes_pod_logs(
             name=pod_name,
             namespace=namespace,
             container=container,
+            since_seconds=since_seconds,
             tail_lines=lines if tail else None,
             limit_bytes=None if lines else 1024 * 1024,  # 1MB limit if no line limit
         )
@@ -589,7 +607,14 @@ def get_kubernetes_pod_logs(
 
 @tool()
 def get_kubernetes_previous_pod_logs(
-    namespace, pod_name, container=None, lines: int = 100, tail: bool = True, instance_name=None, config: RunnableConfig = None
+    namespace,
+    pod_name,
+    container=None,
+    lines: int = 100,
+    tail: bool = True,
+    hours: int = 24,
+    instance_name=None,
+    config: RunnableConfig = None,
 ):
     """
     获取Pod容器上一次实例的日志，用于重启类故障采集。
@@ -600,6 +625,7 @@ def get_kubernetes_previous_pod_logs(
         container (str, optional): 容器名称，多容器Pod建议显式指定
         lines (int, optional): 日志行数，默认100
         tail (bool, optional): True=最后N行，False=开头N行
+        hours (int, optional): 时间窗（小时），默认24；只看上一轮里落在该窗口内的日志
         instance_name (str, optional): 多实例时必须指定集群
         config (RunnableConfig): 工具配置
 
@@ -612,6 +638,7 @@ def get_kubernetes_previous_pod_logs(
     prepare_context(config)
     lines = coerce_int(lines, 100, lo=1, hi=10000)
     tail = coerce_bool(tail, True)
+    since_seconds = _pod_log_since_seconds(hours)
     try:
         core_v1 = client.CoreV1Api()
 
@@ -634,6 +661,7 @@ def get_kubernetes_previous_pod_logs(
             namespace=namespace,
             container=container,
             previous=True,
+            since_seconds=since_seconds,
             tail_lines=lines if tail else None,
             limit_bytes=None if lines else 1024 * 1024,
         )

--- a/server/apps/opspilot/tests/test_agui_stream.py
+++ b/server/apps/opspilot/tests/test_agui_stream.py
@@ -2015,3 +2015,70 @@ def test_tool_end_marks_result_sent_so_chain_end_does_not_resend(monkeypatch):
     assert len(tool_results) == 1
     assert tool_results[0]["content"] == clean
     assert "".join(p["delta"] for p in payloads if p["type"] == "TEXT_MESSAGE_CONTENT") == "已生成附件"
+
+
+def test_agui_stream_hides_planned_step_text_but_keeps_tools(monkeypatch):
+    """分步执行步内正文不推给用户，工具结果仍要回填。"""
+
+    async def _never_interrupted(_execution_id):
+        return False
+
+    monkeypatch.setattr(
+        "apps.opspilot.metis.llm.chain.graph.is_interrupt_requested_async",
+        _never_interrupted,
+    )
+    table = "| Pod | 累计重启 |\n| --- | --- |\n| calico | 9 |"
+    graph = _FakeBasicGraph(
+        [
+            {
+                "event": "on_chat_model_end",
+                "data": {
+                    "output": SimpleNamespace(
+                        content="",
+                        tool_calls=[
+                            {
+                                "id": "tool-1",
+                                "name": "get_high_restart_kubernetes_pods",
+                                "args": {"restart_threshold": 1},
+                            }
+                        ],
+                    )
+                },
+            },
+            {
+                "event": "on_chat_model_end",
+                "data": {
+                    "output": SimpleNamespace(content=table, tool_calls=[]),
+                },
+            },
+            {
+                "event": "on_chain_end",
+                "data": {
+                    "output": {
+                        "messages": [
+                            AIMessage(
+                                content="",
+                                tool_calls=[{"id": "tool-1", "name": "get_high_restart_kubernetes_pods", "args": {}}],
+                            ),
+                            ToolMessage(content='[{"name":"calico"}]', tool_call_id="tool-1"),
+                            AIMessage(content=table),
+                        ]
+                    }
+                },
+            },
+        ]
+    )
+    request = BasicLLMRequest(
+        thread_id="thread-hide-step-text",
+        extra_config={"show_think": False, "opspilot_hide_planned_step_text": True},
+    )
+
+    async def _collect():
+        return _parse_sse_payloads([line async for line in graph.agui_stream(request)])
+
+    payloads = asyncio.run(_collect())
+    types = [p["type"] for p in payloads]
+    assert "TEXT_MESSAGE_CONTENT" not in types
+    tool_results = [p for p in payloads if p["type"] == "TOOL_CALL_RESULT"]
+    assert len(tool_results) == 1
+    assert tool_results[0]["content"] == '[{"name":"calico"}]'

--- a/server/apps/opspilot/tests/test_deepagent_engine_service.py
+++ b/server/apps/opspilot/tests/test_deepagent_engine_service.py
@@ -295,6 +295,7 @@ class TestBuildDeepagentNodes:
         failing_agent_calls=(),
         direct_reply_content=None,
         agent_reply=None,
+        agent_replies=None,
     ):
         gb = _FakeGraphBuilder()
 
@@ -334,8 +335,14 @@ class TestBuildDeepagentNodes:
                 captured.setdefault("visible_tool_calls", []).append([tool.name for tool in visible_request.tools])
             else:
                 captured.setdefault("visible_tool_calls", []).append([tool.name for tool in captured["create_kwargs"]["tools"]])
+            extra = getattr(req, "extra_config", None) or {}
+            captured.setdefault("hide_during_ainvoke", []).append(bool(extra.get("opspilot_hide_planned_step_text")))
             call_index = len(captured["visible_tool_calls"])
-            appended_messages = [AIMessage(content=agent_reply or f"执行结果 {call_index}")]
+            if agent_replies and call_index in agent_replies:
+                reply_text = agent_replies[call_index]
+            else:
+                reply_text = agent_reply or f"执行结果 {call_index}"
+            appended_messages = [AIMessage(content=reply_text)]
             if call_index in failing_agent_calls:
                 from langchain_core.messages import ToolMessage
 
@@ -734,9 +741,9 @@ class TestBuildDeepagentNodes:
         assert "backend" not in kwargs
         assert "skills" not in kwargs
         assert "interrupt_on" not in kwargs
-        # 只返回 deepagent 新增消息（执行步 + 总结轮）
-        assert len(result["messages"]) == 2
-        assert result["messages"][0].content == "执行结果 1"
+        # 执行步正文不对外；只返回总结轮一份答案
+        assert len(result["messages"]) == 1
+        assert result["messages"][0].content == "执行结果 2"
 
     def test_planned_execution_reuses_agent_and_replaces_tools_per_step(self):
         node = ToolsNodes()
@@ -779,7 +786,8 @@ class TestBuildDeepagentNodes:
             [],
         ]
         assert len(captured["ainvoke_messages"]) == 3
-        assert len(result["messages"]) == 3
+        assert len(result["messages"]) == 1
+        assert result["messages"][0].content == "执行结果 3"
         assert all(not isinstance(message, HumanMessage) for message in result["messages"])
 
     def test_planned_execution_hides_deepagent_builtin_tools(self):
@@ -1354,7 +1362,43 @@ class TestBuildDeepagentNodes:
             )
 
         assert len(captured["ainvoke_messages"]) == 2
-        assert all(table in str(getattr(message, "content", "") or "") for message in result["messages"] if getattr(message, "type", "") == "ai")
+        ai_messages = [message for message in result["messages"] if getattr(message, "type", "") == "ai"]
+        assert len(ai_messages) == 1
+        assert table in str(ai_messages[0].content)
+        assert captured["hide_during_ainvoke"] == [True, True]
+        assert req.extra_config.get("opspilot_hide_planned_step_text") is False
+
+    def test_planned_execution_keeps_last_table_when_step_tables_conflict(self):
+        node = ToolsNodes()
+        node.all_tools = [_tool("get_high_restart_kubernetes_pods"), _tool("get_resource_events_timeline")]
+        req = _request(user_message="统计今天 pod 重启")
+        captured = {}
+        cumulative = "| Pod | 累计重启 |\n| --- | --- |\n| calico-kube-controllers | 9 |"
+        today = "| Pod | 今天重启 |\n| --- | --- |\n| calico-kube-controllers | 0 |"
+
+        with patch.object(ToolsNodes, "_build_knowledge_retrieve_tool", return_value=None):
+            result = self._run_wrapper(
+                node,
+                req,
+                captured,
+                plan_payload={
+                    "goal": "统计今天重启",
+                    "steps": [
+                        {"objective": "取累计重启", "tools": ["get_high_restart_kubernetes_pods"]},
+                        {"objective": "取今天事件", "tools": ["get_resource_events_timeline"]},
+                    ],
+                },
+                agent_replies={1: cumulative, 2: today},
+            )
+
+        assert len(captured["ainvoke_messages"]) == 2
+        ai_messages = [message for message in result["messages"] if getattr(message, "type", "") == "ai"]
+        assert len(ai_messages) == 1
+        assert "今天重启" in str(ai_messages[0].content)
+        assert "累计重启" not in str(ai_messages[0].content)
+        assert captured["hide_during_ainvoke"] == [True, True]
+        assert "不要输出 Markdown 表" in str(captured["ainvoke_messages"][0][-1].content)
+        assert "只保留一张表" in str(captured["ainvoke_messages"][1][-1].content)
 
     def test_progressive_disabled_skips_planner_and_binds_all_tools(self, monkeypatch):
         monkeypatch.setenv("OPSPILOT_DEEPAGENT_PROGRESSIVE_TOOLS", "0")
@@ -1400,6 +1444,27 @@ def test_should_skip_planned_summary_for_multi_step_table():
     assert ToolsNodes._should_skip_planned_summary(prose, completed_step_count=1) is True
 
 
+def test_select_visible_planned_messages_keeps_last_table_not_cumulative():
+    from langchain_core.messages import AIMessage, ToolMessage
+
+    cumulative = "| Pod | 累计重启 |\n| --- | --- |\n| calico | 9 |"
+    today = "| Pod | 今天重启 |\n| --- | --- |\n| calico | 0 |"
+    messages = [
+        AIMessage(content="", tool_calls=[{"id": "1", "name": "get_high_restart_kubernetes_pods", "args": {}}]),
+        ToolMessage(content="[{}]", tool_call_id="1"),
+        AIMessage(content=cumulative),
+        AIMessage(content="", tool_calls=[{"id": "2", "name": "get_resource_events_timeline", "args": {}}]),
+        ToolMessage(content="[]", tool_call_id="2"),
+        AIMessage(content=today),
+    ]
+    visible = ToolsNodes._select_visible_planned_messages(messages, summary_ran=False)
+    ai = [item for item in visible if getattr(item, "type", "") == "ai" and not getattr(item, "tool_calls", None)]
+    assert len(ai) == 1
+    assert "今天重启" in str(ai[0].content)
+    assert "累计重启" not in str(ai[0].content)
+    assert sum(1 for item in visible if getattr(item, "type", "") == "tool") == 2
+
+
 def test_planned_step_already_answered_detects_tool_sentence():
     from langchain_core.messages import AIMessage
 
@@ -1438,9 +1503,13 @@ def test_planned_tool_step_guidance_is_policy_not_skill_scan():
     assert "未计划工具" in guidance
     assert "空列表" in guidance
     assert "重规划" in guidance
-    assert "第二份" in guidance
+    assert "不要输出 Markdown 表" in guidance
     assert "execute" not in guidance
     assert "扫技能包" not in guidance
+    last = ToolsNodes._planned_tool_step_guidance(is_last_step=True)
+    assert "只保留一张表" in last
+    assert "时间窗" in last
+    assert "不要输出 Markdown 表" not in last
 
 
 def test_skill_only_step_guidance_lists_real_scripts(tmp_path):

--- a/server/apps/opspilot/tests/test_deepagent_runtime_policy.py
+++ b/server/apps/opspilot/tests/test_deepagent_runtime_policy.py
@@ -1049,6 +1049,38 @@ def test_enforce_k8s_namespace_lookup_strips_cluster_wide_scans():
     ]
 
 
+def test_enforce_k8s_namespace_lookup_skips_resolve_after_cluster_discovery(caplog):
+    import logging
+
+    from apps.opspilot.metis.llm.agent.tool_execution_planner import ToolExecutionPlan, ToolExecutionStep, enforce_k8s_namespace_lookup_first
+
+    caplog.set_level(logging.INFO, logger="opspilot")
+    plan = ToolExecutionPlan(
+        goal="统计今天重启",
+        steps=[
+            ToolExecutionStep(objective="找高频重启", tools=["get_high_restart_kubernetes_pods"]),
+            ToolExecutionStep(objective="事件时间线", tools=["get_resource_events_timeline"]),
+        ],
+    )
+    fixed = enforce_k8s_namespace_lookup_first(
+        plan,
+        {
+            "resolve_k8s_target_from_alert",
+            "get_high_restart_kubernetes_pods",
+            "get_resource_events_timeline",
+        },
+        max_steps=4,
+    )
+    assert [step.tools for step in fixed.steps] == [
+        ["get_high_restart_kubernetes_pods"],
+        ["get_resource_events_timeline"],
+    ]
+    records = [rec for rec in caplog.records if rec.name == "opspilot" and rec.msg.startswith("DeepAgent 规划硬校验：前置发现工具已带 namespace，跳过插入反查")]
+    assert len(records) == 1
+    assert records[0].args == (["get_high_restart_kubernetes_pods"],)
+    assert "get_high_restart_kubernetes_pods" in records[0].getMessage()
+
+
 def test_drop_k8s_followup_steps_after_unresolved_target():
     from apps.opspilot.metis.llm.agent.tool_execution_planner import ToolExecutionStep, drop_k8s_followup_steps_after_unresolved_target
 

--- a/server/apps/opspilot/tests/test_tools_k8s_resources_ext_service.py
+++ b/server/apps/opspilot/tests/test_tools_k8s_resources_ext_service.py
@@ -244,13 +244,16 @@ class TestPreviousPodLogs:
         _, kwargs = core.read_namespaced_pod_log.call_args
         assert kwargs["previous"] is True
         assert kwargs["container"] == "app"
+        assert kwargs["since_seconds"] == 24 * 3600
 
     def test_string_lines_and_tail_are_coerced(self, apis):
         core, _, _ = apis
         core.read_namespaced_pod.return_value = self._pod([SimpleNamespace(name="app")])
         core.read_namespaced_pod_log.return_value = "l1\nl2\nl3"
-        out = res.get_kubernetes_previous_pod_logs.func(namespace="ns", pod_name="p1", lines="2", tail="false", config={})
+        out = res.get_kubernetes_previous_pod_logs.func(namespace="ns", pod_name="p1", lines="2", tail="false", hours="24", config={})
         assert out == "l1\nl2"
+        _, kwargs = core.read_namespaced_pod_log.call_args
+        assert kwargs["since_seconds"] == 24 * 3600
 
     def test_empty_previous_logs(self, apis):
         core, _, _ = apis

--- a/server/apps/opspilot/tests/test_tools_k8s_resources_service.py
+++ b/server/apps/opspilot/tests/test_tools_k8s_resources_service.py
@@ -106,6 +106,7 @@ class TestGetKubernetesPodLogs:
         _, kwargs = fake_core.read_namespaced_pod_log.call_args
         assert kwargs["container"] == "only"
         assert kwargs["tail_lines"] == 100
+        assert kwargs["since_seconds"] == 24 * 3600
 
     def test_empty_logs_message(self, fake_core):
         fake_core.read_namespaced_pod.return_value = self._pod_with_containers(["only"])
@@ -122,10 +123,11 @@ class TestGetKubernetesPodLogs:
     def test_string_lines_and_tail_are_coerced(self, fake_core):
         fake_core.read_namespaced_pod.return_value = self._pod_with_containers(["only"])
         fake_core.read_namespaced_pod_log.return_value = "l1\nl2\nl3\nl4"
-        out = res.get_kubernetes_pod_logs.func(namespace="ns", pod_name="p", lines="2", tail="false", config={})
+        out = res.get_kubernetes_pod_logs.func(namespace="ns", pod_name="p", lines="2", tail="false", hours="1", config={})
         assert out == "l1\nl2"
         _, kwargs = fake_core.read_namespaced_pod_log.call_args
         assert kwargs["tail_lines"] is None
+        assert kwargs["since_seconds"] == 3600
 
     def test_container_creating_message(self, fake_core):
         fake_core.read_namespaced_pod.return_value = self._pod_with_containers(["only"])


### PR DESCRIPTION
默认 hours=24 交给 kubelet sinceSeconds，避免翻全量日志；累计 restartCount 不再当时间窗次数。分步执行隐藏中间正文，只保留与问题口径一致的终稿。