### PR TITLE
bugfix: 日志分组所属组织回显可分配范围

### DIFF
--- a/server/apps/log/serializers/log_group.py
+++ b/server/apps/log/serializers/log_group.py
@@ -51,7 +51,7 @@ class LogGroupSerializer(serializers.ModelSerializer):
         request = self.context.get("request") if hasattr(self, "context") else None
         if request is not None:
             try:
-                visible_organizations = LogAccessScopeService.get_data_scope(request).data_team_ids
+                visible_organizations = LogAccessScopeService.get_visible_organization_ids(request)
             except ValueError:
                 visible_organizations = frozenset()
             organization_queryset = organization_queryset.filter(organization__in=list(visible_organizations))

--- a/server/apps/log/services/access_scope.py
+++ b/server/apps/log/services/access_scope.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from apps.core.exceptions.base_app_exception import BaseAppException
-from apps.core.utils.current_team_scope import resolve_current_team_data_scope, scope_permission_queryset, validate_assignable_organizations
+from apps.core.utils.current_team_scope import (
+    resolve_assignable_organization_ids,
+    resolve_current_team_data_scope,
+    scope_permission_queryset,
+    validate_assignable_organizations,
+)
 from apps.core.utils.permission_utils import get_permission_rules
 from apps.log.constants.permission import PermissionConstants
 from apps.log.models.log_group import LogGroup
@@ -66,6 +71,26 @@ class LogAccessScopeService:
     @classmethod
     def get_manageable_organization_ids(cls, request):
         return set(cls.get_data_scope(request).data_team_ids)
+
+    @classmethod
+    def get_visible_organization_ids(cls, request):
+        """列表/编辑回显用的组织集合：当前数据范围 ∪ 可分配组织。
+
+        只按 current_team 投影会把用户刚选上的其它组织从回显里裁掉，
+        编辑页保存成功后「所属组织」看起来像没回写。
+        """
+        cache_key = "_log_visible_organization_ids"
+        cached = getattr(request, cache_key, None)
+        if cached is not None:
+            return cached
+        visible = set(cls.get_data_scope(request).data_team_ids)
+        try:
+            visible |= set(resolve_assignable_organization_ids(request))
+        except BaseAppException:
+            pass
+        frozen = frozenset(visible)
+        setattr(request, cache_key, frozen)
+        return frozen
 
     @classmethod
     def validate_organizations(cls, request, organizations):

--- a/server/apps/log/tests/test_current_team_data_scope.py
+++ b/server/apps/log/tests/test_current_team_data_scope.py
@@ -86,6 +86,30 @@ def test_shared_log_group_response_projects_organizations_to_current_team(
     assert json.loads(response.content)["data"][0]["organizations"] == [1]
 
 
+def test_shared_log_group_response_keeps_assignable_organizations(
+    authenticated_user,
+    mocker,
+):
+    authenticated_user.is_superuser = True
+    authenticated_user.save(update_fields=["is_superuser"])
+    shared = LogGroup.objects.create(id="shared-assignable", name="shared", rule={})
+    LogGroupOrganization.objects.create(log_group=shared, organization=1)
+    LogGroupOrganization.objects.create(log_group=shared, organization=2)
+    _patch_actor_scope(mocker, scoped_ids=[1], assignable_ids=[1, 2])
+    mocker.patch(
+        "apps.log.services.access_scope.get_permission_rules",
+        return_value={"team": [1, 2], "instance": []},
+    )
+    request = APIRequestFactory().get("/api/v1/log/log_group/", {"page_size": "-1"})
+    request.COOKIES["current_team"] = "1"
+    force_authenticate(request, user=authenticated_user)
+
+    response = LogGroupViewSet.as_view({"get": "list"})(request)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert set(json.loads(response.content)["data"][0]["organizations"]) == {1, 2}
+
+
 def test_log_group_create_requires_organizations(mocker):
     request = _request(is_superuser=False)
     _patch_actor_scope(mocker, scoped_ids=[1], assignable_ids=[1, 2])

--- a/server/apps/log/tests/test_log_group_viewset_views.py
+++ b/server/apps/log/tests/test_log_group_viewset_views.py
@@ -186,6 +186,34 @@ def test_patch_default_group_keeps_star_rule_when_ui_sends_null_mode(api_client,
 
 
 @pytest.mark.django_db
+def test_patch_default_group_list_echoes_assignable_organizations(api_client, authenticated_user, mocker):
+    LogGroup.objects.create(id="default", name="Default", rule={})
+    LogGroupOrganization.objects.create(log_group_id="default", organization=1)
+    mocker.patch(
+        "apps.core.utils.current_team_scope.SystemMgmt.get_authorized_groups_scoped",
+        return_value={"result": True, "data": [1]},
+    )
+    mocker.patch(
+        "apps.core.utils.current_team_scope.SystemMgmt.get_assignable_groups",
+        return_value={"result": True, "data": [1, 2]},
+    )
+    _mock_permission(mocker, teams=[1, 2])
+
+    api_client.cookies["current_team"] = "1"
+    patch_response = api_client.patch(
+        "/api/v1/log/log_group/default/",
+        data={"organizations": [1, 2], "rule": {"mode": None, "conditions": []}},
+        format="json",
+    )
+    list_response = api_client.get("/api/v1/log/log_group/?page_size=-1")
+
+    assert patch_response.status_code == status.HTTP_200_OK
+    assert list_response.status_code == status.HTTP_200_OK
+    item = next(row for row in list_response.json()["data"] if row["id"] == "default")
+    assert set(item["organizations"]) == {1, 2}
+
+
+@pytest.mark.django_db
 def test_patch_default_group_organizations_without_rule_keeps_star(api_client, authenticated_user, mocker):
     LogGroup.objects.create(id="default", name="Default", rule={})
     LogGroupOrganization.objects.create(log_group_id="default", organization=1)


### PR DESCRIPTION
## Summary
- 日志分组 PATCH 已能把编辑页勾选的其它组织写入 `LogGroupOrganization`，但列表 `to_representation` 只按 `current_team` 的 `data_team_ids` 投影。Default 团队下保存 Default + Guest 后，接口仍只回 `[1]`，页面看起来像没回写；再次打开编辑还会把库里其它组织冲掉。
- 回显改为当前数据范围 ∪ 可分配组织（`get_assignable_organization_ids`）。无权分配的组织仍不回显。
- 接续已合并的 #5143（空规则 `*` 回写）。

## Test plan
- [x] `test_shared_log_group_response_keeps_assignable_organizations`：assignable `[1,2]` 时列表同时回显两边
- [x] `test_shared_log_group_response_projects_organizations_to_current_team`：assignable 仅 `[1]` 时仍只回显 `[1]`
- [x] `test_patch_default_group_list_echoes_assignable_organizations`：PATCH `[1,2]` 后 GET 列表含两边
- [ ] 本地：Default 团队编辑 Default 分组，勾选 Default + Guest，确认后列表显示 `Default,Guest`，再打开编辑仍勾选两边


Made with [Cursor](https://cursor.com)