### PR TITLE
fix(监控): 批量采集探测改为有界并发

### DIFF
--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
@@ -17,7 +17,10 @@ import useApiClient from '@/utils/request';
 import useIntegrationApi from '@/app/monitor/api/integration';
 import useEventApi from '@/app/monitor/api/event';
 import FieldGuideTip from '@/components/field-guide-tip';
-import type { PolicyTemplateItem } from '@/app/monitor/(pages)/event/template/templateBulkUtils';
+import {
+  COLLECTION_POLICY_BULK_CONFIG_DEFAULTS,
+  type PolicyTemplateItem
+} from '@/app/monitor/(pages)/event/template/templateBulkUtils';
 import {
   COLLECTION_POLICY_CONTROL_WIDTH,
   COLLECTION_POLICY_FIELD,
@@ -30,7 +33,6 @@ import {
   resolvePolicyTemplateList,
   selectedPolicyTemplates
 } from './automaticPolicyApply';
-import { COLLECTION_POLICY_BULK_CONFIG_DEFAULTS } from '@/app/monitor/(pages)/event/template/templateBulkUtils';
 import { TableDataItem } from '@/app/monitor/types';
 import {
   IntegrationAccessProps,
@@ -46,6 +48,7 @@ import {
   trackSnmpFilterMutexLastChanged
 } from '@/app/monitor/hooks/integration/snmpFilterMutex';
 import { toMonitorNodeOption } from '@/app/monitor/hooks/integration/nodeOptions';
+import { runWithConcurrency } from '@/app/monitor/dashboards/shared/utils/concurrency';
 import BatchEditModal from './batchEditModal';
 import ExcelImportModal from './excelImportModal';
 import PluginGuidePanel from './pluginGuidePanel';
@@ -601,8 +604,9 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
         count: runnableRows.length
       })
     );
-    await Promise.all(
-      runnableRows.map((row) => handleCollectDetect(row, 'batch'))
+    // 有界并发，避免勾选大量实例时瞬时打满探测/节点任务
+    await runWithConcurrency(runnableRows, 3, (row) =>
+      handleCollectDetect(row, 'batch')
     );
   };
 


### PR DESCRIPTION
## Summary
- 接入配置页「批量测试」（连通性探测）由无界 `Promise.all` 改为 `runWithConcurrency(..., 3)`，避免勾选大量实例时瞬时打满探测/节点任务。
- 此前在请求风暴修复中曾落地有界并发，后随无证据的 `page_size=-1` 周边一并撤回；本次仅恢复有界并发，不改动分页行为。

## 问题是什么
页面：监控 → 接入 → 接入配置（自动配置）
文件：`web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx`

UI 对应：
- 单行操作：「测试连通性」（`collectDetect`）
- 批量菜单：「批量测试」（`collectDetectBatch`）
- 状态列：「测试状态 / 未测试」

本 PR **只改批量路径** `handleBatchCollectDetect`，不改单行点击行为。

问题表现：勾选较多实例后执行「批量测试」时，前端会对每个实例同时发起探测任务（无并发上限），容易瞬时打满探测/节点侧任务队列。

## 历史与根因分析

### 1. 功能引入：一开始就是无界并发
| Commit | 作者 | 说明 |
|---|---|---|
| `98cc104654` | @baiyf-git | 接入前采集检测前端入口，仅单行「测试连通性」，尚无批量 |
| `6e06891243` | @baiyf-git | 「优化采集连通性检测」首次加入 `handleBatchCollectDetect`，实现为 `Promise.all(runnableRows.map(...))`，**无并发上限** |

结论：批量测试从落地起就是全并发，并非后来某次改动才放开限制。

### 2. 请求风暴修复前：无人做过并发限制
在 `eb761c4cbf`（消除请求风暴）之前，中间提交（如 `324b0a857e`「优化采集连通性测试交互」、`9dc0f4445d`「测试完成不主动弹窗」等）只调整交互参数（是否弹窗、`'batch'` 模式等），**从未改过批量探测的并发模型**。

因此：请求风暴修复前，没有人「限制过」也没有人「消除过限制」——因为本来就没有限制。

### 3. 第一次加上 3 路有界并发
- `eb761c4cbf` fix(监控): 消除实例回填与列表拉取的请求风暴  
  - 其中把批量采集探测改为 `runWithConcurrency(runnableRows, 3, ...)`  
  - 同提交还改了节点/实例列表分页等周边（含 `page_size=-1` 相关路径）

### 4. 有界并发被误撤回
- `2eea8d16c6` revert: 撤回无证据的 `page_size=-1` 与周边扩展改动  
  - 撤回理由：客户问题根因是已选资产逐实例并发回填；`page_size=-1` 并无连接打满证据  
  - 副作用：批量探测的 `runWithConcurrency(..., 3)` **被一并 revert 回 `Promise.all`**

### 5. 本 PR：只恢复有证据、有必要的那一块
- `b17a22d3ca` / PR #5158：仅恢复批量探测有界并发（上限 3），**不**再改动 `page_size` / 列表分页路径

## 变更说明
```diff
- await Promise.all(
-   runnableRows.map((row) => handleCollectDetect(row, 'batch'))
+ await runWithConcurrency(runnableRows, 3, (row) =>
+   handleCollectDetect(row, 'batch')
  );
```

## Test plan
- [ ] 接入自动配置页勾选少量实例执行批量探测，行为与原先一致
- [ ] 勾选较多实例（如 >10）批量探测时，同时进行的探测任务不超过 3 个，随后按队列继续完成
- [ ] 确认未改动 `page_size` / 实例列表拉取路径
- [ ] 单行「测试连通性」行为不受影响

## Scope check
- 仅提交 `automatic.tsx` 一处改动；未纳入测试脚本、图标、本地配置等无关文件

## Reviewer
请 @baiyf-git 帮忙确认：批量探测有界并发（3）是否符合预期，以及撤回 `page_size=-1` 周边时是否有意保留/不保留该限制。