### PR TITLE
fix(监控): 合并同类请求错误 toast，避免仪表盘并行失败刷屏

### DIFF
--- a/web/src/app/monitor/(pages)/search/page.tsx
+++ b/web/src/app/monitor/(pages)/search/page.tsx
@@ -141,6 +141,18 @@ const SearchView: React.FC = () => {
           instances,
           timeRange: _timeRange
         });
+        // 实例列表尚未对齐时 selectedInstances 可能为空；勿发受控查询以免触发 instance_ids 校验刷屏。
+        if (!Array.isArray(params.instance_ids) || params.instance_ids.length === 0) {
+          if (currentRequestId !== searchRequestIdRef.current) return;
+          setChartItems((prev) =>
+            prev.map((item, i) =>
+              i === index
+                ? { ...item, data: [], loading: false, duration: Date.now() - startTime }
+                : item
+            )
+          );
+          return;
+        }
         const responseData = await post(
           '/monitor/api/metrics_instance/query_by_metric_range/',
           params,

--- a/web/src/app/monitor/(pages)/view/detail/overview.tsx
+++ b/web/src/app/monitor/(pages)/view/detail/overview.tsx
@@ -158,6 +158,13 @@ const Overview: React.FC<ViewDetailProps> = ({
   const fetchViewData = async (data: MetricItem[], type?: string) => {
     setLoading(type !== 'timer');
     try {
+      // 实例身份未就绪时不并发拉指标，避免空标签请求。
+      if (!idValues.length) {
+        data.forEach((metricItem) => {
+          metricItem.viewData = [];
+        });
+        return;
+      }
       const results = await runWithConcurrency(
         data,
         OVERVIEW_QUERY_CONCURRENCY,

--- a/web/src/app/monitor/(pages)/view/monitorView.tsx
+++ b/web/src/app/monitor/(pages)/view/monitorView.tsx
@@ -412,6 +412,10 @@ const MonitorView: React.FC<ViewModalProps> = ({
     if (!options?.force && loadingMetricIds.has(metric.id)) {
       return;
     }
+    // 实例未就绪时不进入并发队列，避免受控查询 instance_ids 为空刷屏。
+    if (!String(form?.instance_id || '').trim()) {
+      return;
+    }
     const isCancelledRequest = cancelledMetricIds.has(metric.id);
     if (isCancelledRequest) {
       setCancelledMetricIds((prev) => {
@@ -440,7 +444,11 @@ const MonitorView: React.FC<ViewModalProps> = ({
       response = await post(
         `/monitor/api/metrics_instance/query_by_metric_range/`,
         params,
-        { signal: abortController.signal },
+        {
+          signal: abortController.signal,
+          // 全量指标并行展开时由卡片空态承接失败，避免同类 400 刷 toast。
+          suppressErrorNotification: true,
+        },
       );
     } catch (error: any) {
       if (error.name === 'AbortError') {

--- a/web/src/app/monitor/api/view.ts
+++ b/web/src/app/monitor/api/view.ts
@@ -20,33 +20,31 @@ const useViewApi = () => {
   // 这些函数会被消费方放进 useEffect/useCallback 依赖数组(如各对象盘的 TopN 取数 effect)。
   // 必须用 useCallback 固定引用,否则每次重渲染都生成新函数 → effect 反复触发 → 重复发起查询。
   const getInstanceQuery = useCallback(
-    async (
-      params: SearchParams = {
-        query: '',
-      },
-      config?: RequestConfig
-    ) => {
-      return await get(`/monitor/api/metrics_instance/query_range/`, {
+    async (params: SearchParams, config?: RequestConfig) => {
+      return await post(
+        `/monitor/api/metrics_instance/query_by_metric_range/`,
         params,
-        ...METRIC_QUERY_REQUEST_CONFIG,
-        ...config,
-      });
+        {
+          ...METRIC_QUERY_REQUEST_CONFIG,
+          ...config,
+        }
+      );
     },
-    [get]
+    [post]
   );
 
   const getInstanceInstantQuery = useCallback(
-    async (
-      params: SearchParams = { query: '' },
-      config?: RequestConfig
-    ) => {
-      return await get(`/monitor/api/metrics_instance/query/`, {
+    async (params: SearchParams, config?: RequestConfig) => {
+      return await post(
+        `/monitor/api/metrics_instance/query_by_metric/`,
         params,
-        ...METRIC_QUERY_REQUEST_CONFIG,
-        ...config,
-      });
+        {
+          ...METRIC_QUERY_REQUEST_CONFIG,
+          ...config,
+        }
+      );
     },
-    [get]
+    [post]
   );
 
   const getInstanceSearch = useCallback(

--- a/web/src/app/monitor/api/view.ts
+++ b/web/src/app/monitor/api/view.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import useApiClient from '@/utils/request';
+import type { RequestConfig } from '@/utils/request';
 import { AxiosRequestConfig } from 'axios';
 import { SearchParams } from '@/app/monitor/types/search';
 import {
@@ -8,6 +9,11 @@ import {
 } from '@/app/monitor/types/view';
 import { InstanceParam } from '@/app/monitor/types';
 
+/** 指标查询类接口由面板自行处理失败态，避免并行请求刷屏 toast。 */
+const METRIC_QUERY_REQUEST_CONFIG: RequestConfig = {
+  suppressErrorNotification: true,
+};
+
 const useViewApi = () => {
   const { get, post, put } = useApiClient();
 
@@ -15,18 +21,32 @@ const useViewApi = () => {
   // 必须用 useCallback 固定引用,否则每次重渲染都生成新函数 → effect 反复触发 → 重复发起查询。
   const getInstanceQuery = useCallback(
     async (
-      params: SearchParams
+      params: SearchParams = {
+        query: '',
+      },
+      config?: RequestConfig
     ) => {
-      return await post(`/monitor/api/metrics_instance/query_by_metric_range/`, params);
+      return await get(`/monitor/api/metrics_instance/query_range/`, {
+        params,
+        ...METRIC_QUERY_REQUEST_CONFIG,
+        ...config,
+      });
     },
-    [post]
+    [get]
   );
 
   const getInstanceInstantQuery = useCallback(
-    async (params: SearchParams) => {
-      return await post(`/monitor/api/metrics_instance/query_by_metric/`, params);
+    async (
+      params: SearchParams = { query: '' },
+      config?: RequestConfig
+    ) => {
+      return await get(`/monitor/api/metrics_instance/query/`, {
+        params,
+        ...METRIC_QUERY_REQUEST_CONFIG,
+        ...config,
+      });
     },
-    [post]
+    [get]
   );
 
   const getInstanceSearch = useCallback(

--- a/web/src/app/monitor/components/metric-views/index.tsx
+++ b/web/src/app/monitor/components/metric-views/index.tsx
@@ -582,6 +582,10 @@ const MetricViews: React.FC<ViewDetailProps> = ({
     if (!options?.force && loadingMetricIds.has(metric.id)) {
       return;
     }
+    // 实例未就绪时不进入并发队列，避免受控查询 instance_ids 为空刷屏。
+    if (!String(instanceId || '').trim()) {
+      return;
+    }
     const isCancelledRequest = cancelledMetricIds.has(metric.id);
     if (isCancelledRequest) {
       setCancelledMetricIds((prev) => {
@@ -612,7 +616,11 @@ const MetricViews: React.FC<ViewDetailProps> = ({
       response = await post(
         `/monitor/api/metrics_instance/query_by_metric_range/`,
         params,
-        { signal: abortController.signal },
+        {
+          signal: abortController.signal,
+          // 全量指标并行展开时由卡片空态承接失败，避免同类 400 刷 toast。
+          suppressErrorNotification: true,
+        },
       );
     } catch (error: any) {
       if (error.name === 'AbortError') {

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
@@ -563,6 +563,14 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
     if (!silent) setLoading(true);
     try {
       if (displayMode === 'dashboard') {
+        // 侧栏切换对象时 URL 会短暂缺少 instance_id；身份未就绪前不发指标请求，避免空打与刷屏。
+        if (!idValues.length) {
+          setSeries({});
+          setPreviousSeries({});
+          setCollectionStatusMetric(null);
+          if (!silent) setLoading(false);
+          return;
+        }
         // 本次刷新冻结一个绝对时间窗,所有序列(含 KPI/采集状态/趋势/对比)复用,
         // 避免每条序列各自现算 now 导致时间戳网格错位、多序列面板 tooltip 只显示一条。
         const frozenTimeValues = freezeTimeValues(timeValues);

--- a/web/src/app/monitor/dashboards/objects/docker/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/docker/dashboard.tsx
@@ -45,7 +45,7 @@ export default function DockerDashboardPage() {
   const timeKey = JSON.stringify(timeValues);
 
   useEffect(() => {
-    if (!isDashboardMode) {
+    if (!isDashboardMode || !idValues.length) {
       setTopBars({});
       return;
     }

--- a/web/src/app/monitor/dashboards/objects/elasticsearch/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/elasticsearch/dashboard.tsx
@@ -74,7 +74,7 @@ export default function ElasticsearchDashboardPage() {
   const timeKey = JSON.stringify(timeValues);
 
   useEffect(() => {
-    if (!isDashboardMode) {
+    if (!isDashboardMode || !idValues.length) {
       setTopNode({});
       return;
     }

--- a/web/src/app/monitor/dashboards/objects/flow-common/conversation-table.tsx
+++ b/web/src/app/monitor/dashboards/objects/flow-common/conversation-table.tsx
@@ -66,8 +66,9 @@ export function FlowConversationTable({
   );
 
   useEffect(() => {
-    if (!dashboard.isDashboardMode || !instanceType) {
+    if (!dashboard.isDashboardMode || !instanceType || !dashboard.idValues.length) {
       setRows([]);
+      setLoading(false);
       return;
     }
 

--- a/web/src/app/monitor/dashboards/objects/flow-common/protocol-breakdown.tsx
+++ b/web/src/app/monitor/dashboards/objects/flow-common/protocol-breakdown.tsx
@@ -59,8 +59,9 @@ export function FlowProtocolBreakdown({
   );
 
   useEffect(() => {
-    if (!dashboard.isDashboardMode || !instanceType) {
+    if (!dashboard.isDashboardMode || !instanceType || !dashboard.idValues.length) {
       setRows([]);
+      setLoading(false);
       return;
     }
 

--- a/web/src/app/monitor/dashboards/objects/host/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/host/dashboard.tsx
@@ -54,7 +54,7 @@ export default function HostDashboardPage() {
   const timeKey = JSON.stringify(timeValues);
 
   useEffect(() => {
-    if (!isDashboardMode) {
+    if (!isDashboardMode || !idValues.length) {
       setTopBars({});
       return;
     }

--- a/web/src/app/monitor/dashboards/objects/kafka/lag-risk-table.tsx
+++ b/web/src/app/monitor/dashboards/objects/kafka/lag-risk-table.tsx
@@ -54,9 +54,12 @@ export function KafkaLagRiskTable({ dashboard, styles }: KafkaLagRiskTableProps)
   const timeKey = JSON.stringify(dashboard.timeValues);
 
   useEffect(() => {
-    if (!dashboard.isDashboardMode) {
+    if (!dashboard.isDashboardMode || !dashboard.idValues.length) {
       setRows([]);
+      setHistory([]);
       setSelectedKey(null);
+      setLoading(false);
+      setHistoryLoading(false);
       return;
     }
 

--- a/web/src/app/monitor/dashboards/objects/mongodb/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mongodb/dashboard.tsx
@@ -251,6 +251,13 @@ export default function MongoDashboardPage() {
     if (!silent) setLoading(true);
     try {
       if (isDashboardMode) {
+        if (!idValues.length) {
+          setSeries({});
+          setPreviousSeries({});
+          setCollectionStatusMetric(null);
+          if (!silent) setLoading(false);
+          return;
+        }
         const frozenTimeValues = freezeTimeValues(timeValues);
         const frozenRange = resolveCollectionStatusRange(frozenTimeValues);
         if (frozenRange) setQueryTimeRange(frozenRange);

--- a/web/src/app/monitor/dashboards/objects/mssql/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mssql/dashboard.tsx
@@ -58,7 +58,7 @@ export default function MssqlDashboardPage() {
   const timeKey = JSON.stringify(timeValues);
 
   useEffect(() => {
-    if (!isDashboardMode) {
+    if (!isDashboardMode || !idValues.length) {
       setTopDb({});
       return;
     }

--- a/web/src/app/monitor/dashboards/objects/mysql/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mysql/dashboard.tsx
@@ -402,6 +402,13 @@ export default function MysqlDashboardPage() {
 
     try {
       if (isDashboardMode) {
+        if (!idValues.length) {
+          setSeries({});
+          setPreviousSeries({});
+          setCollectionStatusMetric(null);
+          if (!silent) setLoading(false);
+          return;
+        }
         const frozenTimeValues = freezeTimeValues(timeValues);
         const frozenRange = resolveCollectionStatusRange(frozenTimeValues);
         if (frozenRange) setQueryTimeRange(frozenRange);

--- a/web/src/app/monitor/dashboards/objects/oracle/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/oracle/dashboard.tsx
@@ -41,7 +41,7 @@ export default function OracleDashboardPage() {
   const timeKey = JSON.stringify(timeValues);
 
   useEffect(() => {
-    if (!isDashboardMode) {
+    if (!isDashboardMode || !idValues.length) {
       setTopBars({});
       return;
     }

--- a/web/src/app/monitor/dashboards/objects/postgresql/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/postgresql/dashboard.tsx
@@ -50,7 +50,7 @@ export default function PostgresqlDashboardPage() {
   const timeKey = JSON.stringify(timeValues);
 
   useEffect(() => {
-    if (!isDashboardMode) {
+    if (!isDashboardMode || !idValues.length) {
       setTopDb({});
       return;
     }

--- a/web/src/utils/antdConfig.ts
+++ b/web/src/utils/antdConfig.ts
@@ -1,6 +1,6 @@
 import { message as antdMessage, notification as antdNotification, Modal } from 'antd';
 
-// 配置全局 message
+// 配置全局 message。请求拦截器另经 requestErrorToast 保证 maxCount / 同文案去重生效。
 antdMessage.config({
   top: 80,
   maxCount: 2,

--- a/web/src/utils/request.ts
+++ b/web/src/utils/request.ts
@@ -5,7 +5,6 @@ import axios, {
 } from "axios";
 import { useEffect, useCallback, useState } from "react";
 import { useAuth } from "@/context/auth";
-import { message } from "antd";
 import { useSession } from "next-auth/react";
 import {
   createSessionExpiredRequestError,
@@ -20,6 +19,7 @@ import {
   renderRequestErrorPresentation,
   type RequestErrorPresentation,
 } from '@/utils/requestErrorPresentation';
+import { showRequestErrorToast } from '@/utils/requestErrorToast';
 import {
   getProxyTimeoutHeaderValue,
   PROXY_TIMEOUT_HEADER,
@@ -136,19 +136,23 @@ apiClient.interceptors.response.use(
         return Promise.reject(error);
       } else if ([400, 403].includes(status)) {
         if (!suppressErrorNotification && presentation) {
-          message.error({
-            content: renderRequestErrorPresentation(presentation),
+          showRequestErrorToast(renderRequestErrorPresentation(presentation), {
             duration: 8,
+            dedupeKey: presentation.message,
           });
         } else if (!suppressErrorNotification && messageText) {
-          message.error(messageText);
+          showRequestErrorToast(messageText);
         }
         return Promise.reject(handledError);
       } else if (status === 500) {
-        if (!suppressErrorNotification && messageText) message.error(messageText);
+        if (!suppressErrorNotification && messageText) {
+          showRequestErrorToast(messageText);
+        }
         return Promise.reject(handledError);
       } else {
-        if (!suppressErrorNotification && messageText) message.error(messageText);
+        if (!suppressErrorNotification && messageText) {
+          showRequestErrorToast(messageText);
+        }
         return Promise.reject(handledError);
       }
     }

--- a/web/src/utils/requestErrorToast.ts
+++ b/web/src/utils/requestErrorToast.ts
@@ -1,0 +1,71 @@
+import { message } from 'antd';
+import type { ReactNode } from 'react';
+
+/** Align with antdConfig defaults; apply once so interceptor toasts honor maxCount. */
+let messageConfigured = false;
+
+const ensureMessageConfig = () => {
+  if (messageConfigured) return;
+  message.config({
+    top: 80,
+    maxCount: 2,
+    duration: 3,
+  });
+  messageConfigured = true;
+};
+
+const recentPlainErrors = new Map<string, number>();
+export const REQUEST_ERROR_TOAST_DEDUPE_WINDOW_MS = 3000;
+
+/**
+ * Decide whether a dedupe key should emit now. Empty keys always emit (rich content).
+ * Exported for unit verification without mounting antd.
+ */
+export const shouldEmitDedupedErrorKey = (
+  dedupeKey: string,
+  now = Date.now(),
+  store: Map<string, number> = recentPlainErrors,
+  windowMs = REQUEST_ERROR_TOAST_DEDUPE_WINDOW_MS,
+): boolean => {
+  if (!dedupeKey) return true;
+  const lastShownAt = store.get(dedupeKey);
+  if (lastShownAt != null && now - lastShownAt < windowMs) {
+    return false;
+  }
+  store.set(dedupeKey, now);
+  return true;
+};
+
+/**
+ * Show an error toast, collapsing identical plain-text messages within a short window.
+ * Prevents dashboard/search parallel 400s from stacking dozens of the same popup.
+ */
+export const showRequestErrorToast = (
+  content: ReactNode,
+  options?: { duration?: number; dedupeKey?: string },
+) => {
+  ensureMessageConfig();
+
+  const dedupeKey =
+    options?.dedupeKey ??
+    (typeof content === 'string' ? content.trim() : '');
+
+  if (!shouldEmitDedupedErrorKey(dedupeKey)) {
+    return false;
+  }
+
+  if (typeof content === 'string') {
+    message.error(content);
+  } else {
+    message.error({
+      content,
+      duration: options?.duration ?? 8,
+    });
+  }
+  return true;
+};
+
+/** Test seam: clear dedupe state between assertions. */
+export const resetRequestErrorToastDedupe = () => {
+  recentPlainErrors.clear();
+};


### PR DESCRIPTION
## Summary
- 请求拦截器对相同错误文案短时去重，并落实 message `maxCount`，避免并行 400 叠出十几条相同弹窗
- 仪表盘在实例身份（`idValues`）未就绪时跳过指标请求；`getInstanceQuery` / `getInstanceInstantQuery` 默认 `suppressErrorNotification`，失败由面板空态承接
- 指标搜索在 `instance_ids` 为空时不发受控查询，避免触发「instance_ids 不能为空」刷屏

## Test plan
- [ ] 打开 PostgreSQL/MySQL 专业仪表盘，侧栏在 MySQL ↔ Postgres 间切换：不应再出现十几条相同 toast
- [ ] 正常有实例的仪表盘仍能加载 KPI/曲线
- [ ] 指标搜索在实例未对齐时不弹「instance_ids 不能为空」刷屏；正常查询仍可用
- [ ] 其它单次操作失败（如保存）仍有 toast 提示

## PR 范围检查
- 仅包含本问题相关生产代码；未纳入测试脚本、Storybook mock、图标与无关本地文件
- 本地已跑通去重逻辑与相关脚本校验（测试文件按约定留在工作区未提交）