### PR TITLE
style(监控): 统一优化监控仪表盘视觉与布局

### DIFF
--- a/web/src/app/monitor/components/monitor-dashboard-widgets/collection-status-card.tsx
+++ b/web/src/app/monitor/components/monitor-dashboard-widgets/collection-status-card.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { Tooltip } from 'antd';
+import { ApiOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import type { CollectionStatusResult } from '@/app/monitor/components/monitor-dashboard-widgets/types';
 import { COLLECTION_STATUS_LEGEND } from '@/app/monitor/components/monitor-dashboard-widgets/runtime';
@@ -28,14 +29,34 @@ export interface CollectionStatusCardStyles extends GuideTooltipStyles {
   statCard?: string;
   collectionStatusCard?: string;
   collectionStatusHeader?: string;
+  statHeader?: string;
   statLabel?: string;
   statTitleWithGuide?: string;
+  statIcon?: string;
+  collectionStatusHeaderIcon?: string;
+  collectionStatusHeaderIconSuccess?: string;
+  collectionStatusHeaderIconWarning?: string;
+  collectionStatusHeaderIconError?: string;
+  collectionStatusHeaderIconEmpty?: string;
+  collectionStatusPulseDot?: string;
   collectionStatusBody?: string;
   collectionStatusValue?: string;
   collectionStatusValueSuccess?: string;
   collectionStatusValueWarning?: string;
   collectionStatusValueError?: string;
   collectionStatusValueEmpty?: string;
+  collectionStatusHeadlineRow?: string;
+  collectionStatusPill?: string;
+  collectionStatusPillDot?: string;
+  collectionStatusPillText?: string;
+  collectionStatusPillSuccess?: string;
+  collectionStatusPillWarning?: string;
+  collectionStatusPillError?: string;
+  collectionStatusPillEmpty?: string;
+  collectionStatusAvailability?: string;
+  collectionStatusAvailabilityVal?: string;
+  collectionStatusAvailabilityLabel?: string;
+  collectionStatusSubMeta?: string;
   collectionStatusTimelineBlock?: string;
   collectionStatusTimelineTitle?: string;
   collectionStatusTimelineHint?: string;
@@ -46,6 +67,9 @@ export interface CollectionStatusCardStyles extends GuideTooltipStyles {
   collectionStatusSegmentError?: string;
   collectionStatusSegmentEmpty?: string;
   collectionStatusTimelineEmpty?: string;
+  collectionStatusTimelineFooter?: string;
+  collectionStatusTimelineScaleRow?: string;
+  collectionStatusTimelineScale?: string;
   collectionStatusLegend?: string;
   collectionStatusLegendItem?: string;
   collectionStatusLegendDot?: string;
@@ -85,6 +109,13 @@ const getStatusTone = (
   return 'empty';
 };
 
+const resolveToneSuffix = (tone: CollectionStatusTone): string => {
+  if (tone === 'success') return 'Success';
+  if (tone === 'warning') return 'Warning';
+  if (tone === 'error') return 'Error';
+  return 'Empty';
+};
+
 const formatSegmentTooltip = (segment: CollectionStatusTimelineSegment): string => {
   const label = TONE_LABEL[segment.tone];
   if (
@@ -104,15 +135,8 @@ const resolveSegmentClass = (
   tone: CollectionStatusTone,
   styles: CollectionStatusCardStyles
 ): string => {
-  const suffix =
-    tone === 'success'
-      ? 'Success'
-      : tone === 'warning'
-        ? 'Warning'
-        : tone === 'error'
-          ? 'Error'
-          : 'Empty';
-  return `${styles.collectionStatusSegment} ${styles[`collectionStatusSegment${suffix}` as keyof CollectionStatusCardStyles] || ''}`;
+  const suffix = resolveToneSuffix(tone);
+  return `${styles.collectionStatusSegment || ''} ${styles[`collectionStatusSegment${suffix}` as keyof CollectionStatusCardStyles] || ''}`.trim();
 };
 
 export const CollectionStatusCard = ({
@@ -130,11 +154,28 @@ export const CollectionStatusCard = ({
     },
   ],
   legendItems = COLLECTION_STATUS_LEGEND,
-  emptyTimelineText,
+  emptyTimelineText = '暂无状态时间线数据',
   className,
   styles,
 }: CollectionStatusCardProps) => {
   const resolvedStatusTone = getStatusTone(status, statusTone);
+  const toneSuffix = resolveToneSuffix(resolvedStatusTone);
+
+  const scaleRange = React.useMemo(() => {
+    if (timeline.length < 2) return null;
+    const first = timeline[0];
+    const last = timeline[timeline.length - 1];
+    if (!Number.isFinite(first?.startMs) || !Number.isFinite(last?.endMs)) return null;
+
+    const startText = dayjs(first.startMs).format('HH:mm');
+    const now = Date.now();
+    const isNearNow = Math.abs(now - last.endMs) < 120_000;
+    const endText = isNearNow ? '刚刚' : dayjs(last.endMs).format('HH:mm');
+
+    return { startText, endText };
+  }, [timeline]);
+
+  const headerClass = styles.collectionStatusHeader || styles.statHeader;
 
   return (
     <div
@@ -142,7 +183,7 @@ export const CollectionStatusCard = ({
         .filter(Boolean)
         .join(' ')}
     >
-      <div className={styles.collectionStatusHeader}>
+      <div className={headerClass}>
         <div className={styles.statLabel}>
           <TitleWithGuide
             title={title}
@@ -151,35 +192,57 @@ export const CollectionStatusCard = ({
             styles={styles}
           />
         </div>
-      </div>
-      <div className={styles.collectionStatusBody}>
         <div
-          className={`${styles.collectionStatusValue} ${
-            styles[
-              `collectionStatusValue${
-                resolvedStatusTone === 'success'
-                  ? 'Success'
-                  : resolvedStatusTone === 'warning'
-                    ? 'Warning'
-                    : resolvedStatusTone === 'error'
-                      ? 'Error'
-                      : 'Empty'
-              }`
-            ]
-          }`}
+          className={[
+            styles.statIcon,
+            styles.collectionStatusHeaderIcon,
+            styles[`collectionStatusHeaderIcon${toneSuffix}` as keyof CollectionStatusCardStyles],
+            'relative flex items-center justify-center shrink-0 w-[30px] h-[30px] rounded-[8px]'
+          ].filter(Boolean).join(' ')}
+          aria-hidden="true"
         >
-          {status.label}
+          <span
+            className={[
+              styles.collectionStatusPulseDot,
+              'absolute top-1 right-1 w-1.5 h-1.5 rounded-full'
+            ].filter(Boolean).join(' ')}
+          />
+          <ApiOutlined className="text-[14px]" />
         </div>
-        <div className={styles.collectionStatusTimelineTitle}>
-          <span>{timelineTitle}</span>
-          {timelineHint ? (
-            <span className={styles.collectionStatusTimelineHint}>{timelineHint}</span>
-          ) : null}
+      </div>
+
+      <div className={[styles.collectionStatusBody, 'flex flex-col flex-1 min-h-0'].filter(Boolean).join(' ')}>
+        <div className={[styles.collectionStatusHeadlineRow, 'flex items-center gap-2 flex-wrap min-h-[28px]'].filter(Boolean).join(' ')}>
+          <div
+            className={[
+              styles.collectionStatusPill,
+              styles[`collectionStatusPill${toneSuffix}` as keyof CollectionStatusCardStyles],
+              'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[13px] font-semibold border transition-all'
+            ].filter(Boolean).join(' ')}
+          >
+            <span
+              className={[
+                styles.collectionStatusPillDot,
+                'w-[7px] h-[7px] rounded-full shrink-0'
+              ].filter(Boolean).join(' ')}
+            />
+            <span className={styles.collectionStatusPillText}>{status.label}</span>
+          </div>
         </div>
-        <div className={styles.collectionStatusTimelineBlock}>
+
+        <div className={[styles.collectionStatusTimelineBlock, 'mt-auto flex flex-col gap-1.5 pt-1.5'].filter(Boolean).join(' ')}>
+          <div className={[styles.collectionStatusTimelineTitle, 'flex items-center justify-between gap-2 text-[11px] font-medium text-[var(--color-text-3)]'].filter(Boolean).join(' ')}>
+            <span>{timelineTitle}</span>
+            {timelineHint ? (
+              <span className={[styles.collectionStatusTimelineHint, 'shrink-0 text-[11px] text-[var(--color-text-4)]'].filter(Boolean).join(' ')}>
+                {timelineHint}
+              </span>
+            ) : null}
+          </div>
+
           {timeline.length > 0 ? (
             <>
-              <div className={styles.collectionStatusTimeline}>
+              <div className={[styles.collectionStatusTimeline, 'grid grid-cols-[repeat(18,minmax(0,1fr))] gap-[3px] items-center py-0.5'].filter(Boolean).join(' ')}>
                 {timeline.map((segment, index) => (
                   <Tooltip
                     key={`${segment.tone}-${segment.startMs ?? index}-${index}`}
@@ -189,24 +252,42 @@ export const CollectionStatusCard = ({
                       </span>
                     }
                   >
-                    <span className={resolveSegmentClass(segment.tone, styles)} />
+                    <span
+                      className={[
+                        resolveSegmentClass(segment.tone, styles),
+                        'block w-full h-2 rounded-[4px] cursor-pointer transition-transform hover:scale-y-125'
+                      ].filter(Boolean).join(' ')}
+                    />
                   </Tooltip>
                 ))}
               </div>
-              <div className={styles.collectionStatusLegend}>
-                {legendItems.map((item) => (
-                  <span key={item.key} className={styles.collectionStatusLegendItem}>
-                    <span
-                      className={styles.collectionStatusLegendDot}
-                      style={{ background: item.color }}
-                    />
-                    {item.label}
+
+              <div className={[styles.collectionStatusTimelineFooter, 'flex flex-col gap-1.5 pt-0.5 text-[11px] text-[var(--color-text-4)] leading-none'].filter(Boolean).join(' ')}>
+                <div className={[styles.collectionStatusTimelineScaleRow, 'flex items-center justify-between gap-2 min-w-0'].filter(Boolean).join(' ')}>
+                  <span className={[styles.collectionStatusTimelineScale, 'tabular-nums whitespace-nowrap text-[11px] text-[var(--color-text-4)]'].filter(Boolean).join(' ')}>
+                    {scaleRange?.startText || ''}
                   </span>
-                ))}
+                  <span className={[styles.collectionStatusTimelineScale, 'tabular-nums whitespace-nowrap text-[11px] text-[var(--color-text-4)]'].filter(Boolean).join(' ')}>
+                    {scaleRange?.endText || ''}
+                  </span>
+                </div>
+                <div className={[styles.collectionStatusLegend, 'flex items-center gap-2 whitespace-nowrap text-[11px] text-[var(--color-text-3)]'].filter(Boolean).join(' ')}>
+                  {legendItems.map((item) => (
+                    <span key={item.key} className={[styles.collectionStatusLegendItem, 'inline-flex items-center gap-1 text-[11px]'].filter(Boolean).join(' ')}>
+                      <span
+                        className={[styles.collectionStatusLegendDot, 'w-1.5 h-1.5 rounded-full shrink-0'].filter(Boolean).join(' ')}
+                        style={{ background: item.color }}
+                      />
+                      {item.label}
+                    </span>
+                  ))}
+                </div>
               </div>
             </>
           ) : emptyTimelineText ? (
-            <div className={styles.collectionStatusTimelineEmpty}>{emptyTimelineText}</div>
+            <div className={[styles.collectionStatusTimelineEmpty, 'py-2 text-center text-[12px] text-[var(--color-text-3)]'].filter(Boolean).join(' ')}>
+              {emptyTimelineText}
+            </div>
           ) : (
             <div className={styles.collectionStatusTimeline} />
           )}

--- a/web/src/app/monitor/dashboards/objects/active-directory/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/active-directory/dashboard.tsx
@@ -59,7 +59,7 @@ export default function ActiveDirectoryDashboardPage() {
       styles={styles}
       dashboardContent={
         <>
-          <div className={styles.sectionLabel}>域控健康概览</div>
+          <div className={styles.sectionLabel}>健康概览</div>
           <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={6} styles={styles} />
 
           <div className={styles.sectionLabel}>LDAP 认证与目录服务</div>

--- a/web/src/app/monitor/dashboards/objects/common/dashboard-components.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/dashboard-components.tsx
@@ -203,10 +203,13 @@ export const SummaryStatCard = ({ summaryCard, className, styles }: SummaryStatC
       value={mainValue.value}
       unit={mainValue.unit}
       icon={getIcon(card.icon)}
-      iconStyle={{ background: `${valueColor ?? card.color}1f`, color: valueColor ?? card.color }}
+      iconStyle={{ background: `${valueColor ?? card.color}1c`, color: valueColor ?? card.color }}
       color={valueColor ?? card.color}
       footer={footerItems.map((item) => (
-        <span key={item.label}>{item.label} {item.value}</span>
+        <span key={item.label} className={styles.statMetaItem}>
+          <span className={styles.statMetaLabel}>{item.label}</span>
+          <span className={styles.statMetaValue}>{item.value}</span>
+        </span>
       ))}
       compare={compare}
       compareFavorableDirection={card.compareFavorableDirection}

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
@@ -553,6 +553,14 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
     if (!silent) setLoading(true);
     try {
       if (displayMode === 'dashboard') {
+        // 侧栏切换对象时 URL 会短暂缺少 instance_id；身份未就绪前不发指标请求，避免空打与刷屏。
+        if (!idValues.length) {
+          setSeries({});
+          setPreviousSeries({});
+          setCollectionStatusMetric(null);
+          if (!silent) setLoading(false);
+          return;
+        }
         // 本次刷新冻结一个绝对时间窗,所有序列(含 KPI/采集状态/趋势/对比)复用,
         // 避免每条序列各自现算 now 导致时间戳网格错位、多序列面板 tooltip 只显示一条。
         const frozenTimeValues = freezeTimeValues(timeValues);

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard.module.scss
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard.module.scss
@@ -5,15 +5,41 @@
   // min-height:100% 保证内容不足时背景铺满,内容超出时由 .content 单一滚动条接管。
   min-height: 100%;
   width: 100%;
-  background: linear-gradient(180deg, #f6f8fc 0%, #f5f7fb 100%);
-  color: #22324a;
+  background: var(--color-background-body);
+  color: var(--color-text-1);
   font-family: Inter, 'PingFang SC', 'Microsoft YaHei', sans-serif;
 }
 
 .shell {
   width: 100%;
-  padding: 18px 20px 28px;
+  padding: 16px 20px 24px;
   box-sizing: border-box;
+}
+
+// 区块小标题：各对象盘复用，避免每盘复制硬编码灰字。
+.sectionLabel {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 16px 2px 10px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--color-text-1);
+}
+
+.sectionLabel::before {
+  content: '';
+  display: inline-block;
+  width: 3px;
+  height: 12px;
+  border-radius: 2px;
+  background: var(--color-primary);
+  flex-shrink: 0;
+}
+
+.dashboardSection + .sectionLabel {
+  margin-top: 22px;
 }
 
 .page :global(.ant-spin-nested-loading),
@@ -24,8 +50,18 @@
 .pageHeader {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  margin-bottom: 12px;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding: 16px 20px 14px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  box-shadow: 0 1px 3px 0 rgba(15, 23, 42, 0.03), 0 1px 2px -1px rgba(15, 23, 42, 0.02);
+  transition: border-color 0.15s ease;
+}
+
+.pageHeader:hover {
+  border-color: color-mix(in srgb, var(--color-primary) 18%, var(--color-border));
 }
 
 .protocolBar {
@@ -86,24 +122,30 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  min-height: 32px;
 }
 
 .titleBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
   min-width: 0;
   flex: 1;
 }
 
 .breadcrumb {
-  margin-bottom: 4px;
+  margin-bottom: 0;
   font-size: 12px;
+  line-height: 1.4;
 }
 
 .title {
   margin: 0;
-  color: #182132;
-  font-size: 28px;
+  color: var(--color-text-1);
+  font-size: 22px;
   font-weight: 700;
-  line-height: 1.15;
+  line-height: 1.25;
+  letter-spacing: -0.02em;
 }
 
 .controlsWrap {
@@ -260,12 +302,13 @@
 .toolbarBackBtn {
   height: 32px !important;
   padding-inline: 12px !important;
-  border-radius: 8px !important;
-  font-size: 13px;
+  border-radius: 6px !important;
+  font-size: 12px;
   font-weight: 500;
   color: var(--color-text-2) !important;
-  border-color: var(--color-border) !important;
+  border: 1px solid var(--color-border) !important;
   background: var(--color-bg) !important;
+  transition: all 0.15s ease;
 }
 
 .toolbarBackBtn:hover {
@@ -278,9 +321,11 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: 6px 0 8px;
-  border-bottom: 1px solid var(--color-border);
+  gap: 16px;
+  padding-top: 12px;
+  padding-bottom: 0;
+  border-top: 1px solid var(--color-border-1);
+  border-bottom: none;
   min-width: 0;
 }
 
@@ -293,34 +338,37 @@
 }
 
 .instanceIcon {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
+  width: 38px;
+  height: 38px;
+  border-radius: 8px;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #27c274;
-  font-size: 20px;
+  color: var(--color-primary);
+  font-size: 19px;
   flex-shrink: 0;
-  background: linear-gradient(135deg, #effdf5 0%, #f6fffb 100%);
-  box-shadow: inset 0 0 0 1px rgba(39, 194, 116, 0.12);
+  background: color-mix(in srgb, var(--color-primary) 10%, var(--color-bg));
+  border: none;
+  box-shadow: none;
 }
 
 .meta {
   display: flex;
-  align-items: center;
-  gap: 6px 10px;
+  align-items: baseline;
+  gap: 4px;
   flex-wrap: wrap;
-  color: #5d7090;
+  color: var(--color-text-3);
   min-width: 0;
 }
 
 .instanceName {
-  color: #182132;
+  color: var(--color-text-1);
   font-size: 18px;
   font-weight: 700;
-  line-height: 1.22;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
   word-break: break-word;
+  margin-right: 4px;
 }
 
 .instanceInfo {
@@ -332,7 +380,7 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 12px;
+  gap: 8px;
   flex-shrink: 0;
   min-width: 0;
 }
@@ -340,21 +388,31 @@
 .instanceSelectorField {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   min-width: 0;
 }
 
 .instanceSelectorLabel {
   color: var(--color-text-3);
-  font-size: 13px;
-  font-weight: 400;
+  font-size: 12px;
+  font-weight: 500;
   white-space: nowrap;
   flex-shrink: 0;
 }
 
 .instanceMetaInline {
-  color: var(--color-text-2);
+  color: var(--color-text-3);
   font-size: 13px;
+  font-weight: 400;
+  line-height: 1.4;
+  background: transparent;
+  border: none;
+  padding: 0;
+  white-space: nowrap;
+}
+
+.instanceMetaInline:first-of-type {
+  color: var(--color-text-2);
   font-weight: 500;
 }
 
@@ -369,6 +427,7 @@
   color: var(--color-text-4);
   font-size: 14px;
   font-weight: 700;
+  margin: 0 3px;
 }
 
 // 次要环境信息（实例ID、时区等）：弱化为浅灰常规字重。
@@ -381,11 +440,16 @@
 }
 
 .inlineInstanceSelector {
-  width: 190px;
-  padding: 0 10px;
-  border-radius: 8px;
+  width: 170px;
+  padding: 0 8px;
+  border-radius: 6px;
   background: var(--color-bg);
   border: 1px solid var(--color-border);
+  transition: border-color 0.15s ease;
+}
+
+.inlineInstanceSelector:hover {
+  border-color: var(--color-primary);
 }
 
 .inlineInstanceSelector :global(.ant-select-selector) {
@@ -435,16 +499,23 @@
 
 .statCard,
 .panel {
-  background: #ffffff;
-  border: 1px solid #e4ebf3;
-  border-radius: 14px;
-  box-shadow: 0 4px 16px rgba(18, 34, 66, 0.04);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  box-shadow: 0 1px 3px 0 rgba(15, 23, 42, 0.04), 0 1px 2px -1px rgba(15, 23, 42, 0.02);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.statCard:hover,
+.panel:hover {
+  border-color: color-mix(in srgb, var(--color-primary) 22%, var(--color-border));
+  box-shadow: 0 4px 12px -2px rgba(15, 23, 42, 0.06), 0 2px 4px -2px rgba(15, 23, 42, 0.02);
 }
 
 .statCard {
   // 收紧卡高:内容自然高度即可,sparkline 由 margin-top:auto 钉底,不再被强行拉空。
-  min-height: 168px;
-  padding: 16px 16px 14px;
+  min-height: 156px;
+  padding: 14px 14px 12px;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -455,57 +526,57 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: 8px;
-  min-height: 32px;
+  min-height: 28px;
 }
 
 .statLabel {
-  color: #334861;
-  font-size: 15px;
-  font-weight: 700;
-  line-height: 1.3;
+  color: var(--color-text-1);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
 }
 
 .statIcon {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
   display: flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  font-size: 16px;
+  font-size: 15px;
 }
 
 .statBody {
   // 不再 flex:1 + space-between 撑开:内容(值/对比/footer)按自然高度紧凑堆叠在顶部,
   // 余量交给 .miniTrend 的 margin-top:auto 钉到卡底,消除文字之间的大块空白。
-  margin-top: 10px;
+  margin-top: 8px;
   min-height: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
 }
 
 .statValue {
-  font-size: 30px;
+  font-size: 26px;
   font-weight: 700;
-  line-height: 1.08;
-  color: #182132;
-  letter-spacing: -0.03em;
+  line-height: 1.15;
+  color: var(--color-text-1);
+  letter-spacing: -0.02em;
   word-break: break-word;
   display: inline-flex;
   align-items: baseline;
   gap: 4px;
   flex-wrap: wrap;
   font-variant-numeric: tabular-nums;
-  min-height: 40px;
+  min-height: 34px;
 }
 
 .statUnit {
-  margin-left: 0;
-  color: #5d728b;
-  font-size: 14px;
-  font-weight: 500;
+  margin-left: 2px;
+  color: var(--color-text-2);
+  font-size: 13px;
+  font-weight: 600;
   line-height: 1;
 }
 
@@ -515,34 +586,50 @@
   gap: 8px;
   flex-wrap: wrap;
   min-height: 18px;
-  color: #64748b;
-  font-size: 14px;
+  color: var(--color-text-2);
+  font-size: 12px;
   font-weight: 500;
 }
 
 .statComparePositive .statCompareValue {
-  color: #ff4d4f;
+  color: var(--color-fail);
 }
 
 .statCompareNegative .statCompareValue {
-  color: #1fa971;
+  color: var(--color-success);
 }
 
 .statCompareFlat .statCompareValue {
-  color: #7e90a7;
+  color: var(--color-text-4);
 }
 
 .statMeta {
   display: flex;
   align-items: center;
-  gap: 6px 10px;
+  gap: 8px 12px;
   flex-wrap: wrap;
-  color: #64748b;
-  font-size: 14px;
-  line-height: 1.5;
-  // 仅按内容占高(单行约 22px,多行自动撑高),不再预留 44px 造成卡内空白。
-  min-height: 22px;
+  font-size: 11px;
+  line-height: 1.4;
+  // 仅按内容占高,不再预留过多高度。
+  min-height: 18px;
   align-content: flex-start;
+}
+
+.statMetaItem {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.statMetaLabel {
+  color: var(--color-text-3);
+  font-weight: 400;
+}
+
+.statMetaValue {
+  color: var(--color-text-2);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
 }
 
 .miniTrend {
@@ -575,26 +662,26 @@
   grid-template-columns: auto auto minmax(0, 1fr);
   gap: 8px;
   align-items: center;
-  min-height: 48px;
-  padding: 10px 12px;
-  border-radius: 10px;
-  background: #f8fbff;
-  border: 1px solid #edf2f9;
+  min-height: 40px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  background: var(--color-fill-1);
+  border: 1px solid var(--color-border);
 }
 
 .uptimeStatusDot {
-  width: 9px;
-  height: 9px;
+  width: 8px;
+  height: 8px;
   border-radius: 999px;
-  background: #94a3b8;
-  box-shadow: 0 0 0 4px rgba(148, 163, 184, 0.12);
+  background: var(--color-text-4);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-text-4) 16%, transparent);
 }
 
 .uptimeStatusMain {
-  color: #31445c;
-  font-size: 13px;
-  font-weight: 800;
-  line-height: 1.2;
+  color: var(--color-text-2);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.3;
 }
 
 .uptimeStatusMainWrap {
@@ -604,18 +691,36 @@
   min-width: 0;
 }
 
+.uptimeStatusSuccess {
+  background: color-mix(in srgb, var(--color-success) 6%, var(--color-bg));
+  border-color: color-mix(in srgb, var(--color-success) 24%, var(--color-border));
+}
+
+.uptimeStatusSuccess .uptimeStatusMain {
+  color: var(--color-success);
+}
+
 .uptimeStatusSuccess .uptimeStatusDot {
-  background: #22c55e;
-  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.12);
+  background: var(--color-success);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-success) 18%, transparent);
+}
+
+.uptimeStatusWarning {
+  background: color-mix(in srgb, var(--color-warning, #faad14) 7%, var(--color-bg));
+  border-color: color-mix(in srgb, var(--color-warning, #faad14) 26%, var(--color-border));
+}
+
+.uptimeStatusWarning .uptimeStatusMain {
+  color: var(--color-warning, #faad14);
 }
 
 .uptimeStatusWarning .uptimeStatusDot {
-  background: #faad14;
-  box-shadow: 0 0 0 4px rgba(250, 173, 20, 0.14);
+  background: var(--color-warning, #faad14);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-warning, #faad14) 18%, transparent);
 }
 
 .uptimeStatusEmpty .uptimeStatusMain {
-  color: #64748b;
+  color: var(--color-text-3);
 }
 
 .miniTrendPlaceholder {
@@ -624,51 +729,168 @@
 }
 
 .collectionStatusCard {
+  // 与同排 StatCard 等高由 grid stretch 对齐；内容高度跟随共享壳。
   justify-content: flex-start;
-  min-height: 168px;
+  min-height: 122px;
 }
 
 .collectionStatusHeader {
-  min-height: 32px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 28px;
+}
+
+.collectionStatusHeaderIcon {
+  position: relative;
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  font-size: 14px;
+  border: none;
+  box-shadow: none;
+  transition: all 0.2s ease;
+}
+
+.collectionStatusHeaderIconSuccess {
+  background: color-mix(in srgb, var(--color-success) 12%, transparent);
+  color: var(--color-success);
+}
+
+.collectionStatusHeaderIconWarning {
+  background: color-mix(in srgb, var(--color-warning, #faad14) 12%, transparent);
+  color: var(--color-warning, #faad14);
+}
+
+.collectionStatusHeaderIconError {
+  background: color-mix(in srgb, var(--color-fail) 12%, transparent);
+  color: var(--color-fail);
+}
+
+.collectionStatusHeaderIconEmpty {
+  background: var(--color-fill-2);
+  color: var(--color-text-4);
+}
+
+.collectionStatusPulseDot {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.collectionStatusHeaderIconSuccess .collectionStatusPulseDot {
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-success) 60%, transparent);
+  animation: collectionStatusPulse 2s infinite ease-out;
+}
+
+@keyframes collectionStatusPulse {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-success) 60%, transparent);
+  }
+  70% {
+    box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-success) 0%, transparent);
+  }
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-success) 0%, transparent);
+  }
 }
 
 .collectionStatusBody {
-  // 由 3 等高行(把每块拉开)改为自然高度紧凑堆叠,文字之间只留固定小间距。
   display: flex;
   flex-direction: column;
   flex: 1;
-  gap: 10px;
   min-height: 0;
+  gap: 4px;
 }
 
-.collectionStatusValue {
-  margin-top: 0;
-  font-size: 30px;
-  font-weight: 700;
-  line-height: 1.05;
-  letter-spacing: -0.03em;
-  min-height: 40px;
+.collectionStatusHeadlineRow {
   display: flex;
   align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  min-height: 28px;
 }
 
-.collectionStatusValueSuccess {
-  color: #22c55e;
+.collectionStatusPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  border-radius: 9999px;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
+  border: 1px solid transparent;
 }
 
-.collectionStatusValueError {
-  color: #ff4d4f;
+.collectionStatusPillDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
 }
 
-.collectionStatusValueEmpty {
-  color: #94a3b8;
+.collectionStatusPillSuccess {
+  background: color-mix(in srgb, var(--color-success) 10%, var(--color-bg));
+  color: var(--color-success);
+  border-color: color-mix(in srgb, var(--color-success) 24%, transparent);
+}
+
+.collectionStatusPillSuccess .collectionStatusPillDot {
+  background: var(--color-success);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-success) 22%, transparent);
+}
+
+.collectionStatusPillError {
+  background: color-mix(in srgb, var(--color-fail) 10%, var(--color-bg));
+  color: var(--color-fail);
+  border-color: color-mix(in srgb, var(--color-fail) 24%, transparent);
+}
+
+.collectionStatusPillError .collectionStatusPillDot {
+  background: var(--color-fail);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-fail) 22%, transparent);
+}
+
+.collectionStatusPillWarning {
+  background: color-mix(in srgb, var(--color-warning, #faad14) 10%, var(--color-bg));
+  color: var(--color-warning, #faad14);
+  border-color: color-mix(in srgb, var(--color-warning, #faad14) 24%, transparent);
+}
+
+.collectionStatusPillEmpty {
+  background: var(--color-fill-1);
+  color: var(--color-text-3);
+  border-color: var(--color-border);
+}
+
+.collectionStatusPillEmpty .collectionStatusPillDot {
+  background: var(--color-text-4);
+}
+
+.collectionStatusTimelineBlock {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding-top: 6px;
 }
 
 .collectionStatusTimelineTitle {
   margin-top: 0;
-  color: #536882;
-  font-size: 14px;
-  font-weight: 700;
+  color: var(--color-text-3);
+  font-size: 11px;
+  font-weight: 500;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -677,76 +899,105 @@
 
 .collectionStatusTimelineHint {
   flex-shrink: 0;
-  color: #94a3b8;
-  font-size: 12px;
-  font-weight: 500;
+  color: var(--color-text-4);
+  font-size: 11px;
+  font-weight: 400;
   white-space: nowrap;
-}
-
-
-.collectionStatusTimelineBlock {
-  margin-top: 0;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
 }
 
 .collectionStatusTimeline {
   display: grid;
   grid-template-columns: repeat(18, minmax(0, 1fr));
-  gap: 4px;
-  margin-top: 8px;
+  gap: 3px;
+  align-items: center;
+  padding: 1px 0;
 }
 
 .collectionStatusSegment {
   display: block;
   min-width: 0;
   width: 100%;
-  height: 22px;
+  height: 8px;
   border-radius: 4px;
   border: 1px solid transparent;
-  background: #d7dfeb;
-  cursor: default;
+  background: var(--color-fill-3, var(--color-fill-2));
+  cursor: pointer;
+  transition: transform 0.15s ease, filter 0.15s ease;
+}
+
+.collectionStatusSegment:hover {
+  transform: scaleY(1.4);
+  filter: brightness(1.08);
 }
 
 .collectionStatusSegmentSuccess {
-  background: #22c55e;
-  border-color: #b6f0c8;
+  background: var(--color-success);
+  border-color: color-mix(in srgb, var(--color-success) 35%, transparent);
 }
 
 .collectionStatusSegmentError {
-  background: #ff4d4f;
-  border-color: #ffc3c3;
+  background: var(--color-fail);
+  border-color: color-mix(in srgb, var(--color-fail) 35%, transparent);
+}
+
+.collectionStatusSegmentWarning {
+  background: var(--color-warning, #faad14);
+  border-color: color-mix(in srgb, var(--color-warning, #faad14) 35%, transparent);
+}
+
+.collectionStatusSegmentEmpty {
+  background: var(--color-fill-3, var(--color-fill-2));
+  border-color: transparent;
+}
+
+.collectionStatusTimelineFooter {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--color-text-4);
+  line-height: 1;
+  padding-top: 2px;
+}
+
+.collectionStatusTimelineScaleRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+
+.collectionStatusTimelineScale {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  color: var(--color-text-4);
+  font-size: 11px;
 }
 
 .collectionStatusLegend {
   display: flex;
   align-items: center;
-  // 三项（正常/无数据/异常）必须保持在一行：用 nowrap + 紧凑 gap/字号，
-  // 即便采集状态卡被压到 KPI 最小宽度（200px）也放得下，不再错位换行。
   flex-wrap: nowrap;
-  gap: 10px;
-  margin-top: 8px;
-  color: #42556d;
-  font-size: 13px;
-  font-weight: 700;
+  gap: 8px;
+  min-width: 0;
+  color: var(--color-text-3);
+  font-size: 11px;
+  font-weight: 400;
   white-space: nowrap;
 }
 
-.collectionStatusLegendItem,
-.chartLegendItem {
+.collectionStatusLegendItem {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
 }
 
-.collectionStatusLegendDot,
-.chartLegendDot {
-  width: 14px;
-  height: 14px;
-  border-radius: 4px;
+.collectionStatusLegendDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
   flex-shrink: 0;
-  box-shadow: inset 0 0 0 1px rgba(19, 33, 56, 0.04);
 }
 
 .sectionHeading {
@@ -755,19 +1006,19 @@
 
 .panelTitle {
   margin: 0;
-  color: #1d2f47;
-  font-size: 18px;
+  color: var(--color-text-1);
+  font-size: 16px;
   font-weight: 700;
-  line-height: 1.25;
+  line-height: 1.3;
   letter-spacing: -0.01em;
 }
 
 .panelSubTitle {
-  margin-top: 4px;
-  color: #92a2b5;
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 1.45;
+  margin-top: 2px;
+  color: var(--color-text-3);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.5;
 }
 
 .chartGrid {
@@ -779,7 +1030,7 @@
 
 .panel {
   min-width: 0;
-  padding: 16px;
+  padding: 14px;
   display: flex;
   flex-direction: column;
 }
@@ -834,9 +1085,38 @@
   align-items: center;
   gap: 10px 12px;
   flex-wrap: wrap;
-  color: #8092ad;
+  color: var(--color-text-1);
   font-size: 12px;
-  font-weight: 800;
+  font-weight: 500;
+}
+
+.chartLegendItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--color-text-2);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.chartLegendDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  border: 1px solid transparent;
+}
+
+.chartLegendDash {
+  width: 12px;
+  height: 0;
+  border-radius: 0;
+  border-top-width: 2px;
+  border-top-style: dashed;
+  background: transparent !important;
 }
 
 .chartWrap {
@@ -907,10 +1187,8 @@
   position: absolute;
   inset: 26px;
   border-radius: 999px;
-  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.98) 0%, rgba(249, 251, 255, 0.98) 62%, rgba(241, 246, 252, 0.96) 100%);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.86),
-    inset 0 -8px 18px rgba(162, 178, 198, 0.08);
+  background: var(--color-fill-1);
+  box-shadow: inset 0 0 0 1px var(--color-border);
   pointer-events: none;
   z-index: 0;
 }
@@ -918,7 +1196,7 @@
 .ringCenter {
   text-align: left;
   padding-bottom: 18px;
-  border-bottom: 1px solid #edf2f9;
+  border-bottom: 1px solid var(--color-border);
   min-height: 132px;
   display: flex;
   flex-direction: column;
@@ -941,17 +1219,17 @@
 }
 
 .ringValue {
-  font-size: 22px;
-  font-weight: 800;
-  line-height: 1.1;
-  color: #182132;
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--color-text-1);
   font-variant-numeric: tabular-nums;
 }
 
 .ringCaption {
-  font-size: 13px;
-  color: #7f93ad;
-  font-weight: 600;
+  font-size: 12px;
+  color: var(--color-text-2);
+  font-weight: 500;
   margin-top: 2px;
 }
 
@@ -1003,10 +1281,10 @@
 }
 
 .metricName {
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
-  color: #42556d;
-  line-height: 1.3;
+  color: var(--color-text-1);
+  line-height: 1.4;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1020,15 +1298,15 @@
 }
 
 .metricPercent {
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 700;
-  color: #22324a;
+  color: var(--color-text-1);
   font-variant-numeric: tabular-nums;
 }
 
 .metricCount {
   font-size: 12px;
-  color: #8a9bb5;
+  color: var(--color-text-2);
   font-weight: 500;
   font-variant-numeric: tabular-nums;
 }
@@ -1076,16 +1354,16 @@
 }
 
 .barLabel {
-  color: #42556d;
-  font-size: 14px;
-  font-weight: 700;
-  line-height: 1.3;
+  color: var(--color-text-1);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
 }
 
 .barTrack {
-  height: 10px;
+  height: 8px;
   border-radius: 999px;
-  background: #edf3fb;
+  background: color-mix(in srgb, var(--color-border) 75%, transparent);
   overflow: hidden;
 }
 
@@ -1104,10 +1382,10 @@
 
 .barValue {
   // 数值是焦点:加大加深加粗,条退为配角。
-  color: #22324a;
-  font-size: 16px;
-  font-weight: 800;
-  line-height: 1.2;
+  color: var(--color-text-1);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.3;
   white-space: nowrap;
   font-variant-numeric: tabular-nums;
 }
@@ -1115,41 +1393,42 @@
 // Top-N 强调行:前几名放大(更大字号 / 更高条 / 更大缩略图),拉开与其余名次的视觉层级。
 .barRowEmphasis {
   .barLabel {
-    font-size: 16px;
-    color: #22324a;
+    font-size: 14px;
+    color: var(--color-text-1);
+    font-weight: 600;
   }
 
   .barValue {
-    font-size: 22px;
+    font-size: 18px;
   }
 
   .barTrack {
-    height: 14px;
+    height: 10px;
   }
 
   .barSpark {
-    height: 36px;
+    height: 32px;
   }
 }
 
 /* 分档榜单尾部(rank ≥4):缩小变淡,退为背景,让重点自然浮现。 */
 .barRowMuted {
-  opacity: 0.7;
+  opacity: 0.85;
 
   .barLabel {
-    font-size: 13px;
-    font-weight: 600;
-    color: #8c95a8;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--color-text-2);
   }
 
   .barValue {
-    font-size: 14px;
-    font-weight: 700;
-    color: #6b7688;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--color-text-2);
   }
 
   .barTrack {
-    height: 7px;
+    height: 6px;
   }
 }
 
@@ -1168,34 +1447,34 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 10px 12px;
-  border-radius: 10px;
-  background: #f7f9fc;
-  border: 1px solid #eef2f8;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: var(--color-fill-1);
+  border: 1px solid var(--color-border);
 }
 
 .statusRowOk {
-  background: #f3fcf7;
-  border-color: #d6f0e0;
+  background: color-mix(in srgb, var(--color-success) 8%, var(--color-bg));
+  border-color: color-mix(in srgb, var(--color-success) 22%, var(--color-border));
 }
 
 .statusRowAlarm {
-  background: #fff1f0;
-  border-color: #ffd6d4;
+  background: color-mix(in srgb, var(--color-fail) 8%, var(--color-bg));
+  border-color: color-mix(in srgb, var(--color-fail) 22%, var(--color-border));
 }
 
 .statusRowUnknown {
-  background: #f7f9fc;
-  border-color: #eef2f8;
+  background: var(--color-fill-1);
+  border-color: var(--color-border);
 }
 
 .statusDotUnknown {
-  background: #cbd5e1;
+  background: var(--color-text-4);
 }
 
 .statusBadgeUnknown {
-  color: #64748b;
-  background: #eef2f7;
+  color: var(--color-text-3);
+  background: var(--color-fill-2);
 }
 
 .statusMain {
@@ -1209,24 +1488,24 @@
   width: 8px;
   height: 8px;
   border-radius: 999px;
-  background: #cbd5e1;
+  background: var(--color-text-4);
   flex-shrink: 0;
 }
 
 .statusDotOk {
-  background: #22c55e;
-  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.14);
+  background: var(--color-success);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-success) 16%, transparent);
 }
 
 .statusDotAlarm {
-  background: #ff4d4f;
-  box-shadow: 0 0 0 3px rgba(255, 77, 79, 0.16);
+  background: var(--color-fail);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-fail) 16%, transparent);
 }
 
 .statusLabel {
-  font-size: 14px;
-  font-weight: 700;
-  color: #42556d;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-2);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1234,22 +1513,22 @@
 
 .statusBadge {
   font-size: 12px;
-  font-weight: 800;
-  padding: 2px 10px;
+  font-weight: 600;
+  padding: 2px 8px;
   border-radius: 999px;
   flex-shrink: 0;
-  background: #eef2f7;
-  color: #64748b;
+  background: var(--color-fill-2);
+  color: var(--color-text-3);
 }
 
 .statusBadgeOk {
-  color: #1fa971;
-  background: rgba(34, 197, 94, 0.12);
+  color: var(--color-success);
+  background: color-mix(in srgb, var(--color-success) 12%, transparent);
 }
 
 .statusBadgeAlarm {
-  color: #d4380d;
-  background: rgba(255, 77, 79, 0.14);
+  color: var(--color-fail);
+  background: color-mix(in srgb, var(--color-fail) 12%, transparent);
 }
 
 .detailMetricRow {
@@ -1262,9 +1541,9 @@
   gap: 14px;
   // 行间距交由 detailRowsFill 的 gap 统一管理(与异常信号条一致);去掉分隔线让两类面板缩略图样式统一。
   padding: 0;
-  color: #667b96;
-  font-size: 13px;
-  font-weight: 700;
+  color: var(--color-text-2);
+  font-size: 12px;
+  font-weight: 500;
 }
 
 .snapshotTilesPanel {
@@ -1277,17 +1556,17 @@
 
 .snapshotTilesTitle {
   margin: 0;
-  color: #1d2f47;
+  color: var(--color-text-1);
   font-size: 14px;
-  font-weight: 700;
-  line-height: 1.3;
+  font-weight: 600;
+  line-height: 1.4;
 }
 
 .snapshotTilesSubTitle {
   margin-top: 2px;
-  color: #92a2b5;
+  color: var(--color-text-4);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 400;
   line-height: 1.4;
 }
 
@@ -1300,17 +1579,17 @@
 .snapshotTile {
   min-width: 0;
   padding: 8px 10px;
-  border: 1px solid #e8edf3;
-  border-radius: 10px;
-  background: #f8fafc;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-fill-1);
 }
 
 .snapshotTileLabel {
   margin-bottom: 4px;
   overflow: hidden;
-  color: #8c95a8;
+  color: var(--color-text-3);
   font-size: 11px;
-  font-weight: 600;
+  font-weight: 500;
   line-height: 1.3;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1321,11 +1600,11 @@
   align-items: center;
   gap: 6px;
   min-width: 0;
-  color: #1f3047;
-  font-size: 15px;
-  font-weight: 800;
+  color: var(--color-text-1);
+  font-size: 14px;
+  font-weight: 600;
   font-variant-numeric: tabular-nums;
-  line-height: 1.25;
+  line-height: 1.3;
 }
 
 @media (max-width: 768px) {
@@ -1335,9 +1614,9 @@
 }
 
 .detailMetricValue {
-  color: #1f3047;
-  font-size: 16px;
-  font-weight: 850;
+  color: var(--color-text-1);
+  font-size: 14px;
+  font-weight: 600;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
   // 数值贴右,跨行对齐成一列(无论该行是 sparkline 还是纯文本)。
@@ -1385,7 +1664,7 @@
   width: 100%;
   height: 8px;
   border-radius: 5px;
-  background: #eef2f7;
+  background: var(--color-fill-2);
   overflow: hidden;
 }
 
@@ -1408,9 +1687,9 @@
   display: flex;
   align-items: center;
   min-height: 72px;
-  color: #94a3b8;
-  font-size: 14px;
-  font-weight: 600;
+  color: var(--color-text-4);
+  font-size: 13px;
+  font-weight: 500;
 }
 
 .titleWithGuide {
@@ -1420,14 +1699,14 @@
 }
 
 .metricGuideIcon {
-  color: #8aa0bc;
-  font-size: 14px;
+  color: var(--color-text-4);
+  font-size: 13px;
 }
 
 .metricGuideTooltip,
 .uptimeStatusTooltip {
   max-width: 360px;
-  color: #5d7090;
+  color: var(--color-text-3);
   font-size: 13px;
   line-height: 1.55;
 }
@@ -1445,21 +1724,21 @@
 
 .metricGuideTooltipRow strong,
 .uptimeStatusTooltipRow strong {
-  color: #23344f;
-  font-size: 14px;
+  color: var(--color-text-1);
+  font-size: 13px;
 }
 
 // guide Tooltip 挂载在 body：需全局覆盖 ant-tooltip 默认深色底，避免浅色字色/深色底或深色字/深色底对比失效。
 :global(.ant-tooltip.lightMetricTooltip) :global(.ant-tooltip-inner) {
-  background: #ffffff;
-  color: #44566f;
-  border: 1px solid #dbe6f3;
-  box-shadow: 0 14px 34px rgba(23, 42, 79, 0.12);
+  background: var(--color-bg);
+  color: var(--color-text-2);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 8px 24px color-mix(in srgb, var(--color-text-1) 12%, transparent);
 }
 
 :global(.ant-tooltip.lightMetricTooltip) :global(.ant-tooltip-arrow::before) {
-  background: #ffffff;
-  border: 1px solid #dbe6f3;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
 }
 
 .metricsMode {
@@ -1669,31 +1948,7 @@
   }
 }
 
-:global(html.dark) .page {
-  background: #0c1624;
-  color: #e8eef7;
-}
-
-:global(html.dark) .title,
-:global(html.dark) .instanceName,
-:global(html.dark) .panelTitle,
-:global(html.dark) .detailMetricValue,
-:global(html.dark) .ringValue,
-:global(html.dark) .metricPercent {
-  color: #f2f6fb;
-}
-
-:global(html.dark) .statCard,
-:global(html.dark) .panel {
-  background: #111d2c;
-  border-color: #2b3a4f;
-  box-shadow: none;
-}
-
-:global(html.dark) .instanceCard {
-  border-color: #26364a;
-}
-
+// 暗色：表面色已走语义 token，此处只补仍依赖硬编码/混色的局部。
 :global(html.dark) .modeSegmented {
   background: var(--color-fill-1) !important;
   border-color: var(--color-border);
@@ -1728,118 +1983,22 @@
   border-right: 1px solid var(--color-border) !important;
 }
 
-:global(html.dark) .instanceMetaDivider::before {
-  color: var(--color-text-4);
-}
-
-:global(html.dark) .instanceMetaMuted,
-:global(html.dark) .instanceSelectorLabel {
-  color: var(--color-text-3);
-}
-
-:global(html.dark) .statLabel,
-:global(html.dark) .detailMetricRow,
-:global(html.dark) .detailEmpty,
-:global(html.dark) .panelSubTitle,
-:global(html.dark) .instanceMetaInline,
-:global(html.dark) .chartLegend,
-:global(html.dark) .metricName,
-:global(html.dark) .barLabel,
-:global(html.dark) .barValue {
-  color: #9eb0c8;
-}
-
-:global(html.dark) .barTrack {
-  background: #25344a;
-}
-
-:global(html.dark) .detailBar {
-  background: #25344a;
-}
-
-:global(html.dark) .statusRow {
-  background: rgba(255, 255, 255, 0.04);
-  border-color: rgba(255, 255, 255, 0.08);
-}
-
-:global(html.dark) .statusRowOk {
-  background: rgba(34, 197, 94, 0.1);
-  border-color: rgba(34, 197, 94, 0.22);
-}
-
-:global(html.dark) .statusRowAlarm {
-  background: rgba(255, 77, 79, 0.12);
-  border-color: rgba(255, 77, 79, 0.28);
-}
-
-:global(html.dark) .snapshotTilesTitle {
-  color: #e8eef8;
-}
-
-:global(html.dark) .snapshotTilesSubTitle,
-:global(html.dark) .snapshotTileLabel {
-  color: #9eb0c8;
-}
-
-:global(html.dark) .snapshotTile {
-  background: rgba(255, 255, 255, 0.04);
-  border-color: rgba(255, 255, 255, 0.08);
-}
-
-:global(html.dark) .snapshotTileValue {
-  color: #e8eef8;
-}
-
-:global(html.dark) .statusLabel {
-  color: #9eb0c8;
-}
-
 :global(html.dark) .collectionStatusSegment {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--color-fill-2);
   border-color: transparent;
 }
 
 :global(html.dark) .collectionStatusSegmentSuccess {
-  background: #22c55e;
-  border-color: rgba(162, 243, 196, 0.35);
+  background: var(--color-success);
+  border-color: color-mix(in srgb, var(--color-success) 40%, transparent);
 }
 
 :global(html.dark) .collectionStatusSegmentError {
-  background: #ff4d4f;
-  border-color: rgba(255, 166, 166, 0.28);
+  background: var(--color-fail);
+  border-color: color-mix(in srgb, var(--color-fail) 40%, transparent);
 }
 
-:global(html.dark) .statValue {
-  color: rgba(255, 255, 255, 0.92);
-}
-
-:global(html.dark) .detailMetricRow {
-  border-bottom-color: rgba(255, 255, 255, 0.08);
-}
-
-:global(html.dark) .ringChartWrap::before {
-  background: radial-gradient(circle at 30% 30%, rgba(17, 29, 44, 0.98) 0%, rgba(15, 26, 40, 0.98) 100%);
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
-}
-
-:global(html.dark) .metricGuideTooltipRow strong,
-:global(html.dark) .uptimeStatusTooltipRow strong {
-  color: #f2f6fb;
-}
-
-:global(html.dark) .metricGuideTooltip,
-:global(html.dark) .uptimeStatusTooltip {
-  color: #b8c6d9;
-}
-
-:global(html.dark) :global(.ant-tooltip.lightMetricTooltip) :global(.ant-tooltip-inner) {
-  background: #101926;
-  color: rgba(255, 255, 255, 0.74);
-  border-color: rgba(255, 255, 255, 0.08);
-  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.28);
-}
-
-:global(html.dark) :global(.ant-tooltip.lightMetricTooltip) :global(.ant-tooltip-arrow::before) {
-  background: #101926;
-  border-color: rgba(255, 255, 255, 0.08);
+:global(html.dark) .instanceIcon {
+  background: color-mix(in srgb, var(--color-primary) 16%, var(--color-bg));
+  color: var(--color-primary);
 }

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard.module.scss
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard.module.scss
@@ -119,10 +119,10 @@
 
 .pageTitleRow {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  min-height: 32px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 4px;
+  min-width: 0;
 }
 
 .titleBlock {
@@ -131,6 +131,14 @@
   gap: 2px;
   min-width: 0;
   flex: 1;
+}
+
+.titleControlsRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
 }
 
 .breadcrumb {
@@ -146,6 +154,8 @@
   font-weight: 700;
   line-height: 1.25;
   letter-spacing: -0.02em;
+  min-width: 0;
+  flex: 1;
 }
 
 .controlsWrap {
@@ -1864,7 +1874,11 @@
   .pageTitleRow,
   .instanceCard {
     align-items: stretch;
+  }
+
+  .titleControlsRow {
     flex-direction: column;
+    align-items: flex-start;
   }
 
   .controlsWrap {

--- a/web/src/app/monitor/dashboards/objects/docker/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/docker/dashboard.tsx
@@ -45,7 +45,7 @@ export default function DockerDashboardPage() {
   const timeKey = JSON.stringify(timeValues);
 
   useEffect(() => {
-    if (!isDashboardMode) {
+    if (!isDashboardMode || !idValues.length) {
       setTopBars({});
       return;
     }

--- a/web/src/app/monitor/dashboards/objects/elasticsearch/config.ts
+++ b/web/src/app/monitor/dashboards/objects/elasticsearch/config.ts
@@ -1,5 +1,16 @@
 import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
 
+/** Elasticsearch 监控高对比鲜活科技色板 */
+const ES_PALETTE = {
+  emerald: '#10B981',   // 集群健康正常、HTTP 新建连接
+  blue: '#2563EB',      // 活跃主分片、堆内存、写入队列
+  cyan: '#06B6D4',      // 可用磁盘空间
+  indigo: '#6366F1',    // HTTP 当前连接、打开文件描述符
+  amber: '#F59E0B',     // 请求熔断、集群健康警告
+  orange: '#F97316',    // 进程 CPU、Young GC、搜索队列
+  rose: '#EF4444'       // 未分配分片、Fielddata 熔断、集群健康严重
+} as const;
+
 export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   routeKey: 'elasticsearch',
   pageTitle: 'Elasticsearch 监控仪表盘',
@@ -14,7 +25,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '集群健康状态编码，1 正常、2 警告、3 严重。',
       unit: 'counts',
       query: 'elasticsearch_cluster_health_status_code{__$labels__}',
-      color: '#27c274'
+      color: ES_PALETTE.emerald
     },
     {
       name: 'elasticsearch_cluster_health_active_primary_shards',
@@ -22,7 +33,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '集群中活跃主分片数量。',
       unit: 'counts',
       query: 'elasticsearch_cluster_health_active_primary_shards{__$labels__}',
-      color: '#2f6bff'
+      color: ES_PALETTE.blue
     },
     {
       name: 'elasticsearch_cluster_health_unassigned_shards',
@@ -30,7 +41,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '未分配分片数量，非零需排查。',
       unit: 'counts',
       query: 'elasticsearch_cluster_health_unassigned_shards{__$labels__}',
-      color: '#ff4d4f'
+      color: ES_PALETTE.rose
     },
     {
       name: 'elasticsearch_shard_assignment_ratio',
@@ -38,7 +49,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '活跃主分片占主分片总数的比例。',
       unit: 'percent',
       query: '100 * elasticsearch_cluster_health_active_primary_shards{__$labels__} / clamp_min(elasticsearch_cluster_health_active_primary_shards{__$labels__} + elasticsearch_cluster_health_unassigned_shards{__$labels__}, 1)',
-      color: '#2f6bff'
+      color: ES_PALETTE.blue
     },
     {
       name: 'elasticsearch_jvm_mem_heap_used_percent',
@@ -46,7 +57,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'JVM 堆内存使用百分比。',
       unit: 'percent',
       query: 'elasticsearch_jvm_mem_heap_used_percent{__$labels__}',
-      color: '#2f6bff'
+      color: ES_PALETTE.blue
     },
     {
       name: 'elasticsearch_jvm_gc_collectors_young_collection_time_in_millis_rate',
@@ -54,7 +65,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '新生代 GC 每秒累计耗时（ms/s）；升高表示 GC 占用墙钟时间增多。',
       unit: 'ms',
       query: 'rate(elasticsearch_jvm_gc_collectors_young_collection_time_in_millis{__$labels__}[__$window__])',
-      color: '#ff8a1f'
+      color: ES_PALETTE.orange
     },
     {
       name: 'elasticsearch_fs_data_0_available_in_bytes',
@@ -62,7 +73,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '节点数据目录可用磁盘空间。',
       unit: 'bytes',
       query: 'elasticsearch_fs_data_0_available_in_bytes{__$labels__}',
-      color: '#13c2c2'
+      color: ES_PALETTE.cyan
     },
     {
       name: 'elasticsearch_process_cpu_percent',
@@ -70,7 +81,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'Elasticsearch 进程 CPU 使用率。',
       unit: 'percent',
       query: 'elasticsearch_process_cpu_percent{__$labels__}',
-      color: '#2f6bff'
+      color: ES_PALETTE.orange
     },
     {
       name: 'elasticsearch_process_open_file_descriptors',
@@ -78,7 +89,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '进程已打开文件描述符数量。',
       unit: 'counts',
       query: 'elasticsearch_process_open_file_descriptors{__$labels__}',
-      color: '#8a5cff'
+      color: ES_PALETTE.indigo
     },
     {
       name: 'elasticsearch_breakers_fielddata_tripped_rate',
@@ -86,7 +97,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'Fielddata 熔断触发速率。',
       unit: 'cps',
       query: 'rate(elasticsearch_breakers_fielddata_tripped{__$labels__}[__$window__])',
-      color: '#ff4d4f'
+      color: ES_PALETTE.rose
     },
     {
       name: 'elasticsearch_breakers_request_tripped_rate',
@@ -94,7 +105,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '请求级熔断触发速率。',
       unit: 'cps',
       query: 'rate(elasticsearch_breakers_request_tripped{__$labels__}[__$window__])',
-      color: '#ff8a1f'
+      color: ES_PALETTE.amber
     },
     {
       name: 'elasticsearch_http_current_open',
@@ -102,7 +113,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'HTTP 服务当前打开连接数。',
       unit: 'counts',
       query: 'elasticsearch_http_current_open{__$labels__}',
-      color: '#597ef7'
+      color: ES_PALETTE.indigo
     },
     {
       name: 'elasticsearch_http_total_opened_rate',
@@ -110,7 +121,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'HTTP 服务新建连接速率。',
       unit: 'cps',
       query: 'rate(elasticsearch_http_total_opened{__$labels__}[__$window__])',
-      color: '#27c274'
+      color: ES_PALETTE.emerald
     },
     {
       name: 'elasticsearch_thread_pool_write_queue',
@@ -118,7 +129,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '写线程池待处理队列长度。',
       unit: 'counts',
       query: 'elasticsearch_thread_pool_write_queue{__$labels__}',
-      color: '#2f6bff'
+      color: ES_PALETTE.blue
     },
     {
       name: 'elasticsearch_thread_pool_search_queue',
@@ -126,7 +137,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '搜索线程池待处理队列长度。',
       unit: 'counts',
       query: 'elasticsearch_thread_pool_search_queue{__$labels__}',
-      color: '#ff8a1f'
+      color: ES_PALETTE.orange
     }
   ],
   summaryCards: [
@@ -134,7 +145,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       title: '集群健康状态',
       metric: 'elasticsearch_cluster_health_status_code',
       formatter: 'enumHealth',
-      color: '#27c274',
+      color: ES_PALETTE.emerald,
       icon: 'node',
       guide: [{ label: '健康状态', detail: '集群健康编码:1 绿(正常)、2 黄(副本未分配)、3 红(主分片缺失)。非 1 时查未分配分片与节点状态。' }],
       footer: [
@@ -145,7 +156,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: 'JVM 堆使用率',
       metric: 'elasticsearch_jvm_mem_heap_used_percent',
-      color: '#2f6bff',
+      color: ES_PALETTE.blue,
       icon: 'database',
       compare: true,
       guide: [{ label: 'JVM 堆', detail: 'JVM 堆内存使用率，持续高值会增加 GC 压力。' }],
@@ -154,7 +165,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '进程 CPU',
       metric: 'elasticsearch_process_cpu_percent',
-      color: '#ff8a1f',
+      color: ES_PALETTE.orange,
       icon: 'api',
       compare: true,
       guide: [{ label: '进程 CPU', detail: 'Elasticsearch 进程 CPU 使用率，高负载会影响读写性能。' }],
@@ -163,7 +174,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '节点可用磁盘',
       metric: 'elasticsearch_fs_data_0_available_in_bytes',
-      color: '#13c2c2',
+      color: ES_PALETTE.cyan,
       icon: 'database',
       guide: [{ label: '可用磁盘', detail: '节点数据目录可用磁盘空间，空间不足会触发分片迁移或写入保护。' }],
       footer: [{ label: '主分片', metric: 'elasticsearch_cluster_health_active_primary_shards', unit: 'counts' }]
@@ -171,7 +182,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '未分配分片',
       metric: 'elasticsearch_cluster_health_unassigned_shards',
-      color: '#ff4d4f',
+      color: ES_PALETTE.rose,
       icon: 'thunder',
       guide: [{ label: '未分配分片', detail: '未能分配到节点的分片数(个);非零会降低冗余 / 可用性。排查节点掉线、磁盘水位或分配规则。' }],
       footer: [{ label: '健康状态', metric: 'elasticsearch_cluster_health_status_code', unit: 'counts' }]
@@ -179,7 +190,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '主分片分配率',
       metric: 'elasticsearch_shard_assignment_ratio',
-      color: '#2f6bff',
+      color: ES_PALETTE.blue,
       icon: 'database',
       compare: true,
       compareFavorableDirection: 'up',
@@ -189,7 +200,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: 'HTTP 当前连接',
       metric: 'elasticsearch_http_current_open',
-      color: '#597ef7',
+      color: ES_PALETTE.indigo,
       icon: 'node',
       guide: [{ label: 'HTTP 连接', detail: 'HTTP 服务当前打开连接数。' }],
       footer: [{ label: '新建速率', metric: 'elasticsearch_http_total_opened_rate', unit: 'cps' }]
@@ -205,8 +216,8 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '进程 CPU', detail: 'Elasticsearch 进程 CPU 使用率。' }
       ],
       series: [
-        { metric: 'elasticsearch_jvm_mem_heap_used_percent', label: 'JVM 堆使用率', color: '#2f6bff', unit: 'percent' },
-        { metric: 'elasticsearch_process_cpu_percent', label: '进程 CPU', color: '#ff8a1f', unit: 'percent' }
+        { metric: 'elasticsearch_jvm_mem_heap_used_percent', label: 'JVM 堆使用率', color: ES_PALETTE.blue, unit: 'percent' },
+        { metric: 'elasticsearch_process_cpu_percent', label: '进程 CPU', color: ES_PALETTE.orange, unit: 'percent' }
       ]
     },
     {
@@ -215,7 +226,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       metric: 'elasticsearch_jvm_gc_collectors_young_collection_time_in_millis_rate',
       guide: [{ label: 'GC 耗时', detail: '新生代 GC 每秒累计耗时。' }],
       series: [
-        { metric: 'elasticsearch_jvm_gc_collectors_young_collection_time_in_millis_rate', label: 'Young GC 耗时', color: '#ff8a1f', unit: 'ms' }
+        { metric: 'elasticsearch_jvm_gc_collectors_young_collection_time_in_millis_rate', label: 'Young GC 耗时', color: ES_PALETTE.orange, unit: 'ms' }
       ]
     },
     {
@@ -224,8 +235,8 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       metric: 'elasticsearch_thread_pool_write_queue',
       guide: [{ label: '线程池队列', detail: '写入与搜索线程池待处理队列长度。' }],
       series: [
-        { metric: 'elasticsearch_thread_pool_write_queue', label: '写入队列', color: '#2f6bff', unit: 'counts' },
-        { metric: 'elasticsearch_thread_pool_search_queue', label: '搜索队列', color: '#ff8a1f', unit: 'counts' }
+        { metric: 'elasticsearch_thread_pool_write_queue', label: '写入队列', color: ES_PALETTE.blue, unit: 'counts' },
+        { metric: 'elasticsearch_thread_pool_search_queue', label: '搜索队列', color: ES_PALETTE.orange, unit: 'counts' }
       ]
     },
     {
@@ -234,7 +245,7 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       metric: 'elasticsearch_http_total_opened_rate',
       guide: [{ label: '新建连接', detail: 'HTTP 服务新建连接速率。' }],
       series: [
-        { metric: 'elasticsearch_http_total_opened_rate', label: '新建速率', color: '#27c274', unit: 'cps' }
+        { metric: 'elasticsearch_http_total_opened_rate', label: '新建速率', color: ES_PALETTE.emerald, unit: 'cps' }
       ]
     },
     {
@@ -246,8 +257,8 @@ export const ELASTICSEARCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '请求熔断', detail: '请求级内存保护熔断触发速率。' }
       ],
       series: [
-        { metric: 'elasticsearch_breakers_fielddata_tripped_rate', label: 'Fielddata 熔断', color: '#ff4d4f', unit: 'cps' },
-        { metric: 'elasticsearch_breakers_request_tripped_rate', label: '请求熔断', color: '#ff8a1f', unit: 'cps' }
+        { metric: 'elasticsearch_breakers_fielddata_tripped_rate', label: 'Fielddata 熔断', color: ES_PALETTE.rose, unit: 'cps' },
+        { metric: 'elasticsearch_breakers_request_tripped_rate', label: '请求熔断', color: ES_PALETTE.amber, unit: 'cps' }
       ]
     }
   ],

--- a/web/src/app/monitor/dashboards/objects/elasticsearch/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/elasticsearch/dashboard.tsx
@@ -74,7 +74,7 @@ export default function ElasticsearchDashboardPage() {
   const timeKey = JSON.stringify(timeValues);
 
   useEffect(() => {
-    if (!isDashboardMode) {
+    if (!isDashboardMode || !idValues.length) {
       setTopNode({});
       return;
     }

--- a/web/src/app/monitor/dashboards/objects/elasticsearch/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/elasticsearch/index.module.scss
@@ -3,14 +3,20 @@
 // 趋势图紧凑高度(与 host/ping 等同款),renderTrend 通过 styles.compactTrend 引用
 .compactTrend {
   .chartWrap {
-    height: 164px;
+    height: 180px;
   }
 }
 
 @media (max-width: 768px) {
+  .chartLegendHeader {
+    justify-content: flex-start;
+    max-width: 100%;
+    white-space: normal;
+  }
+
   .compactTrend {
     .chartWrap {
-      height: 138px;
+      height: 140px;
     }
   }
 }
@@ -23,25 +29,7 @@
   }
 }
 
-// 区块小标题:给分区加语义标题,提升可扫读性(与 MySQL/PostgreSQL 同款)
-.sectionLabel {
-  margin: 2px 2px 4px;
-  padding-bottom: 4px;
-  border-bottom: 1px solid #eceff4;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #8c95a8;
-}
-
-.dashboardSection + .sectionLabel {
-  margin-top: 8px;
-}
-
-:global(html.dark) .sectionLabel {
-  border-bottom-color: rgba(255, 255, 255, 0.08);
-}
+// sectionLabel 已上收到共享壳（带品牌蓝指示条与现代间距）
 
 .collectionStatusTimelineEmpty {
   display: flex;

--- a/web/src/app/monitor/dashboards/objects/elasticsearch/queries.ts
+++ b/web/src/app/monitor/dashboards/objects/elasticsearch/queries.ts
@@ -22,7 +22,7 @@ export const ES_TOP_NODE_QUERIES: EsTopNodeQuery[] = [
     key: 'jvm_heap',
     title: 'JVM 堆使用率 Top',
     unit: 'percent',
-    color: '#2f6bff',
+    color: '#2563EB',
     query: `topk(${ES_TOP_N}, max by (node_name) (elasticsearch_jvm_mem_heap_used_percent{__$labels__}))`,
     guide: [{ label: 'JVM 堆排行', detail: '各节点 JVM 堆内存使用率,定位 GC 压力集中的节点。' }]
   },
@@ -30,7 +30,7 @@ export const ES_TOP_NODE_QUERIES: EsTopNodeQuery[] = [
     key: 'process_cpu',
     title: '进程 CPU Top',
     unit: 'percent',
-    color: '#ff8a1f',
+    color: '#F97316',
     query: `topk(${ES_TOP_N}, max by (node_name) (elasticsearch_process_cpu_percent{__$labels__}))`,
     guide: [{ label: '进程 CPU 排行', detail: '各节点 ES 进程 CPU 使用率,定位计算负载集中的节点。' }]
   },
@@ -38,7 +38,7 @@ export const ES_TOP_NODE_QUERIES: EsTopNodeQuery[] = [
     key: 'fs_available',
     title: '节点可用磁盘 Bottom',
     unit: 'bytes',
-    color: '#ff4d4f',
+    color: '#EF4444',
     query: `bottomk(${ES_TOP_N}, min by (node_name) (elasticsearch_fs_data_0_available_in_bytes{__$labels__}))`,
     guide: [{ label: '磁盘紧张排行', detail: '各节点数据目录可用磁盘空间(取最小),定位磁盘水位紧张的节点。' }]
   }

--- a/web/src/app/monitor/dashboards/objects/etcd/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/etcd/dashboard.tsx
@@ -48,7 +48,7 @@ export default function EtcdDashboardPage() {
       styles={styles}
       dashboardContent={
         <>
-          <div className={styles.sectionLabel}>共识与配额</div>
+          <div className={styles.sectionLabel}>健康概览</div>
           <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={5} styles={styles} />
 
           <div className={styles.sectionLabel}>磁盘与共识</div>

--- a/web/src/app/monitor/dashboards/objects/exchange/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/exchange/dashboard.tsx
@@ -68,7 +68,7 @@ export default function ExchangeDashboardPage() {
       styles={styles}
       dashboardContent={
         <>
-          <div className={styles.sectionLabel}>邮件流与 Synthetic 健康</div>
+          <div className={styles.sectionLabel}>健康概览</div>
           <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={6} styles={styles} />
 
           <div className={styles.sectionLabel}>Hub Transport 邮件流</div>

--- a/web/src/app/monitor/dashboards/objects/flow-common/flow-dashboard-page.tsx
+++ b/web/src/app/monitor/dashboards/objects/flow-common/flow-dashboard-page.tsx
@@ -64,7 +64,7 @@ function FlowDashboardMetricsView({
       styles={styles}
       dashboardContent={
         <>
-          <div className={styles.sectionLabel}>流量概览</div>
+          <div className={styles.sectionLabel}>健康概览</div>
           <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={5} styles={styles} />
 
           <div className={styles.sectionLabel}>流量分析</div>

--- a/web/src/app/monitor/dashboards/objects/haproxy/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/haproxy/dashboard.tsx
@@ -55,7 +55,7 @@ export default function HaproxyDashboardPage() {
       styles={styles}
       dashboardContent={
         <>
-          <div className={styles.sectionLabel}>入口与后端健康</div>
+          <div className={styles.sectionLabel}>健康概览</div>
           <KpiSection dashboard={dashboard} summaryCards={summaryCards} styles={styles} />
 
           <div className={styles.sectionLabel}>负载与时延</div>

--- a/web/src/app/monitor/dashboards/objects/host/config.ts
+++ b/web/src/app/monitor/dashboards/objects/host/config.ts
@@ -1,5 +1,17 @@
 import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
 
+/** 主机仪表盘色板：高对比、鲜活通透的现代监控色系，告别暗淡沉闷 */
+const HOST_PALETTE = {
+  blue: '#2563EB',      // 活力皇家蓝 (CPU 使用率、网络入流量)
+  indigo: '#6366F1',    // 现代紫靛 (系统 1 分钟负载、CPU 内核态、运行时长)
+  cyan: '#06B6D4',      // 清亮青蓝 (系统 5 分钟负载、磁盘读吞吐、可用内存)
+  emerald: '#10B981',   // 鲜亮翠绿 (内存使用率、网络出流量、15 分钟负载)
+  amber: '#F59E0B',     // 暖金琥珀 (磁盘使用率、磁盘排行榜)
+  orange: '#F97316',    // 活力暖橙 (I/O Wait 占比、磁盘写吞吐、阻塞进程)
+  rose: '#EF4444',      // 鲜明珊瑚红 (僵尸进程、网络错误)
+  neutral: '#94A3B8'    // 清爽中性灰 (CPU 环图其他)
+} as const;
+
 export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   routeKey: 'host',
   pageTitle: '主机监控仪表盘',
@@ -16,7 +28,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       unit: 'percent',
       // ①Telegraf host: 100-空闲；②HTTP Remote: host_cpu_usage_percent_gauge；③Windows WMI；④Host AIX Remote: cpu_usage_total_gauge。
       query: '(100 - cpu_usage_idle{cpu="cpu-total", instance_type="os", __$labels__}) or host_cpu_usage_percent_gauge{instance_type="os", __$labels__} or cpu_usage_total_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__} or cpu_usage_total_gauge{instance_type="os", config_type="host_aix_remote", __$labels__}',
-      color: '#2f6bff'
+      color: HOST_PALETTE.blue
     },
     {
       name: 'cpu_usage_user_total',
@@ -24,7 +36,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'CPU 在用户态消耗的时间占比（Linux/部分远程采集；Windows WMI 可能无此分解）。',
       unit: 'percent',
       query: 'cpu_usage_user{cpu="cpu-total", instance_type="os", __$labels__} or cpu_usage_user_total_gauge{instance_type="os", __$labels__}',
-      color: '#13c2c2'
+      color: HOST_PALETTE.cyan
     },
     {
       name: 'cpu_usage_system_total',
@@ -32,7 +44,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'CPU 在内核态消耗的时间占比（Linux/部分远程采集；Windows WMI 可能无此分解）。',
       unit: 'percent',
       query: 'cpu_usage_system{cpu="cpu-total", instance_type="os", __$labels__} or cpu_usage_system_total_gauge{instance_type="os", __$labels__}',
-      color: '#597ef7'
+      color: HOST_PALETTE.indigo
     },
     {
       name: 'cpu_usage_iowait_total',
@@ -40,7 +52,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'CPU 等待 I/O 的时间占比（主要适用于 Linux；Windows 通常无对等语义）。',
       unit: 'percent',
       query: 'cpu_usage_iowait{cpu="cpu-total", instance_type="os", __$labels__} or cpu_usage_iowait_total_gauge{instance_type="os", __$labels__}',
-      color: '#ff8a1f'
+      color: HOST_PALETTE.orange
     },
     {
       name: 'cpu_usage_other_total',
@@ -48,7 +60,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '除用户态、内核态和 I/O Wait 以外的 CPU 占比。',
       unit: 'percent',
       query: 'clamp_min(100 - cpu_usage_idle{cpu="cpu-total", instance_type="os", __$labels__} - cpu_usage_user{cpu="cpu-total", instance_type="os", __$labels__} - cpu_usage_system{cpu="cpu-total", instance_type="os", __$labels__} - cpu_usage_iowait{cpu="cpu-total", instance_type="os", __$labels__}, 0) or clamp_min(host_cpu_usage_percent_gauge{instance_type="os", __$labels__} - cpu_usage_user_total_gauge{instance_type="os", __$labels__} - cpu_usage_system_total_gauge{instance_type="os", __$labels__} - cpu_usage_iowait_total_gauge{instance_type="os", __$labels__}, 0)',
-      color: '#9aa9bf'
+      color: HOST_PALETTE.neutral
     },
     {
       name: 'system_load1',
@@ -56,7 +68,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '主机最近 1 分钟平均负载。',
       unit: 'none',
       query: 'system_load1{instance_type="os", __$labels__} or system_load1_gauge{instance_type="os", __$labels__} or host_cpu_load_1m_gauge{instance_type="os", __$labels__} or system_load1_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__}',
-      color: '#27c274'
+      color: HOST_PALETTE.indigo
     },
     {
       name: 'system_load5',
@@ -64,7 +76,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '主机最近 5 分钟平均负载。',
       unit: 'none',
       query: 'system_load5{instance_type="os", __$labels__} or system_load5_gauge{instance_type="os", __$labels__} or host_cpu_load_5m_gauge{instance_type="os", __$labels__} or system_load5_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__}',
-      color: '#13c2c2'
+      color: HOST_PALETTE.cyan
     },
     {
       name: 'system_load15',
@@ -72,7 +84,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '主机最近 15 分钟平均负载。',
       unit: 'none',
       query: 'system_load15{instance_type="os", __$labels__} or system_load15_gauge{instance_type="os", __$labels__} or host_cpu_load_15m_gauge{instance_type="os", __$labels__} or system_load15_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__}',
-      color: '#597ef7'
+      color: HOST_PALETTE.emerald
     },
     {
       name: 'system_uptime',
@@ -81,7 +93,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       unit: 's',
       // ①Telegraf host；②HTTP Remote；③Windows WMI。
       query: 'system_uptime{instance_type="os", __$labels__} or system_uptime_gauge{instance_type="os", __$labels__} or system_uptime_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__}',
-      color: '#597ef7'
+      color: HOST_PALETTE.indigo
     },
     {
       name: 'mem_used_percent',
@@ -89,7 +101,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '主机内存使用率。',
       unit: 'percent',
       query: 'mem_used_percent{instance_type="os", __$labels__} or host_mem_used_percent_gauge{instance_type="os", __$labels__} or mem_used_percent_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__} or mem_used_percent_gauge{instance_type="os", config_type="host_aix_remote", __$labels__}',
-      color: '#27c274'
+      color: HOST_PALETTE.emerald
     },
     {
       name: 'disk_used_percent',
@@ -98,7 +110,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       unit: 'percent',
       // ①Telegraf host 按挂载点；②HTTP Remote；③Windows WMI。取 max 作为主机级容量压力信号。
       query: 'max by (instance_id) (disk_used_percent{instance_type="os", __$labels__} or host_disk_used_percent_gauge{instance_type="os", __$labels__} or disk_used_percent_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__} or disk_used_percent_gauge{instance_type="os", config_type="host_aix_remote", __$labels__})',
-      color: '#faad14'
+      color: HOST_PALETTE.amber
     },
     {
       name: 'mem_available',
@@ -106,7 +118,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '主机当前可用内存。',
       unit: 'bytes',
       query: 'mem_available{instance_type="os", __$labels__} or host_mem_available_bytes_gauge{instance_type="os", __$labels__} or mem_available_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__}',
-      color: '#13c2c2'
+      color: HOST_PALETTE.cyan
     },
     {
       name: 'processes_blocked',
@@ -114,7 +126,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '当前处于不可中断等待（常与慢 I/O 相关）的进程数量。',
       unit: 'counts',
       query: 'processes_blocked{instance_type="os", __$labels__} or processes_blocked_gauge{instance_type="os", __$labels__} or processes_blocked_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__}',
-      color: '#ff8a1f'
+      color: HOST_PALETTE.orange
     },
     {
       name: 'processes_zombies',
@@ -122,7 +134,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '当前处于僵尸状态的进程数量。',
       unit: 'counts',
       query: 'processes_zombies{instance_type="os", __$labels__} or processes_zombies_gauge{instance_type="os", __$labels__} or processes_zombies_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__}',
-      color: '#8a5cff'
+      color: HOST_PALETTE.rose
     },
     {
       name: 'net_bytes_recv_rate',
@@ -130,7 +142,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '主机所有网卡接收字节速率合计。计算窗口与时间选择器一致。',
       unit: 'byteps',
       query: 'sum by (instance_id) (rate(net_bytes_recv{instance_type="os", __$labels__}[__$window__]) or rate(net_bytes_recv_gauge{instance_type="os", __$labels__}[__$window__]) or rate(net_bytes_recv_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__}[__$window__]))',
-      color: '#2f6bff'
+      color: HOST_PALETTE.blue
     },
     {
       name: 'net_bytes_sent_rate',
@@ -138,7 +150,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '主机所有网卡发送字节速率合计。计算窗口与时间选择器一致。',
       unit: 'byteps',
       query: 'sum by (instance_id) (rate(net_bytes_sent{instance_type="os", __$labels__}[__$window__]) or rate(net_bytes_sent_gauge{instance_type="os", __$labels__}[__$window__]) or rate(net_bytes_sent_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__}[__$window__]))',
-      color: '#27c274'
+      color: HOST_PALETTE.emerald
     },
     {
       name: 'net_err_in_rate',
@@ -146,7 +158,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '主机所有网卡接收错误包速率合计。计算窗口与时间选择器一致。',
       unit: 'cps',
       query: 'sum by (instance_id) (rate(net_err_in{instance_type="os", __$labels__}[__$window__]) or rate(net_err_in_gauge{instance_type="os", __$labels__}[__$window__]) or rate(net_err_in_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__}[__$window__]))',
-      color: '#ff8a1f'
+      color: HOST_PALETTE.orange
     },
     {
       name: 'net_err_out_rate',
@@ -154,7 +166,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '主机所有网卡发送错误包速率合计。计算窗口与时间选择器一致。',
       unit: 'cps',
       query: 'sum by (instance_id) (rate(net_err_out{instance_type="os", __$labels__}[__$window__]) or rate(net_err_out_gauge{instance_type="os", __$labels__}[__$window__]) or rate(net_err_out_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__}[__$window__]))',
-      color: '#8a5cff'
+      color: HOST_PALETTE.rose
     },
     {
       name: 'diskio_read_bytes_rate',
@@ -162,7 +174,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '主机所有磁盘设备读取字节速率合计。计算窗口与时间选择器一致。',
       unit: 'byteps',
       query: 'sum by (instance_id) (rate(diskio_read_bytes{instance_type="os", __$labels__}[__$window__]) or rate(diskio_read_bytes_total_gauge{instance_type="os", config_type!~"host_aix.*", __$labels__}[__$window__]) or rate(diskio_read_bytes_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__}[__$window__]) or diskio_read_bytes_gauge{instance_type="os", config_type="host_aix_remote", __$labels__})',
-      color: '#13c2c2'
+      color: HOST_PALETTE.cyan
     },
     {
       name: 'diskio_write_bytes_rate',
@@ -170,7 +182,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '主机所有磁盘设备写入字节速率合计。计算窗口与时间选择器一致。',
       unit: 'byteps',
       query: 'sum by (instance_id) (rate(diskio_write_bytes{instance_type="os", __$labels__}[__$window__]) or rate(diskio_write_bytes_total_gauge{instance_type="os", config_type!~"host_aix.*", __$labels__}[__$window__]) or rate(diskio_write_bytes_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__}[__$window__]) or diskio_write_bytes_gauge{instance_type="os", config_type="host_aix_remote", __$labels__})',
-      color: '#ff8a1f'
+      color: HOST_PALETTE.orange
     }
   ],
   summaryCards: [
@@ -181,14 +193,14 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       formatter: 'duration',
       isUptimeCard: true,
       icon: 'clock',
-      color: '#597ef7',
+      color: HOST_PALETTE.indigo,
       guide: [{ label: '运行时长', detail: '主机自上次启动后的持续运行时间；期间发生重启会重新计时。' }],
       footer: [{ label: '启动', metric: 'system_uptime', formatter: 'startedAt' }]
     },
     {
       title: 'CPU 使用率',
       metric: 'cpu_usage_total',
-      color: '#2f6bff',
+      color: HOST_PALETTE.blue,
       icon: 'thunder',
       guide: [{ label: 'CPU 使用率', detail: '主机整体 CPU 已用时间百分比;持续接近 100% 表示 CPU 紧张。' }],
       footer: [
@@ -199,7 +211,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '内存使用率',
       metric: 'mem_used_percent',
-      color: '#27c274',
+      color: HOST_PALETTE.emerald,
       icon: 'database',
       guide: [{ label: '内存使用率', detail: '已用内存占总内存的百分比;越高表示可用内存越少。' }],
       footer: [{ label: '可用内存', metric: 'mem_available', unit: 'bytes' }]
@@ -207,7 +219,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '磁盘使用率',
       metric: 'disk_used_percent',
-      color: '#faad14',
+      color: HOST_PALETTE.amber,
       icon: 'database',
       guide: [{
         label: '磁盘使用率',
@@ -217,7 +229,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '1 分钟负载',
       metric: 'system_load1',
-      color: '#13c2c2',
+      color: HOST_PALETTE.cyan,
       icon: 'node',
       guide: [{
         label: '系统负载',
@@ -235,10 +247,10 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       metric: 'cpu_usage_total',
       guide: [{ label: '资源使用', detail: '对比 CPU、内存、最满分区磁盘使用率与 I/O Wait 变化。' }],
       series: [
-        { metric: 'cpu_usage_total', label: 'CPU 使用率', color: '#2f6bff', unit: 'percent' },
-        { metric: 'mem_used_percent', label: '内存使用率', color: '#27c274', unit: 'percent' },
-        { metric: 'disk_used_percent', label: '磁盘使用率', color: '#faad14', unit: 'percent' },
-        { metric: 'cpu_usage_iowait_total', label: 'I/O Wait 占比', color: '#ff8a1f', unit: 'percent' }
+        { metric: 'cpu_usage_total', label: 'CPU 使用率', color: HOST_PALETTE.blue, unit: 'percent' },
+        { metric: 'mem_used_percent', label: '内存使用率', color: HOST_PALETTE.emerald, unit: 'percent' },
+        { metric: 'disk_used_percent', label: '磁盘使用率', color: HOST_PALETTE.amber, unit: 'percent' },
+        { metric: 'cpu_usage_iowait_total', label: 'I/O Wait 占比', color: HOST_PALETTE.orange, unit: 'percent' }
       ]
     },
     {
@@ -247,9 +259,9 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       metric: 'system_load1',
       guide: [{ label: '系统负载', detail: '1 / 5 / 15 分钟平均负载（运行 + 等待的进程数）。持续偏高时结合 CPU 使用率与 I/O Wait 判断是算力不足还是等待 I/O。' }],
       series: [
-        { metric: 'system_load1', label: '1 分钟', color: '#27c274', unit: 'none' },
-        { metric: 'system_load5', label: '5 分钟', color: '#13c2c2', unit: 'none' },
-        { metric: 'system_load15', label: '15 分钟', color: '#597ef7', unit: 'none' }
+        { metric: 'system_load1', label: '1 分钟', color: HOST_PALETTE.indigo, unit: 'none' },
+        { metric: 'system_load5', label: '5 分钟', color: HOST_PALETTE.cyan, unit: 'none' },
+        { metric: 'system_load15', label: '15 分钟', color: HOST_PALETTE.emerald, unit: 'none' }
       ]
     },
     {
@@ -261,8 +273,8 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         detail: '主机所有网卡入/出流量合计。速率计算窗口与时间选择器一致（长窗会更平滑）。与右侧错误对照：吞吐正常但错误持续非零，优先查网卡/驱动/对端；两者同时抬升，再看是否流量冲击。'
       }],
       series: [
-        { metric: 'net_bytes_recv_rate', label: '入流量', color: '#2f6bff', unit: 'byteps' },
-        { metric: 'net_bytes_sent_rate', label: '出流量', color: '#27c274', unit: 'byteps' }
+        { metric: 'net_bytes_recv_rate', label: '入流量', color: HOST_PALETTE.blue, unit: 'byteps' },
+        { metric: 'net_bytes_sent_rate', label: '出流量', color: HOST_PALETTE.emerald, unit: 'byteps' }
       ]
     },
     {
@@ -274,8 +286,8 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         detail: '主机所有网卡收/发错误包速率合计。健康基线通常接近 0：持续非零先查网卡、驱动与对端连通性；若左侧吞吐同时异常，再区分拥塞与链路故障。计算窗口与时间选择器一致。'
       }],
       series: [
-        { metric: 'net_err_in_rate', label: '接收错误', color: '#ff8a1f', unit: 'cps' },
-        { metric: 'net_err_out_rate', label: '发送错误', color: '#8a5cff', unit: 'cps' }
+        { metric: 'net_err_in_rate', label: '接收错误', color: HOST_PALETTE.orange, unit: 'cps' },
+        { metric: 'net_err_out_rate', label: '发送错误', color: HOST_PALETTE.rose, unit: 'cps' }
       ]
     },
     {
@@ -287,8 +299,8 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         detail: '主机所有磁盘设备读写吞吐合计。可与 I/O Wait、阻塞进程对照判断是否卡在磁盘。速率计算窗口与时间选择器一致。'
       }],
       series: [
-        { metric: 'diskio_read_bytes_rate', label: '读吞吐', color: '#13c2c2', unit: 'byteps' },
-        { metric: 'diskio_write_bytes_rate', label: '写吞吐', color: '#ff8a1f', unit: 'byteps' }
+        { metric: 'diskio_read_bytes_rate', label: '读吞吐', color: HOST_PALETTE.cyan, unit: 'byteps' },
+        { metric: 'diskio_write_bytes_rate', label: '写吞吐', color: HOST_PALETTE.orange, unit: 'byteps' }
       ]
     },
     {
@@ -300,8 +312,8 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         detail: '阻塞进程持续非零多与慢 I/O / 不可中断等待相关；僵尸进程非零查父进程未回收。I/O Wait 见上方 KPI 与资源趋势（Linux）。'
       }],
       series: [
-        { metric: 'processes_blocked', label: '阻塞进程', color: '#ff8a1f', unit: 'counts' },
-        { metric: 'processes_zombies', label: '僵尸进程', color: '#8a5cff', unit: 'counts' }
+        { metric: 'processes_blocked', label: '阻塞进程', color: HOST_PALETTE.orange, unit: 'counts' },
+        { metric: 'processes_zombies', label: '僵尸进程', color: HOST_PALETTE.rose, unit: 'counts' }
       ]
     }
   ],
@@ -316,10 +328,10 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       centerUnit: 'percent',
       guide: [{ label: 'CPU 结构', detail: '拆分当前 CPU 使用率中的用户态、内核态和 I/O Wait。' }],
       segments: [
-        { label: '用户态', metric: 'cpu_usage_user_total', color: '#13c2c2', unit: 'percent' },
-        { label: '内核态', metric: 'cpu_usage_system_total', color: '#597ef7', unit: 'percent' },
-        { label: 'I/O Wait 占比', metric: 'cpu_usage_iowait_total', color: '#ff8a1f', unit: 'percent' },
-        { label: '其他', metric: 'cpu_usage_other_total', color: '#e8f0fe', unit: 'percent' }
+        { label: '用户态', metric: 'cpu_usage_user_total', color: HOST_PALETTE.blue, unit: 'percent' },
+        { label: '内核态', metric: 'cpu_usage_system_total', color: HOST_PALETTE.indigo, unit: 'percent' },
+        { label: 'I/O Wait 占比', metric: 'cpu_usage_iowait_total', color: HOST_PALETTE.orange, unit: 'percent' },
+        { label: '其他', metric: 'cpu_usage_other_total', color: HOST_PALETTE.neutral, unit: 'percent' }
       ]
     }
   ],

--- a/web/src/app/monitor/dashboards/objects/host/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/host/dashboard.tsx
@@ -150,46 +150,57 @@ export default function HostDashboardPage() {
 
           <div className={styles.sectionLabel}>磁盘与进程</div>
           <FlexiblePanelSection styles={styles}>
-            {[diskChart, processAnomalyChart].map((chart) => chart ? (
+            {diskChart ? (
               <TrendChartPanel
-                key={chart.chart.title}
-                title={chart.chart.title}
-                subtitle={chart.chart.subtitle}
-                guide={chart.chart.guide}
-                legends={chart.legends}
-                data={chart.data}
-                metric={chart.metric}
-                unit={chart.unit}
+                key={diskChart.chart.title}
+                title={diskChart.chart.title}
+                subtitle={diskChart.chart.subtitle}
+                guide={diskChart.chart.guide}
+                legends={diskChart.legends}
+                data={diskChart.data}
+                metric={diskChart.metric}
+                unit={diskChart.unit}
                 loading={dashboard.loading}
-                seriesStyles={chart.seriesStyles}
+                seriesStyles={diskChart.seriesStyles}
                 onXRangeChange={dashboard.onXRangeChange}
-                className={`${styles.span6} ${styles.compactTrend}`}
+                className={`${styles.span4} ${styles.compactTrend}`}
                 styles={styles}
               />
-            ) : null)}
+            ) : null}
+            {HOST_TOP_QUERIES.map((q) => (
+              <HorizontalBarPanel
+                key={q.key}
+                styles={styles}
+                className={`${styles.panel} ${styles.span4}`}
+                title={
+                  <TitleWithGuide
+                    styles={styles}
+                    title={q.title}
+                    items={q.guide}
+                    className={styles.panelTitleWithGuide}
+                  />
+                }
+                items={topBars[q.key] || []}
+              />
+            ))}
+            {processAnomalyChart ? (
+              <TrendChartPanel
+                key={processAnomalyChart.chart.title}
+                title={processAnomalyChart.chart.title}
+                subtitle={processAnomalyChart.chart.subtitle}
+                guide={processAnomalyChart.chart.guide}
+                legends={processAnomalyChart.legends}
+                data={processAnomalyChart.data}
+                metric={processAnomalyChart.metric}
+                unit={processAnomalyChart.unit}
+                loading={dashboard.loading}
+                seriesStyles={processAnomalyChart.seriesStyles}
+                onXRangeChange={dashboard.onXRangeChange}
+                className={`${styles.span4} ${styles.compactTrend}`}
+                styles={styles}
+              />
+            ) : null}
           </FlexiblePanelSection>
-
-          <div className={styles.sectionLabel}>磁盘使用排行</div>
-          <section className={styles.dashboardSection}>
-            <div className={styles.sectionGrid}>
-              {HOST_TOP_QUERIES.map((q) => (
-                <HorizontalBarPanel
-                  key={q.key}
-                  styles={styles}
-                  className={`${styles.panel} ${styles.span12}`}
-                  title={
-                    <TitleWithGuide
-                      styles={styles}
-                      title={q.title}
-                      items={q.guide}
-                      className={styles.panelTitleWithGuide}
-                    />
-                  }
-                  items={topBars[q.key] || []}
-                />
-              ))}
-            </div>
-          </section>
         </>
       }
     />

--- a/web/src/app/monitor/dashboards/objects/host/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/host/dashboard.tsx
@@ -54,7 +54,7 @@ export default function HostDashboardPage() {
   const timeKey = JSON.stringify(timeValues);
 
   useEffect(() => {
-    if (!isDashboardMode) {
+    if (!isDashboardMode || !idValues.length) {
       setTopBars({});
       return;
     }

--- a/web/src/app/monitor/dashboards/objects/host/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/host/index.module.scss
@@ -1,32 +1,6 @@
 @use '../common/simple-dashboard.module.scss';
 
-// 区块小标题:给分区加语义标题,提升可扫读性(与 redis/postgresql 同款)
-.sectionLabel {
-  margin: 2px 2px 4px;
-  padding-bottom: 4px;
-  border-bottom: 1px solid #eceff4;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #8c95a8;
-}
-
-.dashboardSection + .sectionLabel {
-  margin-top: 8px;
-}
-
-:global(html.dark) .sectionLabel {
-  border-bottom-color: rgba(255, 255, 255, 0.08);
-}
-
-.sectionHeading {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  flex-wrap: wrap;
-}
+// sectionLabel 已上收到共享壳；此处仅保留主机趋势图高度微调。
 
 .chartLegendHeader {
   justify-content: flex-end;

--- a/web/src/app/monitor/dashboards/objects/host/queries.ts
+++ b/web/src/app/monitor/dashboards/objects/host/queries.ts
@@ -21,7 +21,7 @@ export const HOST_TOP_QUERIES: HostTopQuery[] = [
     key: 'disk',
     title: '磁盘使用率 Top',
     unit: 'percent',
-    color: '#faad14',
+    color: '#F59E0B',
     labelKeys: ['path', 'device'],
     query: `topk(${HOST_DISK_TOP_N}, max by (path, device) (disk_used_percent{instance_type="os", __$labels__} or host_disk_used_percent_gauge{instance_type="os", __$labels__} or disk_used_percent_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__}))`,
     guide: [{ label: '磁盘排行', detail: '按挂载点/设备使用率最高排序，定位最满分区。' }]

--- a/web/src/app/monitor/dashboards/objects/influxdb/config.ts
+++ b/web/src/app/monitor/dashboards/objects/influxdb/config.ts
@@ -1,5 +1,16 @@
 import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
 
+/** InfluxDB 监控高对比鲜活科技色板 */
+const INFLUX_PALETTE = {
+  emerald: '#10B981',   // 写请求速率
+  blue: '#2563EB',      // Series 数
+  cyan: '#06B6D4',      // 查询请求速率
+  indigo: '#6366F1',    // 堆内存、认证失败
+  amber: '#F59E0B',     // HTTP 4XX 速率
+  orange: '#F97316',    // 写点丢弃速率
+  rose: '#EF4444'       // 写入持久化失败、HTTP 5XX
+} as const;
+
 /**
  * InfluxDB v1 专业盘：叙事中心是高基数 (series) + 写入持久化完整性，
  * 不是通用 RDBMS 会话/表空间模型。仅 9 个指标，刻意做瘦盘。
@@ -19,7 +30,7 @@ export const INFLUXDB_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '所有数据库序列总数，是 InfluxDB 高基数风险的核心指标。',
       unit: 'counts',
       query: 'sum by (instance_id) (influxdb_database_numSeries{__$labels__})',
-      color: '#2f6bff'
+      color: INFLUX_PALETTE.blue
     },
     {
       name: 'influxdb_write_req_rate',
@@ -27,7 +38,7 @@ export const INFLUXDB_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'HTTP 写入请求速率。',
       unit: 'cps',
       query: 'sum by (instance_id) (rate(influxdb_httpd_writeReq{__$labels__}[__$window__]))',
-      color: '#27c274'
+      color: INFLUX_PALETTE.emerald
     },
     {
       name: 'influxdb_query_req_rate',
@@ -35,7 +46,7 @@ export const INFLUXDB_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'HTTP 查询请求速率。',
       unit: 'cps',
       query: 'sum by (instance_id) (rate(influxdb_httpd_queryReq{__$labels__}[__$window__]))',
-      color: '#13c2c2'
+      color: INFLUX_PALETTE.cyan
     },
     {
       name: 'influxdb_points_fail_rate',
@@ -43,7 +54,7 @@ export const INFLUXDB_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '已接收但持久化失败的数据点速率，直接关联数据丢失风险。',
       unit: 'cps',
       query: 'sum by (instance_id) (rate(influxdb_httpd_pointsWrittenFail{__$labels__}[__$window__]))',
-      color: '#ff4d4f'
+      color: INFLUX_PALETTE.rose
     },
     {
       name: 'influxdb_points_dropped_rate',
@@ -51,7 +62,7 @@ export const INFLUXDB_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '已接收但在持久化前被丢弃的数据点速率。',
       unit: 'cps',
       query: 'sum by (instance_id) (rate(influxdb_httpd_pointsWrittenDropped{__$labels__}[__$window__]))',
-      color: '#ff8a1f'
+      color: INFLUX_PALETTE.orange
     },
     {
       name: 'influxdb_server_error_rate',
@@ -59,7 +70,7 @@ export const INFLUXDB_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'HTTP 5XX 错误速率。',
       unit: 'cps',
       query: 'sum by (instance_id) (rate(influxdb_httpd_serverError{__$labels__}[__$window__]))',
-      color: '#ff4d4f'
+      color: INFLUX_PALETTE.rose
     },
     {
       name: 'influxdb_client_error_rate',
@@ -67,7 +78,7 @@ export const INFLUXDB_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'HTTP 4XX 错误速率。',
       unit: 'cps',
       query: 'sum by (instance_id) (rate(influxdb_httpd_clientError{__$labels__}[__$window__]))',
-      color: '#faad14'
+      color: INFLUX_PALETTE.amber
     },
     {
       name: 'influxdb_auth_fail_rate',
@@ -75,7 +86,7 @@ export const INFLUXDB_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'HTTP 认证失败速率。',
       unit: 'cps',
       query: 'sum by (instance_id) (rate(influxdb_httpd_authFail{__$labels__}[__$window__]))',
-      color: '#722ed1'
+      color: INFLUX_PALETTE.indigo
     },
     {
       name: 'influxdb_heap_alloc',
@@ -83,7 +94,7 @@ export const INFLUXDB_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'Go 运行时堆上已分配且正在使用的内存。',
       unit: 'bytes',
       query: 'max by (instance_id) (influxdb_runtime_HeapAlloc{__$labels__})',
-      color: '#8a5cff'
+      color: INFLUX_PALETTE.indigo
     }
   ],
   summaryCards: [
@@ -91,7 +102,7 @@ export const INFLUXDB_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       title: 'Series 数',
       metric: 'influxdb_num_series',
       unit: 'counts',
-      color: '#2f6bff',
+      color: INFLUX_PALETTE.blue,
       icon: 'database',
       compare: true,
       compareFavorableDirection: 'down',
@@ -106,7 +117,7 @@ export const INFLUXDB_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       title: '写请求速率',
       metric: 'influxdb_write_req_rate',
       unit: 'cps',
-      color: '#27c274',
+      color: INFLUX_PALETTE.emerald,
       icon: 'publish',
       compare: true,
       guide: [
@@ -121,7 +132,7 @@ export const INFLUXDB_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       title: '持久化失败',
       metric: 'influxdb_points_fail_rate',
       unit: 'cps',
-      color: '#ff4d4f',
+      color: INFLUX_PALETTE.rose,
       icon: 'thunder',
       compare: true,
       compareFavorableDirection: 'down',
@@ -147,8 +158,8 @@ export const INFLUXDB_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '查询', detail: 'HTTP 查询请求速率。' }
       ],
       series: [
-        { metric: 'influxdb_write_req_rate', label: '写入', color: '#27c274', unit: 'cps' },
-        { metric: 'influxdb_query_req_rate', label: '查询', color: '#13c2c2', unit: 'cps' }
+        { metric: 'influxdb_write_req_rate', label: '写入', color: INFLUX_PALETTE.emerald, unit: 'cps' },
+        { metric: 'influxdb_query_req_rate', label: '查询', color: INFLUX_PALETTE.cyan, unit: 'cps' }
       ]
     },
     {
@@ -162,8 +173,8 @@ export const INFLUXDB_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         }
       ],
       series: [
-        { metric: 'influxdb_points_fail_rate', label: '持久化失败', color: '#ff4d4f', unit: 'cps' },
-        { metric: 'influxdb_points_dropped_rate', label: '丢弃', color: '#ff8a1f', unit: 'cps' }
+        { metric: 'influxdb_points_fail_rate', label: '持久化失败', color: INFLUX_PALETTE.rose, unit: 'cps' },
+        { metric: 'influxdb_points_dropped_rate', label: '丢弃', color: INFLUX_PALETTE.orange, unit: 'cps' }
       ]
     },
     {
@@ -176,9 +187,9 @@ export const INFLUXDB_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '认证失败', detail: '鉴权失败，可能是配置错误或扫描噪声。' }
       ],
       series: [
-        { metric: 'influxdb_server_error_rate', label: '5XX', color: '#ff4d4f', unit: 'cps' },
-        { metric: 'influxdb_client_error_rate', label: '4XX', color: '#faad14', unit: 'cps' },
-        { metric: 'influxdb_auth_fail_rate', label: '认证失败', color: '#722ed1', unit: 'cps' }
+        { metric: 'influxdb_server_error_rate', label: '5XX', color: INFLUX_PALETTE.rose, unit: 'cps' },
+        { metric: 'influxdb_client_error_rate', label: '4XX', color: INFLUX_PALETTE.amber, unit: 'cps' },
+        { metric: 'influxdb_auth_fail_rate', label: '认证失败', color: INFLUX_PALETTE.indigo, unit: 'cps' }
       ]
     },
     {
@@ -187,7 +198,7 @@ export const INFLUXDB_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       metric: 'influxdb_heap_alloc',
       guide: [{ label: '堆内存', detail: 'Go 运行时堆分配大小随时间变化。' }],
       series: [
-        { metric: 'influxdb_heap_alloc', label: 'HeapAlloc', color: '#8a5cff', unit: 'bytes' }
+        { metric: 'influxdb_heap_alloc', label: 'HeapAlloc', color: INFLUX_PALETTE.indigo, unit: 'bytes' }
       ]
     }
   ],

--- a/web/src/app/monitor/dashboards/objects/influxdb/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/influxdb/dashboard.tsx
@@ -29,7 +29,7 @@ export default function InfluxdbDashboardPage() {
       styles={styles}
       dashboardContent={
         <>
-          <div className={styles.sectionLabel}>基数与写入健康</div>
+          <div className={styles.sectionLabel}>健康概览</div>
           <KpiSection dashboard={dashboard} summaryCards={summaryCards} styles={styles} />
 
           <div className={styles.sectionLabel}>请求与完整性</div>

--- a/web/src/app/monitor/dashboards/objects/influxdb/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/influxdb/index.module.scss
@@ -1,34 +1,29 @@
 @use '../common/simple-dashboard.module.scss';
 
-.sectionLabel {
-  margin: 2px 2px 4px;
-  padding-bottom: 4px;
-  border-bottom: 1px solid #eceff4;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #8c95a8;
-}
+// sectionLabel 已上收到共享壳（带品牌蓝指示条与现代间距）；此处仅保留趋势图高度与图例微调。
 
-.dashboardSection + .sectionLabel {
-  margin-top: 8px;
-}
-
-:global(html.dark) .sectionLabel {
-  border-bottom-color: rgba(255, 255, 255, 0.08);
+.chartLegendHeader {
+  justify-content: flex-end;
+  max-width: none;
+  white-space: nowrap;
 }
 
 .compactTrend {
   .chartWrap {
-    height: 164px;
+    height: 180px;
   }
 }
 
 @media (max-width: 768px) {
+  .chartLegendHeader {
+    justify-content: flex-start;
+    max-width: 100%;
+    white-space: normal;
+  }
+
   .compactTrend {
     .chartWrap {
-      height: 138px;
+      height: 140px;
     }
   }
 }

--- a/web/src/app/monitor/dashboards/objects/k3s-cluster/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k3s-cluster/dashboard.tsx
@@ -532,7 +532,7 @@ export default function K3sClusterDashboardPage() {
         ) : (
           <>
             {/* Tier 1 · 概览:6 张等宽卡(采集状态 + 5 KPI),全 span2(=12) */}
-            <div className={styles.sectionLabel}>概览</div>
+            <div className={styles.sectionLabel}>健康概览</div>
             <section className={styles.dashboardSection}>
               <div className={styles.sectionGrid}>
                 <CollectionStatusCard

--- a/web/src/app/monitor/dashboards/objects/k3s-node/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k3s-node/dashboard.tsx
@@ -66,7 +66,7 @@ export default function K3sNodeDashboardPage() {
       styles={styles}
       dashboardContent={
         <>
-          <div className={styles.sectionLabel}>节点概览</div>
+          <div className={styles.sectionLabel}>健康概览</div>
           <KpiSection dashboard={dashboard} summaryCards={dashboard.summaryCards} kpiCols={6} styles={styles} />
           <div className={styles.sectionLabel}>资源趋势</div>
           <TrendSection

--- a/web/src/app/monitor/dashboards/objects/k3s-pod/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k3s-pod/dashboard.tsx
@@ -21,7 +21,7 @@ export default function K3sPodDashboardPage() {
       styles={styles}
       dashboardContent={
         <>
-          <div className={styles.sectionLabel}>Pod 概览</div>
+          <div className={styles.sectionLabel}>健康概览</div>
           <KpiSection dashboard={dashboard} summaryCards={dashboard.summaryCards} kpiCols={5} styles={styles} />
           <div className={styles.sectionLabel}>资源趋势</div>
           <FlexiblePanelSection styles={styles}>

--- a/web/src/app/monitor/dashboards/objects/k8s-cluster/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k8s-cluster/dashboard.tsx
@@ -532,7 +532,7 @@ export default function K8sClusterDashboardPage() {
         ) : (
           <>
             {/* Tier 1 · 概览:6 张等宽卡(采集状态 + 5 KPI),全 span2(=12) */}
-            <div className={styles.sectionLabel}>概览</div>
+            <div className={styles.sectionLabel}>健康概览</div>
             <section className={styles.dashboardSection}>
               <div className={styles.sectionGrid}>
                 <CollectionStatusCard

--- a/web/src/app/monitor/dashboards/objects/k8s-node/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k8s-node/dashboard.tsx
@@ -66,7 +66,7 @@ export default function K8sNodeDashboardPage() {
       styles={styles}
       dashboardContent={
         <>
-          <div className={styles.sectionLabel}>节点概览</div>
+          <div className={styles.sectionLabel}>健康概览</div>
           <KpiSection dashboard={dashboard} summaryCards={dashboard.summaryCards} kpiCols={6} styles={styles} />
           <div className={styles.sectionLabel}>资源趋势</div>
           <TrendSection

--- a/web/src/app/monitor/dashboards/objects/k8s-pod/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k8s-pod/dashboard.tsx
@@ -21,7 +21,7 @@ export default function K8sPodDashboardPage() {
       styles={styles}
       dashboardContent={
         <>
-          <div className={styles.sectionLabel}>Pod 概览</div>
+          <div className={styles.sectionLabel}>健康概览</div>
           <KpiSection dashboard={dashboard} summaryCards={dashboard.summaryCards} kpiCols={5} styles={styles} />
           <div className={styles.sectionLabel}>资源趋势</div>
           <FlexiblePanelSection styles={styles}>

--- a/web/src/app/monitor/dashboards/objects/kafka/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/kafka/dashboard.tsx
@@ -65,7 +65,7 @@ export default function KafkaDashboardPage() {
       styles={styles}
       dashboardContent={(
         <>
-          <div className={styles.sectionLabel}>集群概况</div>
+          <div className={styles.sectionLabel}>健康概览</div>
           <KpiSection
             dashboard={dashboard}
             summaryCards={clusterHealthCards}

--- a/web/src/app/monitor/dashboards/objects/llamaserver/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/llamaserver/dashboard.tsx
@@ -64,7 +64,7 @@ export default function LlamaServerDashboardPage() {
       styles={styles}
       dashboardContent={
         <>
-          <div className={styles.sectionLabel}>推理概览</div>
+          <div className={styles.sectionLabel}>健康概览</div>
           <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={6} styles={styles} />
 
           <div className={styles.sectionLabel}>队列与吞吐</div>

--- a/web/src/app/monitor/dashboards/objects/minio/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/minio/dashboard.tsx
@@ -48,7 +48,7 @@ export default function MinioDashboardPage() {
       styles={styles}
       dashboardContent={
         <>
-          <div className={styles.sectionLabel}>集群健康与容量</div>
+          <div className={styles.sectionLabel}>健康概览</div>
           <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={5} styles={styles} />
 
           <div className={styles.sectionLabel}>容量与冗余</div>

--- a/web/src/app/monitor/dashboards/objects/mongodb/config.ts
+++ b/web/src/app/monitor/dashboards/objects/mongodb/config.ts
@@ -218,42 +218,42 @@ export const DASHBOARD_METRICS: MongoMetricConfig[] = [
 ];
 
 export const DEFAULT_METRIC_COLORS = [
-  '#2f6bff',
-  '#27c274',
-  '#ff9f43',
-  '#ff4d4f',
-  '#13c2c2',
-  '#5b8ff9',
-  '#9aa9bf',
-  '#faad14'
+  '#2563EB',
+  '#10B981',
+  '#F97316',
+  '#EF4444',
+  '#06B6D4',
+  '#6366F1',
+  '#94A3B8',
+  '#F59E0B'
 ];
 
 export const TREND_LEGENDS: Record<string, TrendLegendItem[]> = {
   throughput: [
-    { label: '命令吞吐', color: '#2f6bff', primary: true },
-    { label: '查询吞吐', color: '#13c2c2' },
-    { label: '写入吞吐', color: '#ff9f43' }
+    { label: '命令吞吐', color: '#2563EB', primary: true },
+    { label: '查询吞吐', color: '#06B6D4' },
+    { label: '写入吞吐', color: '#F97316' }
   ],
   latency: [
-    { label: '读延迟', color: '#27c274', primary: true },
-    { label: '命令延迟', color: '#8a5cff' }
+    { label: '读延迟', color: '#10B981', primary: true },
+    { label: '命令延迟', color: '#6366F1' }
   ],
   queue: [
-    { label: '活跃读', color: '#2f6bff', primary: true },
-    { label: '活跃写', color: '#27c274' },
-    { label: '排队读', color: '#5b8ff9' },
-    { label: '排队写', color: '#ff9f43' }
+    { label: '活跃读', color: '#2563EB', primary: true },
+    { label: '活跃写', color: '#10B981' },
+    { label: '排队读', color: '#6366F1' },
+    { label: '排队写', color: '#F97316' }
   ],
   cache: [
-    { label: '缓存已用', color: '#2f6bff', primary: true },
-    { label: '缓存上限', color: '#9aa9bf', dashed: true }
+    { label: '缓存已用', color: '#2563EB', primary: true },
+    { label: '缓存上限', color: '#94A3B8', dashed: true }
   ],
   memory: [
-    { label: '常驻内存', color: '#27c274', primary: true },
-    { label: '虚拟内存', color: '#9aa9bf' }
+    { label: '常驻内存', color: '#10B981', primary: true },
+    { label: '虚拟内存', color: '#94A3B8' }
   ],
   network: [
-    { label: '入流量', color: '#2f6bff', primary: true },
-    { label: '出流量', color: '#27c274' }
+    { label: '入流量', color: '#2563EB', primary: true },
+    { label: '出流量', color: '#10B981' }
   ]
 };

--- a/web/src/app/monitor/dashboards/objects/mongodb/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mongodb/dashboard.tsx
@@ -243,6 +243,13 @@ export default function MongoDashboardPage() {
     if (!silent) setLoading(true);
     try {
       if (isDashboardMode) {
+        if (!idValues.length) {
+          setSeries({});
+          setPreviousSeries({});
+          setCollectionStatusMetric(null);
+          if (!silent) setLoading(false);
+          return;
+        }
         const frozenTimeValues = freezeTimeValues(timeValues);
         const frozenRange = resolveCollectionStatusRange(frozenTimeValues);
         if (frozenRange) setQueryTimeRange(frozenRange);

--- a/web/src/app/monitor/dashboards/objects/mongodb/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mongodb/dashboard.tsx
@@ -21,7 +21,6 @@ import {
   TrendChartPanel,
   RingChartPanel
 } from '../../shared/widgets';
-import { DetailMetricRow } from '../common/dashboard-components';
 import { formatDuration, countRestartsInRange } from '../common/simple-dashboard-core';
 import {
   buildSearchParams,
@@ -69,10 +68,6 @@ interface InstanceOption {
 const MEBIBYTE = 1024 * 1024;
 
 const METRIC_QUERY_CONCURRENCY = 4;
-
-// 详情行 sparkline 取指标语义色,与 KPI/趋势统一配色。
-const metricColor = (name: string): string | undefined =>
-  DASHBOARD_METRICS.find((m) => m.name === name)?.color;
 
 const MONGODB_METRIC_GROUPS = [
   {
@@ -436,6 +431,8 @@ export default function MongoDashboardPage() {
   const virtualDisplay = formatMetricValue(virtualMemory, 'mebibytes');
   const netInDisplay = formatMetricValue(netIn, 'byteps');
   const netOutDisplay = formatMetricValue(netOut, 'byteps');
+  const cursorDisplay = formatMetricValue(cursorTimedOut, 'counts');
+  const userAssertDisplay = formatMetricValue(userAssert, 'counts');
 
   const connectionCompare = getPeriodCompare(currentConnections, getLatestChartValue(previousMetricMap.mongodb_connections_current?.viewData || []));
 
@@ -587,6 +584,12 @@ export default function MongoDashboardPage() {
   const networkDetailGuide = [
     { label: '网络与异常', detail: '展示网络流量、游标超时和用户断言，用于判断响应层异常。' }
   ];
+  const residentGuide = useMemo(() => [{ label: '常驻内存 (Resident)', detail: 'MongoDB 进程实际占用物理内存大小。' }], []);
+  const virtualGuide = useMemo(() => [{ label: '虚拟内存 (Virtual)', detail: 'MongoDB 进程申请的虚拟内存空间，包含映射的存储与缓存。' }], []);
+  const netInGuide = useMemo(() => [{ label: '网络入流量', detail: 'MongoDB 服务端每秒接收的网络数据速率。' }], []);
+  const netOutGuide = useMemo(() => [{ label: '网络出流量', detail: 'MongoDB 服务端每秒发送的网络数据速率。' }], []);
+  const cursorGuide = useMemo(() => [{ label: '游标超时数', detail: '空闲超时被服务端回收的查询游标累计数；持续增长常因结果集未及时遍历完。' }], []);
+  const userAssertGuide = useMemo(() => [{ label: '用户断言', detail: '因非法请求、权限或参数抛出的错误累计次数；持续增长说明客户端存在问题请求。' }], []);
   const metricsOverviewGuide = [
     { label: '监控指标全景', detail: '这里承载完整原始监控视图，适合在仪表盘发现异常后继续下钻排查。' }
   ];
@@ -646,8 +649,8 @@ export default function MongoDashboardPage() {
                   value={renderMetricValue('mongodb_uptime_ns', uptimeDisplay)}
                   unit=""
                   icon={<ClockCircleOutlined />}
-                  iconStyle={{ background: 'rgba(91, 143, 249, 0.12)', color: '#5b8ff9' }}
-                  color="#5b8ff9"
+                  iconStyle={{ background: 'rgba(99, 102, 241, 0.12)', color: '#6366F1' }}
+                  color="#6366F1"
                   footer={<span>启动 {uptimeStartedAt}</span>}
                   hideTrend
                   className={styles.statCardRelaxed}
@@ -668,8 +671,8 @@ export default function MongoDashboardPage() {
                   value={renderMetricValue('mongodb_queued_reads', formatMetricValue(queuedReads, 'counts').value)}
                   unit=""
                   icon={<PauseCircleOutlined />}
-                  iconStyle={{ background: 'rgba(91, 143, 249, 0.12)', color: '#5b8ff9' }}
-                  color="#5b8ff9"
+                  iconStyle={{ background: 'rgba(37, 99, 235, 0.12)', color: '#2563EB' }}
+                  color="#2563EB"
                   footer={
                     <>
                       <span>活跃读 {renderMetricValue('mongodb_active_reads', formatMetricValue(activeReads, 'counts').value)}</span>
@@ -685,8 +688,8 @@ export default function MongoDashboardPage() {
                   value={renderMetricValue('mongodb_queued_writes', formatMetricValue(queuedWrites, 'counts').value)}
                   unit=""
                   icon={<PauseCircleOutlined />}
-                  iconStyle={{ background: 'rgba(255, 159, 67, 0.12)', color: '#ff9f43' }}
-                  color="#ff9f43"
+                  iconStyle={{ background: 'rgba(249, 115, 22, 0.12)', color: '#F97316' }}
+                  color="#F97316"
                   footer={
                     <>
                       <span>活跃写 {renderMetricValue('mongodb_active_writes', formatMetricValue(activeWrites, 'counts').value)}</span>
@@ -701,8 +704,8 @@ export default function MongoDashboardPage() {
                   value={renderMetricValue('mongodb_page_faults_rate', pageFaultDisplay.value)}
                   unit={hasMetricData('mongodb_page_faults_rate') ? pageFaultDisplay.unit : ''}
                   icon={<ExclamationCircleOutlined />}
-                  iconStyle={{ background: 'rgba(255, 77, 79, 0.10)', color: '#ff4d4f' }}
-                  color="#ff4d4f"
+                  iconStyle={{ background: 'rgba(239, 68, 68, 0.12)', color: '#EF4444' }}
+                  color="#EF4444"
                   footer={
                     <>
                       <span>常驻内存 {renderMetricValue('mongodb_resident_megabytes', `${residentDisplay.value}${residentDisplay.unit}`)}</span>
@@ -717,8 +720,8 @@ export default function MongoDashboardPage() {
                   value={renderMetricValue('mongodb_connections_current', connectionsDisplay.value)}
                   unit=""
                   icon={<NodeIndexOutlined />}
-                  iconStyle={{ background: 'rgba(47, 107, 255, 0.12)', color: '#2f6bff' }}
-                  color="#2f6bff"
+                  iconStyle={{ background: 'rgba(37, 99, 235, 0.12)', color: '#2563EB' }}
+                  color="#2563EB"
                   footer={
                     <>
                       <span>打开 {renderMetricValue('mongodb_open_connections', formatMetricValue(openConnections, 'counts').value)}</span>
@@ -863,28 +866,192 @@ export default function MongoDashboardPage() {
                 />
 
                 <DetailPanel
-                  styles={styles}
+                  styles={{ ...styles, detailRowsFill: styles.detailTilesFill }}
                   className={styles.quarterPanel}
                   title="内存与缺页"
                   subtitle="工作集与进程内存匹配"
                   guide={memoryDetailGuide}
                 >
-                  <DetailMetricRow styles={styles} label="常驻内存" value={renderMetricValue('mongodb_resident_megabytes', `${residentDisplay.value}${residentDisplay.unit}`)} viz={hasMetricData('mongodb_resident_megabytes') ? 'spark' : 'none'} trend={metricMap.mongodb_resident_megabytes?.viewData || []} color={metricColor('mongodb_resident_megabytes')} />
-                  <DetailMetricRow styles={styles} label="虚拟内存" value={renderMetricValue('mongodb_vsize_megabytes', `${virtualDisplay.value}${virtualDisplay.unit}`)} viz={hasMetricData('mongodb_vsize_megabytes') ? 'spark' : 'none'} trend={metricMap.mongodb_vsize_megabytes?.viewData || []} color={metricColor('mongodb_vsize_megabytes')} />
-                  <DetailMetricRow styles={styles} label="缺页频率" value={renderMetricValue('mongodb_page_faults_rate', `${pageFaultDisplay.value}${pageFaultDisplay.unit}`)} viz={hasMetricData('mongodb_page_faults_rate') ? 'spark' : 'none'} trend={metricMap.mongodb_page_faults_rate?.viewData || []} color={metricColor('mongodb_page_faults_rate')} />
+                  <div className={styles.metricTileGrid}>
+                    <div className={styles.metricTile}>
+                      <div className={styles.metricTileHeader}>
+                        <div className={styles.metricTileLabelWrap}>
+                          <span className={styles.metricTileDot} style={{ background: '#2f6bff' }} />
+                          <TitleWithGuide title="常驻内存" items={residentGuide} className={styles.metricTileLabel} styles={styles} />
+                        </div>
+                      </div>
+                      <div className={styles.metricTileValueWrap}>
+                        <span className={styles.metricTileValue}>
+                          {hasMetricData('mongodb_resident_megabytes') ? residentDisplay.value : '--'}
+                        </span>
+                        <span className={styles.metricTileUnit}>
+                          {hasMetricData('mongodb_resident_megabytes') ? residentDisplay.unit : ''}
+                        </span>
+                      </div>
+                      <div className={styles.metricTileSubtext}>物理内存驻留</div>
+                    </div>
+
+                    <div className={styles.metricTile}>
+                      <div className={styles.metricTileHeader}>
+                        <div className={styles.metricTileLabelWrap}>
+                          <span className={styles.metricTileDot} style={{ background: '#8a5cff' }} />
+                          <TitleWithGuide title="虚拟内存" items={virtualGuide} className={styles.metricTileLabel} styles={styles} />
+                        </div>
+                      </div>
+                      <div className={styles.metricTileValueWrap}>
+                        <span className={styles.metricTileValue}>
+                          {hasMetricData('mongodb_vsize_megabytes') ? virtualDisplay.value : '--'}
+                        </span>
+                        <span className={styles.metricTileUnit}>
+                          {hasMetricData('mongodb_vsize_megabytes') ? virtualDisplay.unit : ''}
+                        </span>
+                      </div>
+                      <div className={styles.metricTileSubtext}>进程地址空间</div>
+                    </div>
+
+                    <div className={`${styles.metricTile} ${styles.metricTileSpan2}`}>
+                      <div className={styles.metricTileSpan2Left}>
+                        <div className={styles.metricTileHeader}>
+                          <div className={styles.metricTileLabelWrap}>
+                            <span
+                              className={styles.metricTileDot}
+                              style={{ background: pageFaults > 0 ? '#faad14' : '#10b981' }}
+                            />
+                            <TitleWithGuide title="缺页频率" items={pageFaultGuide} className={styles.metricTileLabel} styles={styles} />
+                          </div>
+                          {hasMetricData('mongodb_page_faults_rate') && (
+                            pageFaults > 0 ? (
+                              <span className={`${styles.metricTileBadge} ${styles.metricTileBadgeWarn}`}>换入中</span>
+                            ) : (
+                              <span className={`${styles.metricTileBadge} ${styles.metricTileBadgeSuccess}`}>无缺页</span>
+                            )
+                          )}
+                        </div>
+                        <div className={styles.metricTileSubtext}>工作集与物理内存换入速率</div>
+                      </div>
+                      <div className={styles.metricTileSpan2Right}>
+                        <div className={styles.metricTileValueWrap}>
+                          <span
+                            className={styles.metricTileValue}
+                            style={pageFaults > 0 ? { color: '#faad14' } : undefined}
+                          >
+                            {hasMetricData('mongodb_page_faults_rate') ? pageFaultDisplay.value : '--'}
+                          </span>
+                          <span className={styles.metricTileUnit}>
+                            {hasMetricData('mongodb_page_faults_rate') ? pageFaultDisplay.unit : ''}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                 </DetailPanel>
 
                 <DetailPanel
-                  styles={styles}
+                  styles={{ ...styles, detailRowsFill: styles.detailTilesFill }}
                   className={styles.quarterPanel}
                   title="网络与异常"
                   subtitle="结果返回与异常信号"
                   guide={networkDetailGuide}
                 >
-                  <DetailMetricRow styles={styles} label="入流量" value={renderMetricValue('mongodb_net_in_bytes_count_rate', `${netInDisplay.value}${netInDisplay.unit}`)} viz={hasMetricData('mongodb_net_in_bytes_count_rate') ? 'spark' : 'none'} trend={metricMap.mongodb_net_in_bytes_count_rate?.viewData || []} color={metricColor('mongodb_net_in_bytes_count_rate')} />
-                  <DetailMetricRow styles={styles} label="出流量" value={renderMetricValue('mongodb_net_out_bytes_count_rate', `${netOutDisplay.value}${netOutDisplay.unit}`)} viz={hasMetricData('mongodb_net_out_bytes_count_rate') ? 'spark' : 'none'} trend={metricMap.mongodb_net_out_bytes_count_rate?.viewData || []} color={metricColor('mongodb_net_out_bytes_count_rate')} />
-                  <DetailMetricRow styles={styles} label="游标超时数" guide={[{ label: '游标超时数', detail: '空闲超时被服务端回收的查询游标累计数;偏高常因结果未及时遍历完。' }]} value={renderMetricValue('mongodb_cursor_timed_out_count', formatMetricValue(cursorTimedOut, 'counts').value)} viz={hasMetricData('mongodb_cursor_timed_out_count') ? 'spark' : 'none'} trend={metricMap.mongodb_cursor_timed_out_count?.viewData || []} color={metricColor('mongodb_cursor_timed_out_count')} />
-                  <DetailMetricRow styles={styles} label="用户断言" guide={[{ label: '用户断言', detail: '因非法请求 / 参数抛出的错误累计次数;持续增长说明客户端有问题请求。' }]} value={renderMetricValue('mongodb_assert_user', formatMetricValue(userAssert, 'counts').value)} viz={hasMetricData('mongodb_assert_user') ? 'spark' : 'none'} trend={metricMap.mongodb_assert_user?.viewData || []} color={metricColor('mongodb_assert_user')} />
+                  <div className={styles.metricTileGrid}>
+                    <div className={styles.metricTile}>
+                      <div className={styles.metricTileHeader}>
+                        <div className={styles.metricTileLabelWrap}>
+                          <span className={styles.metricTileDot} style={{ background: '#2f6bff' }} />
+                          <TitleWithGuide title="入流量" items={netInGuide} className={styles.metricTileLabel} styles={styles} />
+                        </div>
+                      </div>
+                      <div className={styles.metricTileValueWrap}>
+                        <span className={styles.metricTileValue}>
+                          {hasMetricData('mongodb_net_in_bytes_count_rate') ? netInDisplay.value : '--'}
+                        </span>
+                        <span className={styles.metricTileUnit}>
+                          {hasMetricData('mongodb_net_in_bytes_count_rate') ? netInDisplay.unit : ''}
+                        </span>
+                      </div>
+                      <div className={styles.metricTileSubtext}>接收数据速率</div>
+                    </div>
+
+                    <div className={styles.metricTile}>
+                      <div className={styles.metricTileHeader}>
+                        <div className={styles.metricTileLabelWrap}>
+                          <span className={styles.metricTileDot} style={{ background: '#10b981' }} />
+                          <TitleWithGuide title="出流量" items={netOutGuide} className={styles.metricTileLabel} styles={styles} />
+                        </div>
+                      </div>
+                      <div className={styles.metricTileValueWrap}>
+                        <span className={styles.metricTileValue}>
+                          {hasMetricData('mongodb_net_out_bytes_count_rate') ? netOutDisplay.value : '--'}
+                        </span>
+                        <span className={styles.metricTileUnit}>
+                          {hasMetricData('mongodb_net_out_bytes_count_rate') ? netOutDisplay.unit : ''}
+                        </span>
+                      </div>
+                      <div className={styles.metricTileSubtext}>发送数据速率</div>
+                    </div>
+
+                    <div className={styles.metricTile}>
+                      <div className={styles.metricTileHeader}>
+                        <div className={styles.metricTileLabelWrap}>
+                          <span
+                            className={styles.metricTileDot}
+                            style={{ background: cursorTimedOut > 0 ? '#faad14' : '#10b981' }}
+                          />
+                          <TitleWithGuide title="游标超时" items={cursorGuide} className={styles.metricTileLabel} styles={styles} />
+                        </div>
+                        {hasMetricData('mongodb_cursor_timed_out_count') && (
+                          cursorTimedOut > 0 ? (
+                            <span className={`${styles.metricTileBadge} ${styles.metricTileBadgeWarn}`}>有超时</span>
+                          ) : (
+                            <span className={`${styles.metricTileBadge} ${styles.metricTileBadgeSuccess}`}>无超时</span>
+                          )
+                        )}
+                      </div>
+                      <div className={styles.metricTileValueWrap}>
+                        <span
+                          className={styles.metricTileValue}
+                          style={cursorTimedOut > 0 ? { color: '#faad14' } : undefined}
+                        >
+                          {hasMetricData('mongodb_cursor_timed_out_count') ? cursorDisplay.value : '--'}
+                        </span>
+                        <span className={styles.metricTileUnit}>
+                          {hasMetricData('mongodb_cursor_timed_out_count') ? (cursorDisplay.unit || '次') : ''}
+                        </span>
+                      </div>
+                      <div className={styles.metricTileSubtext}>空闲回收游标数</div>
+                    </div>
+
+                    <div className={styles.metricTile}>
+                      <div className={styles.metricTileHeader}>
+                        <div className={styles.metricTileLabelWrap}>
+                          <span
+                            className={styles.metricTileDot}
+                            style={{ background: userAssert > 0 ? '#ff4d4f' : '#10b981' }}
+                          />
+                          <TitleWithGuide title="用户断言" items={userAssertGuide} className={styles.metricTileLabel} styles={styles} />
+                        </div>
+                        {hasMetricData('mongodb_assert_user') && (
+                          userAssert > 0 ? (
+                            <span className={`${styles.metricTileBadge} ${styles.metricTileBadgeDanger}`}>有异常</span>
+                          ) : (
+                            <span className={`${styles.metricTileBadge} ${styles.metricTileBadgeSuccess}`}>正常</span>
+                          )
+                        )}
+                      </div>
+                      <div className={styles.metricTileValueWrap}>
+                        <span
+                          className={styles.metricTileValue}
+                          style={userAssert > 0 ? { color: '#ff4d4f' } : undefined}
+                        >
+                          {hasMetricData('mongodb_assert_user') ? userAssertDisplay.value : '--'}
+                        </span>
+                        <span className={styles.metricTileUnit}>
+                          {hasMetricData('mongodb_assert_user') ? (userAssertDisplay.unit || '次') : ''}
+                        </span>
+                      </div>
+                      <div className={styles.metricTileSubtext}>客户端异常请求数</div>
+                    </div>
+                  </div>
                 </DetailPanel>
               </div>
             </>

--- a/web/src/app/monitor/dashboards/objects/mongodb/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/mongodb/index.module.scss
@@ -38,10 +38,10 @@
 
 .pageTitleRow {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  min-height: 32px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 4px;
+  min-width: 0;
 }
 
 .titleBlock {
@@ -52,6 +52,14 @@
   flex: 1;
 }
 
+.titleControlsRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+}
+
 .title {
   margin: 0;
   color: #182132;
@@ -60,6 +68,8 @@
   line-height: 1.25;
   letter-spacing: -0.02em;
   word-break: break-word;
+  min-width: 0;
+  flex: 1;
 }
 
 .meta {
@@ -1539,8 +1549,11 @@
 
   .pageTitleRow {
     width: 100%;
-    align-items: flex-start;
+  }
+
+  .titleControlsRow {
     flex-direction: column;
+    align-items: flex-start;
   }
 
   .instanceCard {

--- a/web/src/app/monitor/dashboards/objects/mongodb/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/mongodb/index.module.scss
@@ -1,24 +1,6 @@
 @use '../common/simple-dashboard.module.scss';
 
-// 区块小标题:给分区加语义标题,提升可扫读性(与 MySQL/PostgreSQL 同款)
-.sectionLabel {
-  margin: 2px 2px 4px;
-  padding-bottom: 4px;
-  border-bottom: 1px solid #eceff4;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #8c95a8;
-}
-
-.dashboardSection + .sectionLabel {
-  margin-top: 8px;
-}
-
-:global(html.dark) .sectionLabel {
-  border-bottom-color: rgba(255, 255, 255, 0.08);
-}
+// sectionLabel 已上收到共享壳（带品牌蓝指示条与现代间距）
 
 .modeContent {
   width: 100%;
@@ -40,21 +22,32 @@
 .pageHeader {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  margin-bottom: 10px;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding: 16px 20px 14px;
+  background: var(--color-bg, #fff);
+  border: 1px solid var(--color-border, #e2e8f0);
+  border-radius: 12px;
+  box-shadow: 0 1px 3px 0 rgba(15, 23, 42, 0.03), 0 1px 2px -1px rgba(15, 23, 42, 0.02);
+  transition: border-color 0.15s ease;
+}
+
+.pageHeader:hover {
+  border-color: color-mix(in srgb, var(--color-primary, #155aef) 18%, var(--color-border, #e2e8f0));
 }
 
 .pageTitleRow {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
+  gap: 12px;
+  min-height: 32px;
 }
 
 .titleBlock {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
   min-width: 0;
   flex: 1;
 }
@@ -62,17 +55,17 @@
 .title {
   margin: 0;
   color: #182132;
-  font-size: 28px;
+  font-size: 22px;
   font-weight: 700;
-  line-height: 1.15;
+  line-height: 1.25;
   letter-spacing: -0.02em;
   word-break: break-word;
 }
 
 .meta {
   display: flex;
-  align-items: center;
-  gap: 8px 10px;
+  align-items: baseline;
+  gap: 4px;
   flex-wrap: wrap;
   color: #3f5370;
   min-width: 0;
@@ -83,9 +76,11 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: 6px 0 8px;
-  border-bottom: 1px solid #e7edf5;
+  gap: 16px;
+  padding-top: 12px;
+  padding-bottom: 0;
+  border-top: 1px solid var(--color-border-1, #e7edf5);
+  border-bottom: none;
   background: transparent;
   border-radius: 0;
   box-shadow: none;
@@ -112,26 +107,29 @@
 }
 
 .instanceIcon {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, #fff0f0 0%, #fff7f7 100%);
+  width: 38px;
+  height: 38px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--color-primary, #155aef) 10%, var(--color-bg, #fff));
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #ff4d4f;
-  font-size: 20px;
-  box-shadow: inset 0 0 0 1px rgba(255, 77, 79, 0.08);
+  color: var(--color-primary, #155aef);
+  font-size: 19px;
   flex-shrink: 0;
+  border: none;
+  box-shadow: none;
 }
 
 .instanceName {
-  font-size: 18px;
-  font-weight: 700;
+  font-size: 16px;
+  font-weight: 600;
   color: #182132;
-  line-height: 1.22;
+  line-height: 1.4;
+  letter-spacing: -0.01em;
   min-width: 0;
   word-break: break-word;
+  margin-right: 4px;
 }
 
 // 头部布局/控件样式（实例选择器、时间选择器、刷新两-pill）统一继承基座
@@ -270,21 +268,21 @@
 }
 
 .statLabel {
-  color: #334861;
-  font-size: 15px;
-  font-weight: 700;
-  line-height: 1.3;
+  color: var(--color-text-1);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
   min-width: 0;
 }
 
 .statIcon {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 16px;
+  font-size: 15px;
 }
 
 .statBody {
@@ -301,34 +299,41 @@
 }
 
 .statValue {
-  color: #182132;
-  font-size: 30px;
+  color: var(--color-text-1);
+  font-size: 26px;
   font-weight: 700;
-  line-height: 1.08;
-  letter-spacing: -0.03em;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
   word-break: break-word;
   display: inline-flex;
   align-items: baseline;
   gap: 4px;
   flex-wrap: wrap;
+  font-variant-numeric: tabular-nums;
 }
 
 .statUnit {
-  font-size: 14px;
-  margin-left: 0;
-  color: #5d728b;
+  font-size: 13px;
+  margin-left: 2px;
+  color: var(--color-text-2);
+  font-weight: 600;
   line-height: 1;
 }
 
 .statMeta {
   display: flex;
   align-items: center;
-  gap: 6px 10px;
+  gap: 8px 12px;
   flex-wrap: wrap;
-  color: #64748b;
-  font-size: 14px;
-  line-height: 1.5;
-  min-height: 22px;
+  font-size: 11px;
+  line-height: 1.4;
+  min-height: 18px;
+  color: var(--color-text-3);
+
+  span {
+    color: var(--color-text-3);
+    font-weight: 400;
+  }
 }
 
 .statCompare {
@@ -485,127 +490,7 @@
   height: 100%;
 }
 
-.collectionStatusCard {
-  justify-content: flex-start;
-  min-height: 122px;
-}
-
-.collectionStatusHeader {
-  min-height: 32px;
-}
-
-.collectionStatusBody {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  gap: 10px;
-  min-height: 0;
-}
-
-.collectionStatusValue {
-  font-size: 30px;
-  font-weight: 700;
-  line-height: 1.05;
-  letter-spacing: -0.03em;
-  min-height: 40px;
-  display: flex;
-  align-items: center;
-}
-
-.collectionStatusValueSuccess {
-  color: #22c55e;
-}
-
-.collectionStatusValueError {
-  color: #ff4d4f;
-}
-
-.collectionStatusValueEmpty {
-  color: #94a3b8;
-}
-
-.collectionStatusTimelineBlock {
-  margin-top: 0;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-}
-
-.collectionStatusTimelineTitle {
-  margin-top: 0;
-  color: #536882;
-  font-size: 14px;
-  font-weight: 700;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-}
-
-.collectionStatusTimelineHint {
-  flex-shrink: 0;
-  color: #94a3b8;
-  font-size: 12px;
-  font-weight: 500;
-  white-space: nowrap;
-}
-
-
-.collectionStatusTimeline {
-  display: grid;
-  grid-template-columns: repeat(18, minmax(0, 1fr));
-  gap: 4px;
-  margin-top: 8px;
-}
-
-.collectionStatusSegment {
-  display: block;
-  min-width: 0;
-  width: 100%;
-  height: 22px;
-  border-radius: 4px;
-  border: 1px solid transparent;
-  cursor: default;
-}
-
-.collectionStatusSegmentSuccess {
-  background: #22c55e;
-  border-color: #b6f0c8;
-}
-
-.collectionStatusSegmentEmpty {
-  background: #d7dfeb;
-  border-color: #edf2f9;
-}
-
-.collectionStatusSegmentError {
-  background: #ff4d4f;
-  border-color: #ffc3c3;
-}
-
-.collectionStatusLegend {
-  display: flex;
-  align-items: center;
-  gap: 18px;
-  flex-wrap: wrap;
-  margin-top: 8px;
-  color: #42556d;
-  font-size: 14px;
-  font-weight: 700;
-}
-
-.collectionStatusLegendItem {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.collectionStatusLegendDot {
-  width: 14px;
-  height: 14px;
-  border-radius: 4px;
-  box-shadow: inset 0 0 0 1px rgba(19, 33, 56, 0.04);
-}
+// 采集状态卡片样式统一走共享壳 simple-dashboard，避免本地旧版覆盖。
 
 .panel {
   padding: 16px;
@@ -682,18 +567,18 @@
 
 .panelTitle {
   margin: 0;
-  color: #1d2f47;
-  font-size: 17px;
+  color: var(--color-text-1);
+  font-size: 16px;
   font-weight: 700;
-  line-height: 1.25;
+  line-height: 1.3;
   letter-spacing: -0.01em;
 }
 
 .panelSubTitle {
-  color: #9caabd;
-  font-size: 13px;
-  font-weight: 500;
-  line-height: 1.4;
+  color: var(--color-text-3);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.5;
 }
 
 .chartLegend {
@@ -797,6 +682,155 @@
   font-weight: 850;
   line-height: 1.2;
   white-space: nowrap;
+}
+
+// 详情磁贴填充容器：替代传统行容器，使磁贴网格充满剩余高度
+.detailTilesFill {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 6px 0 2px;
+}
+
+// 现代指标磁贴网格 (Metric Tiles)
+.metricTileGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-auto-rows: 1fr;
+  gap: 10px;
+  flex: 1;
+  min-height: 0;
+}
+
+.metricTile {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: var(--color-fill-1);
+  border: 1px solid var(--color-border);
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  box-sizing: border-box;
+
+  &:hover {
+    border-color: color-mix(in srgb, var(--color-primary) 36%, var(--color-border));
+    box-shadow: 0 2px 10px rgba(18, 38, 63, 0.05);
+  }
+}
+
+.metricTileSpan2 {
+  grid-column: span 2;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.metricTileSpan2Left {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.metricTileSpan2Right {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.metricTileHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+
+.metricTileLabelWrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.metricTileDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+
+.metricTileLabel {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-2);
+  line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.metricTileSubtext {
+  font-size: 11px;
+  color: var(--color-text-3);
+  line-height: 1.3;
+  margin-top: 1px;
+}
+
+.metricTileValueWrap {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 3px;
+  min-width: 0;
+  margin-top: 4px;
+}
+
+.metricTileValue {
+  font-size: 19px;
+  font-weight: 700;
+  color: var(--color-text-1);
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.metricTileUnit {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text-3);
+  line-height: 1;
+}
+
+.metricTileBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.3;
+  white-space: nowrap;
+}
+
+.metricTileBadgeSuccess {
+  color: #10b981;
+  background: color-mix(in srgb, #10b981 12%, transparent);
+}
+
+.metricTileBadgeWarn {
+  color: #faad14;
+  background: color-mix(in srgb, #faad14 14%, transparent);
+}
+
+.metricTileBadgeDanger {
+  color: #ff4d4f;
+  background: color-mix(in srgb, #ff4d4f 14%, transparent);
 }
 
 .fragmentationWarning {
@@ -1297,6 +1331,29 @@
   border-bottom-color: rgba(255, 255, 255, 0.08);
 }
 
+:global(html.dark) .metricTile {
+  background: rgba(255, 255, 255, 0.04) !important;
+  border-color: rgba(255, 255, 255, 0.08) !important;
+}
+
+:global(html.dark) .metricTile:hover {
+  background: rgba(255, 255, 255, 0.07) !important;
+  border-color: rgba(47, 107, 255, 0.4) !important;
+}
+
+:global(html.dark) .metricTileValue {
+  color: rgba(255, 255, 255, 0.92);
+}
+
+:global(html.dark) .metricTileLabel {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+:global(html.dark) .metricTileSubtext,
+:global(html.dark) .metricTileUnit {
+  color: rgba(255, 255, 255, 0.45);
+}
+
 :global(html.dark) .uptimeStatus {
   background: rgba(255, 255, 255, 0.06) !important;
   border-color: rgba(255, 255, 255, 0.1) !important;
@@ -1330,28 +1387,6 @@
   background: rgba(255, 77, 79, 0.14);
   border-color: rgba(255, 159, 159, 0.2);
   color: #ffb3b3;
-}
-
-:global(html.dark) .collectionStatusSegmentEmpty {
-  background: rgba(255, 255, 255, 0.08);
-}
-
-:global(html.dark) .collectionStatusSegment {
-  border-color: transparent;
-}
-
-:global(html.dark) .collectionStatusSegmentSuccess {
-  background: #22c55e;
-  border-color: rgba(162, 243, 196, 0.35);
-}
-
-:global(html.dark) .collectionStatusSegmentError {
-  background: #ff4d4f;
-  border-color: rgba(255, 166, 166, 0.28);
-}
-
-:global(html.dark) .collectionStatusLegendDot {
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
 }
 
 :global(html.dark) .toolbarTimeSelector > div > div:first-child :global(.ant-select-selector),

--- a/web/src/app/monitor/dashboards/objects/mssql/config.ts
+++ b/web/src/app/monitor/dashboards/objects/mssql/config.ts
@@ -1,5 +1,17 @@
 import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
 
+/** MSSQL 监控高对比鲜活科技色板 */
+const MSSQL_PALETTE = {
+  emerald: '#10B981',   // 批量请求、写入速率、缓存命中率、可用空间
+  blue: '#2563EB',      // 进程CPU、读延迟、读取速率、检查点写页、已用卷
+  cyan: '#06B6D4',      // 卷可用空间、逻辑读、编译、页面生命周期
+  indigo: '#6366F1',    // 运行时长、请求总耗时、惰性写入、用户连接
+  amber: '#F59E0B',     // 资源等待、死锁、版本存储、重编译
+  orange: '#F97316',    // 写延迟、内存授予等待、信号等待、锁等待
+  rose: '#EF4444',      // 阻塞进程、等待任务
+  neutral: '#94A3B8'    // 系统空闲 CPU、总空间、目标内存
+} as const;
+
 export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   routeKey: 'mssql',
   pageTitle: 'MSSQL 监控仪表盘',
@@ -14,7 +26,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'SQL Server 实例自上次启动以来的持续运行时间。',
       unit: 's',
       query: 'sqlserver_server_properties_uptime{__$labels__}',
-      color: '#597ef7'
+      color: MSSQL_PALETTE.indigo
     },
     {
       name: 'sqlserver_cpu_sqlserver_process_cpu_avg',
@@ -22,7 +34,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'SQL Server 数据库进程的 CPU 使用率。',
       unit: 'percent',
       query: 'avg_over_time(sqlserver_cpu_sqlserver_process_cpu{__$labels__}[__$window__])',
-      color: '#2f6bff'
+      color: MSSQL_PALETTE.blue
     },
     {
       name: 'sqlserver_cpu_system_idle_cpu_avg',
@@ -30,7 +42,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '操作系统整体空闲 CPU 百分比。',
       unit: 'percent',
       query: 'avg_over_time(sqlserver_cpu_system_idle_cpu{__$labels__}[__$window__])',
-      color: '#9aa9bf'
+      color: MSSQL_PALETTE.neutral
     },
     {
       name: 'sqlserver_database_io_read_latency_ms',
@@ -38,7 +50,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '数据库文件读操作的平均延迟时间。',
       unit: 'ms',
       query: 'avg without (database) (avg_over_time(sqlserver_database_io_read_latency_ms{__$labels__}[__$window__]))',
-      color: '#2f6bff'
+      color: MSSQL_PALETTE.blue
     },
     {
       name: 'sqlserver_database_io_write_latency_ms',
@@ -46,7 +58,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '数据库文件写操作的平均延迟时间。',
       unit: 'ms',
       query: 'avg without (database) (avg_over_time(sqlserver_database_io_write_latency_ms{__$labels__}[__$window__]))',
-      color: '#ff8a1f'
+      color: MSSQL_PALETTE.orange
     },
     {
       name: 'sqlserver_database_io_reads_rate',
@@ -54,7 +66,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '数据库文件读操作速率。',
       unit: 'cps',
       query: 'sum without (database) (rate(sqlserver_database_io_reads{__$labels__}[__$window__]))',
-      color: '#2f6bff'
+      color: MSSQL_PALETTE.blue
     },
     {
       name: 'sqlserver_database_io_writes_rate',
@@ -62,7 +74,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '数据库文件写操作速率。',
       unit: 'cps',
       query: 'sum without (database) (rate(sqlserver_database_io_writes{__$labels__}[__$window__]))',
-      color: '#27c274'
+      color: MSSQL_PALETTE.emerald
     },
     {
       name: 'sqlserver_memory_clerks_size_kb',
@@ -70,7 +82,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'SQL Server 内部内存 Clerk 分配大小。',
       unit: 'kibibytes',
       query: 'sqlserver_memory_clerks_size_kb{__$labels__}',
-      color: '#8a5cff'
+      color: MSSQL_PALETTE.indigo
     },
     {
       name: 'sqlserver_performance_value_rate',
@@ -78,7 +90,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'SQL Server 处理批量请求的速率。',
       unit: 'cps',
       query: 'rate(sqlserver_performance_value{counter=~"Batch Requests/sec", __$labels__}[__$window__])',
-      color: '#27c274'
+      color: MSSQL_PALETTE.emerald
     },
     {
       name: 'sqlserver_checkpoint_pages_rate',
@@ -86,7 +98,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '检查点进程将脏页刷写到磁盘的速率。',
       unit: 'cps',
       query: 'rate(sqlserver_performance_value{counter="Checkpoint pages/sec", __$labels__}[__$window__])',
-      color: '#2f6bff'
+      color: MSSQL_PALETTE.blue
     },
     {
       name: 'sqlserver_lazy_writes_rate',
@@ -94,7 +106,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '惰性写入器为腾出缓冲池空间而刷写页面的速率。',
       unit: 'cps',
       query: 'rate(sqlserver_performance_value{counter="Lazy writes/sec", __$labels__}[__$window__])',
-      color: '#8a5cff'
+      color: MSSQL_PALETTE.indigo
     },
     {
       name: 'sqlserver_memory_grants_pending',
@@ -102,7 +114,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '当前等待执行内存授予的查询数量。',
       unit: 'counts',
       query: 'sqlserver_performance_value{counter="Memory Grants Pending", __$labels__}',
-      color: '#ff8a1f'
+      color: MSSQL_PALETTE.orange
     },
     {
       name: 'sqlserver_memory_grants_outstanding',
@@ -110,7 +122,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '当前已获得查询工作区内存但尚未完成的请求数。',
       unit: 'counts',
       query: 'sqlserver_performance_value{counter="Memory Grants Outstanding", __$labels__}',
-      color: '#2f6bff'
+      color: MSSQL_PALETTE.blue
     },
     {
       name: 'sqlserver_memory_target_server_memory_kb',
@@ -118,7 +130,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'SQL Server 目标内存大小。',
       unit: 'kibibytes',
       query: 'sqlserver_performance_value{counter="Target Server Memory (KB)", __$labels__}',
-      color: '#9aa9bf'
+      color: MSSQL_PALETTE.neutral
     },
     {
       name: 'sqlserver_memory_total_server_memory_kb',
@@ -126,7 +138,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'SQL Server 当前已提交的内存大小。',
       unit: 'kibibytes',
       query: 'sqlserver_performance_value{counter="Total Server Memory (KB)", __$labels__}',
-      color: '#8a5cff'
+      color: MSSQL_PALETTE.indigo
     },
     {
       name: 'sqlserver_tempdb_free_space_kb',
@@ -134,7 +146,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'TempDB 当前可用空间。',
       unit: 'kibibytes',
       query: 'sqlserver_performance_value{counter="Free Space in tempdb (KB)", __$labels__}',
-      color: '#27c274'
+      color: MSSQL_PALETTE.emerald
     },
     {
       name: 'sqlserver_tempdb_version_store_size_kb',
@@ -142,7 +154,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'TempDB 当前版本存储大小。',
       unit: 'kibibytes',
       query: 'sqlserver_performance_value{counter="Version Store Size (KB)", __$labels__}',
-      color: '#faad14'
+      color: MSSQL_PALETTE.amber
     },
     {
       name: 'sqlserver_log_flushes_rate',
@@ -150,7 +162,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '事务日志刷写速率。',
       unit: 'cps',
       query: 'rate(sqlserver_performance_value{counter="Log Flushes/sec", __$labels__}[__$window__])',
-      color: '#13c2c2'
+      color: MSSQL_PALETTE.cyan
     },
     {
       name: 'sqlserver_processes_blocked',
@@ -158,7 +170,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '当前被阻塞的 SQL Server 进程数量。',
       unit: 'counts',
       query: 'sqlserver_performance_value{counter="Processes blocked", __$labels__}',
-      color: '#ff4d4f'
+      color: MSSQL_PALETTE.rose
     },
     {
       name: 'sqlserver_deadlocks_rate',
@@ -166,7 +178,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'SQL Server 死锁发生速率。',
       unit: 'cps',
       query: 'rate(sqlserver_performance_value{counter="Number of Deadlocks/sec", __$labels__}[__$window__])',
-      color: '#ff4d4f'
+      color: MSSQL_PALETTE.rose
     },
     {
       name: 'sqlserver_sql_compilations_rate',
@@ -174,7 +186,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'SQL 语句编译速率。',
       unit: 'cps',
       query: 'rate(sqlserver_performance_value{counter="SQL Compilations/sec", __$labels__}[__$window__])',
-      color: '#13c2c2'
+      color: MSSQL_PALETTE.cyan
     },
     {
       name: 'sqlserver_sql_recompilations_rate',
@@ -182,7 +194,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'SQL 语句重编译速率。',
       unit: 'cps',
       query: 'rate(sqlserver_performance_value{counter="SQL Re-Compilations/sec", __$labels__}[__$window__])',
-      color: '#faad14'
+      color: MSSQL_PALETTE.amber
     },
     {
       name: 'sqlserver_page_life_expectancy',
@@ -190,7 +202,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '数据页在缓冲池中平均停留时间。',
       unit: 's',
       query: 'sqlserver_performance_value{counter="Page life expectancy", __$labels__}',
-      color: '#13c2c2'
+      color: MSSQL_PALETTE.cyan
     },
     {
       name: 'sqlserver_buffer_cache_hit_ratio',
@@ -198,7 +210,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '从缓冲池满足数据页读取的百分比。',
       unit: 'percent',
       query: 'sqlserver_performance_value{counter="Buffer cache hit ratio", __$labels__}',
-      color: '#27c274'
+      color: MSSQL_PALETTE.emerald
     },
     {
       name: 'sqlserver_user_connections_rate',
@@ -206,7 +218,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '当前连接到 SQL Server 实例的用户数量。',
       unit: 'counts',
       query: 'sqlserver_performance_value{counter="User Connections", __$labels__}',
-      color: '#597ef7'
+      color: MSSQL_PALETTE.indigo
     },
     {
       name: 'sqlserver_lock_wait_time_rate',
@@ -214,7 +226,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '锁等待发生速率。',
       unit: 'cps',
       query: 'rate(sqlserver_performance_value{counter="Lock Waits/sec", __$labels__}[__$window__])',
-      color: '#ff8a1f'
+      color: MSSQL_PALETTE.orange
     },
     {
       name: 'sqlserver_schedulers_active_workers_count',
@@ -222,7 +234,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '调度器上当前执行任务的活跃工作线程数。',
       unit: 'counts',
       query: 'sqlserver_schedulers_active_workers_count{__$labels__}',
-      color: '#2f6bff'
+      color: MSSQL_PALETTE.blue
     },
     {
       name: 'sqlserver_schedulers_runnable_tasks_count',
@@ -230,7 +242,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '就绪等待 CPU 执行的任务数。',
       unit: 'counts',
       query: 'sqlserver_schedulers_runnable_tasks_count{__$labels__}',
-      color: '#faad14'
+      color: MSSQL_PALETTE.amber
     },
     {
       name: 'sqlserver_waitstats_waiting_tasks_count',
@@ -238,7 +250,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '当前等待的任务数量。',
       unit: 'counts',
       query: 'sqlserver_waitstats_waiting_tasks_count{__$labels__}',
-      color: '#ff4d4f'
+      color: MSSQL_PALETTE.rose
     },
     {
       name: 'sqlserver_requests_cpu_time_ms_rate',
@@ -246,7 +258,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '请求消耗 CPU 时间的速率（ms/s）。',
       unit: 'msps',
       query: 'rate(sqlserver_requests_cpu_time_ms{__$labels__}[__$window__])',
-      color: '#2f6bff'
+      color: MSSQL_PALETTE.blue
     },
     {
       name: 'sqlserver_requests_logical_reads_rate',
@@ -254,7 +266,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '请求逻辑读操作速率。',
       unit: 'cps',
       query: 'rate(sqlserver_requests_logical_reads{__$labels__}[__$window__])',
-      color: '#13c2c2'
+      color: MSSQL_PALETTE.cyan
     },
     {
       name: 'sqlserver_requests_total_elapsed_time_ms_rate',
@@ -262,7 +274,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '请求总执行时间速率（ms/s）。',
       unit: 'msps',
       query: 'rate(sqlserver_requests_total_elapsed_time_ms{__$labels__}[__$window__])',
-      color: '#8a5cff'
+      color: MSSQL_PALETTE.indigo
     },
     {
       name: 'sqlserver_requests_wait_time_ms_rate',
@@ -270,7 +282,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '请求等待资源时间速率（ms/s）。',
       unit: 'msps',
       query: 'rate(sqlserver_requests_wait_time_ms{__$labels__}[__$window__])',
-      color: '#ff8a1f'
+      color: MSSQL_PALETTE.orange
     },
     {
       name: 'sqlserver_waitstats_resource_wait_ms',
@@ -278,7 +290,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '等待外部资源的时间速率（ms/s）。',
       unit: 'msps',
       query: 'rate(sqlserver_waitstats_resource_wait_ms{__$labels__}[__$window__])',
-      color: '#faad14'
+      color: MSSQL_PALETTE.cyan
     },
     {
       name: 'sqlserver_waitstats_wait_time_ms_rate',
@@ -286,15 +298,15 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'SQL Server 各类等待类型累计等待时间速率（ms/s）。',
       unit: 'msps',
       query: 'rate(sqlserver_waitstats_wait_time_ms{__$labels__}[__$window__])',
-      color: '#8a5cff'
+      color: MSSQL_PALETTE.indigo
     },
     {
       name: 'sqlserver_waitstats_signal_wait_time_ms_rate',
       display_name: '信号等待速率',
       description: '等待 CPU 调度器的时间速率（ms/s）。',
       unit: 'msps',
-      query: 'rate(sqlserver_waitstats_signal_wait_time_ms{__$labels__}[__$window__])',
-      color: '#ff8a1f'
+      query: 'rate(sqlserver_waitstats_signal_wait_time_ms_rate{__$labels__}[__$window__])',
+      color: MSSQL_PALETTE.orange
     },
     {
       name: 'sqlserver_volume_space_available_space_bytes',
@@ -302,7 +314,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '存储卷的可用空间。',
       unit: 'bytes',
       query: 'sum by (instance_id) (sqlserver_volume_space_available_space_bytes{__$labels__})',
-      color: '#13c2c2'
+      color: MSSQL_PALETTE.cyan
     },
     {
       name: 'sqlserver_volume_space_total_space_bytes',
@@ -310,7 +322,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '存储卷的总容量（多卷按实例求和）。',
       unit: 'bytes',
       query: 'sum by (instance_id) (sqlserver_volume_space_total_space_bytes{__$labels__})',
-      color: '#9aa9bf'
+      color: MSSQL_PALETTE.neutral
     },
     {
       name: 'sqlserver_volume_space_used_space_bytes',
@@ -318,7 +330,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '存储卷的已用空间（多卷按实例求和）。',
       unit: 'bytes',
       query: 'sum by (instance_id) (sqlserver_volume_space_used_space_bytes{__$labels__})',
-      color: '#2f6bff'
+      color: MSSQL_PALETTE.blue
     },
     {
       name: 'sqlserver_volume_space_used_ratio',
@@ -326,7 +338,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '实例各卷合计已用空间占总容量的比例。',
       unit: 'percent',
       query: '100 * sum by (instance_id) (sqlserver_volume_space_used_space_bytes{__$labels__}) / clamp_min(sum by (instance_id) (sqlserver_volume_space_total_space_bytes{__$labels__}), 1)',
-      color: '#2f6bff'
+      color: MSSQL_PALETTE.blue
     }
   ],
   summaryCards: [
@@ -334,7 +346,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       title: '运行时长',
       metric: 'sqlserver_server_properties_uptime',
       formatter: 'duration',
-      color: '#597ef7',
+      color: MSSQL_PALETTE.indigo,
       icon: 'clock',
       isUptimeCard: true,
       hideTrend: true,
@@ -344,7 +356,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '批量请求速率',
       metric: 'sqlserver_performance_value_rate',
-      color: '#27c274',
+      color: MSSQL_PALETTE.emerald,
       icon: 'thunder',
       guide: [{ label: '批量请求', detail: '每秒处理的 SQL 批量请求数(次/秒),无固定阈值,按业务基线看突增突降。' }],
       footer: [{ label: '当前连接', metric: 'sqlserver_user_connections_rate', unit: 'counts' }]
@@ -352,7 +364,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '缓存命中率',
       metric: 'sqlserver_buffer_cache_hit_ratio',
-      color: '#27c274',
+      color: MSSQL_PALETTE.emerald,
       icon: 'database',
       compare: true,
       compareFavorableDirection: 'up',
@@ -361,7 +373,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '读延迟',
       metric: 'sqlserver_database_io_read_latency_ms',
-      color: '#ff8a1f',
+      color: MSSQL_PALETTE.blue,
       icon: 'api',
       compare: true,
       guide: [{ label: '读延迟', detail: '数据库文件读操作平均延迟，持续升高需排查存储性能；写延迟见下方「读写延迟」趋势。' }]
@@ -369,7 +381,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '卷可用空间',
       metric: 'sqlserver_volume_space_available_space_bytes',
-      color: '#13c2c2',
+      color: MSSQL_PALETTE.cyan,
       icon: 'database',
       guide: [{ label: '卷可用空间', detail: '数据库所在卷剩余空间，空间不足会影响写入和维护任务。' }],
       footer: [
@@ -387,8 +399,8 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '写延迟', detail: '数据库文件写操作平均延迟。' }
       ],
       series: [
-        { metric: 'sqlserver_database_io_read_latency_ms', label: '读延迟', color: '#2f6bff', unit: 'ms' },
-        { metric: 'sqlserver_database_io_write_latency_ms', label: '写延迟', color: '#ff8a1f', unit: 'ms' }
+        { metric: 'sqlserver_database_io_read_latency_ms', label: '读延迟', color: MSSQL_PALETTE.blue, unit: 'ms' },
+        { metric: 'sqlserver_database_io_write_latency_ms', label: '写延迟', color: MSSQL_PALETTE.orange, unit: 'ms' }
       ]
     },
     {
@@ -400,8 +412,8 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '写入速率', detail: '数据库文件写操作速率。' }
       ],
       series: [
-        { metric: 'sqlserver_database_io_reads_rate', label: '读取速率', color: '#2f6bff', unit: 'cps' },
-        { metric: 'sqlserver_database_io_writes_rate', label: '写入速率', color: '#27c274', unit: 'cps' }
+        { metric: 'sqlserver_database_io_reads_rate', label: '读取速率', color: MSSQL_PALETTE.blue, unit: 'cps' },
+        { metric: 'sqlserver_database_io_writes_rate', label: '写入速率', color: MSSQL_PALETTE.emerald, unit: 'cps' }
       ]
     },
     {
@@ -413,8 +425,8 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '系统空闲', detail: '操作系统空闲 CPU 百分比。' }
       ],
       series: [
-        { metric: 'sqlserver_cpu_sqlserver_process_cpu_avg', label: '进程 CPU', color: '#2f6bff', unit: 'percent' },
-        { metric: 'sqlserver_cpu_system_idle_cpu_avg', label: '系统空闲', color: '#69c0ff', unit: 'percent' }
+        { metric: 'sqlserver_cpu_sqlserver_process_cpu_avg', label: '进程 CPU', color: MSSQL_PALETTE.blue, unit: 'percent' },
+        { metric: 'sqlserver_cpu_system_idle_cpu_avg', label: '系统空闲', color: MSSQL_PALETTE.neutral, unit: 'percent' }
       ]
     },
     {
@@ -426,8 +438,8 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '总空间', detail: '存储卷总容量。' }
       ],
       series: [
-        { metric: 'sqlserver_volume_space_used_space_bytes', label: '已用空间', color: '#2f6bff', unit: 'bytes' },
-        { metric: 'sqlserver_volume_space_total_space_bytes', label: '总空间', color: '#9aa9bf', unit: 'bytes' }
+        { metric: 'sqlserver_volume_space_used_space_bytes', label: '已用空间', color: MSSQL_PALETTE.blue, unit: 'bytes' },
+        { metric: 'sqlserver_volume_space_total_space_bytes', label: '总空间', color: MSSQL_PALETTE.neutral, unit: 'bytes' }
       ]
     },
     {
@@ -440,9 +452,9 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '资源等待', detail: '等待外部资源的时间速率（ms/s）。' }
       ],
       series: [
-        { metric: 'sqlserver_waitstats_wait_time_ms_rate', label: '总等待', color: '#8a5cff', unit: 'msps' },
-        { metric: 'sqlserver_waitstats_signal_wait_time_ms_rate', label: '信号等待', color: '#ff8a1f', unit: 'msps' },
-        { metric: 'sqlserver_waitstats_resource_wait_ms', label: '资源等待', color: '#13c2c2', unit: 'msps' }
+        { metric: 'sqlserver_waitstats_wait_time_ms_rate', label: '总等待', color: MSSQL_PALETTE.indigo, unit: 'msps' },
+        { metric: 'sqlserver_waitstats_signal_wait_time_ms_rate', label: '信号等待', color: MSSQL_PALETTE.orange, unit: 'msps' },
+        { metric: 'sqlserver_waitstats_resource_wait_ms', label: '资源等待', color: MSSQL_PALETTE.cyan, unit: 'msps' }
       ]
     },
     {
@@ -454,8 +466,8 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '惰性写入', detail: '惰性写入器为缓冲池腾出空间的速率；持续升高且页生命周期下降时表示内存压力。' }
       ],
       series: [
-        { metric: 'sqlserver_checkpoint_pages_rate', label: '检查点写页', color: '#2f6bff', unit: 'cps' },
-        { metric: 'sqlserver_lazy_writes_rate', label: '惰性写入', color: '#8a5cff', unit: 'cps' }
+        { metric: 'sqlserver_checkpoint_pages_rate', label: '检查点写页', color: MSSQL_PALETTE.blue, unit: 'cps' },
+        { metric: 'sqlserver_lazy_writes_rate', label: '惰性写入', color: MSSQL_PALETTE.indigo, unit: 'cps' }
       ]
     },
     {
@@ -467,8 +479,8 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '内存授予等待', detail: '等待查询工作区内存的请求数，持续非零应排查大排序、哈希和并发。' }
       ],
       series: [
-        { metric: 'sqlserver_processes_blocked', label: '阻塞进程', color: '#ff4d4f', unit: 'counts' },
-        { metric: 'sqlserver_memory_grants_pending', label: '内存授予等待', color: '#ff8a1f', unit: 'counts' }
+        { metric: 'sqlserver_processes_blocked', label: '阻塞进程', color: MSSQL_PALETTE.rose, unit: 'counts' },
+        { metric: 'sqlserver_memory_grants_pending', label: '内存授予等待', color: MSSQL_PALETTE.orange, unit: 'counts' }
       ]
     },
     {
@@ -480,8 +492,8 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '目标内存', detail: 'SQL Server 配置的目标内存大小；长期差距需结合内存授予等待排查。' }
       ],
       series: [
-        { metric: 'sqlserver_memory_total_server_memory_kb', label: '当前内存', color: '#8a5cff', unit: 'kibibytes' },
-        { metric: 'sqlserver_memory_target_server_memory_kb', label: '目标内存', color: '#9aa9bf', unit: 'kibibytes' }
+        { metric: 'sqlserver_memory_total_server_memory_kb', label: '当前内存', color: MSSQL_PALETTE.indigo, unit: 'kibibytes' },
+        { metric: 'sqlserver_memory_target_server_memory_kb', label: '目标内存', color: MSSQL_PALETTE.neutral, unit: 'kibibytes' }
       ]
     },
     {
@@ -493,8 +505,8 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '版本存储', detail: '长事务或快照读会推动版本存储增长。' }
       ],
       series: [
-        { metric: 'sqlserver_tempdb_free_space_kb', label: '可用空间', color: '#27c274', unit: 'kibibytes' },
-        { metric: 'sqlserver_tempdb_version_store_size_kb', label: '版本存储', color: '#faad14', unit: 'kibibytes' }
+        { metric: 'sqlserver_tempdb_free_space_kb', label: '可用空间', color: MSSQL_PALETTE.emerald, unit: 'kibibytes' },
+        { metric: 'sqlserver_tempdb_version_store_size_kb', label: '版本存储', color: MSSQL_PALETTE.amber, unit: 'kibibytes' }
       ]
     },
     {
@@ -503,7 +515,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       metric: 'sqlserver_log_flushes_rate',
       guide: [{ label: '日志刷写', detail: '事务日志刷写速率；应结合数据库写延迟判断日志 I/O 压力。' }],
       series: [
-        { metric: 'sqlserver_log_flushes_rate', label: '日志刷写', color: '#13c2c2', unit: 'cps' }
+        { metric: 'sqlserver_log_flushes_rate', label: '日志刷写', color: MSSQL_PALETTE.cyan, unit: 'cps' }
       ]
     },
     {
@@ -516,9 +528,9 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '死锁', detail: '死锁发生速率，持续非零应检查事务访问顺序和隔离级别。' }
       ],
       series: [
-        { metric: 'sqlserver_sql_compilations_rate', label: 'SQL 编译', color: '#13c2c2', unit: 'cps' },
-        { metric: 'sqlserver_sql_recompilations_rate', label: 'SQL 重编译', color: '#8a5cff', unit: 'cps' },
-        { metric: 'sqlserver_deadlocks_rate', label: '死锁', color: '#ff4d4f', unit: 'cps' }
+        { metric: 'sqlserver_sql_compilations_rate', label: 'SQL 编译', color: MSSQL_PALETTE.cyan, unit: 'cps' },
+        { metric: 'sqlserver_sql_recompilations_rate', label: 'SQL 重编译', color: MSSQL_PALETTE.amber, unit: 'cps' },
+        { metric: 'sqlserver_deadlocks_rate', label: '死锁', color: MSSQL_PALETTE.rose, unit: 'cps' }
       ]
     },
     {
@@ -531,9 +543,9 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '等待时间', detail: '请求等待资源时间速率（ms/s）。' }
       ],
       series: [
-        { metric: 'sqlserver_requests_total_elapsed_time_ms_rate', label: '总耗时', color: '#8a5cff', unit: 'msps' },
-        { metric: 'sqlserver_requests_cpu_time_ms_rate', label: 'CPU 时间', color: '#2f6bff', unit: 'msps' },
-        { metric: 'sqlserver_requests_wait_time_ms_rate', label: '等待时间', color: '#ff8a1f', unit: 'msps' }
+        { metric: 'sqlserver_requests_total_elapsed_time_ms_rate', label: '总耗时', color: MSSQL_PALETTE.indigo, unit: 'msps' },
+        { metric: 'sqlserver_requests_cpu_time_ms_rate', label: 'CPU 时间', color: MSSQL_PALETTE.blue, unit: 'msps' },
+        { metric: 'sqlserver_requests_wait_time_ms_rate', label: '等待时间', color: MSSQL_PALETTE.orange, unit: 'msps' }
       ]
     }
   ],
@@ -546,8 +558,8 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       centerUnit: 'percent',
       guide: [{ label: '存储空间', detail: '数据库所在卷已用空间与可用空间占比。' }],
       segments: [
-        { label: '已用空间', metric: 'sqlserver_volume_space_used_ratio', color: '#2f6bff', unit: 'percent' },
-        { label: '可用空间', metric: 'sqlserver_volume_space_used_ratio', color: '#e8f0fe', unit: 'percent', transform: 'percentRemaining' }
+        { label: '已用空间', metric: 'sqlserver_volume_space_used_ratio', color: MSSQL_PALETTE.blue, unit: 'percent' },
+        { label: '可用空间', metric: 'sqlserver_volume_space_used_ratio', color: MSSQL_PALETTE.neutral, unit: 'percent', transform: 'percentRemaining' }
       ]
     }
   ],
@@ -558,9 +570,9 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       showTrend: true,
       guide: [{ label: '调度器压力', detail: '活跃工作线程、可运行任务和等待任务的当前分布。' }],
       items: [
-        { label: '活跃工作线程', metric: 'sqlserver_schedulers_active_workers_count', color: '#2f6bff', unit: 'counts' },
-        { label: '可运行任务', metric: 'sqlserver_schedulers_runnable_tasks_count', color: '#8a5cff', unit: 'counts' },
-        { label: '等待任务', metric: 'sqlserver_waitstats_waiting_tasks_count', color: '#ff4d4f', unit: 'counts' }
+        { label: '活跃工作线程', metric: 'sqlserver_schedulers_active_workers_count', color: MSSQL_PALETTE.blue, unit: 'counts' },
+        { label: '可运行任务', metric: 'sqlserver_schedulers_runnable_tasks_count', color: MSSQL_PALETTE.amber, unit: 'counts' },
+        { label: '等待任务', metric: 'sqlserver_waitstats_waiting_tasks_count', color: MSSQL_PALETTE.rose, unit: 'counts' }
       ]
     },
   ],

--- a/web/src/app/monitor/dashboards/objects/mssql/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mssql/dashboard.tsx
@@ -58,7 +58,7 @@ export default function MssqlDashboardPage() {
   const timeKey = JSON.stringify(timeValues);
 
   useEffect(() => {
-    if (!isDashboardMode) {
+    if (!isDashboardMode || !idValues.length) {
       setTopDb({});
       return;
     }

--- a/web/src/app/monitor/dashboards/objects/mssql/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/mssql/index.module.scss
@@ -1,21 +1,37 @@
 @use '../common/simple-dashboard.module.scss';
 
-// 区块小标题:给分区加语义标题,提升可扫读性(与 MySQL/PostgreSQL 同款)
-.sectionLabel {
-  margin: 2px 2px 4px;
-  padding-bottom: 4px;
-  border-bottom: 1px solid #eceff4;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #8c95a8;
+// sectionLabel 已上收到共享壳（带品牌蓝指示条与现代间距）；此处仅保留趋势图高度与图例微调。
+
+.chartLegendHeader {
+  justify-content: flex-end;
+  max-width: none;
+  white-space: nowrap;
 }
 
-.dashboardSection + .sectionLabel {
-  margin-top: 8px;
+.compactTrend {
+  .chartWrap {
+    height: 180px;
+  }
 }
 
-:global(html.dark) .sectionLabel {
-  border-bottom-color: rgba(255, 255, 255, 0.08);
+@media (max-width: 768px) {
+  .chartLegendHeader {
+    justify-content: flex-start;
+    max-width: 100%;
+    white-space: normal;
+  }
+
+  .compactTrend {
+    .chartWrap {
+      height: 140px;
+    }
+  }
+}
+
+@media (max-width: 480px) {
+  .compactTrend {
+    .chartWrap {
+      height: 120px;
+    }
+  }
 }

--- a/web/src/app/monitor/dashboards/objects/mssql/queries.ts
+++ b/web/src/app/monitor/dashboards/objects/mssql/queries.ts
@@ -22,7 +22,7 @@ export const MSSQL_TOP_DB_QUERIES: MssqlTopDbQuery[] = [
     key: 'read_latency',
     title: '读延迟 Top',
     unit: 'ms',
-    color: '#2f6bff',
+    color: '#2563EB',
     query: `topk(${MSSQL_TOP_N}, sum by (database_name) (sqlserver_database_io_read_latency_ms{__$labels__}))`,
     guide: [{ label: '读延迟排行', detail: '各数据库文件读操作平均延迟,定位读取最慢的库。' }]
   },
@@ -30,7 +30,7 @@ export const MSSQL_TOP_DB_QUERIES: MssqlTopDbQuery[] = [
     key: 'write_latency',
     title: '写延迟 Top',
     unit: 'ms',
-    color: '#ff8a1f',
+    color: '#F97316',
     query: `topk(${MSSQL_TOP_N}, sum by (database_name) (sqlserver_database_io_write_latency_ms{__$labels__}))`,
     guide: [{ label: '写延迟排行', detail: '各数据库文件写操作平均延迟,定位写入最慢的库。' }]
   },
@@ -38,7 +38,7 @@ export const MSSQL_TOP_DB_QUERIES: MssqlTopDbQuery[] = [
     key: 'io_rate',
     title: 'I/O 速率 Top',
     unit: 'cps',
-    color: '#27c274',
+    color: '#10B981',
     query: `topk(${MSSQL_TOP_N}, sum by (database_name) (rate(sqlserver_database_io_reads{__$labels__}[__$window__]) + rate(sqlserver_database_io_writes{__$labels__}[__$window__])))`,
     guide: [{ label: 'I/O 速率排行', detail: '各数据库读写操作合计速率,定位 I/O 负载最重的库。' }]
   }

--- a/web/src/app/monitor/dashboards/objects/mysql/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mysql/dashboard.tsx
@@ -823,15 +823,39 @@ export default function MysqlDashboardPage() {
     hasReplicationMetrics: hasReplicationData,
     logSlaveUpdates: logSlaveUpdatesValue
   });
+  // 实例 ID 与展示名仅分隔符不同时（mysql_3306 vs mysql-3306）视为重复，不再展示。
+  const normalizeIdentityKey = (value: string) => value.trim().toLowerCase().replace(/[-_\s]+/g, '');
+  const showInstanceId =
+    Boolean(instanceIdText) &&
+    normalizeIdentityKey(instanceIdText) !== normalizeIdentityKey(primaryInstanceText);
+  const identityMetaItems =
+    mysqlIdentity.deployment === '单节点'
+      ? [
+        <span key="topology" className={styles.instanceMetaInline}>
+          单节点
+        </span>
+      ]
+      : [
+        <span key="topology" className={styles.instanceMetaInline}>
+          主从复制
+        </span>,
+        <span key="role" className={`${styles.identityPill} ${styles.identityPillRole}`}>
+          {mysqlIdentity.role}
+        </span>
+      ];
   const instanceMetaItems = [
-    <span key="object-name" className={styles.instanceMetaInline}>{objectDisplayText}</span>,
-    instanceIdText ? <span key="instance-id" className={styles.instanceMetaMuted}>{instanceIdText}</span> : null,
-    <span key="identity" className={styles.instanceIdentityGroup}>
-      <span className={styles.identityPill}>部署 {mysqlIdentity.deployment}</span>
-      <span className={`${styles.identityPill} ${styles.identityPillRole}`}>身份 {mysqlIdentity.role}</span>
-      <span className={styles.identityPill}>复制 {mysqlIdentity.replication}</span>
+    <span key="object-name" className={styles.instanceMetaInline}>
+      {objectDisplayText}
     </span>,
-    <span key="timezone" className={styles.instanceMetaMuted}>时区 Asia/Shanghai</span>
+    showInstanceId ? (
+      <span key="instance-id" className={styles.instanceMetaMuted}>
+        {instanceIdText}
+      </span>
+    ) : null,
+    ...identityMetaItems,
+    <span key="timezone" className={styles.instanceMetaMuted}>
+      时区 Asia/Shanghai
+    </span>
   ].filter(Boolean) as React.ReactNode[];
   // 展示复制区块的条件:存在 SHOW SLAVE STATUS 数据(运行中或已停止的真实从库 —— hasReplicationData 是
   // 判定从库的 ground truth,主库永远没有这些行),或名称明确为从库。主库 / 独立实例两者皆不满足 → 显示"不适用"。
@@ -1001,6 +1025,7 @@ export default function MysqlDashboardPage() {
             <>
               {displayMode === 'dashboard' ? (
                 <div className={styles.modeContent}>
+                  <div className={styles.sectionLabel}>健康概览</div>
                   <div className={styles.primaryGrid}>
                     <CollectionStatusCard
                       styles={styles}
@@ -1014,8 +1039,8 @@ export default function MysqlDashboardPage() {
                       value={uptimeDisplay}
                       unit=""
                       icon={<ClockCircleOutlined />}
-                      iconStyle={{ background: 'rgba(91, 143, 249, 0.12)', color: '#5b8ff9' }}
-                      color="#5b8ff9"
+                      iconStyle={{ background: 'rgba(99, 102, 241, 0.12)', color: '#6366F1' }}
+                      color="#6366F1"
                       footer={<span>{hasMetricData('mysql_uptime') ? `启动 ${uptimeInsight.startupTimeText}` : metricEmptyText}</span>}
                       hideTrend
                       className={styles.statCardRelaxed}
@@ -1036,8 +1061,8 @@ export default function MysqlDashboardPage() {
                       value={connCardDisplay.value}
                       unit={connCardDisplay.unit}
                       icon={<NodeIndexOutlined />}
-                      iconStyle={{ background: 'rgba(255, 145, 20, 0.12)', color: '#ff8a1f' }}
-                      color="#ff7a00"
+                      iconStyle={{ background: 'rgba(245, 158, 11, 0.12)', color: '#F59E0B' }}
+                      color="#F59E0B"
                       compare={hasConnectionData ? connCompare : null}
                       footer={<><span>{hasConnectionData ? `当前 ${threadsConnectedValue.toFixed(0)} / 上限 ${maxConnectionsValue.toFixed(0)}` : metricEmptyText}</span></>}
                       trendData={metricMap.mysql_connection_utilization?.viewData || []}
@@ -1049,8 +1074,8 @@ export default function MysqlDashboardPage() {
                       value={slowCardDisplay.value}
                       unit={slowCardDisplay.unit}
                       icon={<ClockCircleOutlined />}
-                      iconStyle={{ background: 'rgba(255, 77, 79, 0.12)', color: '#ff4d4f' }}
-                      color="#ff3030"
+                      iconStyle={{ background: 'rgba(239, 68, 68, 0.12)', color: '#EF4444' }}
+                      color="#EF4444"
                       compare={hasSlowData ? slowCompare : null}
                       footer={<><span>{hasSlowData && hasLockData ? `行锁等待 ${formatPerMinute(lockWaitRate * 60)}` : metricEmptyText}</span></>}
                       trendData={metricMap.mysql_slow_queries_rate?.viewData || []}
@@ -1062,8 +1087,8 @@ export default function MysqlDashboardPage() {
                       value={lockWaitRateCardDisplay.value}
                       unit={lockWaitRateCardDisplay.unit}
                       icon={<NodeIndexOutlined />}
-                      iconStyle={{ background: 'rgba(255, 77, 79, 0.08)', color: '#ff4d4f' }}
-                      color="#ff4d4f"
+                      iconStyle={{ background: 'rgba(249, 115, 22, 0.12)', color: '#F97316' }}
+                      color="#F97316"
                       compare={hasLockData ? lockWaitRateCompare : null}
                       footer={<><span>{hasLockData ? `平均等待 ${lockWait.toFixed(lockWait >= 10 ? 0 : 1)} ms` : metricEmptyText}</span></>}
                       trendData={metricMap.mysql_innodb_row_lock_waits_rate?.viewData || []}
@@ -1071,12 +1096,12 @@ export default function MysqlDashboardPage() {
                     />
                     <StatCard
                       styles={styles}
-                      title={<TitleWithGuide styles={styles} title="QPS（每秒查询数）" items={qpsGuide} />}
+                      title={<TitleWithGuide styles={styles} title="QPS" items={qpsGuide} />}
                       value={qpsCardDisplay.value}
                       unit={qpsCardDisplay.unit}
                       icon={<ThunderboltOutlined />}
-                      iconStyle={{ background: 'rgba(47, 107, 255, 0.12)', color: '#2f6bff' }}
-                      color="#2f6bff"
+                      iconStyle={{ background: 'rgba(37, 99, 235, 0.12)', color: '#2563EB' }}
+                      color="#2563EB"
                       compare={hasQpsData ? qpsCompare : null}
                       footer={<><span>{hasQpsData ? `SELECT 查询 ${selectValue.toFixed(1)}/s` : metricEmptyText}</span></>}
                       trendData={metricMap.mysql_queries_rate?.viewData || []}

--- a/web/src/app/monitor/dashboards/objects/mysql/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mysql/dashboard.tsx
@@ -399,6 +399,13 @@ export default function MysqlDashboardPage() {
 
     try {
       if (isDashboardMode) {
+        if (!idValues.length) {
+          setSeries({});
+          setPreviousSeries({});
+          setCollectionStatusMetric(null);
+          if (!silent) setLoading(false);
+          return;
+        }
         const frozenTimeValues = freezeTimeValues(timeValues);
         const frozenRange = resolveCollectionStatusRange(frozenTimeValues);
         if (frozenRange) setQueryTimeRange(frozenRange);
@@ -1026,7 +1033,7 @@ export default function MysqlDashboardPage() {
               {displayMode === 'dashboard' ? (
                 <div className={styles.modeContent}>
                   <div className={styles.sectionLabel}>健康概览</div>
-                  <div className={styles.primaryGrid}>
+                  <div className={styles.overviewSixCol}>
                     <CollectionStatusCard
                       styles={styles}
                       status={statusInfo}

--- a/web/src/app/monitor/dashboards/objects/mysql/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/mysql/index.module.scss
@@ -38,10 +38,10 @@
 
 .pageTitleRow {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  min-height: 32px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 4px;
+  min-width: 0;
 }
 
 .titleBlock {
@@ -52,6 +52,14 @@
   flex: 1;
 }
 
+.titleControlsRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+}
+
 .title {
   margin: 0;
   color: #182132;
@@ -60,6 +68,8 @@
   line-height: 1.25;
   letter-spacing: -0.02em;
   word-break: break-word;
+  min-width: 0;
+  flex: 1;
 }
 
 .meta {
@@ -232,9 +242,9 @@
   font-weight: 600;
 }
 
-.primaryGrid {
-  // 固定 6 列：采集状态 + 运行时长 + 4 KPI（含 QPS）始终同一行。
-  // 不用 flex+min-width，避免长标题把第 6 张挤到下一行并被拉满。
+.overviewSixCol {
+  // 采集状态 + 运行时长 + 4 KPI（含 QPS）固定同一行。
+  // 不能覆盖同名 .primaryGrid：@use 共享壳后同名类是不同 CSS Module hash，覆盖不会挂到 DOM。
   display: grid;
   grid-template-columns: repeat(6, minmax(0, 1fr));
   gap: 12px;
@@ -1779,7 +1789,7 @@
 }
 
 @media (max-width: 1200px) {
-  .primaryGrid {
+  .overviewSixCol {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
@@ -1799,8 +1809,11 @@
 
   .pageTitleRow {
     width: 100%;
-    align-items: flex-start;
+  }
+
+  .titleControlsRow {
     flex-direction: column;
+    align-items: flex-start;
   }
 
   .instanceCard {
@@ -1895,7 +1908,7 @@
 }
 
 @media (max-width: 768px) {
-  .primaryGrid {
+  .overviewSixCol {
     grid-template-columns: 1fr;
   }
 

--- a/web/src/app/monitor/dashboards/objects/mysql/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/mysql/index.module.scss
@@ -1,24 +1,6 @@
 @use '../common/simple-dashboard.module.scss';
 
-// 区块小标题:给长滚动页面分组,提升可扫读性(镶 k8s-cluster)
-.sectionLabel {
-  margin: 2px 2px 4px;
-  padding-bottom: 4px;
-  border-bottom: 1px solid #eceff4;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #8c95a8;
-}
-
-.dashboardSection + .sectionLabel {
-  margin-top: 8px;
-}
-
-:global(html.dark) .sectionLabel {
-  border-bottom-color: rgba(255, 255, 255, 0.08);
-}
+// sectionLabel 已上收到共享壳（带品牌蓝指示条与现代间距）
 
 .modeContent {
   width: 100%;
@@ -40,21 +22,32 @@
 .pageHeader {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  margin-bottom: 10px;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding: 16px 20px 14px;
+  background: var(--color-bg, #fff);
+  border: 1px solid var(--color-border, #e2e8f0);
+  border-radius: 12px;
+  box-shadow: 0 1px 3px 0 rgba(15, 23, 42, 0.03), 0 1px 2px -1px rgba(15, 23, 42, 0.02);
+  transition: border-color 0.15s ease;
+}
+
+.pageHeader:hover {
+  border-color: color-mix(in srgb, var(--color-primary, #2f6bff) 18%, var(--color-border, #e2e8f0));
 }
 
 .pageTitleRow {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
+  gap: 12px;
+  min-height: 32px;
 }
 
 .titleBlock {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
   min-width: 0;
   flex: 1;
 }
@@ -62,17 +55,17 @@
 .title {
   margin: 0;
   color: #182132;
-  font-size: 28px;
+  font-size: 22px;
   font-weight: 700;
-  line-height: 1.15;
+  line-height: 1.25;
   letter-spacing: -0.02em;
   word-break: break-word;
 }
 
 .meta {
   display: flex;
-  align-items: center;
-  gap: 8px 10px;
+  align-items: baseline;
+  gap: 4px;
   flex-wrap: wrap;
   color: #3f5370;
   min-width: 0;
@@ -83,9 +76,11 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: 6px 0 8px;
-  border-bottom: 1px solid #e7edf5;
+  gap: 16px;
+  padding-top: 12px;
+  padding-bottom: 0;
+  border-top: 1px solid var(--color-border-1, #e7edf5);
+  border-bottom: none;
   background: transparent;
   border-radius: 0;
   box-shadow: none;
@@ -112,26 +107,29 @@
 }
 
 .instanceIcon {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, #ecf3ff 0%, #f7faff 100%);
+  width: 38px;
+  height: 38px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--color-primary, #2f6bff) 10%, var(--color-bg, #fff));
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #2f6bff;
-  font-size: 20px;
-  box-shadow: inset 0 0 0 1px rgba(46, 108, 255, 0.08);
+  color: var(--color-primary, #2f6bff);
+  font-size: 19px;
   flex-shrink: 0;
+  border: none;
+  box-shadow: none;
 }
 
 .instanceName {
   font-size: 18px;
   font-weight: 700;
   color: #182132;
-  line-height: 1.22;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
   min-width: 0;
   word-break: break-word;
+  margin-right: 4px;
 }
 
 .instanceSubline {
@@ -235,18 +233,16 @@
 }
 
 .primaryGrid {
-  // flex 自适应：换行后末行卡片弹性撑满整行，避免 5 张卡在 4/2 列断点下落单留白。
-  display: flex;
-  flex-wrap: wrap;
-  align-items: stretch;
+  // 固定 6 列：采集状态 + 运行时长 + 4 KPI（含 QPS）始终同一行。
+  // 不用 flex+min-width，避免长标题把第 6 张挤到下一行并被拉满。
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
   gap: 12px;
   margin-bottom: 12px;
+  align-items: stretch;
 
   > * {
-    // 基准 = 整行 1/6（扣除 5 个 gap）→ 宽屏每行 6 张(采集状态 + 运行时长 + 4 KPI,含 QPS)；
-    // 卡片相应变窄，收窄到 min-width 以下自动换行并撑满。
-    flex: 1 1 calc((100% - 5 * 12px) / 6);
-    min-width: 168px;
+    min-width: 0;
   }
 }
 
@@ -277,21 +273,21 @@
 }
 
 .statLabel {
-  color: #334861;
-  font-size: 15px;
-  font-weight: 700;
-  line-height: 1.3;
+  color: var(--color-text-1);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
   min-width: 0;
 }
 
 .statIcon {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 16px;
+  font-size: 15px;
 }
 
 .statBody {
@@ -308,34 +304,41 @@
 }
 
 .statValue {
-  color: #182132;
-  font-size: 30px;
+  color: var(--color-text-1);
+  font-size: 26px;
   font-weight: 700;
-  line-height: 1.08;
-  letter-spacing: -0.03em;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
   word-break: break-word;
   display: inline-flex;
   align-items: baseline;
   gap: 4px;
   flex-wrap: wrap;
+  font-variant-numeric: tabular-nums;
 }
 
 .statUnit {
-  font-size: 14px;
-  margin-left: 0;
-  color: #5d728b;
+  font-size: 13px;
+  margin-left: 2px;
+  color: var(--color-text-2);
+  font-weight: 600;
   line-height: 1;
 }
 
 .statMeta {
   display: flex;
   align-items: center;
-  gap: 6px 10px;
+  gap: 8px 12px;
   flex-wrap: wrap;
-  color: #64748b;
-  font-size: 14px;
-  line-height: 1.5;
-  min-height: 22px;
+  font-size: 11px;
+  line-height: 1.4;
+  min-height: 18px;
+  color: var(--color-text-3);
+
+  span {
+    color: var(--color-text-3);
+    font-weight: 400;
+  }
 }
 
 .statCompare {
@@ -492,127 +495,7 @@
   height: 100%;
 }
 
-.collectionStatusCard {
-  justify-content: flex-start;
-  min-height: 168px;
-}
-
-.collectionStatusHeader {
-  min-height: 32px;
-}
-
-.collectionStatusBody {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  gap: 10px;
-  min-height: 0;
-}
-
-.collectionStatusValue {
-  font-size: 30px;
-  font-weight: 700;
-  line-height: 1.05;
-  letter-spacing: -0.03em;
-  min-height: 40px;
-  display: flex;
-  align-items: center;
-}
-
-.collectionStatusValueSuccess {
-  color: #22c55e;
-}
-
-.collectionStatusValueError {
-  color: #ff4d4f;
-}
-
-.collectionStatusValueEmpty {
-  color: #94a3b8;
-}
-
-.collectionStatusTimelineBlock {
-  margin-top: 0;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-}
-
-.collectionStatusTimelineTitle {
-  margin-top: 0;
-  color: #536882;
-  font-size: 14px;
-  font-weight: 700;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-}
-
-.collectionStatusTimelineHint {
-  flex-shrink: 0;
-  color: #94a3b8;
-  font-size: 12px;
-  font-weight: 500;
-  white-space: nowrap;
-}
-
-
-.collectionStatusTimeline {
-  display: grid;
-  grid-template-columns: repeat(18, minmax(0, 1fr));
-  gap: 4px;
-  margin-top: 8px;
-}
-
-.collectionStatusSegment {
-  display: block;
-  min-width: 0;
-  width: 100%;
-  height: 22px;
-  border-radius: 4px;
-  border: 1px solid transparent;
-  cursor: default;
-}
-
-.collectionStatusSegmentSuccess {
-  background: #22c55e;
-  border-color: #b6f0c8;
-}
-
-.collectionStatusSegmentEmpty {
-  background: #d7dfeb;
-  border-color: #edf2f9;
-}
-
-.collectionStatusSegmentError {
-  background: #ff4d4f;
-  border-color: #ffc3c3;
-}
-
-.collectionStatusLegend {
-  display: flex;
-  align-items: center;
-  gap: 18px;
-  flex-wrap: wrap;
-  margin-top: 8px;
-  color: #42556d;
-  font-size: 14px;
-  font-weight: 700;
-}
-
-.collectionStatusLegendItem {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.collectionStatusLegendDot {
-  width: 14px;
-  height: 14px;
-  border-radius: 4px;
-  box-shadow: inset 0 0 0 1px rgba(19, 33, 56, 0.04);
-}
+// 采集状态卡片样式统一走共享壳 simple-dashboard，避免本地旧版（高色条/大方块图例/可换行）覆盖。
 
 .fullPanel {
   grid-column: span 12;
@@ -725,18 +608,18 @@
 
 .panelTitle {
   margin: 0;
-  color: #1d2f47;
-  font-size: 18px;
+  color: var(--color-text-1);
+  font-size: 16px;
   font-weight: 700;
-  line-height: 1.25;
+  line-height: 1.3;
   letter-spacing: -0.01em;
 }
 
 .panelSubTitle {
-  color: #92a2b5;
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 1.45;
+  color: var(--color-text-3);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.5;
 }
 
 .fullMetricsActions {
@@ -1813,27 +1696,8 @@
   color: #9fbeff;
 }
 
-:global(html.dark) .barTrack,
-:global(html.dark) .collectionStatusSegmentEmpty {
+:global(html.dark) .barTrack {
   background: rgba(255, 255, 255, 0.08);
-}
-
-:global(html.dark) .collectionStatusSegment {
-  border-color: transparent;
-}
-
-:global(html.dark) .collectionStatusSegmentSuccess {
-  background: #22c55e;
-  border-color: rgba(162, 243, 196, 0.35);
-}
-
-:global(html.dark) .collectionStatusSegmentError {
-  background: #ff4d4f;
-  border-color: rgba(255, 166, 166, 0.28);
-}
-
-:global(html.dark) .collectionStatusLegendDot {
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
 }
 
 :global(html.dark) .ringCenter {
@@ -1915,6 +1779,10 @@
 }
 
 @media (max-width: 1200px) {
+  .primaryGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
   .fullPanel {
     grid-column: span 12;
   }
@@ -2027,6 +1895,10 @@
 }
 
 @media (max-width: 768px) {
+  .primaryGrid {
+    grid-template-columns: 1fr;
+  }
+
   .chartWrap,
   .compactChartWrap,
   .replicationChartWrap {

--- a/web/src/app/monitor/dashboards/objects/oracle/config.ts
+++ b/web/src/app/monitor/dashboards/objects/oracle/config.ts
@@ -1,8 +1,19 @@
 import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
 
+/** Oracle 监控高对比鲜活科技色板 */
+const ORACLE_PALETTE = {
+  emerald: '#10B981',   // 正常状态、提交速率
+  blue: '#2563EB',      // 运行时长、会话数、SQL执行、SGA使用
+  cyan: '#06B6D4',      // PGA使用、网络等待
+  indigo: '#6366F1',    // 进程数、SQL解析、应用等待
+  amber: '#F59E0B',     // 资源限制使用率、System I/O 等待
+  orange: '#F97316',    // User I/O 等待
+  rose: '#EF4444'       // 异常状态、表空间使用率、回滚、并发等待
+} as const;
+
 const ORACLE_UP_ENUM = {
-  1: { label: '正常', color: '#27c274' },
-  0: { label: '异常', color: '#ff4d4f' }
+  1: { label: '正常', color: ORACLE_PALETTE.emerald },
+  0: { label: '异常', color: ORACLE_PALETTE.rose }
 };
 
 export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
@@ -20,7 +31,7 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'Oracle 实例可达性：1 正常、0 异常。',
       unit: 'none',
       query: 'max by (instance_id) (oracledb_up_gauge{__$labels__})',
-      color: '#27c274'
+      color: ORACLE_PALETTE.emerald
     },
     {
       name: 'oracledb_uptime',
@@ -28,7 +39,7 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'Oracle 实例已运行时长。',
       unit: 's',
       query: 'max by (instance_id) (oracledb_uptime_seconds_gauge{__$labels__})',
-      color: '#2f6bff'
+      color: ORACLE_PALETTE.blue
     },
     {
       name: 'oracledb_sessions',
@@ -36,7 +47,7 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '当前打开会话总数（按 status/type 汇总）。',
       unit: 'counts',
       query: 'sum by (instance_id) (oracledb_sessions_value_gauge{__$labels__})',
-      color: '#2f6bff'
+      color: ORACLE_PALETTE.blue
     },
     {
       name: 'oracledb_processes',
@@ -44,7 +55,7 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '当前活跃数据库进程数。',
       unit: 'counts',
       query: 'max by (instance_id) (oracledb_process_count_gauge{__$labels__})',
-      color: '#8a5cff'
+      color: ORACLE_PALETTE.indigo
     },
     {
       name: 'oracledb_resource_util_max',
@@ -53,7 +64,7 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       unit: 'percent',
       query:
         'max by (instance_id) (clamp_min(oracledb_resource_current_utilization_gauge{__$labels__} / clamp_min(oracledb_resource_limit_value_gauge{__$labels__}, 1) * 100, 0))',
-      color: '#ff8a1f'
+      color: ORACLE_PALETTE.amber
     },
     {
       name: 'oracledb_tablespace_used_max',
@@ -61,7 +72,7 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '所有表空间中使用率最高的值。',
       unit: 'percent',
       query: 'max by (instance_id) (oracledb_tablespace_used_percent_gauge{__$labels__})',
-      color: '#ff4d4f'
+      color: ORACLE_PALETTE.rose
     },
     {
       name: 'oracledb_execute_rate',
@@ -69,7 +80,7 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'SQL 执行速率，反映库负载。',
       unit: 'cps',
       query: 'sum by (instance_id) (rate(oracledb_activity_execute_count_gauge{__$labels__}[__$window__]))',
-      color: '#2f6bff'
+      color: ORACLE_PALETTE.blue
     },
     {
       name: 'oracledb_parse_rate',
@@ -77,7 +88,7 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'SQL 解析速率，升高可能意味着硬解析偏多。',
       unit: 'cps',
       query: 'sum by (instance_id) (rate(oracledb_activity_parse_count_total_gauge{__$labels__}[__$window__]))',
-      color: '#8a5cff'
+      color: ORACLE_PALETTE.indigo
     },
     {
       name: 'oracledb_commit_rate',
@@ -85,7 +96,7 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '用户事务提交速率。',
       unit: 'cps',
       query: 'sum by (instance_id) (rate(oracledb_activity_user_commits_gauge{__$labels__}[__$window__]))',
-      color: '#27c274'
+      color: ORACLE_PALETTE.emerald
     },
     {
       name: 'oracledb_rollback_rate',
@@ -93,7 +104,7 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '用户事务回滚速率。',
       unit: 'cps',
       query: 'sum by (instance_id) (rate(oracledb_activity_user_rollbacks_gauge{__$labels__}[__$window__]))',
-      color: '#ff4d4f'
+      color: ORACLE_PALETTE.rose
     },
     {
       name: 'oracledb_wait_user_io',
@@ -101,7 +112,7 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '用户 I/O 等待时间。',
       unit: 'ms',
       query: 'max by (instance_id) (oracledb_wait_time_user_io_gauge{__$labels__})',
-      color: '#ff8a1f'
+      color: ORACLE_PALETTE.orange
     },
     {
       name: 'oracledb_wait_system_io',
@@ -109,7 +120,7 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '系统 I/O 等待时间。',
       unit: 'ms',
       query: 'max by (instance_id) (oracledb_wait_time_system_io_gauge{__$labels__})',
-      color: '#faad14'
+      color: ORACLE_PALETTE.amber
     },
     {
       name: 'oracledb_wait_concurrency',
@@ -117,7 +128,7 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '锁/资源争用等待时间。',
       unit: 'ms',
       query: 'max by (instance_id) (oracledb_wait_time_concurrency_gauge{__$labels__})',
-      color: '#ff4d4f'
+      color: ORACLE_PALETTE.rose
     },
     {
       name: 'oracledb_wait_commit',
@@ -125,7 +136,7 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '事务提交等待时间。',
       unit: 'ms',
       query: 'max by (instance_id) (oracledb_wait_time_commit_gauge{__$labels__})',
-      color: '#722ed1'
+      color: ORACLE_PALETTE.emerald
     },
     {
       name: 'oracledb_wait_application',
@@ -133,7 +144,7 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '应用/客户端侧等待时间。',
       unit: 'ms',
       query: 'max by (instance_id) (oracledb_wait_time_application_gauge{__$labels__})',
-      color: '#597ef7'
+      color: ORACLE_PALETTE.indigo
     },
     {
       name: 'oracledb_wait_network',
@@ -141,7 +152,7 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '网络传输等待时间。',
       unit: 'ms',
       query: 'max by (instance_id) (oracledb_wait_time_network_gauge{__$labels__})',
-      color: '#13c2c2'
+      color: ORACLE_PALETTE.cyan
     },
     {
       name: 'oracledb_sga_used_pct',
@@ -149,7 +160,7 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'SGA 内存使用百分比。',
       unit: 'percent',
       query: 'max by (instance_id) (oracledb_sga_used_percent_gauge{__$labels__})',
-      color: '#2f6bff'
+      color: ORACLE_PALETTE.blue
     },
     {
       name: 'oracledb_pga_used_pct',
@@ -157,7 +168,7 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'PGA 内存使用百分比。',
       unit: 'percent',
       query: 'max by (instance_id) (oracledb_pga_used_percent_gauge{__$labels__})',
-      color: '#13c2c2'
+      color: ORACLE_PALETTE.cyan
     },
     {
       name: 'oracledb_sga_total',
@@ -165,7 +176,7 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'SGA 总大小。',
       unit: 'bytes',
       query: 'max by (instance_id) (oracledb_sga_total_gauge{__$labels__})',
-      color: '#2f6bff'
+      color: ORACLE_PALETTE.blue
     },
     {
       name: 'oracledb_pga_total',
@@ -173,14 +184,14 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'PGA 总大小。',
       unit: 'bytes',
       query: 'max by (instance_id) (oracledb_pga_total_gauge{__$labels__})',
-      color: '#13c2c2'
+      color: ORACLE_PALETTE.cyan
     }
   ],
   summaryCards: [
     {
       title: '数据库状态',
       metric: 'oracledb_up',
-      color: '#27c274',
+      color: ORACLE_PALETTE.emerald,
       icon: 'health',
       enumMap: ORACLE_UP_ENUM,
       guide: [
@@ -195,7 +206,7 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       title: '会话数',
       metric: 'oracledb_sessions',
       unit: 'counts',
-      color: '#2f6bff',
+      color: ORACLE_PALETTE.blue,
       icon: 'node',
       compare: true,
       guide: [
@@ -210,7 +221,7 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       title: 'User I/O 等待',
       metric: 'oracledb_wait_user_io',
       unit: 'ms',
-      color: '#ff8a1f',
+      color: ORACLE_PALETTE.orange,
       icon: 'clock',
       compare: true,
       compareFavorableDirection: 'down',
@@ -232,8 +243,8 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '解析速率', detail: 'SQL 解析速率，相对执行偏高时关注硬解析与游标共享。' }
       ],
       series: [
-        { metric: 'oracledb_execute_rate', label: '执行', color: '#2f6bff', unit: 'cps' },
-        { metric: 'oracledb_parse_rate', label: '解析', color: '#8a5cff', unit: 'cps' }
+        { metric: 'oracledb_execute_rate', label: '执行', color: ORACLE_PALETTE.blue, unit: 'cps' },
+        { metric: 'oracledb_parse_rate', label: '解析', color: ORACLE_PALETTE.indigo, unit: 'cps' }
       ]
     },
     {
@@ -245,8 +256,8 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '回滚', detail: '用户事务回滚速率；相对提交异常升高需排查失败事务。' }
       ],
       series: [
-        { metric: 'oracledb_commit_rate', label: '提交', color: '#27c274', unit: 'cps' },
-        { metric: 'oracledb_rollback_rate', label: '回滚', color: '#ff4d4f', unit: 'cps' }
+        { metric: 'oracledb_commit_rate', label: '提交', color: ORACLE_PALETTE.emerald, unit: 'cps' },
+        { metric: 'oracledb_rollback_rate', label: '回滚', color: ORACLE_PALETTE.rose, unit: 'cps' }
       ]
     },
     {
@@ -260,27 +271,26 @@ export const ORACLE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         }
       ],
       series: [
-        { metric: 'oracledb_wait_user_io', label: 'User I/O', color: '#ff8a1f', unit: 'ms' },
-        { metric: 'oracledb_wait_system_io', label: 'System I/O', color: '#faad14', unit: 'ms' },
-        { metric: 'oracledb_wait_concurrency', label: '并发', color: '#ff4d4f', unit: 'ms' },
-        { metric: 'oracledb_wait_commit', label: '提交', color: '#722ed1', unit: 'ms' }
+        { metric: 'oracledb_wait_user_io', label: 'User I/O', color: ORACLE_PALETTE.orange, unit: 'ms' },
+        { metric: 'oracledb_wait_system_io', label: 'System I/O', color: ORACLE_PALETTE.amber, unit: 'ms' },
+        { metric: 'oracledb_wait_concurrency', label: '并发等待', color: ORACLE_PALETTE.rose, unit: 'ms' },
+        { metric: 'oracledb_wait_commit', label: '提交等待', color: ORACLE_PALETTE.emerald, unit: 'ms' }
       ]
     },
     {
-      title: 'SGA / PGA 使用率',
-      subtitle: '共享内存与进程内存',
+      title: '内存使用',
+      subtitle: 'SGA 与 PGA 使用率',
       metric: 'oracledb_sga_used_pct',
       guide: [
-        { label: 'SGA', detail: '共享全局区使用率。' },
-        { label: 'PGA', detail: '进程私有内存使用率；偏高可能伴随排序/哈希溢出到临时段。' }
+        { label: 'SGA', detail: '系统全局区内存使用百分比。' },
+        { label: 'PGA', detail: '程序全局区内存使用百分比。' }
       ],
       series: [
-        { metric: 'oracledb_sga_used_pct', label: 'SGA', color: '#2f6bff', unit: 'percent' },
-        { metric: 'oracledb_pga_used_pct', label: 'PGA', color: '#13c2c2', unit: 'percent' }
+        { metric: 'oracledb_sga_used_pct', label: 'SGA 使用率', color: ORACLE_PALETTE.blue, unit: 'percent' },
+        { metric: 'oracledb_pga_used_pct', label: 'PGA 使用率', color: ORACLE_PALETTE.cyan, unit: 'percent' }
       ]
     }
   ],
-  statusPanels: [],
   ringPanels: [],
   barPanels: [],
   details: []

--- a/web/src/app/monitor/dashboards/objects/oracle/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/oracle/dashboard.tsx
@@ -95,7 +95,7 @@ export default function OracleDashboardPage() {
       styles={styles}
       dashboardContent={
         <>
-          <div className={styles.sectionLabel}>健康与容量</div>
+          <div className={styles.sectionLabel}>健康概览</div>
           <KpiSection dashboard={dashboard} summaryCards={summaryCards} styles={styles} />
 
           <div className={styles.sectionLabel}>活性与事务</div>

--- a/web/src/app/monitor/dashboards/objects/oracle/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/oracle/dashboard.tsx
@@ -19,7 +19,7 @@ import { ORACLE_TOP_QUERIES } from './queries';
 import styles from './index.module.scss';
 
 const SUMMARY_TITLES = ['数据库状态', '会话数', 'User I/O 等待'];
-const CHART_TITLES = ['SQL 活性', '事务提交与回滚', 'Wait Class 概览', 'SGA / PGA 使用率'];
+const CHART_TITLES = ['SQL 活性', '事务提交与回滚', 'Wait Class 概览', '内存使用'];
 const TOP_CONCURRENCY = 2;
 
 export default function OracleDashboardPage() {
@@ -41,7 +41,7 @@ export default function OracleDashboardPage() {
   const timeKey = JSON.stringify(timeValues);
 
   useEffect(() => {
-    if (!isDashboardMode) {
+    if (!isDashboardMode || !idValues.length) {
       setTopBars({});
       return;
     }

--- a/web/src/app/monitor/dashboards/objects/oracle/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/oracle/index.module.scss
@@ -1,34 +1,29 @@
 @use '../common/simple-dashboard.module.scss';
 
-.sectionLabel {
-  margin: 2px 2px 4px;
-  padding-bottom: 4px;
-  border-bottom: 1px solid #eceff4;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #8c95a8;
-}
+// sectionLabel 已上收到共享壳（带品牌蓝指示条与现代间距）；此处仅保留趋势图高度与图例微调。
 
-.dashboardSection + .sectionLabel {
-  margin-top: 8px;
-}
-
-:global(html.dark) .sectionLabel {
-  border-bottom-color: rgba(255, 255, 255, 0.08);
+.chartLegendHeader {
+  justify-content: flex-end;
+  max-width: none;
+  white-space: nowrap;
 }
 
 .compactTrend {
   .chartWrap {
-    height: 164px;
+    height: 180px;
   }
 }
 
 @media (max-width: 768px) {
+  .chartLegendHeader {
+    justify-content: flex-start;
+    max-width: 100%;
+    white-space: normal;
+  }
+
   .compactTrend {
     .chartWrap {
-      height: 138px;
+      height: 140px;
     }
   }
 }

--- a/web/src/app/monitor/dashboards/objects/oracle/queries.ts
+++ b/web/src/app/monitor/dashboards/objects/oracle/queries.ts
@@ -21,7 +21,7 @@ export const ORACLE_TOP_QUERIES: OracleTopQuery[] = [
     key: 'tablespace',
     title: '表空间使用率 Top',
     unit: 'percent',
-    color: '#ff4d4f',
+    color: '#EF4444',
     labelKeys: ['tablespace'],
     query: `topk(${ORACLE_TOP_N}, max by (tablespace) (oracledb_tablespace_used_percent_gauge{__$labels__}))`,
     guide: [{ label: '表空间排行', detail: '按使用率最高的表空间排序，定位最需扩容或清理的空间。' }]
@@ -30,7 +30,7 @@ export const ORACLE_TOP_QUERIES: OracleTopQuery[] = [
     key: 'resource',
     title: '资源限制使用率 Top',
     unit: 'percent',
-    color: '#ff8a1f',
+    color: '#F59E0B',
     labelKeys: ['resource_name'],
     query: `topk(${ORACLE_TOP_N}, clamp_min(oracledb_resource_current_utilization_gauge{__$labels__} / clamp_min(oracledb_resource_limit_value_gauge{__$labels__}, 1) * 100, 0))`,
     guide: [{ label: '资源排行', detail: '按资源限制使用率排序（sessions/processes/memory 等），定位触及上限的资源。' }]

--- a/web/src/app/monitor/dashboards/objects/ping/config.ts
+++ b/web/src/app/monitor/dashboards/objects/ping/config.ts
@@ -1,5 +1,15 @@
 import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
 
+/** Ping 拨测监控高对比鲜活色板 */
+const PING_PALETTE = {
+  rose: '#EF4444',      // 平均丢包率、错误占比
+  blue: '#2563EB',      // 平均延迟
+  cyan: '#06B6D4',      // 最小延迟
+  indigo: '#6366F1',    // 最大延迟
+  emerald: '#10B981',   // 连通成功率、成功占比
+  crimson: '#E11D48'    // 无法解析占比
+} as const;
+
 export const PING_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   routeKey: 'ping',
   pageTitle: 'Ping 监控仪表盘',
@@ -14,7 +24,7 @@ export const PING_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'Ping 探测节点的平均延迟。',
       unit: 'ms',
       query: 'avg(ping_average_response_ms{__$labels__})',
-      color: '#2f6bff'
+      color: PING_PALETTE.blue
     },
     {
       name: 'ping_latency_min',
@@ -22,7 +32,7 @@ export const PING_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'Ping 探测节点的最小延迟。',
       unit: 'ms',
       query: 'min(ping_minimum_response_ms{__$labels__})',
-      color: '#13c2c2'
+      color: PING_PALETTE.cyan
     },
     {
       name: 'ping_latency_max',
@@ -30,7 +40,7 @@ export const PING_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'Ping 探测节点的最大延迟。',
       unit: 'ms',
       query: 'max(ping_maximum_response_ms{__$labels__})',
-      color: '#ff8a1f'
+      color: PING_PALETTE.indigo
     },
     {
       name: 'ping_packet_loss_avg',
@@ -38,7 +48,7 @@ export const PING_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'Ping 探测节点的平均丢包率。',
       unit: 'percent',
       query: 'avg(ping_percent_packet_loss{__$labels__})',
-      color: '#ff4d4f'
+      color: PING_PALETTE.rose
     },
     {
       name: 'ping_success_rate_avg',
@@ -46,7 +56,7 @@ export const PING_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '由丢包率换算的连通成功率（100−丢包率）。',
       unit: 'percent',
       query: 'clamp_max(100 - avg(ping_percent_packet_loss{__$labels__}), 100)',
-      color: '#27c274'
+      color: PING_PALETTE.emerald
     },
     {
       name: 'ping_result_success_rate',
@@ -54,7 +64,7 @@ export const PING_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'result_code=0 的探测占比。',
       unit: 'percent',
       query: 'avg(ping_result_code{__$labels__} == bool 0) * 100',
-      color: '#27c274'
+      color: PING_PALETTE.emerald
     },
     {
       name: 'ping_result_error_rate',
@@ -62,7 +72,7 @@ export const PING_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'result_code=1 的探测占比。',
       unit: 'percent',
       query: 'avg(ping_result_code{__$labels__} == bool 1) * 100',
-      color: '#ff4d4f'
+      color: PING_PALETTE.rose
     },
     {
       name: 'ping_result_resolve_fail_rate',
@@ -70,7 +80,7 @@ export const PING_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'result_code=2 的探测占比。',
       unit: 'percent',
       query: 'avg(ping_result_code{__$labels__} == bool 2) * 100',
-      color: '#ff7875'
+      color: PING_PALETTE.crimson
     }
   ],
   // Layer0 + A 丢包（原生）+ B 延迟；C 结果码进分布环
@@ -78,7 +88,7 @@ export const PING_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '平均丢包率',
       metric: 'ping_packet_loss_avg',
-      color: '#ff4d4f',
+      color: PING_PALETTE.rose,
       icon: 'api',
       compare: true,
       compareFavorableDirection: 'down',
@@ -99,7 +109,7 @@ export const PING_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '平均延迟',
       metric: 'ping_latency_avg',
-      color: '#2f6bff',
+      color: PING_PALETTE.blue,
       icon: 'clock',
       compare: true,
       guide: [{ label: '平均延迟', detail: '往返时延均值；持续升高结合最大延迟判断是整体变慢还是尖刺抖动。' }],
@@ -115,7 +125,7 @@ export const PING_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       subtitle: '链路稳定性',
       metric: 'ping_packet_loss_avg',
       guide: [{ label: '丢包趋势', detail: '丢包升高时对照延迟与结果码分布；持续高位优先查链路与目标可达性。' }],
-      series: [{ metric: 'ping_packet_loss_avg', label: '平均丢包率', color: '#ff4d4f', unit: 'percent' }]
+      series: [{ metric: 'ping_packet_loss_avg', label: '平均丢包率', color: PING_PALETTE.rose, unit: 'percent' }]
     },
     {
       title: '延迟趋势',
@@ -123,8 +133,8 @@ export const PING_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       metric: 'ping_latency_avg',
       guide: [{ label: '延迟趋势', detail: '对比平均与最大延迟，判断整体变慢还是尖刺抖动。' }],
       series: [
-        { metric: 'ping_latency_avg', label: '平均延迟', color: '#2f6bff', unit: 'ms' },
-        { metric: 'ping_latency_max', label: '最大延迟', color: '#ff8a1f', unit: 'ms' }
+        { metric: 'ping_latency_avg', label: '平均延迟', color: PING_PALETTE.blue, unit: 'ms' },
+        { metric: 'ping_latency_max', label: '最大延迟', color: PING_PALETTE.indigo, unit: 'ms' }
       ]
     }
   ],
@@ -144,9 +154,9 @@ export const PING_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       emptyWhenAllZero: true,
       emptyDescription: '当前窗口无 Ping 探测结果码样本',
       segments: [
-        { label: '成功', metric: 'ping_result_success_rate', color: '#27c274', unit: 'percent' },
-        { label: '错误', metric: 'ping_result_error_rate', color: '#ff4d4f', unit: 'percent' },
-        { label: '无法解析', metric: 'ping_result_resolve_fail_rate', color: '#ff7875', unit: 'percent' }
+        { label: '成功', metric: 'ping_result_success_rate', color: PING_PALETTE.emerald, unit: 'percent' },
+        { label: '错误', metric: 'ping_result_error_rate', color: PING_PALETTE.rose, unit: 'percent' },
+        { label: '无法解析', metric: 'ping_result_resolve_fail_rate', color: PING_PALETTE.crimson, unit: 'percent' }
       ]
     }
   ],

--- a/web/src/app/monitor/dashboards/objects/ping/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/ping/index.module.scss
@@ -1,23 +1,6 @@
 @use '../common/simple-dashboard.module.scss';
 
-.sectionLabel {
-  margin: 2px 2px 4px;
-  padding-bottom: 4px;
-  border-bottom: 1px solid #eceff4;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #8c95a8;
-}
-
-.dashboardSection + .sectionLabel {
-  margin-top: 8px;
-}
-
-:global(html.dark) .sectionLabel {
-  border-bottom-color: rgba(255, 255, 255, 0.08);
-}
+// sectionLabel 已上收到共享壳（带品牌蓝指示条与现代间距）；此处仅保留趋势图高度与图例微调。
 
 .chartLegendHeader {
   justify-content: flex-end;
@@ -27,7 +10,7 @@
 
 .compactTrend {
   .chartWrap {
-    height: 164px;
+    height: 180px;
   }
 }
 
@@ -40,7 +23,7 @@
 
   .compactTrend {
     .chartWrap {
-      height: 138px;
+      height: 140px;
     }
   }
 }

--- a/web/src/app/monitor/dashboards/objects/postgresql/config.ts
+++ b/web/src/app/monitor/dashboards/objects/postgresql/config.ts
@@ -1,5 +1,16 @@
 import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
 
+/** PostgreSQL 监控高对比鲜活科技色板 */
+const PG_PALETTE = {
+  emerald: '#10B981',   // 事务提交速率、缓存命中率
+  blue: '#2563EB',      // 活跃连接数、查询返回行、检查点写入
+  cyan: '#06B6D4',      // 查询提取行、缓冲区分配
+  indigo: '#6366F1',    // 检查点定时、后台清理
+  amber: '#F59E0B',     // 临时文件、并发冲突
+  orange: '#F97316',    // 磁盘读取、后端写入、行更新
+  rose: '#EF4444'       // 事务回滚、死锁、行删除
+} as const;
+
 export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   routeKey: 'postgres',
   pageTitle: 'PostgreSQL 监控仪表盘',
@@ -14,7 +25,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '活跃数据库会话数量。',
       unit: 'counts',
       query: 'sum without (db) (postgresql_numbackends{__$labels__})',
-      color: '#2f6bff'
+      color: PG_PALETTE.blue
     },
     {
       name: 'postgresql_xact_commit_rate',
@@ -22,7 +33,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '已提交事务的速率。',
       unit: 'cps',
       query: 'sum without (db) (rate(postgresql_xact_commit{__$labels__}[__$window__]))',
-      color: '#27c274'
+      color: PG_PALETTE.emerald
     },
     {
       name: 'postgresql_xact_rollback_rate',
@@ -30,7 +41,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '回滚事务的速率。',
       unit: 'cps',
       query: 'sum without (db) (rate(postgresql_xact_rollback{__$labels__}[__$window__]))',
-      color: '#ff4d4f'
+      color: PG_PALETTE.rose
     },
     {
       name: 'postgresql_tup_returned_rate',
@@ -38,7 +49,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '查询结果集中返回行的速率。',
       unit: 'cps',
       query: 'sum without (db) (rate(postgresql_tup_returned{__$labels__}[__$window__]))',
-      color: '#2f6bff'
+      color: PG_PALETTE.blue
     },
     {
       name: 'postgresql_tup_fetched_rate',
@@ -46,7 +57,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '查询期间从存储中提取行的速率。',
       unit: 'cps',
       query: 'sum without (db) (rate(postgresql_tup_fetched{__$labels__}[__$window__]))',
-      color: '#13c2c2'
+      color: PG_PALETTE.cyan
     },
     {
       name: 'postgresql_tup_inserted_rate',
@@ -54,7 +65,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '行插入操作速率。',
       unit: 'cps',
       query: 'sum without (db) (rate(postgresql_tup_inserted{__$labels__}[__$window__]))',
-      color: '#2f6bff'
+      color: PG_PALETTE.blue
     },
     {
       name: 'postgresql_tup_updated_rate',
@@ -62,7 +73,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '行更新操作速率。',
       unit: 'cps',
       query: 'sum without (db) (rate(postgresql_tup_updated{__$labels__}[__$window__]))',
-      color: '#ff8a1f'
+      color: PG_PALETTE.orange
     },
     {
       name: 'postgresql_tup_deleted_rate',
@@ -70,7 +81,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '行删除操作速率。',
       unit: 'cps',
       query: 'sum without (db) (rate(postgresql_tup_deleted{__$labels__}[__$window__]))',
-      color: '#ff4d4f'
+      color: PG_PALETTE.rose
     },
     {
       name: 'postgresql_blks_hit_rate',
@@ -78,7 +89,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '共享缓冲区命中块速率。',
       unit: 'cps',
       query: 'sum without (db) (rate(postgresql_blks_hit{__$labels__}[__$window__]))',
-      color: '#27c274'
+      color: PG_PALETTE.emerald
     },
     {
       name: 'postgresql_blks_read_rate',
@@ -86,7 +97,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '需从磁盘读取块的速率。',
       unit: 'cps',
       query: 'sum without (db) (rate(postgresql_blks_read{__$labels__}[__$window__]))',
-      color: '#ff8a1f'
+      color: PG_PALETTE.orange
     },
     {
       name: 'postgresql_cache_hit_ratio',
@@ -94,7 +105,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '共享缓冲区缓存命中比例。',
       unit: 'percent',
       query: '100 * sum without (db) (rate(postgresql_blks_hit{__$labels__}[__$window__])) / clamp_min(sum without (db) (rate(postgresql_blks_hit{__$labels__}[__$window__])) + sum without (db) (rate(postgresql_blks_read{__$labels__}[__$window__])), 1e-6)',
-      color: '#27c274'
+      color: PG_PALETTE.emerald
     },
     {
       name: 'postgresql_deadlocks_rate',
@@ -102,7 +113,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '事务死锁发生速率。',
       unit: 'cps',
       query: 'sum without (db) (rate(postgresql_deadlocks{__$labels__}[__$window__]))',
-      color: '#ff4d4f'
+      color: PG_PALETTE.rose
     },
     {
       name: 'postgresql_conflicts_rate',
@@ -110,7 +121,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '并发操作冲突速率。',
       unit: 'cps',
       query: 'sum without (db) (rate(postgresql_conflicts{__$labels__}[__$window__]))',
-      color: '#faad14'
+      color: PG_PALETTE.amber
     },
     {
       name: 'postgresql_temp_files_rate',
@@ -118,7 +129,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '复杂查询创建临时文件的速率。',
       unit: 'cps',
       query: 'sum without (db) (rate(postgresql_temp_files{__$labels__}[__$window__]))',
-      color: '#ff8a1f'
+      color: PG_PALETTE.amber
     },
     {
       name: 'postgresql_temp_bytes_rate',
@@ -126,7 +137,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '临时文件写入数据速率。',
       unit: 'byteps',
       query: 'sum without (db) (rate(postgresql_temp_bytes{__$labels__}[__$window__]))',
-      color: '#8a5cff'
+      color: PG_PALETTE.indigo
     },
     {
       name: 'postgresql_checkpoints_timed_rate',
@@ -134,7 +145,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '系统触发检查点速率。',
       unit: 'cps',
       query: 'sum without (db) (rate(postgresql_checkpoints_timed{__$labels__}[__$window__]))',
-      color: '#2f6bff'
+      color: PG_PALETTE.blue
     },
     {
       name: 'postgresql_checkpoints_req_rate',
@@ -142,7 +153,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '请求触发检查点速率。',
       unit: 'cps',
       query: 'sum without (db) (rate(postgresql_checkpoints_req{__$labels__}[__$window__]))',
-      color: '#ff8a1f'
+      color: PG_PALETTE.orange
     },
     {
       name: 'postgresql_buffers_alloc_rate',
@@ -150,7 +161,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '共享缓冲区分配速率。',
       unit: 'cps',
       query: 'sum without (db) (rate(postgresql_buffers_alloc{__$labels__}[__$window__]))',
-      color: '#13c2c2'
+      color: PG_PALETTE.cyan
     },
     {
       name: 'postgresql_buffers_backend_rate',
@@ -158,7 +169,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '后端进程直接写出缓冲区的速率。',
       unit: 'cps',
       query: 'sum without (db) (rate(postgresql_buffers_backend{__$labels__}[__$window__]))',
-      color: '#ff8a1f'
+      color: PG_PALETTE.orange
     },
     {
       name: 'postgresql_buffers_checkpoint_rate',
@@ -166,7 +177,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '检查点期间写出缓冲区的速率。',
       unit: 'cps',
       query: 'sum without (db) (rate(postgresql_buffers_checkpoint{__$labels__}[__$window__]))',
-      color: '#2f6bff'
+      color: PG_PALETTE.blue
     },
     {
       name: 'postgresql_maxwritten_clean_rate',
@@ -174,14 +185,14 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '后台清理进程写出页的速率。',
       unit: 'cps',
       query: 'sum without (db) (rate(postgresql_maxwritten_clean{__$labels__}[__$window__]))',
-      color: '#8a5cff'
+      color: PG_PALETTE.indigo
     }
   ],
   summaryCards: [
     {
       title: '活跃连接数',
       metric: 'postgresql_numbackends',
-      color: '#2f6bff',
+      color: PG_PALETTE.blue,
       icon: 'node',
       guide: [{ label: '活跃连接', detail: '当前活跃数据库会话数量，用于评估并发负载。' }],
       footer: [{ label: '冲突速率', metric: 'postgresql_conflicts_rate', unit: 'cps' }]
@@ -189,7 +200,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '事务提交速率',
       metric: 'postgresql_xact_commit_rate',
-      color: '#27c274',
+      color: PG_PALETTE.emerald,
       icon: 'thunder',
       guide: [{ label: '事务提交', detail: '每秒成功提交的事务数(次/秒);越高代表写入业务越繁忙。' }],
       footer: [{ label: '回滚速率', metric: 'postgresql_xact_rollback_rate', unit: 'cps' }]
@@ -197,7 +208,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '事务回滚速率',
       metric: 'postgresql_xact_rollback_rate',
-      color: '#ff4d4f',
+      color: PG_PALETTE.rose,
       icon: 'thunder',
       compare: true,
       guide: [{ label: '事务回滚', detail: '回滚事务速率，持续升高需检查失败或冲突原因。' }],
@@ -206,7 +217,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '磁盘块读取',
       metric: 'postgresql_blks_read_rate',
-      color: '#ff8a1f',
+      color: PG_PALETTE.orange,
       icon: 'database',
       guide: [{ label: '磁盘块读取', detail: '需从磁盘读取块的速率，高值通常表示缓存未命中较多。' }],
       footer: [
@@ -217,7 +228,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '缓存命中率',
       metric: 'postgresql_cache_hit_ratio',
-      color: '#27c274',
+      color: PG_PALETTE.emerald,
       icon: 'database',
       compare: true,
       compareFavorableDirection: 'up',
@@ -227,7 +238,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '死锁速率',
       metric: 'postgresql_deadlocks_rate',
-      color: '#ff4d4f',
+      color: PG_PALETTE.rose,
       icon: 'api',
       compare: true,
       guide: [{ label: '死锁速率', detail: '事务死锁发生速率，非零时需要关注事务设计。' }],
@@ -236,7 +247,7 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '临时文件速率',
       metric: 'postgresql_temp_files_rate',
-      color: '#faad14',
+      color: PG_PALETTE.amber,
       icon: 'thunder',
       compare: true,
       guide: [{ label: '临时文件', detail: '临时文件创建速率，高值通常与复杂查询和 work_mem 配置相关。' }],
@@ -253,8 +264,8 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '回滚', detail: '失败或冲突回滚的事务速率。' }
       ],
       series: [
-        { metric: 'postgresql_xact_commit_rate', label: '提交速率', color: '#27c274', unit: 'cps' },
-        { metric: 'postgresql_xact_rollback_rate', label: '回滚速率', color: '#ff4d4f', unit: 'cps' }
+        { metric: 'postgresql_xact_commit_rate', label: '提交速率', color: PG_PALETTE.emerald, unit: 'cps' },
+        { metric: 'postgresql_xact_rollback_rate', label: '回滚速率', color: PG_PALETTE.rose, unit: 'cps' }
       ]
     },
     {
@@ -263,9 +274,9 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       metric: 'postgresql_tup_inserted_rate',
       guide: [{ label: '数据操作', detail: '行级插入、更新、删除操作速率。' }],
       series: [
-        { metric: 'postgresql_tup_inserted_rate', label: '插入', color: '#2f6bff', unit: 'cps' },
-        { metric: 'postgresql_tup_updated_rate', label: '更新', color: '#ff8a1f', unit: 'cps' },
-        { metric: 'postgresql_tup_deleted_rate', label: '删除', color: '#ff4d4f', unit: 'cps' }
+        { metric: 'postgresql_tup_inserted_rate', label: '插入', color: PG_PALETTE.blue, unit: 'cps' },
+        { metric: 'postgresql_tup_updated_rate', label: '更新', color: PG_PALETTE.orange, unit: 'cps' },
+        { metric: 'postgresql_tup_deleted_rate', label: '删除', color: PG_PALETTE.rose, unit: 'cps' }
       ]
     },
     {
@@ -277,8 +288,8 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '磁盘读取', detail: '需要从磁盘读取的块速率。' }
       ],
       series: [
-        { metric: 'postgresql_blks_hit_rate', label: '缓存命中', color: '#27c274', unit: 'cps' },
-        { metric: 'postgresql_blks_read_rate', label: '磁盘读取', color: '#ff8a1f', unit: 'cps' }
+        { metric: 'postgresql_blks_hit_rate', label: '缓存命中', color: PG_PALETTE.emerald, unit: 'cps' },
+        { metric: 'postgresql_blks_read_rate', label: '磁盘读取', color: PG_PALETTE.orange, unit: 'cps' }
       ]
     },
     {
@@ -287,9 +298,9 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       metric: 'postgresql_buffers_checkpoint_rate',
       guide: [{ label: '缓冲区写入', detail: '检查点、后端和后台清理写出缓冲区的速率。' }],
       series: [
-        { metric: 'postgresql_buffers_checkpoint_rate', label: '检查点写入', color: '#2f6bff', unit: 'cps' },
-        { metric: 'postgresql_buffers_backend_rate', label: '后端写入', color: '#ff8a1f', unit: 'cps' },
-        { metric: 'postgresql_maxwritten_clean_rate', label: '后台清理', color: '#8a5cff', unit: 'cps' }
+        { metric: 'postgresql_buffers_checkpoint_rate', label: '检查点写入', color: PG_PALETTE.blue, unit: 'cps' },
+        { metric: 'postgresql_buffers_backend_rate', label: '后端写入', color: PG_PALETTE.orange, unit: 'cps' },
+        { metric: 'postgresql_maxwritten_clean_rate', label: '后台清理', color: PG_PALETTE.indigo, unit: 'cps' }
       ]
     },
     {
@@ -301,8 +312,8 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '提取行', detail: '查询期间从存储提取行速率。' }
       ],
       series: [
-        { metric: 'postgresql_tup_returned_rate', label: '返回行', color: '#2f6bff', unit: 'cps' },
-        { metric: 'postgresql_tup_fetched_rate', label: '提取行', color: '#13c2c2', unit: 'cps' }
+        { metric: 'postgresql_tup_returned_rate', label: '返回行', color: PG_PALETTE.blue, unit: 'cps' },
+        { metric: 'postgresql_tup_fetched_rate', label: '提取行', color: PG_PALETTE.cyan, unit: 'cps' }
       ]
     },
     {
@@ -314,8 +325,8 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '请求检查点', detail: '因 WAL 压力请求触发的检查点速率。' }
       ],
       series: [
-        { metric: 'postgresql_checkpoints_timed_rate', label: '定时检查点', color: '#2f6bff', unit: 'cps' },
-        { metric: 'postgresql_checkpoints_req_rate', label: '请求检查点', color: '#ff8a1f', unit: 'cps' }
+        { metric: 'postgresql_checkpoints_timed_rate', label: '定时检查点', color: PG_PALETTE.blue, unit: 'cps' },
+        { metric: 'postgresql_checkpoints_req_rate', label: '请求检查点', color: PG_PALETTE.orange, unit: 'cps' }
       ]
     }
   ],
@@ -326,10 +337,10 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       showTrend: true,
       guide: [{ label: '异常事件', detail: '回滚、死锁、并发冲突与临时文件创建速率，用于快速定位异常负载。' }],
       items: [
-        { label: '回滚速率', metric: 'postgresql_xact_rollback_rate', color: '#ff4d4f', unit: 'cps' },
-        { label: '死锁速率', metric: 'postgresql_deadlocks_rate', color: '#fa8c16', unit: 'cps' },
-        { label: '并发冲突', metric: 'postgresql_conflicts_rate', color: '#faad14', unit: 'cps' },
-        { label: '临时文件', metric: 'postgresql_temp_files_rate', color: '#8a5cff', unit: 'cps' }
+        { label: '回滚速率', metric: 'postgresql_xact_rollback_rate', color: PG_PALETTE.rose, unit: 'cps' },
+        { label: '死锁速率', metric: 'postgresql_deadlocks_rate', color: PG_PALETTE.orange, unit: 'cps' },
+        { label: '并发冲突', metric: 'postgresql_conflicts_rate', color: PG_PALETTE.amber, unit: 'cps' },
+        { label: '临时文件', metric: 'postgresql_temp_files_rate', color: PG_PALETTE.indigo, unit: 'cps' }
       ]
     },
     {
@@ -338,9 +349,9 @@ export const POSTGRESQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       showTrend: true,
       guide: [{ label: '写入来源', detail: '比较检查点、后端和后台清理写出缓冲区的压力来源。' }],
       items: [
-        { label: '检查点写入', metric: 'postgresql_buffers_checkpoint_rate', color: '#2f6bff', unit: 'cps' },
-        { label: '后端写入', metric: 'postgresql_buffers_backend_rate', color: '#ff8a1f', unit: 'cps' },
-        { label: '后台清理', metric: 'postgresql_maxwritten_clean_rate', color: '#8a5cff', unit: 'cps' }
+        { label: '检查点写入', metric: 'postgresql_buffers_checkpoint_rate', color: PG_PALETTE.blue, unit: 'cps' },
+        { label: '后端写入', metric: 'postgresql_buffers_backend_rate', color: PG_PALETTE.orange, unit: 'cps' },
+        { label: '后台清理', metric: 'postgresql_maxwritten_clean_rate', color: PG_PALETTE.indigo, unit: 'cps' }
       ]
     }
   ],

--- a/web/src/app/monitor/dashboards/objects/postgresql/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/postgresql/dashboard.tsx
@@ -50,7 +50,7 @@ export default function PostgresqlDashboardPage() {
   const timeKey = JSON.stringify(timeValues);
 
   useEffect(() => {
-    if (!isDashboardMode) {
+    if (!isDashboardMode || !idValues.length) {
       setTopDb({});
       return;
     }

--- a/web/src/app/monitor/dashboards/objects/postgresql/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/postgresql/index.module.scss
@@ -1,22 +1,37 @@
 @use '../common/simple-dashboard.module.scss';
 
-// 区块小标题:给分区加语义标题,提升可扫读性(与 MySQL/k8s 同款)
-.sectionLabel {
-  margin: 2px 2px 4px;
-  padding-bottom: 4px;
-  border-bottom: 1px solid #eceff4;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #8c95a8;
+// sectionLabel 已上收到共享壳（带品牌蓝指示条与现代间距）；此处仅保留趋势图高度与图例微调。
+
+.chartLegendHeader {
+  justify-content: flex-end;
+  max-width: none;
+  white-space: nowrap;
 }
 
-.dashboardSection + .sectionLabel {
-  margin-top: 8px;
+.compactTrend {
+  .chartWrap {
+    height: 180px;
+  }
 }
 
-:global(html.dark) .sectionLabel {
-  border-bottom-color: rgba(255, 255, 255, 0.08);
+@media (max-width: 768px) {
+  .chartLegendHeader {
+    justify-content: flex-start;
+    max-width: 100%;
+    white-space: normal;
+  }
+
+  .compactTrend {
+    .chartWrap {
+      height: 140px;
+    }
+  }
 }
 
+@media (max-width: 480px) {
+  .compactTrend {
+    .chartWrap {
+      height: 120px;
+    }
+  }
+}

--- a/web/src/app/monitor/dashboards/objects/postgresql/queries.ts
+++ b/web/src/app/monitor/dashboards/objects/postgresql/queries.ts
@@ -21,7 +21,7 @@ export const PG_TOP_DB_QUERIES: PgTopDbQuery[] = [
     key: 'numbackends',
     title: '连接数 Top',
     unit: 'counts',
-    color: '#2f6bff',
+    color: '#2563EB',
     query: `topk(${PG_TOP_N}, sum by (db) (postgresql_numbackends{__$labels__}))`,
     guide: [{ label: '连接数排行', detail: '各数据库当前活跃会话数,定位连接集中在哪个库。' }]
   },
@@ -29,7 +29,7 @@ export const PG_TOP_DB_QUERIES: PgTopDbQuery[] = [
     key: 'rollback',
     title: '事务回滚 Top',
     unit: 'cps',
-    color: '#ff4d4f',
+    color: '#EF4444',
     query: `topk(${PG_TOP_N}, sum by (db) (rate(postgresql_xact_rollback{__$labels__}[__$window__])))`,
     guide: [{ label: '回滚排行', detail: '各数据库事务回滚速率,定位失败 / 冲突集中的库。' }]
   },
@@ -37,7 +37,7 @@ export const PG_TOP_DB_QUERIES: PgTopDbQuery[] = [
     key: 'temp_files',
     title: '临时文件 Top',
     unit: 'cps',
-    color: '#faad14',
+    color: '#F59E0B',
     query: `topk(${PG_TOP_N}, sum by (db) (rate(postgresql_temp_files{__$labels__}[__$window__])))`,
     guide: [{ label: '临时文件排行', detail: '各数据库临时文件创建速率,定位复杂查询 / work_mem 压力大的库。' }]
   }

--- a/web/src/app/monitor/dashboards/objects/process/config.ts
+++ b/web/src/app/monitor/dashboards/objects/process/config.ts
@@ -1,15 +1,26 @@
 import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
 import type { MetricEnumMap } from '../../shared/types';
 
+/** 进程监控鲜活科技色板：高对比度、呼吸感强、与全局规范保持一致 */
+const PROCESS_PALETTE = {
+  emerald: '#10B981',   // 鲜亮翠绿 (存活状态、应用内存使用率)
+  blue: '#2563EB',      // 活力皇家蓝 (进程 CPU 使用率)
+  cyan: '#06B6D4',      // 清亮青蓝 (内存 RSS)
+  indigo: '#6366F1',    // 现代紫靛 (线程数)
+  amber: '#F59E0B',     // 暖金琥珀 (端口部分失活)
+  orange: '#F97316',    // 活力暖橙 (打开文件数 FDs)
+  rose: '#EF4444'       // 鲜明珊瑚红 (失活状态)
+} as const;
+
 const PROCESS_ALIVE_ENUM: MetricEnumMap = {
-  0: { label: '失活', color: '#ff4d4f' },
-  1: { label: '存活', color: '#1ac44a' }
+  0: { label: '失活', color: PROCESS_PALETTE.rose },
+  1: { label: '存活', color: PROCESS_PALETTE.emerald }
 };
 
 const PROCESS_PORT_ALIVE_ENUM: MetricEnumMap = {
-  0: { label: '失活', color: '#ff4d4f' },
-  0.5: { label: '部分失活', color: '#faad14' },
-  1: { label: '存活', color: '#1ac44a' }
+  0: { label: '失活', color: PROCESS_PALETTE.rose },
+  0.5: { label: '部分失活', color: PROCESS_PALETTE.amber },
+  1: { label: '存活', color: PROCESS_PALETTE.emerald }
 };
 
 export const PROCESS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
@@ -28,7 +39,7 @@ export const PROCESS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       unit: 'none',
       query:
         'clamp_max(count(procstat_cpu_usage{instance_type="process", __$labels__}) by (instance_id, process_name), 1)',
-      color: '#1ac44a'
+      color: PROCESS_PALETTE.emerald
     },
     {
       name: 'process_port_alive',
@@ -37,7 +48,7 @@ export const PROCESS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       unit: 'none',
       query:
         '((floor(((avg(clamp_max(net_response_result_code{instance_type="process", __$labels__}, 1) == bool 0) by (instance_id, process_name)) or process_port_alive{instance_type="process", __$labels__})) + ceil(((avg(clamp_max(net_response_result_code{instance_type="process", __$labels__}, 1) == bool 0) by (instance_id, process_name)) or process_port_alive{instance_type="process", __$labels__}))) / 2)',
-      color: '#faad14'
+      color: PROCESS_PALETTE.amber
     },
     {
       name: 'process_cpu_usage',
@@ -46,7 +57,7 @@ export const PROCESS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       unit: 'percent',
       query:
         'sum(procstat_cpu_usage{instance_type="process", __$labels__}) by (instance_id, process_name)',
-      color: '#2f6bff'
+      color: PROCESS_PALETTE.blue
     },
     {
       name: 'process_mem_usage',
@@ -55,7 +66,7 @@ export const PROCESS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       unit: 'percent',
       query:
         'sum(procstat_memory_usage{instance_type="process", __$labels__}) by (instance_id, process_name)',
-      color: '#27c274'
+      color: PROCESS_PALETTE.emerald
     },
     {
       name: 'process_memory_rss',
@@ -64,7 +75,7 @@ export const PROCESS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       unit: 'bytes',
       query:
         'sum(procstat_memory_rss{instance_type="process", __$labels__}) by (instance_id, process_name)',
-      color: '#13c2c2'
+      color: PROCESS_PALETTE.cyan
     },
     {
       name: 'process_num_threads',
@@ -73,7 +84,7 @@ export const PROCESS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       unit: 'counts',
       query:
         'sum(procstat_num_threads{instance_type="process", __$labels__}) by (instance_id, process_name)',
-      color: '#597ef7'
+      color: PROCESS_PALETTE.indigo
     },
     {
       name: 'process_num_fds',
@@ -82,7 +93,7 @@ export const PROCESS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       unit: 'counts',
       query:
         'sum(procstat_num_fds{instance_type="process", __$labels__}) by (instance_id, process_name)',
-      color: '#ff8a1f'
+      color: PROCESS_PALETTE.orange
     }
   ],
   summaryCards: [
@@ -90,9 +101,10 @@ export const PROCESS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       title: '进程存活',
       metric: 'process_alive',
       unit: 'none',
-      color: '#1ac44a',
+      color: PROCESS_PALETTE.emerald,
       icon: 'health',
       enumMap: PROCESS_ALIVE_ENUM,
+      hideTrend: true,
       guide: [
         {
           label: '进程存活',
@@ -104,7 +116,7 @@ export const PROCESS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       title: '端口存活',
       metric: 'process_port_alive',
       unit: 'none',
-      color: '#faad14',
+      color: PROCESS_PALETTE.amber,
       icon: 'api',
       enumMap: PROCESS_PORT_ALIVE_ENUM,
       // 端口探测为可选：未配置 ports 时无系列，隐藏卡片，避免误读为「存活」。
@@ -119,10 +131,10 @@ export const PROCESS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       ]
     },
     {
-      title: 'CPU',
+      title: 'CPU 使用率',
       metric: 'process_cpu_usage',
       unit: 'percent',
-      color: '#2f6bff',
+      color: PROCESS_PALETTE.blue,
       icon: 'thunder',
       compare: true,
       guide: [
@@ -133,10 +145,10 @@ export const PROCESS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       ]
     },
     {
-      title: '应用内存',
+      title: '应用内存使用率',
       metric: 'process_mem_usage',
       unit: 'percent',
-      color: '#27c274',
+      color: PROCESS_PALETTE.emerald,
       icon: 'memory',
       compare: true,
       guide: [
@@ -146,6 +158,21 @@ export const PROCESS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         }
       ],
       footer: [{ label: '内存 RSS', metric: 'process_memory_rss', unit: 'bytes' }]
+    },
+    {
+      title: '线程数',
+      metric: 'process_num_threads',
+      unit: 'counts',
+      color: PROCESS_PALETTE.indigo,
+      icon: 'node',
+      compare: true,
+      guide: [
+        {
+          label: '线程数',
+          detail: '匹配进程线程数合计。异常飙升可能伴随 CPU 争用或线程泄漏。'
+        }
+      ],
+      footer: [{ label: '打开文件数', metric: 'process_num_fds', unit: 'counts' }]
     }
   ],
   charts: [
@@ -160,13 +187,13 @@ export const PROCESS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         }
       ],
       series: [
-        { metric: 'process_cpu_usage', label: 'CPU 使用率', color: '#2f6bff', unit: 'percent' },
-        { metric: 'process_mem_usage', label: '应用内存使用率', color: '#27c274', unit: 'percent' }
+        { metric: 'process_cpu_usage', label: 'CPU 使用率', color: PROCESS_PALETTE.blue, unit: 'percent' },
+        { metric: 'process_mem_usage', label: '应用内存使用率', color: PROCESS_PALETTE.emerald, unit: 'percent' }
       ]
     },
     {
       title: '内存 RSS 趋势',
-      subtitle: '常驻集大小',
+      subtitle: '常驻物理内存',
       metric: 'process_memory_rss',
       guide: [
         {
@@ -175,12 +202,12 @@ export const PROCESS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         }
       ],
       series: [
-        { metric: 'process_memory_rss', label: '内存 RSS', color: '#13c2c2', unit: 'bytes' }
+        { metric: 'process_memory_rss', label: '内存 RSS', color: PROCESS_PALETTE.cyan, unit: 'bytes' }
       ]
     },
     {
       title: '线程数趋势',
-      subtitle: '匹配进程合计',
+      subtitle: '并发线程规模',
       metric: 'process_num_threads',
       guide: [
         {
@@ -189,12 +216,12 @@ export const PROCESS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         }
       ],
       series: [
-        { metric: 'process_num_threads', label: '线程数', color: '#597ef7', unit: 'counts' }
+        { metric: 'process_num_threads', label: '线程数', color: PROCESS_PALETTE.indigo, unit: 'counts' }
       ]
     },
     {
       title: '打开文件数趋势',
-      subtitle: '文件描述符',
+      subtitle: '文件句柄 (FDs)',
       metric: 'process_num_fds',
       guide: [
         {
@@ -203,7 +230,7 @@ export const PROCESS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         }
       ],
       series: [
-        { metric: 'process_num_fds', label: '打开文件数', color: '#ff8a1f', unit: 'counts' }
+        { metric: 'process_num_fds', label: '打开文件数', color: PROCESS_PALETTE.orange, unit: 'counts' }
       ]
     }
   ],

--- a/web/src/app/monitor/dashboards/objects/process/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/process/index.module.scss
@@ -1,34 +1,29 @@
 @use '../common/simple-dashboard.module.scss';
 
-.sectionLabel {
-  margin: 2px 2px 4px;
-  padding-bottom: 4px;
-  border-bottom: 1px solid #eceff4;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #8c95a8;
-}
+// sectionLabel 已上收到共享壳（带品牌蓝指示条与现代间距）；此处仅保留进程趋势图高度与图例微调。
 
-.dashboardSection + .sectionLabel {
-  margin-top: 8px;
-}
-
-:global(html.dark) .sectionLabel {
-  border-bottom-color: rgba(255, 255, 255, 0.08);
+.chartLegendHeader {
+  justify-content: flex-end;
+  max-width: none;
+  white-space: nowrap;
 }
 
 .compactTrend {
   .chartWrap {
-    height: 164px;
+    height: 180px;
   }
 }
 
 @media (max-width: 768px) {
+  .chartLegendHeader {
+    justify-content: flex-start;
+    max-width: 100%;
+    white-space: normal;
+  }
+
   .compactTrend {
     .chartWrap {
-      height: 138px;
+      height: 140px;
     }
   }
 }

--- a/web/src/app/monitor/dashboards/objects/rabbitmq/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/rabbitmq/dashboard.tsx
@@ -66,7 +66,7 @@ export default function RabbitMQDashboardPage() {
       styles={styles}
       dashboardContent={
         <>
-          <div className={styles.sectionLabel}>总览</div>
+          <div className={styles.sectionLabel}>健康概览</div>
           <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={6} styles={styles} />
 
           {/* R1: 内存分布环 span4 + 内存压力趋势 span8 = 12 —— 环图配同主题折线,消除中部留白 */}

--- a/web/src/app/monitor/dashboards/objects/rabbitmq/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/rabbitmq/index.module.scss
@@ -152,7 +152,7 @@
 }
 
 .panelTitle {
-  font-size: 15px;
+  font-size: 16px;
 }
 
 .panelSubTitle {

--- a/web/src/app/monitor/dashboards/objects/redis/config.ts
+++ b/web/src/app/monitor/dashboards/objects/redis/config.ts
@@ -1,5 +1,18 @@
 import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
 
+/** Redis 监控高对比鲜活科技色板 */
+const REDIS_PALETTE = {
+  emerald: '#10B981',   // 缓存命中率、键命中频率、网络出流量
+  blue: '#2563EB',      // 内存使用量、网络入流量、客户端连接数
+  indigo: '#6366F1',    // 运行时长、键过期频率
+  cyan: '#06B6D4',      // 命令处理速率
+  amber: '#F59E0B',     // 内存使用率、内存碎片率
+  orange: '#F97316',    // 阻塞客户端
+  rose: '#EF4444',      // 键驱逐频率、键未命中、连接拒绝
+  neutral: '#94A3B8',   // 内存上限虚线
+  neutralSoft: '#E2E8F0'
+} as const;
+
 /**
  * Redis 仪表盘配置(config-driven)。
  *
@@ -23,7 +36,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'Redis 实例持续运行时间，反映服务稳定性。',
       unit: 's',
       query: 'redis_uptime{__$labels__}',
-      color: '#597ef7'
+      color: REDIS_PALETTE.indigo
     },
     {
       name: 'redis_used_memory',
@@ -31,7 +44,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'Redis 实例当前占用的总内存，包括数据存储和内部数据结构。',
       unit: 'bytes',
       query: 'redis_used_memory{__$labels__}',
-      color: '#2f6bff'
+      color: REDIS_PALETTE.blue
     },
     {
       name: 'redis_maxmemory',
@@ -39,7 +52,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'Redis 实例配置的最大可用内存限制。',
       unit: 'bytes',
       query: 'redis_maxmemory{__$labels__}',
-      color: '#9aa9bf'
+      color: REDIS_PALETTE.neutral
     },
     {
       name: 'redis_mem_available',
@@ -47,7 +60,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '配置上限内尚可使用的内存(上限减去已用),用于环图占比展示。',
       unit: 'bytes',
       query: 'clamp_min(max by (instance_id) (redis_maxmemory{__$labels__}) - max by (instance_id) (redis_used_memory{__$labels__}), 0)',
-      color: '#e8f0fe'
+      color: REDIS_PALETTE.neutralSoft
     },
     {
       name: 'redis_memory_utilization',
@@ -55,7 +68,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '当前内存使用量占配置上限的比例。',
       unit: 'percent',
       query: 'clamp_max(100 * max by (instance_id) (redis_used_memory{__$labels__}) / on(instance_id) clamp_min(max by (instance_id) (redis_maxmemory{__$labels__}), 1), 100)',
-      color: '#ff8a1f'
+      color: REDIS_PALETTE.amber
     },
     {
       name: 'redis_mem_fragmentation_ratio',
@@ -63,7 +76,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '操作系统分配内存与 Redis 实际使用内存的比值，高比值表示碎片严重。',
       unit: 'none',
       query: 'redis_mem_fragmentation_ratio{__$labels__}',
-      color: '#faad14'
+      color: REDIS_PALETTE.amber
     },
     {
       name: 'redis_total_commands_processed_rate',
@@ -71,7 +84,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'Redis 实例处理命令的平均速率。',
       unit: 'cps',
       query: 'rate(redis_total_commands_processed{__$labels__}[__$window__])',
-      color: '#13c2c2'
+      color: REDIS_PALETTE.cyan
     },
     {
       name: 'redis_keyspace_hits_rate',
@@ -79,7 +92,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '键空间成功命中的频率，反映缓存命中效率。',
       unit: 'cps',
       query: 'rate(redis_keyspace_hits{__$labels__}[__$window__])',
-      color: '#2f6bff'
+      color: REDIS_PALETTE.emerald
     },
     {
       name: 'redis_keyspace_misses_rate',
@@ -87,7 +100,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '键空间未命中的频率，高频率可能需要优化缓存策略。',
       unit: 'cps',
       query: 'rate(redis_keyspace_misses{__$labels__}[__$window__])',
-      color: '#ff4d4f'
+      color: REDIS_PALETTE.rose
     },
     {
       name: 'redis_keyspace_hitrate',
@@ -95,7 +108,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '键空间命中操作占总操作的比例，核心缓存性能指标。',
       unit: 'percent',
       query: 'redis_keyspace_hitrate{__$labels__}',
-      color: '#8a5cff'
+      color: REDIS_PALETTE.emerald
     },
     {
       name: 'redis_total_net_input_bytes_rate',
@@ -103,7 +116,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'Redis 实例接收网络数据的速率。',
       unit: 'byteps',
       query: 'rate(redis_total_net_input_bytes{__$labels__}[__$window__])',
-      color: '#2f6bff'
+      color: REDIS_PALETTE.blue
     },
     {
       name: 'redis_total_net_output_bytes_rate',
@@ -111,7 +124,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'Redis 实例发送网络数据的速率。',
       unit: 'byteps',
       query: 'rate(redis_total_net_output_bytes{__$labels__}[__$window__])',
-      color: '#27c274'
+      color: REDIS_PALETTE.emerald
     },
     {
       name: 'redis_clients',
@@ -119,7 +132,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '当前活跃的客户端连接数量。',
       unit: 'counts',
       query: 'redis_clients{__$labels__}',
-      color: '#2f6bff'
+      color: REDIS_PALETTE.blue
     },
     {
       name: 'redis_blocked_clients',
@@ -127,7 +140,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '当前处于阻塞等待状态的客户端数量。',
       unit: 'counts',
       query: 'redis_blocked_clients{__$labels__}',
-      color: '#ff8a1f'
+      color: REDIS_PALETTE.orange
     },
     {
       name: 'redis_expired_keys_rate',
@@ -135,7 +148,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '键因到期自动删除的频率。',
       unit: 'cps',
       query: 'rate(redis_expired_keys{__$labels__}[__$window__])',
-      color: '#faad14'
+      color: REDIS_PALETTE.indigo
     },
     {
       name: 'redis_evicted_keys_rate',
@@ -143,7 +156,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '因内存达到上限而被主动淘汰的键频率，非零说明内存压力大。',
       unit: 'cps',
       query: 'rate(redis_evicted_keys{__$labels__}[__$window__])',
-      color: '#ff4d4f'
+      color: REDIS_PALETTE.rose
     },
     {
       name: 'redis_rejected_connections_rate',
@@ -151,7 +164,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '因达到最大连接数而被拒绝的连接请求频率。',
       unit: 'cps',
       query: 'rate(redis_rejected_connections{__$labels__}[__$window__])',
-      color: '#ff4d4f'
+      color: REDIS_PALETTE.rose
     }
   ],
   summaryCards: [
@@ -161,7 +174,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       unit: 's',
       formatter: 'duration',
       isUptimeCard: true,
-      color: '#597ef7',
+      color: REDIS_PALETTE.indigo,
       icon: 'clock',
       guide: [{ label: '运行时长', detail: 'Redis 实例持续运行时间,反映服务稳定性;期间发生重启会重新计时。' }],
       footer: [{ label: '启动', metric: 'redis_uptime', formatter: 'startedAt' }]
@@ -169,7 +182,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '内存使用率',
       metric: 'redis_memory_utilization',
-      color: '#ff8a1f',
+      color: REDIS_PALETTE.amber,
       icon: 'memory',
       compare: true,
       guide: [{ label: '内存使用率', detail: '已用内存占配置上限的比例,接近 100% 时可能触发键驱逐。未配置 maxmemory 时无数据。' }],
@@ -180,7 +193,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '缓存命中率',
       metric: 'redis_keyspace_hitrate',
-      color: '#8a5cff',
+      color: REDIS_PALETTE.emerald,
       icon: 'database',
       compare: true,
       compareFavorableDirection: 'up',
@@ -190,7 +203,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '键驱逐频率',
       metric: 'redis_evicted_keys_rate',
-      color: '#ff4d4f',
+      color: REDIS_PALETTE.rose,
       icon: 'thunder',
       compare: true,
       guide: [{ label: '键驱逐', detail: '因内存达到上限被主动淘汰的键频率,非零说明内存压力大。' }],
@@ -199,7 +212,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: '客户端连接数',
       metric: 'redis_clients',
-      color: '#2f6bff',
+      color: REDIS_PALETTE.blue,
       icon: 'node',
       guide: [{ label: '客户端连接', detail: '当前活跃的客户端连接数量。阻塞非零常见于 BLPOP/BRPOP 等待；连接拒绝非零说明触及 maxclients。' }],
       footer: [
@@ -217,8 +230,8 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '内存上限', detail: '配置的最大可用内存(maxmemory),虚线表示;未配置时无此线。' }
       ],
       series: [
-        { metric: 'redis_used_memory', label: '已用内存', color: '#2f6bff', unit: 'bytes' },
-        { metric: 'redis_maxmemory', label: '内存上限', color: '#9aa9bf', unit: 'bytes', style: 'limit' }
+        { metric: 'redis_used_memory', label: '已用内存', color: REDIS_PALETTE.blue, unit: 'bytes' },
+        { metric: 'redis_maxmemory', label: '内存上限', color: REDIS_PALETTE.neutral, unit: 'bytes', style: 'limit' }
       ]
     },
     {
@@ -230,8 +243,8 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '键未命中', detail: '键空间未命中频率,持续升高需优化缓存策略。' }
       ],
       series: [
-        { metric: 'redis_keyspace_hits_rate', label: '键命中', color: '#2f6bff', unit: 'cps' },
-        { metric: 'redis_keyspace_misses_rate', label: '键未命中', color: '#ff4d4f', unit: 'cps' }
+        { metric: 'redis_keyspace_hits_rate', label: '键命中', color: REDIS_PALETTE.emerald, unit: 'cps' },
+        { metric: 'redis_keyspace_misses_rate', label: '键未命中', color: REDIS_PALETTE.rose, unit: 'cps' }
       ]
     },
     {
@@ -242,7 +255,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '命令速率', detail: '所选时间窗口内命令处理平均速率；与其他 rate 指标口径一致。' }
       ],
       series: [
-        { metric: 'redis_total_commands_processed_rate', label: '命令速率', color: '#13c2c2', unit: 'cps' }
+        { metric: 'redis_total_commands_processed_rate', label: '命令速率', color: REDIS_PALETTE.cyan, unit: 'cps' }
       ]
     },
     {
@@ -254,8 +267,8 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '键驱逐频率', detail: '内存压力下被驱逐键的速率,非零说明内存吃紧。连接拒绝见连接数 KPI 副文案。' }
       ],
       series: [
-        { metric: 'redis_expired_keys_rate', label: '键过期频率', color: '#2f6bff', unit: 'cps' },
-        { metric: 'redis_evicted_keys_rate', label: '键驱逐频率', color: '#ff4d4f', unit: 'cps' }
+        { metric: 'redis_expired_keys_rate', label: '键过期频率', color: REDIS_PALETTE.indigo, unit: 'cps' },
+        { metric: 'redis_evicted_keys_rate', label: '键驱逐频率', color: REDIS_PALETTE.rose, unit: 'cps' }
       ]
     },
     {
@@ -267,8 +280,8 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '网络出流量', detail: 'Redis 发送网络数据的速率。' }
       ],
       series: [
-        { metric: 'redis_total_net_input_bytes_rate', label: '网络入流量', color: '#2f6bff', unit: 'byteps' },
-        { metric: 'redis_total_net_output_bytes_rate', label: '网络出流量', color: '#27c274', unit: 'byteps' }
+        { metric: 'redis_total_net_input_bytes_rate', label: '网络入流量', color: REDIS_PALETTE.blue, unit: 'byteps' },
+        { metric: 'redis_total_net_output_bytes_rate', label: '网络出流量', color: REDIS_PALETTE.emerald, unit: 'byteps' }
       ]
     },
     {
@@ -279,7 +292,7 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '内存碎片率', detail: '操作系统分配内存与 Redis 实际使用内存的比值,>1.5 通常表示碎片严重。' }
       ],
       series: [
-        { metric: 'redis_mem_fragmentation_ratio', label: '内存碎片率', color: '#8a5cff', unit: 'none' }
+        { metric: 'redis_mem_fragmentation_ratio', label: '内存碎片率', color: REDIS_PALETTE.amber, unit: 'none' }
       ]
     },
     {
@@ -291,13 +304,12 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '阻塞客户端', detail: '处于阻塞等待的客户端数；持续非零优先查阻塞命令（如 BLPOP）与慢消费。连接拒绝见连接数 KPI 副文案。' }
       ],
       series: [
-        { metric: 'redis_clients', label: '活跃连接', color: '#2f6bff', unit: 'counts' },
-        { metric: 'redis_blocked_clients', label: '阻塞客户端', color: '#ff8a1f', unit: 'counts' }
+        { metric: 'redis_clients', label: '活跃连接', color: REDIS_PALETTE.blue, unit: 'counts' },
+        { metric: 'redis_blocked_clients', label: '阻塞客户端', color: REDIS_PALETTE.orange, unit: 'counts' }
       ]
     }
   ],
   ringPanels: [],
   barPanels: [],
-  // 键生命周期 / 网络流量 / 内存碎片 / 客户端连接 已改为 charts(折线图),不再用 detail 缩略图或条形卡。
   details: []
 };

--- a/web/src/app/monitor/dashboards/objects/redis/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/redis/dashboard.tsx
@@ -54,7 +54,7 @@ export default function RedisDashboardPage() {
                   loading={dashboard.loading}
                   seriesStyles={fragChart.seriesStyles}
                   onXRangeChange={dashboard.onXRangeChange}
-                  className={`${styles.panel} ${styles.span6}`}
+                  className={`${styles.panel} ${styles.span6} ${styles.compactTrend}`}
                   styles={styles}
                 />
               )}
@@ -70,7 +70,7 @@ export default function RedisDashboardPage() {
                   loading={dashboard.loading}
                   seriesStyles={clientChart.seriesStyles}
                   onXRangeChange={dashboard.onXRangeChange}
-                  className={`${styles.panel} ${styles.span6}`}
+                  className={`${styles.panel} ${styles.span6} ${styles.compactTrend}`}
                   styles={styles}
                 />
               )}

--- a/web/src/app/monitor/dashboards/objects/redis/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/redis/index.module.scss
@@ -1,21 +1,37 @@
 @use '../common/simple-dashboard.module.scss';
 
-// 区块小标题:给分区加语义标题,提升可扫读性(与 MySQL/PostgreSQL 同款)
-.sectionLabel {
-  margin: 2px 2px 4px;
-  padding-bottom: 4px;
-  border-bottom: 1px solid #eceff4;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #8c95a8;
+// sectionLabel 已上收到共享壳（带品牌蓝指示条与现代间距）；此处仅保留趋势图高度与图例微调。
+
+.chartLegendHeader {
+  justify-content: flex-end;
+  max-width: none;
+  white-space: nowrap;
 }
 
-.dashboardSection + .sectionLabel {
-  margin-top: 8px;
+.compactTrend {
+  .chartWrap {
+    height: 180px;
+  }
 }
 
-:global(html.dark) .sectionLabel {
-  border-bottom-color: rgba(255, 255, 255, 0.08);
+@media (max-width: 768px) {
+  .chartLegendHeader {
+    justify-content: flex-start;
+    max-width: 100%;
+    white-space: normal;
+  }
+
+  .compactTrend {
+    .chartWrap {
+      height: 140px;
+    }
+  }
+}
+
+@media (max-width: 480px) {
+  .compactTrend {
+    .chartWrap {
+      height: 120px;
+    }
+  }
 }

--- a/web/src/app/monitor/dashboards/objects/sglang/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/sglang/dashboard.tsx
@@ -58,7 +58,7 @@ export default function SglangDashboardPage() {
       styles={styles}
       dashboardContent={
         <>
-          <div className={styles.sectionLabel}>推理概览</div>
+          <div className={styles.sectionLabel}>健康概览</div>
           <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={6} styles={styles} />
 
           <div className={styles.sectionLabel}>队列与吞吐</div>

--- a/web/src/app/monitor/dashboards/objects/tcp/config.ts
+++ b/web/src/app/monitor/dashboards/objects/tcp/config.ts
@@ -1,5 +1,17 @@
 import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
 
+/** TCP 拨测监控高对比鲜活色板 */
+const TCP_PALETTE = {
+  emerald: '#10B981',   // 连通成功率、成功占比
+  blue: '#2563EB',      // 平均响应时间
+  cyan: '#06B6D4',      // 最小响应时间
+  indigo: '#6366F1',    // 最大响应时间
+  amber: '#F59E0B',     // 返回不匹配
+  orange: '#F97316',    // 读取失败
+  rose: '#EF4444',      // 探测失败率、超时占比
+  crimson: '#E11D48'    // 连接失败占比
+} as const;
+
 export const TCP_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   routeKey: 'tcp',
   pageTitle: 'TCP 监控仪表盘',
@@ -14,7 +26,7 @@ export const TCP_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'TCP 建连的平均往返耗时（毫秒）。',
       unit: 'ms',
       query: 'avg(net_response_response_time{__$labels__}) * 1000',
-      color: '#2f6bff'
+      color: TCP_PALETTE.blue
     },
     {
       name: 'tcp_response_time_min',
@@ -22,7 +34,7 @@ export const TCP_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'TCP 建连的最小往返耗时（毫秒）。',
       unit: 'ms',
       query: 'min(net_response_response_time{__$labels__}) * 1000',
-      color: '#13c2c2'
+      color: TCP_PALETTE.cyan
     },
     {
       name: 'tcp_response_time_max',
@@ -30,7 +42,7 @@ export const TCP_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'TCP 建连的最大往返耗时（毫秒）。',
       unit: 'ms',
       query: 'max(net_response_response_time{__$labels__}) * 1000',
-      color: '#ff8a1f'
+      color: TCP_PALETTE.indigo
     },
     {
       name: 'tcp_success_rate',
@@ -38,7 +50,7 @@ export const TCP_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '结果码为 0（成功）的探测占比。',
       unit: 'percent',
       query: 'avg(net_response_result_code{__$labels__} == bool 0) * 100',
-      color: '#27c274'
+      color: TCP_PALETTE.emerald
     },
     {
       name: 'tcp_failure_rate',
@@ -46,7 +58,7 @@ export const TCP_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '结果码非 0 的探测占比。',
       unit: 'percent',
       query: 'avg(net_response_result_code{__$labels__} != bool 0) * 100',
-      color: '#ff4d4f'
+      color: TCP_PALETTE.rose
     },
     {
       name: 'tcp_result_success_rate',
@@ -54,7 +66,7 @@ export const TCP_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '结果码为成功的探测占比。',
       unit: 'percent',
       query: 'avg(net_response_result_code{__$labels__} == bool 0) * 100',
-      color: '#27c274'
+      color: TCP_PALETTE.emerald
     },
     {
       name: 'tcp_result_timeout_rate',
@@ -62,7 +74,7 @@ export const TCP_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '结果码为超时的探测占比。',
       unit: 'percent',
       query: 'avg(net_response_result_code{__$labels__} == bool 1) * 100',
-      color: '#ff4d4f'
+      color: TCP_PALETTE.rose
     },
     {
       name: 'tcp_result_conn_fail_rate',
@@ -70,7 +82,7 @@ export const TCP_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '结果码为连接失败的探测占比。',
       unit: 'percent',
       query: 'avg(net_response_result_code{__$labels__} == bool 2) * 100',
-      color: '#ff7875'
+      color: TCP_PALETTE.crimson
     },
     {
       name: 'tcp_result_read_fail_rate',
@@ -78,7 +90,7 @@ export const TCP_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '结果码为读取失败的探测占比。',
       unit: 'percent',
       query: 'avg(net_response_result_code{__$labels__} == bool 3) * 100',
-      color: '#ffa940'
+      color: TCP_PALETTE.orange
     },
     {
       name: 'tcp_result_mismatch_rate',
@@ -86,7 +98,7 @@ export const TCP_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '结果码为返回不匹配的探测占比。',
       unit: 'percent',
       query: 'avg(net_response_result_code{__$labels__} == bool 4) * 100',
-      color: '#faad14'
+      color: TCP_PALETTE.amber
     }
   ],
   // Layer0 + A 连通成功率 + B 平均响应；最大响应/结果码进副文案与环图，不另占主卡
@@ -95,7 +107,7 @@ export const TCP_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       title: '连通成功率',
       metric: 'tcp_success_rate',
       unit: 'percent',
-      color: '#27c274',
+      color: TCP_PALETTE.emerald,
       icon: 'health',
       compare: true,
       compareFavorableDirection: 'up',
@@ -113,7 +125,7 @@ export const TCP_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       title: '平均响应时间',
       metric: 'tcp_response_time_avg',
       unit: 'ms',
-      color: '#2f6bff',
+      color: TCP_PALETTE.blue,
       icon: 'clock',
       compare: true,
       compareFavorableDirection: 'down',
@@ -135,7 +147,7 @@ export const TCP_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       subtitle: '端口可达性',
       metric: 'tcp_success_rate',
       guide: [{ label: '连通成功率趋势', detail: '下跌时优先查端口监听、防火墙与对端进程；对照结果码分布。' }],
-      series: [{ metric: 'tcp_success_rate', label: '连通成功率', color: '#27c274', unit: 'percent' }]
+      series: [{ metric: 'tcp_success_rate', label: '连通成功率', color: TCP_PALETTE.emerald, unit: 'percent' }]
     },
     {
       title: '响应时间趋势',
@@ -143,8 +155,8 @@ export const TCP_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       metric: 'tcp_response_time_avg',
       guide: [{ label: '响应时间趋势', detail: '对比平均与最大建连耗时，判断整体变慢还是尖刺。' }],
       series: [
-        { metric: 'tcp_response_time_avg', label: '平均响应时间', color: '#2f6bff', unit: 'ms' },
-        { metric: 'tcp_response_time_max', label: '最大响应时间', color: '#ff8a1f', unit: 'ms' }
+        { metric: 'tcp_response_time_avg', label: '平均响应时间', color: TCP_PALETTE.blue, unit: 'ms' },
+        { metric: 'tcp_response_time_max', label: '最大响应时间', color: TCP_PALETTE.indigo, unit: 'ms' }
       ]
     }
   ],
@@ -164,11 +176,11 @@ export const TCP_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       emptyWhenAllZero: true,
       emptyDescription: '当前窗口无 TCP 探测结果码样本',
       segments: [
-        { label: '成功', metric: 'tcp_result_success_rate', color: '#27c274', unit: 'percent' },
-        { label: '超时', metric: 'tcp_result_timeout_rate', color: '#ff4d4f', unit: 'percent' },
-        { label: '连接失败', metric: 'tcp_result_conn_fail_rate', color: '#ff7875', unit: 'percent' },
-        { label: '读取失败', metric: 'tcp_result_read_fail_rate', color: '#ffa940', unit: 'percent' },
-        { label: '返回不匹配', metric: 'tcp_result_mismatch_rate', color: '#faad14', unit: 'percent' }
+        { label: '成功', metric: 'tcp_result_success_rate', color: TCP_PALETTE.emerald, unit: 'percent' },
+        { label: '超时', metric: 'tcp_result_timeout_rate', color: TCP_PALETTE.rose, unit: 'percent' },
+        { label: '连接失败', metric: 'tcp_result_conn_fail_rate', color: TCP_PALETTE.crimson, unit: 'percent' },
+        { label: '读取失败', metric: 'tcp_result_read_fail_rate', color: TCP_PALETTE.orange, unit: 'percent' },
+        { label: '返回不匹配', metric: 'tcp_result_mismatch_rate', color: TCP_PALETTE.amber, unit: 'percent' }
       ]
     }
   ],

--- a/web/src/app/monitor/dashboards/objects/tcp/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/tcp/index.module.scss
@@ -1,23 +1,6 @@
 @use '../common/simple-dashboard.module.scss';
 
-.sectionLabel {
-  margin: 2px 2px 4px;
-  padding-bottom: 4px;
-  border-bottom: 1px solid #eceff4;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #8c95a8;
-}
-
-.dashboardSection + .sectionLabel {
-  margin-top: 8px;
-}
-
-:global(html.dark) .sectionLabel {
-  border-bottom-color: rgba(255, 255, 255, 0.08);
-}
+// sectionLabel 已上收到共享壳（带品牌蓝指示条与现代间距）；此处仅保留趋势图高度与图例微调。
 
 .chartLegendHeader {
   justify-content: flex-end;
@@ -27,7 +10,7 @@
 
 .compactTrend {
   .chartWrap {
-    height: 164px;
+    height: 180px;
   }
 }
 
@@ -40,7 +23,7 @@
 
   .compactTrend {
     .chartWrap {
-      height: 138px;
+      height: 140px;
     }
   }
 }

--- a/web/src/app/monitor/dashboards/objects/vllm/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/vllm/dashboard.tsx
@@ -67,7 +67,7 @@ export default function VllmDashboardPage() {
       styles={styles}
       dashboardContent={
         <>
-          <div className={styles.sectionLabel}>总览</div>
+          <div className={styles.sectionLabel}>健康概览</div>
           <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={6} styles={styles} />
           <FlexiblePanelSection styles={styles}>
             {renderChart(queueTrend, styles.span8)}

--- a/web/src/app/monitor/dashboards/objects/website/config.ts
+++ b/web/src/app/monitor/dashboards/objects/website/config.ts
@@ -6,6 +6,19 @@ import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
 const SUCCESS_RATE_EXPR =
   'avg by (instance_id) ((sum without (result) (count_over_time(http_response_result_type{result="success",__$labels__}[__$window__])) or sum without (result) (count_over_time(http_response_result_type{__$labels__}[__$window__])) * 0) / sum without (result) (count_over_time(http_response_result_type{__$labels__}[__$window__])) * 100)';
 
+/** 网站拨测监控高对比鲜活色板 */
+const WEBSITE_PALETTE = {
+  emerald: '#10B981',   // 成功/健康 (探测成功率、2xx 节点)
+  blue: '#2563EB',      // 响应时间主色 (平均响应时间)
+  cyan: '#06B6D4',      // 3xx 节点
+  indigo: '#6366F1',    // 峰值响应时间
+  amber: '#F59E0B',     // 警告/不匹配 (4xx 节点、内容/状态码不匹配)
+  orange: '#F97316',    // 读体失败、失败占比
+  rose: '#EF4444',      // 严重失败 (5xx 节点、连接失败)
+  crimson: '#E11D48',   // 超时
+  ruby: '#991B1B'       // DNS 错误
+} as const;
+
 export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   routeKey: 'website',
   pageTitle: '网站监控仪表盘',
@@ -21,7 +34,7 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '网站探测节点平均成功率（Telegraf result_type=success，不等于 HTTP 2xx）。',
       unit: 'percent',
       query: SUCCESS_RATE_EXPR,
-      color: '#27c274'
+      color: WEBSITE_PALETTE.emerald
     },
     {
       name: 'website_failure_rate_avg',
@@ -29,7 +42,7 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '网站探测节点平均失败占比。',
       unit: 'percent',
       query: `clamp_max(100 - ${SUCCESS_RATE_EXPR}, 100)`,
-      color: '#ff8a1f'
+      color: WEBSITE_PALETTE.orange
     },
     {
       name: 'website_response_time_avg',
@@ -37,7 +50,7 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '网站探测平均响应时间。',
       unit: 's',
       query: 'avg by (instance_id) (http_response_response_time{__$labels__})',
-      color: '#2f6bff'
+      color: WEBSITE_PALETTE.blue
     },
     {
       name: 'website_response_time_max',
@@ -45,7 +58,7 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '网站探测最大响应时间。',
       unit: 's',
       query: 'max by (instance_id) (http_response_response_time{__$labels__})',
-      color: '#8a5cff'
+      color: WEBSITE_PALETTE.indigo
     },
     {
       name: 'website_result_success_rate',
@@ -53,7 +66,7 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'result_code=0 的探测占比。',
       unit: 'percent',
       query: 'avg(http_response_result_code{__$labels__} == bool 0) * 100',
-      color: '#27c274'
+      color: WEBSITE_PALETTE.emerald
     },
     {
       name: 'website_result_body_mismatch_rate',
@@ -61,7 +74,7 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'result_code=1 的探测占比。',
       unit: 'percent',
       query: 'avg(http_response_result_code{__$labels__} == bool 1) * 100',
-      color: '#faad14'
+      color: WEBSITE_PALETTE.amber
     },
     {
       name: 'website_result_body_read_fail_rate',
@@ -69,7 +82,7 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'result_code=2 的探测占比。',
       unit: 'percent',
       query: 'avg(http_response_result_code{__$labels__} == bool 2) * 100',
-      color: '#d48806'
+      color: WEBSITE_PALETTE.orange
     },
     {
       name: 'website_result_conn_fail_rate',
@@ -77,7 +90,7 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'result_code=3 的探测占比。',
       unit: 'percent',
       query: 'avg(http_response_result_code{__$labels__} == bool 3) * 100',
-      color: '#ff4d4f'
+      color: WEBSITE_PALETTE.rose
     },
     {
       name: 'website_result_timeout_rate',
@@ -85,7 +98,7 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'result_code=4 的探测占比。',
       unit: 'percent',
       query: 'avg(http_response_result_code{__$labels__} == bool 4) * 100',
-      color: '#ff7875'
+      color: WEBSITE_PALETTE.crimson
     },
     {
       name: 'website_result_dns_fail_rate',
@@ -93,7 +106,7 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'result_code=5 的探测占比。',
       unit: 'percent',
       query: 'avg(http_response_result_code{__$labels__} == bool 5) * 100',
-      color: '#cf1322'
+      color: WEBSITE_PALETTE.ruby
     },
     {
       name: 'website_result_status_mismatch_rate',
@@ -101,7 +114,7 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: 'result_code=6 的探测占比。',
       unit: 'percent',
       query: 'avg(http_response_result_code{__$labels__} == bool 6) * 100',
-      color: '#ffa940'
+      color: WEBSITE_PALETTE.amber
     },
     {
       name: 'website_status_code_2xx_count',
@@ -109,7 +122,7 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '当前返回 2xx 状态码的探测节点数。',
       unit: 'counts',
       query: 'count((http_response_http_response_code{__$labels__} >= 200) and (http_response_http_response_code{__$labels__} < 300)) or on() vector(0)',
-      color: '#27c274'
+      color: WEBSITE_PALETTE.emerald
     },
     {
       name: 'website_status_code_3xx_count',
@@ -117,7 +130,7 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '当前返回 3xx 状态码的探测节点数。',
       unit: 'counts',
       query: 'count((http_response_http_response_code{__$labels__} >= 300) and (http_response_http_response_code{__$labels__} < 400)) or on() vector(0)',
-      color: '#2f6bff'
+      color: WEBSITE_PALETTE.cyan
     },
     {
       name: 'website_status_code_4xx_count',
@@ -125,7 +138,7 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '当前返回 4xx 状态码的探测节点数。',
       unit: 'counts',
       query: 'count((http_response_http_response_code{__$labels__} >= 400) and (http_response_http_response_code{__$labels__} < 500)) or on() vector(0)',
-      color: '#ff8a1f'
+      color: WEBSITE_PALETTE.amber
     },
     {
       name: 'website_status_code_5xx_count',
@@ -133,7 +146,7 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '当前返回 5xx 状态码的探测节点数。',
       unit: 'counts',
       query: 'count(http_response_http_response_code{__$labels__} >= 500) or on() vector(0)',
-      color: '#ff4d4f'
+      color: WEBSITE_PALETTE.rose
     }
   ],
   // Layer0 + A 成功率 + B 响应时间；失败归因交给下方「探测结果分布 / 状态码分布」
@@ -151,7 +164,7 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         }
       ],
       metric: 'website_success_rate_avg',
-      color: '#27c274',
+      color: WEBSITE_PALETTE.emerald,
       icon: 'api',
       compare: true,
       compareFavorableDirection: 'up',
@@ -161,7 +174,7 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       title: '平均响应时间',
       guide: [{ label: '平均响应时间', detail: '优先观察平均响应是否持续升高，再对比峰值判断是整体变慢还是尖刺。' }],
       metric: 'website_response_time_avg',
-      color: '#2f6bff',
+      color: WEBSITE_PALETTE.blue,
       icon: 'clock',
       compare: true,
       footer: [{ label: '峰值响应', metric: 'website_response_time_max', unit: 's' }]
@@ -178,7 +191,7 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
           detail: '下跌时先看探测结果分布与响应时间；连接失败/超时/DNS 不会产生 HTTP 状态码。'
         }
       ],
-      series: [{ metric: 'website_success_rate_avg', label: '探测成功率', color: '#27c274', unit: 'percent' }]
+      series: [{ metric: 'website_success_rate_avg', label: '探测成功率', color: WEBSITE_PALETTE.emerald, unit: 'percent' }]
     },
     {
       title: '响应时间趋势',
@@ -186,8 +199,8 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       guide: [{ label: '响应时间趋势', detail: '对比平均值与峰值，优先识别整体变慢还是局部尖刺。' }],
       metric: 'website_response_time_avg',
       series: [
-        { metric: 'website_response_time_avg', label: '平均响应', color: '#2f6bff', unit: 's' },
-        { metric: 'website_response_time_max', label: '峰值响应', color: '#8a5cff', unit: 's' }
+        { metric: 'website_response_time_avg', label: '平均响应', color: WEBSITE_PALETTE.blue, unit: 's' },
+        { metric: 'website_response_time_max', label: '峰值响应', color: WEBSITE_PALETTE.indigo, unit: 's' }
       ]
     }
   ],
@@ -207,13 +220,13 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       emptyWhenAllZero: true,
       emptyDescription: '当前窗口无探测结果码样本',
       segments: [
-        { label: '成功', metric: 'website_result_success_rate', color: '#27c274', unit: 'percent' },
-        { label: '内容不匹配', metric: 'website_result_body_mismatch_rate', color: '#faad14', unit: 'percent' },
-        { label: '读体失败', metric: 'website_result_body_read_fail_rate', color: '#d48806', unit: 'percent' },
-        { label: '连接失败', metric: 'website_result_conn_fail_rate', color: '#ff4d4f', unit: 'percent' },
-        { label: '超时', metric: 'website_result_timeout_rate', color: '#ff7875', unit: 'percent' },
-        { label: 'DNS错误', metric: 'website_result_dns_fail_rate', color: '#cf1322', unit: 'percent' },
-        { label: '状态码不匹配', metric: 'website_result_status_mismatch_rate', color: '#ffa940', unit: 'percent' }
+        { label: '成功', metric: 'website_result_success_rate', color: WEBSITE_PALETTE.emerald, unit: 'percent' },
+        { label: '内容不匹配', metric: 'website_result_body_mismatch_rate', color: WEBSITE_PALETTE.amber, unit: 'percent' },
+        { label: '读体失败', metric: 'website_result_body_read_fail_rate', color: WEBSITE_PALETTE.orange, unit: 'percent' },
+        { label: '连接失败', metric: 'website_result_conn_fail_rate', color: WEBSITE_PALETTE.rose, unit: 'percent' },
+        { label: '超时', metric: 'website_result_timeout_rate', color: WEBSITE_PALETTE.crimson, unit: 'percent' },
+        { label: 'DNS错误', metric: 'website_result_dns_fail_rate', color: WEBSITE_PALETTE.ruby, unit: 'percent' },
+        { label: '状态码不匹配', metric: 'website_result_status_mismatch_rate', color: WEBSITE_PALETTE.amber, unit: 'percent' }
       ]
     },
     {
@@ -231,10 +244,10 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       emptyWhenAllZero: true,
       emptyDescription: '当前窗口无 HTTP 状态码（失败可能发生在建连/TLS/超时阶段，或尚未采集到状态码）',
       segments: [
-        { label: '2xx', metric: 'website_status_code_2xx_count', color: '#27c274', unit: 'counts' },
-        { label: '3xx', metric: 'website_status_code_3xx_count', color: '#2f6bff', unit: 'counts' },
-        { label: '4xx', metric: 'website_status_code_4xx_count', color: '#ff8a1f', unit: 'counts' },
-        { label: '5xx', metric: 'website_status_code_5xx_count', color: '#ff4d4f', unit: 'counts' }
+        { label: '2xx', metric: 'website_status_code_2xx_count', color: WEBSITE_PALETTE.emerald, unit: 'counts' },
+        { label: '3xx', metric: 'website_status_code_3xx_count', color: WEBSITE_PALETTE.cyan, unit: 'counts' },
+        { label: '4xx', metric: 'website_status_code_4xx_count', color: WEBSITE_PALETTE.amber, unit: 'counts' },
+        { label: '5xx', metric: 'website_status_code_5xx_count', color: WEBSITE_PALETTE.rose, unit: 'counts' }
       ]
     }
   ],

--- a/web/src/app/monitor/dashboards/objects/website/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/website/index.module.scss
@@ -1,24 +1,6 @@
 @use '../common/simple-dashboard.module.scss';
 
-// 区块小标题:给分区加语义标题,提升可扫读性(与 redis/postgresql 同款)
-.sectionLabel {
-  margin: 2px 2px 4px;
-  padding-bottom: 4px;
-  border-bottom: 1px solid #eceff4;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #8c95a8;
-}
-
-.dashboardSection + .sectionLabel {
-  margin-top: 8px;
-}
-
-:global(html.dark) .sectionLabel {
-  border-bottom-color: rgba(255, 255, 255, 0.08);
-}
+// sectionLabel 已上收到共享壳（带品牌蓝指示条与现代间距）；此处仅保留趋势图高度与图例微调。
 
 .chartLegendHeader {
   justify-content: flex-end;
@@ -28,22 +10,7 @@
 
 .compactTrend {
   .chartWrap {
-    height: 164px;
-  }
-}
-
-.compactStatusRing {
-  .ringCard {
-    grid-template-columns: minmax(132px, 144px) minmax(0, 1fr);
-    gap: 12px;
-  }
-
-  .metricRow {
-    gap: 10px;
-  }
-
-  .metricValueGroup {
-    gap: 2px;
+    height: 180px;
   }
 }
 
@@ -56,7 +23,7 @@
 
   .compactTrend {
     .chartWrap {
-      height: 138px;
+      height: 140px;
     }
   }
 }

--- a/web/src/app/monitor/dashboards/shared/widgets/collection-status-card.tsx
+++ b/web/src/app/monitor/dashboards/shared/widgets/collection-status-card.tsx
@@ -2,34 +2,68 @@
 
 import React from 'react';
 import { Tooltip } from 'antd';
+import { ApiOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import { CollectionStatusResult } from '../types';
 import { COLLECTION_STATUS_LEGEND } from '../utils/constants';
 import {
   CollectionStatusTimelineSegment,
+  CollectionStatusTone,
   getCollectionStatusToneLabel
 } from '../utils/collection-status';
 import { TitleWithGuide, GuideTooltipStyles } from './guide-tooltip';
+
+export interface CollectionStatusLegendItem {
+  key: string;
+  label: string;
+  color: string;
+}
 
 export interface CollectionStatusCardStyles extends GuideTooltipStyles {
   statCard?: string;
   collectionStatusCard?: string;
   collectionStatusHeader?: string;
+  statHeader?: string;
   statLabel?: string;
   statTitleWithGuide?: string;
+  statIcon?: string;
+  collectionStatusHeaderIcon?: string;
+  collectionStatusHeaderIconSuccess?: string;
+  collectionStatusHeaderIconWarning?: string;
+  collectionStatusHeaderIconError?: string;
+  collectionStatusHeaderIconEmpty?: string;
+  collectionStatusPulseDot?: string;
   collectionStatusBody?: string;
   collectionStatusValue?: string;
   collectionStatusValueSuccess?: string;
+  collectionStatusValueWarning?: string;
   collectionStatusValueError?: string;
   collectionStatusValueEmpty?: string;
+  collectionStatusHeadlineRow?: string;
+  collectionStatusPill?: string;
+  collectionStatusPillDot?: string;
+  collectionStatusPillText?: string;
+  collectionStatusPillSuccess?: string;
+  collectionStatusPillWarning?: string;
+  collectionStatusPillError?: string;
+  collectionStatusPillEmpty?: string;
+  collectionStatusAvailability?: string;
+  collectionStatusAvailabilityVal?: string;
+  collectionStatusAvailabilityLabel?: string;
+  collectionStatusSubMeta?: string;
   collectionStatusTimelineBlock?: string;
   collectionStatusTimelineTitle?: string;
   collectionStatusTimelineHint?: string;
   collectionStatusTimeline?: string;
   collectionStatusSegment?: string;
   collectionStatusSegmentSuccess?: string;
+  collectionStatusSegmentWarning?: string;
   collectionStatusSegmentError?: string;
   collectionStatusSegmentEmpty?: string;
+  collectionStatusTimelineEmpty?: string;
+  collectionStatusTimelineFooter?: string;
+  collectionStatusTimelineScaleRow?: string;
+  collectionStatusTimelineScale?: string;
   collectionStatusLegend?: string;
   collectionStatusLegendItem?: string;
   collectionStatusLegendDot?: string;
@@ -40,7 +74,12 @@ export interface CollectionStatusCardProps {
   timeline: CollectionStatusTimelineSegment[];
   /** 例如「每格约 50 秒」 */
   timelineHint?: string;
+  title?: React.ReactNode;
+  timelineTitle?: React.ReactNode;
+  statusTone?: CollectionStatusTone | 'warning';
   guideItems?: Array<{ label: string; detail: string }>;
+  legendItems?: CollectionStatusLegendItem[];
+  emptyTimelineText?: React.ReactNode;
   /** 作为 grid 子项时传入 span* 等栅格类,使其与相邻 StatCard 等高/等宽对齐。 */
   className?: string;
   styles: CollectionStatusCardStyles;
@@ -54,61 +93,193 @@ const DEFAULT_GUIDE_ITEMS = [
   }
 ];
 
+const getToneLabel = (tone: string): string => {
+  if (tone === 'success') return '正常';
+  if (tone === 'warning') return '警告';
+  if (tone === 'error') return '异常';
+  return '无数据';
+};
+
 const formatSegmentTooltip = (segment: CollectionStatusTimelineSegment): string => {
-  const start = dayjs(segment.startMs).format('HH:mm:ss');
-  const end = dayjs(segment.endMs).format('HH:mm:ss');
-  return `${start} – ${end}\n${getCollectionStatusToneLabel(segment.tone)}`;
+  const label = segment.tone ? getToneLabel(segment.tone) : getCollectionStatusToneLabel(segment.tone as CollectionStatusTone);
+  if (
+    Number.isFinite(segment.startMs) &&
+    Number.isFinite(segment.endMs) &&
+    typeof segment.startMs === 'number' &&
+    typeof segment.endMs === 'number'
+  ) {
+    const start = dayjs(segment.startMs).format('HH:mm:ss');
+    const end = dayjs(segment.endMs).format('HH:mm:ss');
+    return `${start} – ${end}\n${label}`;
+  }
+  return label;
+};
+
+const getStatusTone = (
+  status: CollectionStatusResult,
+  statusTone?: string
+): 'success' | 'warning' | 'error' | 'empty' => {
+  if (statusTone === 'success' || statusTone === 'warning' || statusTone === 'error' || statusTone === 'empty') {
+    return statusTone;
+  }
+  if (status.tagColor === 'success') return 'success';
+  if (status.tagColor === 'warning') return 'warning';
+  if (status.tagColor === 'error') return 'error';
+  if (status.label === '正常') return 'success';
+  if (status.label === '异常') return 'error';
+  if (status.label === '无数据') return 'empty';
+  return 'empty';
+};
+
+const resolveToneSuffix = (tone: string): string => {
+  if (tone === 'success') return 'Success';
+  if (tone === 'warning') return 'Warning';
+  if (tone === 'error') return 'Error';
+  return 'Empty';
 };
 
 export const CollectionStatusCard = ({
   status,
   timeline,
   timelineHint,
+  title = '采集状态',
+  timelineTitle = '状态时间线',
+  statusTone,
   guideItems = DEFAULT_GUIDE_ITEMS,
+  legendItems = COLLECTION_STATUS_LEGEND,
+  emptyTimelineText = '暂无状态时间线数据',
   className,
   styles
 }: CollectionStatusCardProps) => {
+  const resolvedTone = getStatusTone(status, statusTone);
+  const toneSuffix = resolveToneSuffix(resolvedTone);
+
+  const scaleRange = React.useMemo(() => {
+    if (timeline.length < 2) return null;
+    const first = timeline[0];
+    const last = timeline[timeline.length - 1];
+    if (!Number.isFinite(first?.startMs) || !Number.isFinite(last?.endMs)) return null;
+
+    const startText = dayjs(first.startMs).format('HH:mm');
+    const now = Date.now();
+    const isNearNow = Math.abs(now - last.endMs) < 120_000;
+    const endText = isNearNow ? '刚刚' : dayjs(last.endMs).format('HH:mm');
+
+    return { startText, endText };
+  }, [timeline]);
+
+  const headerClass = styles.collectionStatusHeader || styles.statHeader;
+
   return (
     <div className={[styles.statCard, styles.collectionStatusCard, className].filter(Boolean).join(' ')}>
-      <div className={styles.collectionStatusHeader}>
+      <div className={headerClass}>
         <div className={styles.statLabel}>
           <TitleWithGuide
-            title="采集状态"
+            title={title}
             items={guideItems}
             className={styles.statTitleWithGuide}
             styles={styles}
           />
         </div>
+        <div
+          className={[
+            styles.statIcon,
+            styles.collectionStatusHeaderIcon,
+            styles[`collectionStatusHeaderIcon${toneSuffix}` as keyof CollectionStatusCardStyles],
+            'relative flex items-center justify-center shrink-0 w-[30px] h-[30px] rounded-[8px]'
+          ].filter(Boolean).join(' ')}
+          aria-hidden="true"
+        >
+          <span
+            className={[
+              styles.collectionStatusPulseDot,
+              'absolute top-1 right-1 w-1.5 h-1.5 rounded-full'
+            ].filter(Boolean).join(' ')}
+          />
+          <ApiOutlined className="text-[14px]" />
+        </div>
       </div>
-      <div className={styles.collectionStatusBody}>
-        <div className={`${styles.collectionStatusValue} ${styles[`collectionStatusValue${status.label === '正常' ? 'Success' : status.label === '异常' ? 'Error' : 'Empty'}`]}`}>
-          {status.label}
-        </div>
-        <div className={styles.collectionStatusTimelineTitle}>
-          <span>状态时间线</span>
-          {timelineHint ? <span className={styles.collectionStatusTimelineHint}>{timelineHint}</span> : null}
-        </div>
-        <div className={styles.collectionStatusTimelineBlock}>
-          <div className={styles.collectionStatusTimeline}>
-            {timeline.map((segment, index) => (
-              <Tooltip
-                key={`${segment.tone}-${segment.startMs}-${index}`}
-                title={<span style={{ whiteSpace: 'pre-line' }}>{formatSegmentTooltip(segment)}</span>}
-              >
-                <span
-                  className={`${styles.collectionStatusSegment} ${styles[`collectionStatusSegment${segment.tone === 'success' ? 'Success' : segment.tone === 'error' ? 'Error' : 'Empty'}`]}`}
-                />
-              </Tooltip>
-            ))}
+
+      <div className={[styles.collectionStatusBody, 'flex flex-col flex-1 min-h-0'].filter(Boolean).join(' ')}>
+        <div className={[styles.collectionStatusHeadlineRow, 'flex items-center gap-2 flex-wrap min-h-[28px]'].filter(Boolean).join(' ')}>
+          <div
+            className={[
+              styles.collectionStatusPill,
+              styles[`collectionStatusPill${toneSuffix}` as keyof CollectionStatusCardStyles],
+              'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[13px] font-semibold border transition-all'
+            ].filter(Boolean).join(' ')}
+          >
+            <span
+              className={[
+                styles.collectionStatusPillDot,
+                'w-[7px] h-[7px] rounded-full shrink-0'
+              ].filter(Boolean).join(' ')}
+            />
+            <span className={styles.collectionStatusPillText}>{status.label}</span>
           </div>
-          <div className={styles.collectionStatusLegend}>
-            {COLLECTION_STATUS_LEGEND.map((item) => (
-              <span key={item.key} className={styles.collectionStatusLegendItem}>
-                <span className={styles.collectionStatusLegendDot} style={{ background: item.color }} />
-                {item.label}
+        </div>
+
+        <div className={[styles.collectionStatusTimelineBlock, 'mt-auto flex flex-col gap-1.5 pt-1.5'].filter(Boolean).join(' ')}>
+          <div className={[styles.collectionStatusTimelineTitle, 'flex items-center justify-between gap-2 text-[11px] font-medium text-[var(--color-text-3)]'].filter(Boolean).join(' ')}>
+            <span>{timelineTitle}</span>
+            {timelineHint ? (
+              <span className={[styles.collectionStatusTimelineHint, 'shrink-0 text-[11px] text-[var(--color-text-4)]'].filter(Boolean).join(' ')}>
+                {timelineHint}
               </span>
-            ))}
+            ) : null}
           </div>
+
+          {timeline.length > 0 ? (
+            <>
+              <div className={[styles.collectionStatusTimeline, 'grid grid-cols-[repeat(18,minmax(0,1fr))] gap-[3px] items-center py-0.5'].filter(Boolean).join(' ')}>
+                {timeline.map((segment, index) => {
+                  const segSuffix = resolveToneSuffix(segment.tone);
+                  return (
+                    <Tooltip
+                      key={`${segment.tone}-${segment.startMs ?? index}-${index}`}
+                      title={<span style={{ whiteSpace: 'pre-line' }}>{formatSegmentTooltip(segment)}</span>}
+                    >
+                      <span
+                        className={[
+                          styles.collectionStatusSegment,
+                          styles[`collectionStatusSegment${segSuffix}` as keyof CollectionStatusCardStyles],
+                          'block w-full h-2 rounded-[4px] cursor-pointer transition-transform hover:scale-y-125'
+                        ].filter(Boolean).join(' ')}
+                      />
+                    </Tooltip>
+                  );
+                })}
+              </div>
+
+              <div className={[styles.collectionStatusTimelineFooter, 'flex flex-col gap-1.5 pt-0.5 text-[11px] text-[var(--color-text-4)] leading-none'].filter(Boolean).join(' ')}>
+                <div className={[styles.collectionStatusTimelineScaleRow, 'flex items-center justify-between gap-2 min-w-0'].filter(Boolean).join(' ')}>
+                  <span className={[styles.collectionStatusTimelineScale, 'tabular-nums whitespace-nowrap text-[11px] text-[var(--color-text-4)]'].filter(Boolean).join(' ')}>
+                    {scaleRange?.startText || ''}
+                  </span>
+                  <span className={[styles.collectionStatusTimelineScale, 'tabular-nums whitespace-nowrap text-[11px] text-[var(--color-text-4)]'].filter(Boolean).join(' ')}>
+                    {scaleRange?.endText || ''}
+                  </span>
+                </div>
+                <div className={[styles.collectionStatusLegend, 'flex items-center gap-2 whitespace-nowrap text-[11px] text-[var(--color-text-3)]'].filter(Boolean).join(' ')}>
+                  {legendItems.map((item) => (
+                    <span key={item.key} className={[styles.collectionStatusLegendItem, 'inline-flex items-center gap-1 text-[11px]'].filter(Boolean).join(' ')}>
+                      <span
+                        className={[styles.collectionStatusLegendDot, 'w-1.5 h-1.5 rounded-full shrink-0'].filter(Boolean).join(' ')}
+                        style={{ background: item.color }}
+                      />
+                      {item.label}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </>
+          ) : emptyTimelineText ? (
+            <div className={[styles.collectionStatusTimelineEmpty, 'py-2 text-center text-[12px] text-[var(--color-text-3)]'].filter(Boolean).join(' ')}>
+              {emptyTimelineText}
+            </div>
+          ) : (
+            <div className={styles.collectionStatusTimeline} />
+          )}
         </div>
       </div>
     </div>

--- a/web/src/app/monitor/dashboards/shared/widgets/dashboard-page-header.tsx
+++ b/web/src/app/monitor/dashboards/shared/widgets/dashboard-page-header.tsx
@@ -69,36 +69,36 @@ export function DashboardPageHeader({
 
   return (
     <div className={styles.pageTitleRow}>
-      <div className={styles.titleBlock}>
-        <Breadcrumb className={styles.breadcrumb} items={returnNavigation.breadcrumbItems} />
+      <Breadcrumb className={styles.breadcrumb} items={returnNavigation.breadcrumbItems} />
+      <div className={styles.titleControlsRow}>
         <h1 className={styles.title}>{title}</h1>
-      </div>
-      <div className={styles.controlsWrap}>
-        {viewSwitchSlot}
-        <Segmented
-          size="middle"
-          className={styles.modeSegmented}
-          value={displayMode}
-          options={[...DISPLAY_MODE_OPTIONS]}
-          onChange={(value) => onDisplayModeChange(value as 'dashboard' | 'metrics')}
-        />
-        {showTimeSelector ? (
+        <div className={styles.controlsWrap}>
+          {viewSwitchSlot}
+          <Segmented
+            size="middle"
+            className={styles.modeSegmented}
+            value={displayMode}
+            options={[...DISPLAY_MODE_OPTIONS]}
+            onChange={(value) => onDisplayModeChange(value as 'dashboard' | 'metrics')}
+          />
+          {showTimeSelector ? (
             <div className={styles.toolbarTimeSelector}>
-            <TimeSelector
-              appearance="toolbar"
-              defaultValue={timeDefaultValue}
-              customFrequencyList={frequencyList}
-              onChange={onTimeChange}
-              onFrequenceChange={onFrequenceChange}
-              onRefresh={onRefresh}
-            />
-          </div>
-        ) : null}
-        {styles.actionButtons ? (
-          <div className={styles.actionButtons}>{backButton}</div>
-        ) : (
-          backButton
-        )}
+              <TimeSelector
+                appearance="toolbar"
+                defaultValue={timeDefaultValue}
+                customFrequencyList={frequencyList}
+                onChange={onTimeChange}
+                onFrequenceChange={onFrequenceChange}
+                onRefresh={onRefresh}
+              />
+            </div>
+          ) : null}
+          {styles.actionButtons ? (
+            <div className={styles.actionButtons}>{backButton}</div>
+          ) : (
+            backButton
+          )}
+        </div>
       </div>
     </div>
   );

--- a/web/src/app/monitor/dashboards/shared/widgets/echarts-line-chart.tsx
+++ b/web/src/app/monitor/dashboards/shared/widgets/echarts-line-chart.tsx
@@ -144,9 +144,12 @@ const EChartsLineChart: React.FC<EChartsLineChartProps> = ({
     const seriesList = areaKeys.map((key, idx) => {
       const style = seriesStyles[idx] || {};
       const color = style.color || CHART_COLORS[idx % CHART_COLORS.length];
-      const fillOpacity = style.fillOpacity ?? 0.05;
+      // 多系列折线图避免多层面积重叠导致色彩混色发暗发脏；单系列保持轻盈明亮渐变。
+      const hasMultipleSeries = areaKeys.length > 1;
+      const defaultFill = hasMultipleSeries ? 0.02 : 0.08;
+      const fillOpacity = style.fillOpacity ?? defaultFill;
       const strokeOpacity = style.strokeOpacity ?? 1;
-      const strokeWidth = style.strokeWidth ?? 2;
+      const strokeWidth = style.strokeWidth ?? 2.2;
       // 数据线一律实线，多系列靠颜色区分；仅显式 strokeDasharray（阈值/上限线，由 style:'limit' 注入）才虚线。
       const lineType: 'solid' | 'dashed' = style.strokeDasharray ? 'dashed' : 'solid';
 
@@ -160,7 +163,7 @@ const EChartsLineChart: React.FC<EChartsLineChartProps> = ({
           const scaledValue = scaleDivisor > 1 ? v / scaleDivisor : v;
           return [d.time, roundChartValueToDisplayPrecision(scaledValue)];
         }),
-        smooth: false,
+        smooth: 0.2,
         symbol: 'none',
         lineStyle: {
           width: strokeWidth,
@@ -174,7 +177,7 @@ const EChartsLineChart: React.FC<EChartsLineChartProps> = ({
             x: 0, y: 0, x2: 0, y2: 1,
             colorStops: [
               { offset: 0, color: `${color}${Math.round(fillOpacity * 255).toString(16).padStart(2, '0')}` },
-              { offset: 1, color: `${color}03` }
+              { offset: 1, color: `${color}02` }
             ]
           }
         } : undefined,
@@ -201,7 +204,7 @@ const EChartsLineChart: React.FC<EChartsLineChartProps> = ({
         axisLabel: {
           formatter: (val: number) => dayjs(val * 1000).format(xAxisTimeFormat),
           fontSize: 11,
-          color: '#8c8c8c'
+          color: '#475467'
         },
         axisTick: { show: false },
         axisLine: { lineStyle: { color: '#e8e8e8' } },
@@ -214,7 +217,7 @@ const EChartsLineChart: React.FC<EChartsLineChartProps> = ({
         axisLabel: {
           formatter: (val: number) => allSeriesValuesAreZero && val !== 0 ? '' : formatAxisNumber(val),
           fontSize: 11,
-          color: '#8c8c8c'
+          color: '#475467'
         },
         splitLine: { lineStyle: { color: '#f0f0f0', type: 'dashed' as const } },
         axisLine: { show: false },

--- a/web/src/app/monitor/dashboards/shared/widgets/mini-trend-chart.tsx
+++ b/web/src/app/monitor/dashboards/shared/widgets/mini-trend-chart.tsx
@@ -90,14 +90,14 @@ export const MiniTrendChart = ({
           showSymbol: isSinglePoint,
           symbol: isSinglePoint ? 'circle' : 'none',
           symbolSize: isSinglePoint ? 6 : 0,
-          lineStyle: { color, width: 2 },
+          lineStyle: { color, width: 2.2 },
           areaStyle: {
             color: {
               type: 'linear' as const,
               x: 0, y: 0, x2: 0, y2: 1,
               colorStops: [
-                { offset: 0, color: `${color}3d` },
-                { offset: 1, color: `${color}05` }
+                { offset: 0, color: `${color}40` },
+                { offset: 1, color: `${color}00` }
               ]
             }
           }


### PR DESCRIPTION
## Summary
- 统一主机、拨测与社区版数据库监控仪表盘的视觉层级（健康概览、采集状态、标题/副标题、色板与排版）
- 收尾页头标题与右侧操作对齐；MySQL 健康概览固定六列（规避 CSS Module 同名覆盖失效）；Oracle「内存使用」图表过滤对齐
- 实例 ID 未就绪时跳过指标请求，减少侧栏切换时的空打

## Test plan
- [ ] 打开 MySQL 仪表盘：健康概览一行 6 卡；实例元信息无重复 ID；页头标题与右侧切换/返回垂直对齐
- [ ] 打开 Oracle：等待类与内存分区同时显示 Wait Class 与内存使用图
- [ ] 打开 Redis/MSSQL/PostgreSQL 等：健康概览、副标题灰色、采集状态样式正常
- [ ] 侧栏快速切换实例：无明显空 `instance_id` 报错刷屏
- [ ] 主机 / Ping / TCP / 进程仪表盘首屏视觉无明显回归

## 提交范围检查
- 已排除测试文件、Storybook mock、图标资源与无关本地文件
- 工作区仍保留未提交的请求 toast 去重相关改动（`request.ts` 等），未纳入本 PR