### PR TITLE
fix(监控): 去掉仪表盘实例元信息中的重复灰色标签

### DIFF
--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
@@ -1015,7 +1015,13 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
   const metaMetricChips = (config.metaMetrics || [])
     .filter((m) => hasMetricData(m.metric))
     .map((m) => `${m.label}: ${formatField({ label: m.label, metric: m.metric, unit: m.unit })}`);
-  const objectMetaItems = [objectDisplayText, ...metaMetricChips, ...(config.metaItems || []), '时区: Asia/Shanghai'];
+  // 与对象展示名仅大小写/分隔符不同的 meta（如 Ping vs ping、TCP vs tcp）视为重复，不再展示。
+  const normalizeMetaKey = (value: string) => value.trim().toLowerCase().replace(/[-_\s]+/g, '');
+  const objectMetaKey = normalizeMetaKey(objectDisplayText);
+  const dedupedConfigMetaItems = (config.metaItems || []).filter(
+    (item) => normalizeMetaKey(item) !== objectMetaKey
+  );
+  const objectMetaItems = [objectDisplayText, ...metaMetricChips, ...dedupedConfigMetaItems, '时区: Asia/Shanghai'];
 
   const onTimeChange = (val: number[], originValue: number | null) => setTimeValues({ timeRange: val, originValue });
   const onXRangeChange = (arr: [Dayjs, Dayjs]) => {


### PR DESCRIPTION
## Summary
- 共享仪表盘页头组装 `objectMetaItems` 时，过滤与对象展示名仅大小写/分隔符不同的 `metaItems`（如 `Ping`/`ping`、`TCP`/`tcp`）
- 避免 Ping、TCP 等拨测仪表盘灰色元信息重复堆叠

## Test plan
- [ ] 打开 Ping 仪表盘：元信息为 `对象名 · Telegraf · 时区…`，不再出现第二个 `ping`
- [ ] 打开 TCP 仪表盘：不再出现第二个 `tcp`
- [ ] 打开 Docker 等同类配置：对象名与小写类型标签不重复
- [ ] 打开 Website（`网站` + `web`）：不受影响，仍展示 `web`

## 提交范围检查
- 仅 1 个产品文件；未纳入测试、图标与本地无关文件