### PR TITLE
feat(opspilot): 按最近重启时间列出 Pod，避免误用累计次数排序

### DIFF
--- a/server/apps/opspilot/language/en.yaml
+++ b/server/apps/opspilot/language/en.yaml
@@ -334,6 +334,8 @@ tools:
         description: Discover all failed or abnormal Pods in the cluster
       get_high_restart_kubernetes_pods:
         description: Discover frequently restarting unstable Pods
+      get_recently_restarted_kubernetes_pods:
+        description: List recently restarted Pods ordered by last restart time
       get_kubernetes_contexts:
         description: Get kubectl context information, display currently available contexts and active context
       get_kubernetes_namespaces:

--- a/server/apps/opspilot/language/zh-Hans.yaml
+++ b/server/apps/opspilot/language/zh-Hans.yaml
@@ -328,6 +328,8 @@ tools:
         description: 发现集群中所有失败或异常的Pod
       get_high_restart_kubernetes_pods:
         description: 发现频繁重启的不稳定Pod
+      get_recently_restarted_kubernetes_pods:
+        description: 按最近一次重启时间列出最近重启过的Pod
       get_kubernetes_contexts:
         description: 获取kubectl上下文信息，显示当前可用的上下文和当前活动的上下文
       get_kubernetes_namespaces:

--- a/server/apps/opspilot/management/tools/tools.yml
+++ b/server/apps/opspilot/management/tools/tools.yml
@@ -512,18 +512,21 @@ toolkits:
     description: "深度诊断单个Pod的所有问题 - 一站式故障排查\n\n**何时使用此工具：**\n- 用户说\"这个Pod有问题，帮我看看\"\
       \n- 已知具体Pod名称，需要全面分析\n- 从 get_failed_pods 或 get_pending_pods 发现问题Pod后\n- 需要详细的诊断报告（状态+事件+资源+卷）\n\
       \n**工具能力（最全面的Pod诊断）：**\n- Pod所有Conditions（Ready、Initialized、ContainersReady等）\n\
-      - 容器状态详情（waiting/running/terminated，含退出码）\n- Init容器状态（初始化失败诊断）\n- 资源requests和limits配置\n\
+      - 容器状态详情（waiting/running/terminated，含退出码）\n- 每个容器的 last_state（上一轮终止原因和退出码）\n\
+      - Init容器状态（初始化失败诊断）\n- 资源requests和limits配置\n\
       - 挂载卷配置（PVC/ConfigMap/Secret/HostPath）\n- 最近10个相关事件（时间排序）\n- 重启策略和节点信息\n\n**诊断维度：**\n\
       1. 容器健康：状态、退出码、重启次数\n2. 资源配置：CPU/内存requests和limits\n3. 依赖检查：ConfigMap、Secret、PVC是否存在\n\
       4. 事件分析：Warning/Error事件的原因和消息\n5. 节点信息：调度到哪个节点，节点是否健康\n\nArgs:\n    namespace\
       \ (str): Pod所在命名空间（必填）\n    pod_name (str): Pod名称（必填）\n    config (RunnableConfig):\
       \ 工具配置（自动传递）\n\nReturns:\n    JSON格式，包含完整的诊断信息：\n    - phase: Pod状态（Running/Pending/Failed）\n\
-      \    - conditions[]: 所有Condition详情\n    - containers[]: 容器状态（state、restart_count、image）\n\
-      \    - init_containers[]: Init容器状态\n    - resource_requests: 资源请求配置\n    - resource_limits:\
+      \    - conditions[]: 所有Condition详情\n    - containers[]: 容器状态（state、restart_count、last_state、image）\n\
+      \    - init_containers[]: Init容器状态（含 last_state）\n    - resource_requests: 资源请求配置\n    - resource_limits:\
       \ 资源限制配置\n    - volumes[]: 卷挂载信息\n    - recent_events[]: 最近事件（按时间排序）\n    -\
-      \ node: 所在节点\n    - restart_policy: 重启策略\n\n**配合其他工具使用：**\n- 查看日志定位错误 → 使用 get_kubernetes_pod_logs\n\
+      \ node: 所在节点\n    - restart_policy: 重启策略\n\n**配合其他工具使用：**\n- 容器已重启、需要上一轮日志 →\
+      \ 使用 get_kubernetes_previous_pod_logs\n- 查看当前轮日志 → 使用 get_kubernetes_pod_logs\n\
       - 检查镜像拉取问题 → 查看events中的ImagePull相关错误\n- 资源不足 → 使用 get_kubernetes_node_capacity\
-      \ 检查节点容量\n- 需要重启恢复 → 使用 restart_pod\n- 卷挂载问题 → 使用 check_kubernetes_persistent_volumes"
+      \ 检查节点容量\n- 怀疑探针误杀 → 使用 validate_probe_configuration\n- 需要重启恢复 → 使用 restart_pod\n\
+      - 卷挂载问题 → 使用 check_kubernetes_persistent_volumes"
     parameters:
       namespace:
         type: string
@@ -699,17 +702,19 @@ toolkits:
       - 分析应用崩溃、异常退出的具体原因\n\n**工具能力：**\n- 获取容器的标准输出日志（stdout/stderr）\n- 支持多容器Pod（可指定容器名）\n\
       - 可获取最近N行或开头N行\n- 自动处理单容器Pod（无需指定容器名）\n\n**日志分析场景：**\n- CrashLoopBackOff → 查看最后100行，找panic/error\n\
       - ImagePullBackOff → 日志为空，检查镜像地址\n- OOMKilled → 查看崩溃前日志，分析内存占用\n- 应用错误 → 搜索Exception、Error、Failed关键词\n\
-      \n**重要提示：**\n- 本工具只能获取当前运行容器的日志\n- 如果容器已重启，无法获取上一次的日志（需要--previous参数，暂不支持）\n\
+      \n**重要提示：**\n- 本工具只能获取当前运行容器的日志\n- 容器已重启时，上一轮日志用 get_kubernetes_previous_pod_logs\n\
+      - 默认只取近 24 小时，再按 lines 截取\n\
       - 日志默认最多1MB，超大日志会被截断\n\nArgs:\n    namespace (str): Pod所在命名空间（必填）\n    pod_name\
       \ (str): Pod名称（必填）\n    container (str, optional): 容器名称，多容器Pod必须指定\n       \
       \ - None: 自动选择第一个容器（仅适用于单容器Pod）\n        - \"app\": 指定名为app的容器\n    lines (int,\
-      \ optional): 日志行数，默认100\n        - 100: 适合快速查看最近日志\n        - 500: 查看更多上下文\n\
+      optional): 日志行数，默认100\n        - 100: 适合快速查看最近日志\n        - 500: 查看更多上下文\n\
       \        - 50: 只看最关键的错误\n    tail (bool, optional): True=最后N行，False=开头N行，默认True\n\
-      \        - True: 查看最新日志（推荐）\n        - False: 查看启动初期日志\n    config (RunnableConfig):\
-      \ 工具配置（自动传递）\n\nReturns:\n    日志文本内容，或错误信息：\n    - 成功: 容器的实际日志输出\n    - 失败:\
+      \        - True: 查看最新日志（推荐）\n        - False: 查看启动初期日志\n    hours (int, optional):\
+      \ 时间窗（小时），默认24；最大168\n    config (RunnableConfig): 工具配置（自动传递）\n\nReturns:\n\
+      \    日志文本内容，或错误信息：\n    - 成功: 容器的实际日志输出\n    - 失败:\
       \ 错误原因（Pod不存在、容器不存在、容器创建中等）\n\n**配合其他工具使用：**\n- 发现Pod问题 → 使用 diagnose_kubernetes_pod_issues\
-      \ 确定需要查看哪个Pod\n- 日志显示OOM → 使用 check_oom_events 分析内存配置\n- 日志显示网络错误 → 使用 trace_service_chain\
-      \ 检查服务链路\n- 需要重启恢复 → 使用 restart_pod"
+      \ 确定需要查看哪个Pod\n- 容器已重启 → 使用 get_kubernetes_previous_pod_logs\n- 日志显示OOM → 使用 check_oom_events 分析内存配置\n\
+      - 日志显示网络错误 → 使用 trace_service_chain 检查服务链路\n- 需要重启恢复 → 使用 restart_pod"
     parameters:
       namespace:
         type: string
@@ -728,6 +733,44 @@ toolkits:
         description: ''
         required: false
       tail:
+        type: string
+        description: ''
+        required: false
+      hours:
+        type: string
+        description: ''
+        required: false
+  - name: get_kubernetes_previous_pod_logs
+    description: "获取Pod容器上一次实例的日志，用于重启类故障采集。\n\n**何时使用此工具：**\n- 已知具体 Pod，分析频繁重启的上一轮死因\n\
+      - diagnose 已给出 last_state，需要对照崩溃现场日志\n- 当前轮日志干净，但 restart_count > 0\n\n**重要提示：**\n\
+      - kubelet 只保留最近一次 previous 日志，不能还原全部历史重启\n- 不要用本工具扫全集群；必须带 namespace 和 pod_name\n\
+      \nArgs:\n    namespace (str): Pod所在命名空间\n    pod_name (str): Pod名称\n    container\
+      \ (str, optional): 容器名称，多容器Pod必须指定\n    lines (int, optional): 日志行数，默认100\n\
+      \    tail (bool, optional): True=最后N行，False=开头N行\n    hours (int, optional):\
+      \ 时间窗（小时），默认24\n    config (RunnableConfig): 工具配置\n\nReturns:\n    str: previous\
+      \ 容器日志文本，或错误信息"
+    parameters:
+      namespace:
+        type: string
+        description: ''
+        required: true
+      pod_name:
+        type: string
+        description: ''
+        required: true
+      container:
+        type: string
+        description: ''
+        required: false
+      lines:
+        type: string
+        description: ''
+        required: false
+      tail:
+        type: string
+        description: ''
+        required: false
+      hours:
         type: string
         description: ''
         required: false
@@ -770,6 +813,26 @@ toolkits:
       - 调度问题深入分析 → 使用 diagnose_pending_pod_issues\n- 检查节点状态 → 使用 diagnose_node_issues\n\
       - 存储问题 → 使用 check_kubernetes_persistent_volumes"
     parameters: {}
+  - name: get_recently_restarted_kubernetes_pods
+    description: "按最近一次重启时间列出最近重启过的 Pod（默认 Top 10）\n\n**何时使用此工具：**\n- 用户要按重启时间排序、列出最近重启的\
+      \ Pod\n- 「最近 10 个重启的 Pod」「按照重启时间排序」\n- 需要看谁最近刚重启过，而不是谁累计 restartCount 最高\n\n\
+      **不要用此工具：**\n- 已知具体 Pod 问重启原因 → diagnose_kubernetes_pod_issues\n- 只想按累计次数找长期不稳定\
+      \ Pod → get_high_restart_kubernetes_pods\n- 问今天/近 N 小时重启了几次 → 本工具给不出时间窗次数\n\n\
+      **工具能力：**\n- 一次 list pods，按每个 Pod 最近一次重启时间降序取 Top-N\n- 重启时间优先取当前轮 startedAt，否则上一轮\
+      \ finishedAt；没有时间戳则跳过\n- restart_count 只展示累计值，不是排序键，也不是窗口次数\n\nArgs:\n    namespace\
+      \ (str, optional): 命名空间；省略则扫描全部命名空间\n    top_n (int, optional): 返回条数，默认 10，最大\
+      \ 50\n    instance_name (str, optional): 多实例时指定集群；省略则扫描全部已配置实例\n    config (RunnableConfig):\
+      \ 工具配置（自动传递）\n\nReturns:\n    JSON 对象：\n    - sort: last_restart_time_desc\n\
+      \    - restart_count_note: 累计次数口径说明\n    - items[]: pod、namespace、container、last_restart_time、restart_count、ready、node"
+    parameters:
+      namespace:
+        type: string
+        description: ''
+        required: false
+      top_n:
+        type: string
+        description: ''
+        required: false
   - name: get_resource_events_timeline
     description: "获取资源的事件时间线，追溯问题演变过程\n\n**何时使用此工具：**\n- 回溯资源的历史状态变化和事件序列\n- 分析间歇性或周期性发生的故障模式\n\
       - 确定问题首次出现的时间点和触发条件\n- 为根因分析提供时间维度的事件上下文\n\n**工具能力：**\n- 按时间顺序展示所有Kubernetes事件\n\

--- a/server/apps/opspilot/metis/llm/agent/tool_execution_planner.py
+++ b/server/apps/opspilot/metis/llm/agent/tool_execution_planner.py
@@ -71,6 +71,27 @@ _K8S_NAMESPACE_LOOKUP_HINT = (
     "反查只是前置，后续取证/诊断步骤须对齐助手任务说明，不要只规划反查就结束。"
 )
 
+_K8S_POD_RESTART_RCA_HINT = (
+    "能力导读：已指定具体 Pod 问重启原因时，规划 diagnose_kubernetes_pod_issues"
+    " → get_kubernetes_previous_pod_logs → get_resource_events_timeline；"
+    "怀疑探针再加 validate_probe_configuration。"
+    "禁止 analyze_pod_restart_pattern / describe_kubernetes_resource / "
+    "list_kubernetes_pods / list_kubernetes_events。"
+)
+
+_K8S_RECENTLY_RESTARTED_TOOL = "get_recently_restarted_kubernetes_pods"
+_K8S_HIGH_RESTART_TOOL = "get_high_restart_kubernetes_pods"
+_K8S_RESTART_TIME_SORT_RE = re.compile(
+    r"重启时间|按时间.{0,12}重启|最近的?\s*\d*\s*个?重启|最近重启|" r"recently\s+restarted|sort(?:ed)?\s+by\s+restart\s+time",
+    re.IGNORECASE,
+)
+_K8S_RESTART_TIME_SORT_HINT = (
+    "能力导读：用户要按重启时间排序、列出最近重启的 Pod 时，必须规划 "
+    "get_recently_restarted_kubernetes_pods；禁止 get_high_restart_kubernetes_pods。"
+    "后者只按累计 restartCount 过滤，没有重启时间，也不能当时间窗次数。"
+    "restart_count 只作展示，不是排序键。"
+)
+
 _K8S_NAMESPACE_RESOLVE_TOOL = "resolve_k8s_target_from_alert"
 _K8S_NAMESPACE_SCAN_TOOLS = frozenset(
     {
@@ -84,6 +105,7 @@ _K8S_NAMESPACE_LOOKUP_TOOLS = frozenset({_K8S_NAMESPACE_RESOLVE_TOOL})
 _K8S_CLUSTER_DISCOVERY_TOOLS = frozenset(
     {
         "get_high_restart_kubernetes_pods",
+        "get_recently_restarted_kubernetes_pods",
         "get_failed_kubernetes_pods",
         "get_pending_kubernetes_pods",
         "get_not_ready_kubernetes_pods",
@@ -95,11 +117,22 @@ _K8S_NAMESPACE_REQUIRED_TOOLS = frozenset(
     {
         "diagnose_kubernetes_pod_issues",
         "get_kubernetes_pod_logs",
+        "get_kubernetes_previous_pod_logs",
         "get_resource_events_timeline",
         "describe_kubernetes_resource",
         "get_kubernetes_resource_yaml",
         "exec_in_pod",
         "validate_probe_configuration",
+    }
+)
+
+_K8S_KNOWN_POD_DIAGNOSE_TOOL = "diagnose_kubernetes_pod_issues"
+_K8S_KNOWN_POD_SCAN_TOOLS = frozenset(
+    {
+        "analyze_pod_restart_pattern",
+        "describe_kubernetes_resource",
+        "list_kubernetes_pods",
+        "list_kubernetes_events",
     }
 )
 
@@ -550,6 +583,59 @@ def enforce_k8s_namespace_lookup_first(
     return ToolExecutionPlan(goal=plan.goal, steps=steps)
 
 
+def drop_cluster_scan_tools_for_known_pod_diagnose(plan: ToolExecutionPlan) -> ToolExecutionPlan:
+    """已知 Pod 走 diagnose 时去掉全集群扫描和整份 describe，避免撑爆上下文。"""
+    planned = {tool for step in plan.steps for tool in (step.tools or [])}
+    if _K8S_KNOWN_POD_DIAGNOSE_TOOL not in planned:
+        return plan
+    cleaned: list[ToolExecutionStep] = []
+    for step in plan.steps:
+        tools = [tool for tool in (step.tools or []) if tool not in _K8S_KNOWN_POD_SCAN_TOOLS]
+        if not tools:
+            continue
+        if tools != list(step.tools):
+            cleaned.append(step.model_copy(update={"tools": tools}))
+        else:
+            cleaned.append(step)
+    return ToolExecutionPlan(goal=plan.goal, steps=cleaned)
+
+
+def rewrite_high_restart_to_recent_for_time_sort(
+    plan: ToolExecutionPlan,
+    available_names: set[str],
+    user_message: str = "",
+) -> ToolExecutionPlan:
+    """按重启时间列出最近 Pod 时，把累计次数扫描改成按时间排序的扫描。"""
+    if _K8S_RECENTLY_RESTARTED_TOOL not in available_names:
+        return plan
+    if not _K8S_RESTART_TIME_SORT_RE.search(user_message or ""):
+        return plan
+    planned = {tool for step in plan.steps for tool in (step.tools or [])}
+    if _K8S_KNOWN_POD_DIAGNOSE_TOOL in planned or _K8S_HIGH_RESTART_TOOL not in planned:
+        return plan
+    cleaned: list[ToolExecutionStep] = []
+    changed = False
+    for step in plan.steps:
+        tools = []
+        for tool in step.tools or []:
+            name = _K8S_RECENTLY_RESTARTED_TOOL if tool == _K8S_HIGH_RESTART_TOOL else tool
+            if name not in tools:
+                tools.append(name)
+        if tools != list(step.tools):
+            changed = True
+            cleaned.append(step.model_copy(update={"tools": tools}))
+        else:
+            cleaned.append(step)
+    if not changed:
+        return plan
+    logger.info(
+        "DeepAgent 规划硬校验：按重启时间排序改写 tool=%s -> tool=%s",
+        _K8S_HIGH_RESTART_TOOL,
+        _K8S_RECENTLY_RESTARTED_TOOL,
+    )
+    return ToolExecutionPlan(goal=plan.goal, steps=cleaned)
+
+
 def drop_k8s_followup_steps_after_unresolved_target(steps: Sequence[ToolExecutionStep]) -> list[ToolExecutionStep]:
     """反查已收口后，去掉重复反查和仍依赖 namespace 的后续步骤。"""
     skip = _K8S_NAMESPACE_LOOKUP_TOOLS | _K8S_NAMESPACE_SCAN_TOOLS | _K8S_NAMESPACE_REQUIRED_TOOLS
@@ -869,6 +955,8 @@ class ToolExecutionPlanner:
         lines = []
         has_monitor = False
         has_k8s_lookup = False
+        has_pod_diagnose = False
+        has_restart_time_sort = False
         has_attachment = False
         used = 0
         skill_block = self._skill_catalog(skill_packages)
@@ -884,6 +972,10 @@ class ToolExecutionPlanner:
                 has_monitor = True
             if name in _K8S_NAMESPACE_LOOKUP_TOOLS:
                 has_k8s_lookup = True
+            if name == _K8S_KNOWN_POD_DIAGNOSE_TOOL:
+                has_pod_diagnose = True
+            if name in {_K8S_RECENTLY_RESTARTED_TOOL, _K8S_HIGH_RESTART_TOOL}:
+                has_restart_time_sort = True
             if name == GENERATE_ATTACHMENT_FILE_TOOL_NAME:
                 has_attachment = True
             # 预算耗尽后只保留工具名，避免 60+ 长描述撑爆 8K 窗口。
@@ -903,6 +995,10 @@ class ToolExecutionPlanner:
             hints.append(_MONITOR_CATALOG_HINT)
         if has_k8s_lookup:
             hints.append(_K8S_NAMESPACE_LOOKUP_HINT)
+        if has_pod_diagnose:
+            hints.append(_K8S_POD_RESTART_RCA_HINT)
+        if has_restart_time_sort:
+            hints.append(_K8S_RESTART_TIME_SORT_HINT)
         if has_attachment:
             hints.append(_ATTACHMENT_CATALOG_HINT)
         if declared_source_tools:
@@ -963,6 +1059,8 @@ class ToolExecutionPlanner:
             steps=steps,
         )
         plan = enforce_k8s_namespace_lookup_first(plan, available_names, max_steps=self._max_steps)
+        plan = drop_cluster_scan_tools_for_known_pod_diagnose(plan)
+        plan = rewrite_high_restart_to_recent_for_time_sort(plan, available_names, user_message=user_message)
         plan = enforce_skill_report_source_tools(
             plan,
             available_names,

--- a/server/apps/opspilot/metis/llm/chain/deepagent_assembly.py
+++ b/server/apps/opspilot/metis/llm/chain/deepagent_assembly.py
@@ -99,7 +99,10 @@ class DeepAgentAssemblyMixin:
 
     @classmethod
     def _select_visible_planned_messages(cls, messages, *, summary_ran: bool) -> list:
-        """分步过程只给用户看一份终稿：工具结果保留，正文只留最后一张表或最后一段作答。"""
+        """分步过程只给用户看一份终稿：工具结果保留，正文只留最后一份作答。
+
+        summary_ran 保留调用契约；有无 summary 都取 answers[-1]，避免中间表盖掉更晚的无表终稿。
+        """
         visible: list = []
         answers: list = []
         stubs: list = []
@@ -116,11 +119,7 @@ class DeepAgentAssemblyMixin:
             visible.append(message)
         chosen = None
         if answers:
-            if summary_ran:
-                chosen = answers[-1]
-            else:
-                table_answers = [item for item in answers if cls._MARKDOWN_TABLE_RE.search(str(item.content or ""))]
-                chosen = (table_answers or answers)[-1]
+            chosen = answers[-1]
         elif stubs:
             chosen = stubs[-1]
         if chosen is not None:

--- a/server/apps/opspilot/metis/llm/chain/deepagent_assembly.py
+++ b/server/apps/opspilot/metis/llm/chain/deepagent_assembly.py
@@ -197,10 +197,17 @@ class DeepAgentAssemblyMixin:
             tail = (
                 "本步给出用户可见的最终答案：只保留一张表，口径必须对齐用户问题。"
                 "用户问今天或某时间窗时，以事件时间线为准；累计 restart_count 不是该时间窗次数，禁止写成「今天重启了 N 次」。"
+                "用户问按重启时间排序或最近重启的 Pod 时，以 last_restart_time 为准，禁止按累计 restart_count 排序。"
+                "已知具体 Pod 的重启原因时，以 diagnose 的 last_state、previous 日志和定点事件为准，不要把当前轮日志当成上一轮死因。"
                 "若与前面累计名单矛盾，只保留时间窗结论，不要再贴口径不同的第二张表。"
             )
         else:
-            tail = "本步证据只给后续步骤用，不要输出 Markdown 表或最终结论。" "用户问今天或某时间窗时，禁止把累计 restart_count 写成该时间窗的次数。"
+            tail = (
+                "本步证据只给后续步骤用，不要输出 Markdown 表或最终结论。"
+                "用户问今天或某时间窗时，禁止把累计 restart_count 写成该时间窗的次数。"
+                "用户问按重启时间排序或最近重启的 Pod 时，以 last_restart_time 为准，禁止按累计 restart_count 排序。"
+                "已知具体 Pod 的重启原因时，优先看 last_state 和 previous 日志。"
+            )
         return (
             "【工具执行】只调用本步骤计划/可见工具。"
             "未计划工具会被拒绝，不要改调其他工具，也不要当作步骤失败去重规划。"

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/__init__.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/__init__.py
@@ -42,6 +42,7 @@ from apps.opspilot.metis.llm.tools.kubernetes.diagnostics import (
     get_kubernetes_orphaned_resources,
     get_not_ready_kubernetes_pods,
     get_pending_kubernetes_pods,
+    get_recently_restarted_kubernetes_pods,
 )
 from apps.opspilot.metis.llm.tools.kubernetes.diagnostics_advanced import (
     check_network_policies_blocking,
@@ -116,6 +117,7 @@ __all__ = [
     "get_pending_kubernetes_pods",
     "get_not_ready_kubernetes_pods",
     "get_high_restart_kubernetes_pods",
+    "get_recently_restarted_kubernetes_pods",
     "get_kubernetes_node_capacity",
     "get_kubernetes_orphaned_resources",
     "diagnose_kubernetes_pod_issues",

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/diagnostics.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/diagnostics.py
@@ -13,13 +13,45 @@ from apps.opspilot.metis.llm.tools.kubernetes.utils import coerce_int, format_by
 _EVENT_TIME_MIN = datetime.min.replace(tzinfo=timezone.utc)
 
 
+def _container_last_state(container) -> dict:
+    terminated = getattr(getattr(container, "last_state", None), "terminated", None)
+    if terminated is None:
+        return {}
+    finished_at = getattr(terminated, "finished_at", None)
+    return {
+        "reason": getattr(terminated, "reason", None),
+        "exit_code": getattr(terminated, "exit_code", None),
+        "finished_at": finished_at.isoformat() if finished_at else None,
+        "message": getattr(terminated, "message", None),
+    }
+
+
+def _as_utc_datetime(timestamp):
+    if timestamp is None or not isinstance(timestamp, datetime):
+        return None
+    if timestamp.tzinfo is None or timestamp.utcoffset() is None:
+        return timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(timezone.utc)
+
+
 def _event_sort_time(event):
     timestamp = getattr(event, "last_timestamp", None)
     if timestamp is None:
         return _EVENT_TIME_MIN
-    if timestamp.tzinfo is None or timestamp.utcoffset() is None:
-        return timestamp.replace(tzinfo=timezone.utc)
-    return timestamp.astimezone(timezone.utc)
+    return _as_utc_datetime(timestamp) or _EVENT_TIME_MIN
+
+
+def _container_last_restart_at(container):
+    """最近一次重启时间：优先当前轮 startedAt，否则上一轮 terminated.finishedAt。"""
+    running = getattr(getattr(container, "state", None), "running", None)
+    started_at = _as_utc_datetime(getattr(running, "started_at", None) if running is not None else None)
+    if started_at is not None:
+        return started_at
+    terminated = getattr(getattr(container, "last_state", None), "terminated", None)
+    return _as_utc_datetime(getattr(terminated, "finished_at", None) if terminated is not None else None)
+
+
+_RESTART_COUNT_NOTE = "restart_count 是当前 Pod UID 上该容器自创建以来的累计次数，不是时间窗内次数，也不是排序键。"
 
 
 @tool()
@@ -326,6 +358,8 @@ def get_high_restart_kubernetes_pods(restart_threshold: int = 5, instance_name=N
     **注意：** restart_count 是容器自创建以来的累计次数，不是今天或指定时间窗内的次数。
     用户问「今天重启了几次」时，本工具不能当作时间窗答案；必须再用
     get_resource_events_timeline 等按时间过滤，且不要把累计次数写成「今天重启了 N 次」。
+    用户要按重启时间排序、列出最近重启的 Pod 时，使用 get_recently_restarted_kubernetes_pods，
+    不要用本工具：这里没有重启时间，也不能按累计次数冒充「最近重启」。
 
     **与analyze_pod_restart_pattern的区别：**
     - 本工具：快速列表，找出"哪些Pod在重启"
@@ -394,6 +428,104 @@ def _get_high_restart_kubernetes_pods_on_instance(restart_threshold, config: Run
         return json.dumps(high_restart)
     except ApiException as e:
         return json.dumps({"error": f"获取高重启Pod列表失败: {str(e)}"})
+
+
+@tool()
+def get_recently_restarted_kubernetes_pods(namespace=None, top_n: int = 10, instance_name=None, config: RunnableConfig = None):
+    """
+    按最近一次重启时间列出最近重启过的 Pod（默认 Top 10）
+
+    **何时使用此工具：**
+    - 用户要按重启时间排序、列出最近重启的 Pod
+    - 「最近 10 个重启的 Pod」「按照重启时间排序」
+    - 需要看谁最近刚重启过，而不是谁累计 restartCount 最高
+
+    **不要用此工具：**
+    - 已知具体 Pod 问重启原因 → diagnose_kubernetes_pod_issues
+    - 只想按累计次数找长期不稳定 Pod → get_high_restart_kubernetes_pods
+    - 问今天/近 N 小时重启了几次 → 本工具给不出时间窗次数
+
+    **工具能力：**
+    - 一次 list pods，按每个 Pod 最近一次重启时间降序取 Top-N
+    - 重启时间优先取当前轮 startedAt，否则上一轮 finishedAt；没有时间戳则跳过
+    - restart_count 只展示累计值，不是排序键，也不是窗口次数
+
+    Args:
+        namespace (str, optional): 命名空间；省略则扫描全部命名空间
+        top_n (int, optional): 返回条数，默认 10，最大 50
+        instance_name (str, optional): 多实例时指定集群；省略则扫描全部已配置实例
+        config (RunnableConfig): 工具配置（自动传递）
+
+    Returns:
+        JSON 对象：
+        - sort: last_restart_time_desc
+        - restart_count_note: 累计次数口径说明
+        - items[]: pod、namespace、container、last_restart_time、restart_count、ready、node
+    """
+    namespace = str(namespace).strip() if namespace else None
+    top_n = coerce_int(top_n, 10, lo=1, hi=50)
+    return run_scan_tool(config, instance_name, lambda bound: _get_recently_restarted_kubernetes_pods_on_instance(namespace, top_n, bound))
+
+
+def _iter_pod_container_statuses(pod):
+    for attr in ("container_statuses", "init_container_statuses"):
+        statuses = getattr(getattr(pod, "status", None), attr, None) or []
+        for container in statuses:
+            yield container
+
+
+def _recent_restart_row(pod, container, restarted_at):
+    return {
+        "pod": pod.metadata.name,
+        "namespace": pod.metadata.namespace,
+        "container": getattr(container, "name", None),
+        "last_restart_time": restarted_at.isoformat(),
+        "restart_count": int(getattr(container, "restart_count", 0) or 0),
+        "ready": bool(getattr(container, "ready", False)),
+        "node": getattr(getattr(pod, "spec", None), "node_name", None),
+        "_sort": restarted_at,
+    }
+
+
+def _best_recent_restart_row(pod):
+    best = None
+    for container in _iter_pod_container_statuses(pod):
+        restart_count = int(getattr(container, "restart_count", 0) or 0)
+        if restart_count < 1:
+            continue
+        restarted_at = _container_last_restart_at(container)
+        if restarted_at is None:
+            continue
+        row = _recent_restart_row(pod, container, restarted_at)
+        if best is None or (restarted_at, restart_count) > (best["_sort"], best["restart_count"]):
+            best = row
+    return best
+
+
+def _get_recently_restarted_kubernetes_pods_on_instance(namespace, top_n, config: RunnableConfig = None):
+    prepare_context(config)
+    try:
+        core_v1 = client.CoreV1Api()
+        if namespace:
+            pods = core_v1.list_namespaced_pod(namespace)
+        else:
+            pods = core_v1.list_pod_for_all_namespaces()
+        rows = []
+        for pod in pods.items:
+            row = _best_recent_restart_row(pod)
+            if row is not None:
+                rows.append(row)
+        rows.sort(key=lambda item: item["_sort"], reverse=True)
+        items = [{key: value for key, value in row.items() if key != "_sort"} for row in rows[:top_n]]
+        return json.dumps(
+            {
+                "sort": "last_restart_time_desc",
+                "restart_count_note": _RESTART_COUNT_NOTE,
+                "items": items,
+            }
+        )
+    except ApiException as e:
+        return json.dumps({"error": f"获取最近重启Pod列表失败: {str(e)}"})
 
 
 @tool()
@@ -681,6 +813,7 @@ def diagnose_kubernetes_pod_issues(namespace, pod_name, instance_name=None, conf
     **工具能力（最全面的Pod诊断）：**
     - Pod所有Conditions（Ready、Initialized、ContainersReady等）
     - 容器状态详情（waiting/running/terminated，含退出码）
+    - 每个容器的 last_state（上一轮终止 reason、exit_code、finished_at、message）
     - Init容器状态（初始化失败诊断）
     - 资源requests和limits配置
     - 挂载卷配置（PVC/ConfigMap/Secret/HostPath）
@@ -703,8 +836,8 @@ def diagnose_kubernetes_pod_issues(namespace, pod_name, instance_name=None, conf
         JSON格式，包含完整的诊断信息：
         - phase: Pod状态（Running/Pending/Failed）
         - conditions[]: 所有Condition详情
-        - containers[]: 容器状态（state、restart_count、image）
-        - init_containers[]: Init容器状态
+        - containers[]: 容器状态（state、restart_count、last_state、image）
+        - init_containers[]: Init容器状态（含 last_state）
         - resource_requests: 资源请求配置
         - resource_limits: 资源限制配置
         - volumes[]: 卷挂载信息
@@ -713,9 +846,11 @@ def diagnose_kubernetes_pod_issues(namespace, pod_name, instance_name=None, conf
         - restart_policy: 重启策略
 
     **配合其他工具使用：**
-    - 查看日志定位错误 → 使用 get_kubernetes_pod_logs
+    - 容器已重启、需要上一轮日志 → 使用 get_kubernetes_previous_pod_logs
+    - 查看当前轮日志 → 使用 get_kubernetes_pod_logs
     - 检查镜像拉取问题 → 查看events中的ImagePull相关错误
     - 资源不足 → 使用 get_kubernetes_node_capacity 检查节点容量
+    - 怀疑探针误杀 → 使用 validate_probe_configuration
     - 需要重启恢复 → 使用 restart_pod
     - 卷挂载问题 → 使用 check_kubernetes_persistent_volumes
     """
@@ -798,6 +933,7 @@ def diagnose_kubernetes_pod_issues(namespace, pod_name, instance_name=None, conf
                         "finished_at": container.state.terminated.finished_at.isoformat() if container.state.terminated.finished_at else None,
                     }
 
+                container_info["last_state"] = _container_last_state(container)
                 diagnosis["containers"].append(container_info)
 
         # Init容器状态
@@ -824,6 +960,7 @@ def diagnose_kubernetes_pod_issues(namespace, pod_name, instance_name=None, conf
                         "exit_code": init_container.state.terminated.exit_code,
                     }
 
+                init_info["last_state"] = _container_last_state(init_container)
                 diagnosis["init_containers"].append(init_info)
 
         # 资源请求和限制

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/resources.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/resources.py
@@ -619,10 +619,19 @@ def get_kubernetes_previous_pod_logs(
     """
     获取Pod容器上一次实例的日志，用于重启类故障采集。
 
+    **何时使用此工具：**
+    - 已知具体 Pod，分析频繁重启的上一轮死因
+    - diagnose 已给出 last_state，需要对照崩溃现场日志
+    - 当前轮日志干净，但 restart_count > 0
+
+    **重要提示：**
+    - kubelet 只保留最近一次 previous 日志，不能还原全部历史重启
+    - 不要用本工具扫全集群；必须带 namespace 和 pod_name
+
     Args:
         namespace (str): Pod所在命名空间
         pod_name (str): Pod名称
-        container (str, optional): 容器名称，多容器Pod建议显式指定
+        container (str, optional): 容器名称，多容器Pod必须指定
         lines (int, optional): 日志行数，默认100
         tail (bool, optional): True=最后N行，False=开头N行
         hours (int, optional): 时间窗（小时），默认24；只看上一轮里落在该窗口内的日志

--- a/server/apps/opspilot/metis/llm/tools/kubernetes/resources.py
+++ b/server/apps/opspilot/metis/llm/tools/kubernetes/resources.py
@@ -16,8 +16,15 @@ _DEFAULT_LOG_HOURS = 24
 _MAX_LOG_HOURS = 168
 
 
-def _pod_log_since_seconds(hours) -> int:
-    return coerce_int(hours, _DEFAULT_LOG_HOURS, lo=1, hi=_MAX_LOG_HOURS) * 3600
+def _pod_log_since_seconds(hours, *, default=_DEFAULT_LOG_HOURS):
+    """hours -> kubelet sinceSeconds（相对当前时间的滚动窗口）。
+
+    default=None 表示省略 hours 时不限窗，不传 since_seconds。
+    """
+    if default is None and (hours is None or hours == ""):
+        return None
+    fallback = _DEFAULT_LOG_HOURS if default is None else default
+    return coerce_int(hours, fallback, lo=1, hi=_MAX_LOG_HOURS) * 3600
 
 
 @tool()
@@ -515,7 +522,7 @@ def get_kubernetes_pod_logs(
     **重要提示：**
     - 本工具只能获取当前运行容器的日志
     - 容器已重启时，上一轮日志用 get_kubernetes_previous_pod_logs
-    - 默认只取近 24 小时，再按 lines 截取；频繁重启先看当天即可
+    - 默认只取近 24 小时（滚动窗口），再按 lines 截取
     - 日志默认最多1MB，超大日志会被截断
 
     Args:
@@ -531,7 +538,7 @@ def get_kubernetes_pod_logs(
         tail (bool, optional): True=最后N行，False=开头N行，默认True
             - True: 查看最新日志（推荐）
             - False: 查看启动初期日志
-        hours (int, optional): 时间窗（小时），默认24，对应当天；最大168
+        hours (int, optional): 近 N 小时（滚动窗口），默认24；最大168
         config (RunnableConfig): 工具配置（自动传递）
 
     Returns:
@@ -612,7 +619,7 @@ def get_kubernetes_previous_pod_logs(
     container=None,
     lines: int = 100,
     tail: bool = True,
-    hours: int = 24,
+    hours=None,
     instance_name=None,
     config: RunnableConfig = None,
 ):
@@ -625,7 +632,7 @@ def get_kubernetes_previous_pod_logs(
         container (str, optional): 容器名称，多容器Pod建议显式指定
         lines (int, optional): 日志行数，默认100
         tail (bool, optional): True=最后N行，False=开头N行
-        hours (int, optional): 时间窗（小时），默认24；只看上一轮里落在该窗口内的日志
+        hours (int, optional): 近 N 小时（滚动窗口）；默认不限窗。仅显式传入时才按 sinceSeconds 过滤
         instance_name (str, optional): 多实例时必须指定集群
         config (RunnableConfig): 工具配置
 
@@ -638,7 +645,7 @@ def get_kubernetes_previous_pod_logs(
     prepare_context(config)
     lines = coerce_int(lines, 100, lo=1, hi=10000)
     tail = coerce_bool(tail, True)
-    since_seconds = _pod_log_since_seconds(hours)
+    since_seconds = _pod_log_since_seconds(hours, default=None)
     try:
         core_v1 = client.CoreV1Api()
 
@@ -656,21 +663,26 @@ def get_kubernetes_previous_pod_logs(
         if not container and pod.spec.containers and len(pod.spec.containers) == 1:
             container = pod.spec.containers[0].name
 
-        logs = core_v1.read_namespaced_pod_log(
-            name=pod_name,
-            namespace=namespace,
-            container=container,
-            previous=True,
-            since_seconds=since_seconds,
-            tail_lines=lines if tail else None,
-            limit_bytes=None if lines else 1024 * 1024,
-        )
+        log_kwargs = {
+            "name": pod_name,
+            "namespace": namespace,
+            "container": container,
+            "previous": True,
+            "tail_lines": lines if tail else None,
+            "limit_bytes": None if lines else 1024 * 1024,
+        }
+        if since_seconds is not None:
+            log_kwargs["since_seconds"] = since_seconds
+        logs = core_v1.read_namespaced_pod_log(**log_kwargs)
 
         if not tail and logs:
             log_lines = logs.split("\n")
             logs = "\n".join(log_lines[:lines])
 
         if not logs:
+            if since_seconds is not None:
+                window_hours = since_seconds // 3600
+                return f"Pod {pod_name} 容器 {container} 在近 {window_hours} 小时滚动窗口内没有 previous 日志。" f"这不等于没有 previous 容器；可加大 hours 或不传 hours（不限窗）再查。"
             return f"Pod {pod_name} 容器 {container} 没有上一次实例的日志输出"
 
         return logs

--- a/server/apps/opspilot/tests/test_deepagent_engine_service.py
+++ b/server/apps/opspilot/tests/test_deepagent_engine_service.py
@@ -1481,8 +1481,8 @@ def test_select_visible_planned_messages_keeps_last_prose_over_earlier_table():
     visible = ToolsNodes._select_visible_planned_messages(messages, summary_ran=False)
     ai = [item for item in visible if getattr(item, "type", "") == "ai" and not getattr(item, "tool_calls", None)]
     assert len(ai) == 1
-    assert "今天 0 次" in str(ai[0].content)
-    assert "累计重启" not in str(ai[0].content)
+    assert str(ai[0].content) == later
+    assert "| Pod |" not in str(ai[0].content)
     assert sum(1 for item in visible if getattr(item, "type", "") == "tool") == 2
 
 

--- a/server/apps/opspilot/tests/test_deepagent_engine_service.py
+++ b/server/apps/opspilot/tests/test_deepagent_engine_service.py
@@ -1465,6 +1465,27 @@ def test_select_visible_planned_messages_keeps_last_table_not_cumulative():
     assert sum(1 for item in visible if getattr(item, "type", "") == "tool") == 2
 
 
+def test_select_visible_planned_messages_keeps_last_prose_over_earlier_table():
+    from langchain_core.messages import AIMessage, ToolMessage
+
+    cumulative = "| Pod | 累计重启 |\n| --- | --- |\n| calico | 9 |"
+    later = "以上名单累计重启均发生在 24 小时前，今天 0 次。"
+    messages = [
+        AIMessage(content="", tool_calls=[{"id": "1", "name": "get_high_restart_kubernetes_pods", "args": {}}]),
+        ToolMessage(content="[{}]", tool_call_id="1"),
+        AIMessage(content=cumulative),
+        AIMessage(content="", tool_calls=[{"id": "2", "name": "get_resource_events_timeline", "args": {}}]),
+        ToolMessage(content="[]", tool_call_id="2"),
+        AIMessage(content=later),
+    ]
+    visible = ToolsNodes._select_visible_planned_messages(messages, summary_ran=False)
+    ai = [item for item in visible if getattr(item, "type", "") == "ai" and not getattr(item, "tool_calls", None)]
+    assert len(ai) == 1
+    assert "今天 0 次" in str(ai[0].content)
+    assert "累计重启" not in str(ai[0].content)
+    assert sum(1 for item in visible if getattr(item, "type", "") == "tool") == 2
+
+
 def test_planned_step_already_answered_detects_tool_sentence():
     from langchain_core.messages import AIMessage
 

--- a/server/apps/opspilot/tests/test_deepagent_engine_service.py
+++ b/server/apps/opspilot/tests/test_deepagent_engine_service.py
@@ -1509,6 +1509,9 @@ def test_planned_tool_step_guidance_is_policy_not_skill_scan():
     last = ToolsNodes._planned_tool_step_guidance(is_last_step=True)
     assert "只保留一张表" in last
     assert "时间窗" in last
+    assert "last_restart_time" in last
+    assert "last_state" in last
+    assert "previous" in last
     assert "不要输出 Markdown 表" not in last
 
 

--- a/server/apps/opspilot/tests/test_deepagent_runtime_policy.py
+++ b/server/apps/opspilot/tests/test_deepagent_runtime_policy.py
@@ -559,6 +559,88 @@ async def test_planner_catalog_prepends_k8s_namespace_lookup_hint():
 
 
 @pytest.mark.asyncio
+async def test_planner_catalog_prepends_known_pod_restart_rca_hint():
+    tools = [
+        _tool("diagnose_kubernetes_pod_issues", "诊断 Pod"),
+        _tool("get_kubernetes_previous_pod_logs", "上一轮日志"),
+        _tool("get_resource_events_timeline", "事件时间线"),
+        _tool("analyze_pod_restart_pattern", "扫描重启模式"),
+        _tool("describe_kubernetes_resource", "描述资源"),
+        _tool("list_kubernetes_pods", "列出 Pod"),
+        _tool("list_kubernetes_events", "列出事件"),
+    ]
+
+    class FakeLLM:
+        def __init__(self):
+            self.messages = None
+
+        async def ainvoke(self, messages, config=None):
+            self.messages = messages
+            return AIMessage(
+                content=json.dumps(
+                    {
+                        "goal": "分析指定 Pod 重启原因",
+                        "steps": [
+                            {
+                                "objective": "诊断",
+                                "tools": [
+                                    "diagnose_kubernetes_pod_issues",
+                                    "analyze_pod_restart_pattern",
+                                    "describe_kubernetes_resource",
+                                    "list_kubernetes_events",
+                                ],
+                            }
+                        ],
+                    },
+                    ensure_ascii=False,
+                )
+            )
+
+    llm = FakeLLM()
+    plan = await ToolExecutionPlanner(llm).plan("分析 kube-system/coredns-xxx 频繁重启的原因", tools)
+    prompt = "\n".join(str(message.content) for message in llm.messages)
+    assert "已指定具体 Pod 问重启原因" in prompt
+    assert "get_kubernetes_previous_pod_logs" in prompt
+    assert "禁止 analyze_pod_restart_pattern" in prompt
+    assert "describe_kubernetes_resource" in prompt
+    assert [step.tools for step in plan.steps] == [["diagnose_kubernetes_pod_issues"]]
+
+
+@pytest.mark.asyncio
+async def test_planner_catalog_prepends_restart_time_sort_hint():
+    tools = [
+        _tool("get_high_restart_kubernetes_pods", "发现频繁重启的不稳定Pod"),
+        _tool("get_recently_restarted_kubernetes_pods", "按最近一次重启时间列出最近重启过的 Pod"),
+    ]
+
+    class FakeLLM:
+        def __init__(self):
+            self.messages = None
+
+        async def ainvoke(self, messages, config=None):
+            self.messages = messages
+            return AIMessage(
+                content=json.dumps(
+                    {
+                        "goal": "按重启时间列最近 Pod",
+                        "steps": [{"objective": "累计高重启", "tools": ["get_high_restart_kubernetes_pods"]}],
+                    },
+                    ensure_ascii=False,
+                )
+            )
+
+    llm = FakeLLM()
+    plan = await ToolExecutionPlanner(llm).plan(
+        "按照重启时间排序，列出最近的 10 个重启的 pod，并展示重启时间和次数",
+        tools,
+    )
+    prompt = "\n".join(str(message.content) for message in llm.messages)
+    assert "必须规划 get_recently_restarted_kubernetes_pods" in prompt
+    assert "禁止 get_high_restart_kubernetes_pods" in prompt
+    assert [step.tools for step in plan.steps] == [["get_recently_restarted_kubernetes_pods"]]
+
+
+@pytest.mark.asyncio
 async def test_planner_task_prompt_includes_agent_system_prompt():
     tools = [
         _tool("resolve_k8s_target_from_alert", "从告警解析目标"),
@@ -1079,6 +1161,106 @@ def test_enforce_k8s_namespace_lookup_skips_resolve_after_cluster_discovery(capl
     assert len(records) == 1
     assert records[0].args == (["get_high_restart_kubernetes_pods"],)
     assert "get_high_restart_kubernetes_pods" in records[0].getMessage()
+
+
+def test_drop_cluster_scan_tools_for_known_pod_diagnose():
+    from apps.opspilot.metis.llm.agent.tool_execution_planner import (
+        ToolExecutionPlan,
+        ToolExecutionStep,
+        drop_cluster_scan_tools_for_known_pod_diagnose,
+    )
+
+    plan = ToolExecutionPlan(
+        goal="分析指定 Pod 重启",
+        steps=[
+            ToolExecutionStep(
+                objective="诊断",
+                tools=["diagnose_kubernetes_pod_issues", "list_kubernetes_events", "describe_kubernetes_resource"],
+            ),
+            ToolExecutionStep(objective="扫集群", tools=["analyze_pod_restart_pattern", "list_kubernetes_pods"]),
+            ToolExecutionStep(objective="上一轮日志", tools=["get_kubernetes_previous_pod_logs"]),
+        ],
+    )
+    fixed = drop_cluster_scan_tools_for_known_pod_diagnose(plan)
+    assert [step.tools for step in fixed.steps] == [
+        ["diagnose_kubernetes_pod_issues"],
+        ["get_kubernetes_previous_pod_logs"],
+    ]
+
+    mixed = ToolExecutionPlan(
+        goal="先巡检再诊断",
+        steps=[
+            ToolExecutionStep(objective="高重启名单", tools=["get_high_restart_kubernetes_pods"]),
+            ToolExecutionStep(objective="诊断", tools=["diagnose_kubernetes_pod_issues"]),
+        ],
+    )
+    kept = drop_cluster_scan_tools_for_known_pod_diagnose(mixed)
+    assert [step.tools for step in kept.steps] == [
+        ["get_high_restart_kubernetes_pods"],
+        ["diagnose_kubernetes_pod_issues"],
+    ]
+
+
+def test_rewrite_high_restart_to_recent_for_time_sort():
+    from apps.opspilot.metis.llm.agent.tool_execution_planner import (
+        ToolExecutionPlan,
+        ToolExecutionStep,
+        rewrite_high_restart_to_recent_for_time_sort,
+    )
+
+    available = {"get_high_restart_kubernetes_pods", "get_recently_restarted_kubernetes_pods"}
+    plan = ToolExecutionPlan(
+        goal="按重启时间列最近 Pod",
+        steps=[ToolExecutionStep(objective="找高频重启", tools=["get_high_restart_kubernetes_pods"])],
+    )
+    fixed = rewrite_high_restart_to_recent_for_time_sort(
+        plan,
+        available,
+        user_message="按照重启时间排序，列出最近的 10 个重启的 pod，并展示重启时间和次数",
+    )
+    assert [step.tools for step in fixed.steps] == [["get_recently_restarted_kubernetes_pods"]]
+
+    count_only = rewrite_high_restart_to_recent_for_time_sort(
+        plan,
+        available,
+        user_message="找出累计重启次数很高的不稳定 Pod",
+    )
+    assert [step.tools for step in count_only.steps] == [["get_high_restart_kubernetes_pods"]]
+
+    mixed = ToolExecutionPlan(
+        goal="先名单再诊断",
+        steps=[
+            ToolExecutionStep(objective="高重启名单", tools=["get_high_restart_kubernetes_pods"]),
+            ToolExecutionStep(objective="诊断", tools=["diagnose_kubernetes_pod_issues"]),
+        ],
+    )
+    kept = rewrite_high_restart_to_recent_for_time_sort(
+        mixed,
+        available | {"diagnose_kubernetes_pod_issues"},
+        user_message="按照重启时间排序，列出最近的 10 个重启的 pod",
+    )
+    assert [step.tools for step in kept.steps] == [
+        ["get_high_restart_kubernetes_pods"],
+        ["diagnose_kubernetes_pod_issues"],
+    ]
+
+
+def test_enforce_k8s_namespace_lookup_first_prepends_for_previous_logs():
+    from apps.opspilot.metis.llm.agent.tool_execution_planner import ToolExecutionPlan, ToolExecutionStep, enforce_k8s_namespace_lookup_first
+
+    plan = ToolExecutionPlan(
+        goal="上一轮日志",
+        steps=[ToolExecutionStep(objective="取 previous 日志", tools=["get_kubernetes_previous_pod_logs"])],
+    )
+    fixed = enforce_k8s_namespace_lookup_first(
+        plan,
+        {"resolve_k8s_target_from_alert", "get_kubernetes_previous_pod_logs"},
+        max_steps=4,
+    )
+    assert [step.tools for step in fixed.steps] == [
+        ["resolve_k8s_target_from_alert"],
+        ["get_kubernetes_previous_pod_logs"],
+    ]
 
 
 def test_drop_k8s_followup_steps_after_unresolved_target():

--- a/server/apps/opspilot/tests/test_kubernetes_data_collection_tools.py
+++ b/server/apps/opspilot/tests/test_kubernetes_data_collection_tools.py
@@ -756,7 +756,12 @@ def test_kubernetes_tools_loader_metadata_includes_node_diagnostics_and_collecti
     assert "collect_k8s_context_by_target_type" in tool_names
     assert "build_incident_evidence_package" in tool_names
     assert "get_kubernetes_previous_pod_logs" in tool_names
+    previous = next(tool for tool in kubernetes_item["tools"] if tool["name"] == "get_kubernetes_previous_pod_logs")
+    assert "上一轮" in previous["description"]
     assert "get_not_ready_kubernetes_pods" in tool_names
+    assert "get_recently_restarted_kubernetes_pods" in tool_names
+    recent = next(tool for tool in kubernetes_item["tools"] if tool["name"] == "get_recently_restarted_kubernetes_pods")
+    assert "重启时间" in recent["description"]
     assert "get_kubernetes_pods_top" in tool_names
     assert "get_kubernetes_nodes_top" in tool_names
     assert "exec_in_pod" in tool_names

--- a/server/apps/opspilot/tests/test_tools_k8s_diagnostics_service.py
+++ b/server/apps/opspilot/tests/test_tools_k8s_diagnostics_service.py
@@ -2,7 +2,7 @@
 
 mock prepare_context(kubeconfig 边界)与 client.CoreV1Api,用 SimpleNamespace
 构造真实形态的 V1Pod/V1Node/V1Event 对象驱动各诊断工具,断言失败/Pending/高重启
-Pod 识别、节点容量百分比计算、孤立资源过滤、单 Pod 深度诊断结构与 404/ApiException
+与按重启时间排序的最近重启 Pod 识别、节点容量百分比计算、孤立资源过滤、单 Pod 深度诊断结构与 404/ApiException
 包装。不连真实集群。
 """
 
@@ -29,8 +29,10 @@ def _state(waiting=None, terminated=None, running=None):
     return SimpleNamespace(waiting=waiting, terminated=terminated, running=running)
 
 
-def _cstatus(name="app", ready=False, restart_count=0, image="img:1", state=None, image_id="id"):
-    return SimpleNamespace(name=name, ready=ready, restart_count=restart_count, image=image, image_id=image_id, state=state or _state())
+def _cstatus(name="app", ready=False, restart_count=0, image="img:1", state=None, image_id="id", last_state=None):
+    return SimpleNamespace(
+        name=name, ready=ready, restart_count=restart_count, image=image, image_id=image_id, state=state or _state(), last_state=last_state
+    )
 
 
 def _meta(name="p", ns="default", owner=None, ts=None):
@@ -213,6 +215,104 @@ class TestHighRestart:
         assert "error" in out
 
 
+class TestRecentlyRestarted:
+    def test_sorts_by_last_restart_time_not_restart_count(self, core):
+        old = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        recent = datetime(2026, 9, 3, 9, tzinfo=timezone.utc)
+        core.list_pod_for_all_namespaces.return_value = _items(
+            [
+                _pod(
+                    name="old-high",
+                    cstatuses=[_cstatus(restart_count=30000, ready=True, state=_state(running=SimpleNamespace(started_at=old)))],
+                ),
+                _pod(
+                    name="new-once",
+                    cstatuses=[_cstatus(restart_count=1, ready=True, state=_state(running=SimpleNamespace(started_at=recent)))],
+                ),
+            ]
+        )
+        out = json.loads(d.get_recently_restarted_kubernetes_pods.invoke({"config": {}}))
+        assert out["sort"] == "last_restart_time_desc"
+        assert "累计" in out["restart_count_note"]
+        assert [row["pod"] for row in out["items"]] == ["new-once", "old-high"]
+        assert out["items"][0]["last_restart_time"] == recent.isoformat()
+        assert out["items"][0]["restart_count"] == 1
+        assert out["items"][1]["restart_count"] == 30000
+
+    def test_top_n_truncates(self, core):
+        t1 = datetime(2026, 9, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 9, 2, tzinfo=timezone.utc)
+        t3 = datetime(2026, 9, 3, tzinfo=timezone.utc)
+        core.list_pod_for_all_namespaces.return_value = _items(
+            [
+                _pod(name="a", cstatuses=[_cstatus(restart_count=1, state=_state(running=SimpleNamespace(started_at=t1)))]),
+                _pod(name="b", cstatuses=[_cstatus(restart_count=1, state=_state(running=SimpleNamespace(started_at=t2)))]),
+                _pod(name="c", cstatuses=[_cstatus(restart_count=1, state=_state(running=SimpleNamespace(started_at=t3)))]),
+            ]
+        )
+        out = json.loads(d.get_recently_restarted_kubernetes_pods.invoke({"top_n": 2, "config": {}}))
+        assert [row["pod"] for row in out["items"]] == ["c", "b"]
+
+    def test_string_top_n_is_coerced(self, core):
+        ts = datetime(2026, 9, 3, tzinfo=timezone.utc)
+        core.list_pod_for_all_namespaces.return_value = _items(
+            [_pod(cstatuses=[_cstatus(restart_count=1, state=_state(running=SimpleNamespace(started_at=ts)))])]
+        )
+        out = json.loads(d.get_recently_restarted_kubernetes_pods.func(top_n="10", config={}))
+        assert len(out["items"]) == 1
+
+    def test_restart_count_zero_skipped(self, core):
+        ts = datetime(2026, 9, 3, tzinfo=timezone.utc)
+        core.list_pod_for_all_namespaces.return_value = _items(
+            [_pod(cstatuses=[_cstatus(restart_count=0, ready=True, state=_state(running=SimpleNamespace(started_at=ts)))])]
+        )
+        out = json.loads(d.get_recently_restarted_kubernetes_pods.invoke({"config": {}}))
+        assert out["items"] == []
+
+    def test_missing_timestamp_skipped(self, core):
+        core.list_pod_for_all_namespaces.return_value = _items([_pod(cstatuses=[_cstatus(restart_count=9)])])
+        out = json.loads(d.get_recently_restarted_kubernetes_pods.invoke({"config": {}}))
+        assert out["items"] == []
+
+    def test_crashloop_uses_last_state_finished_at(self, core):
+        finished = datetime(2026, 9, 3, 10, tzinfo=timezone.utc)
+        cs = _cstatus(
+            restart_count=12,
+            ready=False,
+            state=_state(waiting=SimpleNamespace(reason="CrashLoopBackOff", message="back-off")),
+            last_state=SimpleNamespace(terminated=SimpleNamespace(reason="Error", exit_code=1, finished_at=finished, message="boom")),
+        )
+        core.list_pod_for_all_namespaces.return_value = _items([_pod(name="crashy", ns="prod", cstatuses=[cs])])
+        out = json.loads(d.get_recently_restarted_kubernetes_pods.invoke({"config": {}}))
+        assert out["items"][0]["pod"] == "crashy"
+        assert out["items"][0]["namespace"] == "prod"
+        assert out["items"][0]["container"] == "app"
+        assert out["items"][0]["last_restart_time"] == finished.isoformat()
+        assert out["items"][0]["restart_count"] == 12
+
+    def test_init_container_restart_included(self, core):
+        ts = datetime(2026, 9, 3, tzinfo=timezone.utc)
+        init_cs = _cstatus(name="init", restart_count=2, state=_state(running=SimpleNamespace(started_at=ts)))
+        core.list_pod_for_all_namespaces.return_value = _items([_pod(cstatuses=[], init_cstatuses=[init_cs])])
+        out = json.loads(d.get_recently_restarted_kubernetes_pods.invoke({"config": {}}))
+        assert out["items"][0]["container"] == "init"
+        assert out["items"][0]["restart_count"] == 2
+
+    def test_namespace_filter(self, core):
+        ts = datetime(2026, 9, 3, tzinfo=timezone.utc)
+        core.list_namespaced_pod.return_value = _items(
+            [_pod(name="nacos-0", ns="nacos", cstatuses=[_cstatus(restart_count=2, state=_state(running=SimpleNamespace(started_at=ts)))])]
+        )
+        out = json.loads(d.get_recently_restarted_kubernetes_pods.invoke({"namespace": "nacos", "config": {}}))
+        assert out["items"][0]["pod"] == "nacos-0"
+        core.list_namespaced_pod.assert_called_once_with("nacos")
+
+    def test_api_exception_wrapped(self, core):
+        core.list_pod_for_all_namespaces.side_effect = ApiException(status=500)
+        out = json.loads(d.get_recently_restarted_kubernetes_pods.invoke({"config": {}}))
+        assert "error" in out
+
+
 class TestNodeCapacity:
     def test_percentages_computed(self, core):
         node = SimpleNamespace(
@@ -325,6 +425,31 @@ class TestDiagnosePod:
         vol_types = {v["name"]: v["type"] for v in out["volumes"]}
         assert vol_types == {"v1": "pvc", "v2": "hostpath"}
         assert out["recent_events"][0]["reason"] == "BackOff"
+        assert out["containers"][0]["last_state"] == {}
+        assert out["init_containers"][0]["last_state"] == {}
+
+    def test_includes_last_state_from_previous_termination(self, core):
+        ts = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        running_cs = _cstatus(
+            name="app",
+            ready=True,
+            restart_count=12,
+            state=_state(running=SimpleNamespace(started_at=ts)),
+            last_state=SimpleNamespace(
+                terminated=SimpleNamespace(reason="OOMKilled", exit_code=137, finished_at=ts, message="memory limit exceeded")
+            ),
+        )
+        core.read_namespaced_pod.return_value = _pod(name="px", cstatuses=[running_cs])
+        core.list_namespaced_event.return_value = _items([])
+
+        out = json.loads(d.diagnose_kubernetes_pod_issues.invoke({"namespace": "default", "pod_name": "px", "config": {}}))
+        assert out["containers"][0]["restart_count"] == 12
+        assert out["containers"][0]["last_state"] == {
+            "reason": "OOMKilled",
+            "exit_code": 137,
+            "finished_at": ts.isoformat(),
+            "message": "memory limit exceeded",
+        }
 
     def test_recent_events_sort_handles_aware_and_missing_timestamps(self, core):
         older = datetime(2024, 1, 1, tzinfo=timezone.utc)

--- a/server/apps/opspilot/tests/test_tools_k8s_resources_ext_service.py
+++ b/server/apps/opspilot/tests/test_tools_k8s_resources_ext_service.py
@@ -240,11 +240,11 @@ class TestPreviousPodLogs:
         core.read_namespaced_pod_log.return_value = "panic: boom\nstack trace"
         out = res.get_kubernetes_previous_pod_logs.invoke({"namespace": "ns", "pod_name": "p1", "config": {}})
         assert "panic: boom" in out
-        # previous=True 必须传入
+        # previous=True 必须传入；默认不限窗，避免 sinceSeconds 误杀昨日崩溃日志
         _, kwargs = core.read_namespaced_pod_log.call_args
         assert kwargs["previous"] is True
         assert kwargs["container"] == "app"
-        assert kwargs["since_seconds"] == 24 * 3600
+        assert "since_seconds" not in kwargs
 
     def test_string_lines_and_tail_are_coerced(self, apis):
         core, _, _ = apis
@@ -261,6 +261,19 @@ class TestPreviousPodLogs:
         core.read_namespaced_pod_log.return_value = ""
         out = res.get_kubernetes_previous_pod_logs.invoke({"namespace": "ns", "pod_name": "p1", "config": {}})
         assert "没有上一次实例的日志" in out
+        assert "滚动窗口" not in out
+
+    def test_empty_previous_logs_with_hours_window(self, apis):
+        core, _, _ = apis
+        core.read_namespaced_pod.return_value = self._pod([SimpleNamespace(name="app")])
+        core.read_namespaced_pod_log.return_value = ""
+        out = res.get_kubernetes_previous_pod_logs.func(namespace="ns", pod_name="p1", hours=24, config={})
+        assert "近 24 小时滚动窗口内没有 previous 日志" in out
+        assert "不传 hours" in out
+        assert "没有上一次实例的日志" not in out
+        assert "没有可用的 previous 日志" not in out
+        _, kwargs = core.read_namespaced_pod_log.call_args
+        assert kwargs["since_seconds"] == 24 * 3600
 
     def test_no_previous_terminated_container(self, apis):
         core, _, _ = apis


### PR DESCRIPTION
新增 get_recently_restarted_kubernetes_pods，按 last_restart_time 取 Top-N；已知 Pod 死因走 last_state 与 previous 日志。规划器把「按重启时间」从 get_high_restart 改写到新工具。