### PR TITLE
bugfix: 兼容日志分组空规则回写

### DIFF
--- a/server/apps/log/serializers/log_group.py
+++ b/server/apps/log/serializers/log_group.py
@@ -110,6 +110,8 @@ class LogGroupSerializer(serializers.ModelSerializer):
         if not isinstance(value, dict):
             raise serializers.ValidationError("日志分组规则必须是对象（object）格式")
 
+        value = LogGroupQueryBuilder.normalize_star_rule(value)
+
         try:
             LogGroupQueryBuilder.validate_rule(
                 value,

--- a/server/apps/log/tests/test_log_group_builder_pure.py
+++ b/server/apps/log/tests/test_log_group_builder_pure.py
@@ -21,9 +21,24 @@ def test_json_to_logsql_empty_rule_returns_empty():
     assert LogGroupQueryBuilder.json_to_logsql_expression({}) == ""
 
 
+@pytest.mark.parametrize(
+    "rule",
+    [
+        {"mode": None, "conditions": []},
+        {"mode": None},
+    ],
+)
+def test_json_to_logsql_null_mode_empty_conditions_is_star(rule):
+    assert LogGroupQueryBuilder.json_to_logsql_expression(rule) == ""
+    assert LogGroupQueryBuilder.normalize_star_rule(rule) == {}
+    classification, mode = LogGroupQueryBuilder.classify_rule_mode(rule)
+    assert classification == LogGroupQueryBuilder.MODE_VALID
+    assert mode == "AND"
+
+
 @pytest.mark.parametrize("rule", [None, [], "", 0, False])
 def test_json_to_logsql_falsey_non_object_rule_raises(rule):
-    with pytest.raises(ValueError, match="AND or OR"):
+    with pytest.raises(ValueError, match=LogGroupQueryBuilder.INVALID_RULE_MODE_MESSAGE):
         LogGroupQueryBuilder.json_to_logsql_expression(rule)
 
 
@@ -63,7 +78,7 @@ def test_json_to_logsql_unknown_mode_raises():
         ],
     }
 
-    with pytest.raises(ValueError, match="AND or OR"):
+    with pytest.raises(ValueError, match=LogGroupQueryBuilder.INVALID_RULE_MODE_MESSAGE):
         LogGroupQueryBuilder.json_to_logsql_expression(rule)
 
 
@@ -180,6 +195,13 @@ def test_build_query_combines_user_and_group_filter():
 
 def test_build_query_all_empty_rule_groups_returns_user_query():
     g = _group("g1", rule={})
+    out, info = LogGroupQueryBuilder.build_query_with_groups("host:web", ["g1"], resolved_groups=[g])
+    assert out == "host:web"
+    assert info[0]["status"] == "empty_rule"
+
+
+def test_build_query_null_mode_empty_conditions_is_empty_rule():
+    g = _group("g1", rule={"mode": None, "conditions": []})
     out, info = LogGroupQueryBuilder.build_query_with_groups("host:web", ["g1"], resolved_groups=[g])
     assert out == "host:web"
     assert info[0]["status"] == "empty_rule"

--- a/server/apps/log/tests/test_log_group_rule_validation_pure.py
+++ b/server/apps/log/tests/test_log_group_rule_validation_pure.py
@@ -1,6 +1,7 @@
 import pytest
 
 from apps.log.serializers.log_group import LogGroupSerializer
+from apps.log.utils.log_group import LogGroupQueryBuilder
 
 
 pytestmark = pytest.mark.unit
@@ -15,12 +16,35 @@ def _payload(rule):
     }
 
 
-@pytest.mark.parametrize("mode", ["ADN", "", None, 1])
+@pytest.mark.parametrize("mode", ["ADN", "", 1])
 def test_serializer_rejects_unknown_rule_mode(mode):
     serializer = LogGroupSerializer(data=_payload({"mode": mode, "conditions": []}))
 
     assert serializer.is_valid() is False
-    assert "AND or OR" in str(serializer.errors["rule"])
+    assert str(serializer.errors["rule"][0]) == LogGroupQueryBuilder.INVALID_RULE_MODE_MESSAGE
+
+
+@pytest.mark.parametrize(
+    "rule",
+    [
+        {"mode": None, "conditions": []},
+        {"mode": None},
+    ],
+)
+def test_serializer_normalizes_null_mode_empty_conditions_to_star_rule(rule):
+    serializer = LogGroupSerializer(data=_payload(rule))
+
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["rule"] == {}
+
+
+def test_serializer_still_rejects_null_mode_when_conditions_present():
+    serializer = LogGroupSerializer(
+        data=_payload({"mode": None, "conditions": [{"field": "cluster", "op": "==", "value": "prod"}]})
+    )
+
+    assert serializer.is_valid() is False
+    assert str(serializer.errors["rule"][0]) == LogGroupQueryBuilder.INVALID_RULE_MODE_MESSAGE
 
 
 def test_serializer_rejects_non_object_rule():

--- a/server/apps/log/tests/test_log_group_viewset_views.py
+++ b/server/apps/log/tests/test_log_group_viewset_views.py
@@ -129,7 +129,8 @@ def test_create_rejects_unknown_rule_mode_without_persisting(api_client, authent
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert "AND or OR" in response.json()["message"]
+    assert "所有条件" in response.json()["message"]
+    assert "任意条件" in response.json()["message"]
     assert not LogGroup.objects.filter(id="invalid-mode").exists()
 
 
@@ -162,6 +163,46 @@ def test_create_with_unauthorized_organization_rejected(api_client, authenticate
     # 序列化器 validate_organizations 拒绝无权限组织
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert not LogGroup.objects.filter(id="y").exists()
+
+
+@pytest.mark.django_db
+def test_patch_default_group_keeps_star_rule_when_ui_sends_null_mode(api_client, authenticated_user, mocker):
+    LogGroup.objects.create(id="default", name="Default", rule={})
+    LogGroupOrganization.objects.create(log_group_id="default", organization=1)
+    _mock_permission(mocker, teams=[1, 2])
+
+    api_client.cookies["current_team"] = "1"
+    response = api_client.patch(
+        "/api/v1/log/log_group/default/",
+        data={"organizations": [1, 2], "rule": {"mode": None, "conditions": []}},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert LogGroup.objects.get(id="default").rule == {}
+    assert set(
+        LogGroupOrganization.objects.filter(log_group_id="default").values_list("organization", flat=True)
+    ) == {1, 2}
+
+
+@pytest.mark.django_db
+def test_patch_default_group_organizations_without_rule_keeps_star(api_client, authenticated_user, mocker):
+    LogGroup.objects.create(id="default", name="Default", rule={})
+    LogGroupOrganization.objects.create(log_group_id="default", organization=1)
+    _mock_permission(mocker, teams=[1, 2])
+
+    api_client.cookies["current_team"] = "1"
+    response = api_client.patch(
+        "/api/v1/log/log_group/default/",
+        data={"organizations": [1, 2]},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert LogGroup.objects.get(id="default").rule == {}
+    assert set(
+        LogGroupOrganization.objects.filter(log_group_id="default").values_list("organization", flat=True)
+    ) == {1, 2}
 
 
 @pytest.mark.django_db

--- a/server/apps/log/utils/log_group.py
+++ b/server/apps/log/utils/log_group.py
@@ -12,6 +12,7 @@ class LogGroupQueryBuilder:
 
     DENY_ALL_QUERY = '(__bk_lite_log_scope__:"deny-1") AND (__bk_lite_log_scope__:"deny-2")'
     VALID_RULE_MODES = frozenset({"AND", "OR"})
+    INVALID_RULE_MODE_MESSAGE = "规则匹配方式仅支持「所有条件」或「任意条件」"
     MODE_VALID = "valid"
     MODE_LEGACY_OR = "legacy_or"
     MODE_LEGACY_EMPTY_RULE = "legacy_empty_rule"
@@ -24,8 +25,24 @@ class LogGroupQueryBuilder:
     LEGACY_REGEX_SPECIAL_CHARS = frozenset(r"\.^$*+?{}[]|()")
 
     @classmethod
+    def normalize_star_rule(cls, rule_json):
+        """把前端 Default `*` 回写的空规则收成 {}。
+
+        分组页没有规则编辑器时会提交 {mode: null, conditions: []}，这与库里的空对象
+        同义，不是非法 mode。带真实条件的 null mode 不在此兼容。
+        """
+        if not isinstance(rule_json, dict):
+            return rule_json
+        mode = rule_json.get("mode", "AND")
+        conditions = rule_json.get("conditions", [])
+        if mode is None and isinstance(conditions, list) and not conditions:
+            return {}
+        return rule_json
+
+    @classmethod
     def classify_rule_mode(cls, rule_json):
         """按历史运行语义分类规则模式，不回显不可信的原始值。"""
+        rule_json = cls.normalize_star_rule(rule_json)
         if not isinstance(rule_json, dict):
             return cls.MODE_INVALID, None
 
@@ -44,11 +61,12 @@ class LogGroupQueryBuilder:
     def validate_rule_mode(cls, rule_json):
         classification, normalized_mode = cls.classify_rule_mode(rule_json)
         if classification != cls.MODE_VALID:
-            raise ValueError("Rule mode must be AND or OR")
+            raise ValueError(cls.INVALID_RULE_MODE_MESSAGE)
         return normalized_mode
 
     @classmethod
     def validate_rule(cls, rule_json, *, allow_legacy_or=False, require_legacy_safe=False):
+        rule_json = cls.normalize_star_rule(rule_json)
         mode, used_legacy_or = cls._resolve_rule_mode(rule_json, allow_legacy_or=allow_legacy_or)
         conditions = rule_json.get("conditions", [])
         if not isinstance(conditions, list):
@@ -108,7 +126,7 @@ class LogGroupQueryBuilder:
             return normalized_mode, False
         if classification == cls.MODE_LEGACY_OR and allow_legacy_or:
             return "OR", True
-        raise ValueError("Rule mode must be AND or OR")
+        raise ValueError(cls.INVALID_RULE_MODE_MESSAGE)
 
     @staticmethod
     def _configured_legacy_or_group_ids():
@@ -200,6 +218,7 @@ class LogGroupQueryBuilder:
     def json_to_logsql_expression(cls, rule_json, *, allow_legacy_or=False, preserve_legacy_structure=False):
         """将规则JSON转换为VictoriaLogs LogsQL表达式"""
 
+        rule_json = cls.normalize_star_rule(rule_json)
         # 如果不存在规则，返回空字符串
         if rule_json == {}:
             return ""
@@ -308,7 +327,8 @@ class LogGroupQueryBuilder:
 
         for group in groups:
             try:
-                if group.rule == {}:
+                rule = cls.normalize_star_rule(group.rule)
+                if rule == {}:
                     invalid_group_status[group.id] = "empty_rule"
                     continue
                 if legacy_migration_mode and cls._is_legacy_falsey_non_object(group.rule):
@@ -316,9 +336,9 @@ class LogGroupQueryBuilder:
                     continue
 
                 allow_legacy_or = legacy_migration_mode or str(group.id) in legacy_or_group_ids
-                classification, _ = cls.classify_rule_mode(group.rule)
+                classification, _ = cls.classify_rule_mode(rule)
                 condition = cls.json_to_logsql_expression(
-                    group.rule,
+                    rule,
                     allow_legacy_or=allow_legacy_or,
                     preserve_legacy_structure=legacy_migration_mode,
                 )

--- a/web/package.json
+++ b/web/package.json
@@ -57,6 +57,7 @@
     "test:log-alert-raw-columns": "pnpm exec tsx scripts/log-alert-raw-columns-test.ts",
     "test:event-user-display": "pnpm exec tsx scripts/event-user-display-test.ts",
     "test:log-group-field-bootstrap": "pnpm exec tsx scripts/log-group-field-bootstrap-test.ts",
+    "test:log-group-write-payload": "pnpm exec tsx scripts/log-group-write-payload-test.ts",
     "test:log-search-field-stats": "pnpm exec tsx scripts/log-search-field-stats-test.ts",
     "test:log-analysis-group-bootstrap": "pnpm exec tsx scripts/log-analysis-group-bootstrap-test.ts",
     "test:log-terminal-token": "pnpm exec tsx scripts/log-terminal-token-test.ts && pnpm exec vitest run 'src/app/log/(pages)/search/logTerminal/__tests__/interaction.test.tsx'",

--- a/web/scripts/log-group-write-payload-test.ts
+++ b/web/scripts/log-group-write-payload-test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+
+import { buildLogGroupSubmitPayload } from '../src/app/log/(pages)/integration/grouping/logGroupWritePayload';
+
+const organizations = [1, 2];
+
+const builtInPayload = buildLogGroupSubmitPayload({
+  values: { organizations, name: 'Default' },
+  term: null,
+  conditions: [{ field: null, op: null, value: '' }],
+  id: 'default',
+  isBuiltIn: true
+});
+
+assert.deepEqual(builtInPayload, {
+  organizations,
+  name: 'Default',
+  id: 'default',
+  rule: {}
+});
+
+const customPayload = buildLogGroupSubmitPayload({
+  values: { organizations, name: 'app' },
+  term: 'AND',
+  conditions: [{ field: 'cluster', op: '==', value: 'prod' }],
+  id: 'g-1',
+  isBuiltIn: false
+});
+
+assert.deepEqual(customPayload.rule, {
+  mode: 'AND',
+  conditions: [{ field: 'cluster', op: '==', value: 'prod' }]
+});
+
+const starPayload = buildLogGroupSubmitPayload({
+  values: { organizations, name: 'custom-star' },
+  term: null,
+  conditions: [],
+  id: 'g-star',
+  isBuiltIn: false
+});
+
+assert.deepEqual(starPayload.rule, {});
+
+console.log('log-group-write-payload validation passed');

--- a/web/src/app/log/(pages)/integration/grouping/editInstance.tsx
+++ b/web/src/app/log/(pages)/integration/grouping/editInstance.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/app/log/hooks/integration/common/other';
 import { v4 as uuidv4 } from 'uuid';
 import type { LogGroupFieldSource } from './fieldBootstrap';
+import { buildLogGroupSubmitPayload } from './logGroupWritePayload';
 
 const EditInstance = forwardRef<ModalRef, ModalProps>(
   ({ onSuccess, fields = [], fieldSource }, ref) => {
@@ -120,14 +121,13 @@ const EditInstance = forwardRef<ModalRef, ModalProps>(
 
     const handleSubmit = () => {
       formRef.current?.validateFields().then((values) => {
-        const params = {
-          ...values,
-          rule: {
-            mode: term,
-            conditions
-          },
-          id: isAdd ? uuidv4() : configForm.id
-        };
+        const params = buildLogGroupSubmitPayload({
+          values,
+          term,
+          conditions,
+          id: isAdd ? uuidv4() : configForm.id,
+          isBuiltIn
+        });
         handleOperate(params);
       });
     };
@@ -183,7 +183,10 @@ const EditInstance = forwardRef<ModalRef, ModalProps>(
 
     // 自定义验证条件列表
     const validateDimensions = async () => {
-      if (!conditions.length || !term) {
+      if (!term) {
+        return Promise.reject(new Error(t('log.integration.ruleModeRequired')));
+      }
+      if (!conditions.length) {
         return Promise.reject(new Error(t('common.required')));
       }
       if (
@@ -239,7 +242,7 @@ const EditInstance = forwardRef<ModalRef, ModalProps>(
                     <span>{t('log.integration.meetRule')}</span>
                     <Select
                       className="ml-[8px] flex-1"
-                      placeholder={t('log.integration.rule')}
+                      placeholder={t('log.integration.ruleModePlaceholder')}
                       showSearch
                       optionFilterProp="label"
                       value={term}

--- a/web/src/app/log/(pages)/integration/grouping/logGroupWritePayload.ts
+++ b/web/src/app/log/(pages)/integration/grouping/logGroupWritePayload.ts
@@ -1,0 +1,29 @@
+import { FilterItem, GroupInfo } from '@/app/log/types/integration';
+
+export const buildLogGroupSubmitPayload = ({
+  values,
+  term,
+  conditions,
+  id,
+  isBuiltIn
+}: {
+  values: GroupInfo;
+  term: string | null;
+  conditions: FilterItem[];
+  id: GroupInfo['id'];
+  isBuiltIn: boolean;
+}): GroupInfo => {
+  const params: GroupInfo = {
+    ...values,
+    id
+  };
+  if (isBuiltIn || !term) {
+    params.rule = {};
+    return params;
+  }
+  params.rule = {
+    mode: term,
+    conditions
+  };
+  return params;
+};

--- a/web/src/app/log/locales/en.json
+++ b/web/src/app/log/locales/en.json
@@ -207,6 +207,8 @@
       "excludeContainers": "Neglected Containers",
       "haltWith": "Merge up to and including the first line that matches the condition. For example, when logs end with a semicolon ;, it will include the line with the semicolon to indicate the end. Suitable for cases with clear end markers.",
       "conditionValidate": "Tags, conditions, or values cannot be empty.",
+      "ruleModeRequired": "Select All Conditions or Any Condition",
+      "ruleModePlaceholder": "All Conditions or Any Condition",
       "fieldDiscoveryExpandedTip": "No recent labels found. Expanded lookup to the last 24 hours.",
       "fieldDiscoveryFallbackTip": "No recommended labels found. You can enter a log field name manually.",
       "fieldDiscoveryPermissionTip": "Dynamic labels cannot be loaded with current permissions. You can enter a log field name manually.",

--- a/web/src/app/log/locales/zh.json
+++ b/web/src/app/log/locales/zh.json
@@ -207,6 +207,8 @@
       "excludeContainers": "忽略的容器",
       "haltWith": "合并到第一个符合条件的行（包含这行）。比如日志以分号 ; 结尾时，会把带分号的行也合并进来表示结束。适合有明确结束标记的情况。",
       "conditionValidate": "标签、条件或值不能为空",
+      "ruleModeRequired": "请选择「所有条件」或「任意条件」",
+      "ruleModePlaceholder": "请选择所有条件或任意条件",
       "fieldDiscoveryExpandedTip": "未找到最近标签，已扩大到最近24小时。",
       "fieldDiscoveryFallbackTip": "暂无可推荐标签，可手动输入日志字段名。",
       "fieldDiscoveryPermissionTip": "当前权限无法加载动态标签，可手动输入日志字段名。",

--- a/web/src/app/log/types/integration.ts
+++ b/web/src/app/log/types/integration.ts
@@ -64,8 +64,8 @@ export interface GroupInfo {
 }
 
 export interface GroupRule {
-  mode: string;
-  conditions: FilterItem[];
+  mode?: string | null;
+  conditions?: FilterItem[];
 }
 
 export interface FilterItem {


### PR DESCRIPTION
## Summary
- 兼容 Default 分组的 `*` 空规则：前端会把缺省 mode 回写成 `null`，写入/查询都把它收成 `{}`，只改组织不再 400。
- `ADN` 等非法 mode、以及带真实条件的 `mode: null` 仍拒绝，查询侧 fail-closed 不变。
- 匹配方式提示改为页面上的「所有条件 / 任意条件」。

Follow-up of #4096 / #4086.

## Test plan
- [x] `uv run pytest apps/log/tests/test_log_group_rule_validation_pure.py apps/log/tests/test_log_group_builder_pure.py --no-cov`
- [x] `pnpm exec tsx scripts/log-group-write-payload-test.ts`
- [ ] 日志接入 → 日志分组 → 编辑 Default，加一个组织后确认，应保存成功且规则仍为 `*`
- [ ] 新建自定义分组，选择「所有条件」并填条件，应仍可保存


Made with [Cursor](https://cursor.com)