### PR TITLE
fix(monitor): 指标搜索支持当前语言展示名与 ID

### DIFF
--- a/server/apps/monitor/filters/monitor_metrics.py
+++ b/server/apps/monitor/filters/monitor_metrics.py
@@ -3,7 +3,7 @@ from django_filters import BaseInFilter, BooleanFilter, CharFilter, FilterSet, N
 
 from apps.monitor.filters.id_filters import filter_positive_int_field
 from apps.monitor.models.monitor_metrics import Metric, MetricGroup
-from apps.monitor.utils.snmp_ifmib_capability import get_ifmib_metric_names_matching_keyword
+from apps.monitor.utils.metric_keyword import apply_metric_keyword_filter
 
 
 class MetricGroupFilter(FilterSet):
@@ -62,14 +62,8 @@ class MetricFilter(FilterSet):
         return filter_positive_int_field(queryset, "monitor_plugin_id", value)
 
     def filter_keyword(self, queryset, _name, value):
-        keyword = str(value or "").strip()
-        if not keyword:
-            return queryset
         locale = getattr(getattr(self.request, "user", None), "locale", "")
-        localized_names = get_ifmib_metric_names_matching_keyword(keyword, locale)
-        return queryset.filter(
-            Q(name__icontains=keyword) | Q(display_name__icontains=keyword) | Q(description__icontains=keyword) | Q(name__in=localized_names)
-        )
+        return apply_metric_keyword_filter(queryset, value, locale)
 
     @staticmethod
     def filter_include_ifmib(queryset, _name, value):

--- a/server/apps/monitor/utils/metric_keyword.py
+++ b/server/apps/monitor/utils/metric_keyword.py
@@ -4,6 +4,9 @@
 `monitor_object_metric.<Object>.<metric>.name`（见 MetricViewSet.list）。
 DB 的 display_name 多为英文模板名，按库字段 icontains 搜「内存」会空结果。
 此处按账号 locale 扫描同一份语言包，把命中的指标 ID 并入过滤条件。
+
+语言包键按监控对象隔离；同一 metric ID 在不同对象上的展示名可能不同。
+反查必须限定到 queryset 内的对象，避免跨对象文案误命中裸 name__in。
 """
 
 from django.db.models import Q
@@ -24,34 +27,54 @@ def locale_for_metric_language(locale: str) -> str:
     return raw or "en"
 
 
-def get_locale_metric_names_matching_keyword(keyword: str, locale: str) -> set[str]:
-    """返回当前 locale 展示名（或 IF-MIB 文案）包含 keyword 的指标 ID。"""
-    needle = str(keyword or "").strip().casefold()
-    if not needle:
-        return set()
+def get_locale_metric_names_matching_keyword(
+    keyword: str,
+    locale: str,
+    object_names: list[str] | tuple[str, ...] | set[str] | None = None,
+) -> dict[str, set[str]]:
+    """返回 {监控对象名: 展示名包含 keyword 的指标 ID 集合}。
 
-    names = set(get_ifmib_metric_names_matching_keyword(keyword, locale))
+    ``object_names`` 为空时不扫描语言包（只保留调用方另行合并的 IF-MIB 等闭集），
+    避免无对象上下文时跨对象误命中。
+    """
+    needle = str(keyword or "").strip().casefold()
+    scoped = {str(name) for name in (object_names or []) if str(name or "").strip()}
+    if not needle or not scoped:
+        return {}
+
     lan = LanguageLoader(app=LanguageConstants.APP, default_lang=locale_for_metric_language(locale))
     metrics_root = lan.get(LanguageConstants.MONITOR_OBJECT_METRIC)
     if not isinstance(metrics_root, dict):
-        return names
+        return {}
 
-    for object_metrics in metrics_root.values():
+    matched: dict[str, set[str]] = {}
+    for object_name in scoped:
+        object_metrics = metrics_root.get(object_name)
         if not isinstance(object_metrics, dict):
             continue
+        hits: set[str] = set()
         for metric_name, entry in object_metrics.items():
             display = entry.get("name") if isinstance(entry, dict) else entry
             if needle in str(display or "").casefold():
-                names.add(str(metric_name))
-    return names
+                hits.add(str(metric_name))
+        if hits:
+            matched[object_name] = hits
+    return matched
 
 
 def apply_metric_keyword_filter(queryset, keyword, locale=""):
-    """按 keyword 过滤指标：ID / DB 展示名 / 描述 / 当前语言包展示名。"""
+    """按 keyword 过滤指标：ID / DB 展示名 / 描述 / 当前对象语言包展示名。"""
     keyword = str(keyword or "").strip()
     if not keyword:
         return queryset
-    localized_names = get_locale_metric_names_matching_keyword(keyword, locale)
-    return queryset.filter(
-        Q(name__icontains=keyword) | Q(display_name__icontains=keyword) | Q(description__icontains=keyword) | Q(name__in=localized_names)
-    )
+
+    object_names = [name for name in queryset.order_by().values_list("monitor_object__name", flat=True).distinct() if name]
+    localized_by_object = get_locale_metric_names_matching_keyword(keyword, locale, object_names)
+    ifmib_names = get_ifmib_metric_names_matching_keyword(keyword, locale)
+
+    condition = Q(name__icontains=keyword) | Q(display_name__icontains=keyword) | Q(description__icontains=keyword)
+    if ifmib_names:
+        condition |= Q(name__in=ifmib_names)
+    for object_name, metric_names in localized_by_object.items():
+        condition |= Q(monitor_object__name=object_name, name__in=metric_names)
+    return queryset.filter(condition)

--- a/server/apps/monitor/utils/metric_keyword.py
+++ b/server/apps/monitor/utils/metric_keyword.py
@@ -1,0 +1,57 @@
+"""指标目录 keyword 过滤：同时匹配指标 ID 与当前 UI 语言的展示名。
+
+列表接口在序列化阶段用 LanguageLoader 把 `display_name` 覆盖为
+`monitor_object_metric.<Object>.<metric>.name`（见 MetricViewSet.list）。
+DB 的 display_name 多为英文模板名，按库字段 icontains 搜「内存」会空结果。
+此处按账号 locale 扫描同一份语言包，把命中的指标 ID 并入过滤条件。
+"""
+
+from django.db.models import Q
+
+from apps.core.utils.loader import LanguageLoader
+from apps.monitor.constants.language import LanguageConstants
+from apps.monitor.utils.snmp_ifmib_capability import get_ifmib_metric_names_matching_keyword
+
+
+def locale_for_metric_language(locale: str) -> str:
+    """LanguageLoader 只认 en / zh-Hans 文件名。"""
+    raw = str(locale or "").strip()
+    lowered = raw.lower().replace("_", "-")
+    if lowered.startswith("zh"):
+        return "zh-Hans"
+    if lowered.startswith("en"):
+        return "en"
+    return raw or "en"
+
+
+def get_locale_metric_names_matching_keyword(keyword: str, locale: str) -> set[str]:
+    """返回当前 locale 展示名（或 IF-MIB 文案）包含 keyword 的指标 ID。"""
+    needle = str(keyword or "").strip().casefold()
+    if not needle:
+        return set()
+
+    names = set(get_ifmib_metric_names_matching_keyword(keyword, locale))
+    lan = LanguageLoader(app=LanguageConstants.APP, default_lang=locale_for_metric_language(locale))
+    metrics_root = lan.get(LanguageConstants.MONITOR_OBJECT_METRIC)
+    if not isinstance(metrics_root, dict):
+        return names
+
+    for object_metrics in metrics_root.values():
+        if not isinstance(object_metrics, dict):
+            continue
+        for metric_name, entry in object_metrics.items():
+            display = entry.get("name") if isinstance(entry, dict) else entry
+            if needle in str(display or "").casefold():
+                names.add(str(metric_name))
+    return names
+
+
+def apply_metric_keyword_filter(queryset, keyword, locale=""):
+    """按 keyword 过滤指标：ID / DB 展示名 / 描述 / 当前语言包展示名。"""
+    keyword = str(keyword or "").strip()
+    if not keyword:
+        return queryset
+    localized_names = get_locale_metric_names_matching_keyword(keyword, locale)
+    return queryset.filter(
+        Q(name__icontains=keyword) | Q(display_name__icontains=keyword) | Q(description__icontains=keyword) | Q(name__in=localized_names)
+    )

--- a/server/apps/monitor/views/monitor_metrics.py
+++ b/server/apps/monitor/views/monitor_metrics.py
@@ -19,13 +19,9 @@ from apps.monitor.models.monitor_metrics import Metric, MetricGroup
 from apps.monitor.models.monitor_object import MonitorObject
 from apps.monitor.serializers.monitor_metrics import MetricGroupSerializer, MetricSerializer
 from apps.monitor.utils.metric_enum_locale import localize_metric_enum_unit
+from apps.monitor.utils.metric_keyword import apply_metric_keyword_filter
 from apps.monitor.utils.metric_query_labels import ensure_metric_labels_placeholder, is_raw_vector_selector
-from apps.monitor.utils.snmp_ifmib_capability import (
-    COMMON_IFMIB_METRIC_NAMES,
-    IFMIB_ZH_DISPLAY_TEXTS,
-    get_ifmib_metric_names_matching_keyword,
-    is_ifmib_capable_plugin,
-)
+from apps.monitor.utils.snmp_ifmib_capability import COMMON_IFMIB_METRIC_NAMES, IFMIB_ZH_DISPLAY_TEXTS, is_ifmib_capable_plugin
 from apps.monitor.utils.victoriametrics_api import VictoriaMetricsAPI
 
 # PromQL 中紧跟 `{` 的指标名（用于目录兜底提取）。
@@ -152,10 +148,7 @@ def apply_inherited_metric_filters(queryset, query_params, locale=""):
         queryset = queryset.filter(name__in=[value for value in names.split(",") if value])
     keyword = str(query_params.get("keyword") or "").strip()
     if keyword:
-        localized_names = get_ifmib_metric_names_matching_keyword(keyword, locale)
-        queryset = queryset.filter(
-            Q(name__icontains=keyword) | Q(display_name__icontains=keyword) | Q(description__icontains=keyword) | Q(name__in=localized_names)
-        )
+        queryset = apply_metric_keyword_filter(queryset, keyword, locale)
     is_ifmib = query_params.get("is_ifmib")
     if is_ifmib is not None and str(is_ifmib).strip() != "":
         normalized = str(is_ifmib).strip().lower()


### PR DESCRIPTION
## 做了什么

- 监控指标搜索同时匹配指标 ID 与当前 UI 语言的展示名（中文界面搜「内存」，英文界面搜 Memory）
- 搜 `mem_used` 等 ID 仍可用
- 下拉仍显示「展示名 + id」

## 没做什么

- 不改下拉展示样式
- 不改指标目录数据结构

## 说明

列表接口展示名来自语言包；原先 keyword 只过滤 DB `name`（id），导致「内存」无结果。