### PR TITLE
feat(监控): Host 磁盘默认排除文件系统类型增加 cdfs

### DIFF
--- a/agents/stargazer/api/monitor.py
+++ b/agents/stargazer/api/monitor.py
@@ -323,7 +323,7 @@ async def windows_wmi_metrics(request):
     disk_include_fstypes = request.headers.get("disk_include_fstypes", "")
     disk_exclude_fstypes = request.headers.get(
         "disk_exclude_fstypes",
-        "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32",
+        "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32,cdfs",
     )
     raw_timeout = request.headers.get("timeout", "60")
     try:
@@ -380,7 +380,7 @@ async def host_metrics(request):
     disk_include_fstypes = request.headers.get("disk_include_fstypes", "")
     disk_exclude_fstypes = request.headers.get(
         "disk_exclude_fstypes",
-        "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32",
+        "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32,cdfs",
     )
     ansible_node_id = request.headers.get("ansible_node_id", "")
     winrm_scheme = request.headers.get("winrm_scheme", "https")

--- a/server/apps/monitor/services/module_ingest.py
+++ b/server/apps/monitor/services/module_ingest.py
@@ -87,7 +87,7 @@ DEFAULT_HOST_COLLECT_MODULES = ("cpu", "disk", "diskio", "mem", "net", "processe
 DEFAULT_COLLECT_INTERVAL = 60
 # 与 Switch SNMP General UI.json timeout.default_value 对齐；缺了会留下 {{ timeout }}s，Telegraf 整份配置解析失败。
 DEFAULT_SNMP_TIMEOUT = 10
-DEFAULT_DISK_EXCLUDE_FSTYPES = "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32"
+DEFAULT_DISK_EXCLUDE_FSTYPES = "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32,cdfs"
 
 # CMDB 带凭据创建场景：套用 Host Remote（远程采集）模板
 HOST_REMOTE_PLUGIN_NAME = "Host Remote"

--- a/server/apps/monitor/services/ui_template_locale.py
+++ b/server/apps/monitor/services/ui_template_locale.py
@@ -101,7 +101,7 @@ _EN_FALLBACKS = {
     "URL必须以http://或https://开头，IPv6地址需使用方括号": "URL must start with http:// or https://; IPv6 addresses must use brackets",
     "请输入有效的域名、IPv4或IPv6地址（IPv6无需方括号）": "Enter a valid domain name, IPv4 address, or IPv6 address (IPv6 does not need brackets)",
     "推荐仅采集 Linux 的 ext4、xfs、btrfs，或 Windows 的 NTFS、ReFS；留空表示不按类型限制。": "We recommend collecting only Linux ext4, xfs, and btrfs, or Windows NTFS and ReFS. Leave empty to avoid filesystem-type filtering.",
-    "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。": "Temporary or container filesystems: tmpfs, devtmpfs, overlay, aufs, squashfs; optical media: iso9660; common USB filesystems: vfat, exfat, fat, fat32. The denylist takes precedence over the allowlist; NTFS is not excluded by default.",
+    "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660、cdfs；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。": "Temporary or container filesystems: tmpfs, devtmpfs, overlay, aufs, squashfs; optical media: iso9660, cdfs; common USB filesystems: vfat, exfat, fat, fat32. The denylist takes precedence over the allowlist; NTFS is not excluded by default.",
     "从设备请求数据的超时时间，超过配置时间（例如 10 秒）的请求将被视为失败": "Timeout for requesting data from the device. Requests exceeding the configured duration, for example 10 seconds, are treated as failures.",
     "监控的目标主机的 IP 地址，用于标识数据收集的来源": "IP address of the monitored target host, used to identify the source of collected data.",
     "安全级别设置，例如 authPriv 表示同时使用认证和隐私（加密）": "Security-level setting; for example, authPriv enables both authentication and privacy (encryption).",

--- a/server/apps/monitor/support-files/plugins/Telegraf/host/os/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/host/os/UI.json
@@ -112,10 +112,10 @@
       "label": "排除的文件系统类型",
       "type": "input",
       "required": false,
-      "default_value": "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32",
+      "default_value": "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32,cdfs",
       "description": "逗号分隔；黑名单优先于仅采集列表，例如 vfat,exfat,ntfs。",
-      "tooltip": "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。",
-      "guide_short": "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。",
+      "tooltip": "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660、cdfs；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。",
+      "guide_short": "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660、cdfs；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。",
       "widget_props": {
         "placeholder": "vfat,exfat,ntfs"
       },

--- a/server/apps/monitor/support-files/plugins/Telegraf/host/os/disk.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/host/os/disk.child.toml.j2
@@ -24,4 +24,4 @@ def apply(metric):
 
     [processors.starlark.constants]
         disk_include_fstypes = "{{ disk_include_fstypes | default('', true) | replace('\\', '\\\\') | replace('"', '\\"') }}"
-        disk_exclude_fstypes = "{{ disk_exclude_fstypes | default('tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32') | replace('\\', '\\\\') | replace('"', '\\"') }}"
+        disk_exclude_fstypes = "{{ disk_exclude_fstypes | default('tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32,cdfs') | replace('\\', '\\\\') | replace('"', '\\"') }}"

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/host/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/host/UI.json
@@ -92,10 +92,10 @@
       "label": "排除的文件系统类型",
       "type": "input",
       "required": false,
-      "default_value": "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32",
+      "default_value": "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32,cdfs",
       "description": "逗号分隔；黑名单优先于仅采集列表，例如 vfat,exfat,ntfs。",
-      "tooltip": "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。",
-      "guide_short": "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。",
+      "tooltip": "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660、cdfs；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。",
+      "guide_short": "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660、cdfs；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。",
       "widget_props": {
         "placeholder": "vfat,exfat,ntfs"
       },

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/host/host.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/host/host.child.toml.j2
@@ -17,7 +17,7 @@
         port = "{{ port | default('', true) }}"
         metrics_modules = "{{ metrics_modules | default('cpu,mem,disk,diskio,net,processes,system', true) }}"
         disk_include_fstypes = "{{ disk_include_fstypes | default('', true) }}"
-        disk_exclude_fstypes = "{{ disk_exclude_fstypes | default('tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32') }}"
+        disk_exclude_fstypes = "{{ disk_exclude_fstypes | default('tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32,cdfs') }}"
         winrm_scheme = "{{ winrm_scheme | default('https', true) }}"
         winrm_transport = "{{ winrm_transport | default('ntlm', true) }}"
         winrm_cert_validation = "{{ winrm_cert_validation | default('false', true) }}"

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/UI.json
@@ -113,10 +113,10 @@
       "label": "排除的文件系统类型",
       "type": "input",
       "required": false,
-      "default_value": "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32",
+      "default_value": "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32,cdfs",
       "description": "逗号分隔；黑名单优先于仅采集列表，例如 FAT,FAT32,exFAT。",
-      "tooltip": "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。",
-      "guide_short": "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。",
+      "tooltip": "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660、cdfs；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。",
+      "guide_short": "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660、cdfs；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。",
       "widget_props": {
         "placeholder": "FAT,FAT32,exFAT"
       },

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/windows_wmi.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/windows_wmi.child.toml.j2
@@ -12,7 +12,7 @@
         namespace = "{{ namespace | default('root\\cimv2', true) }}"
         metrics_modules = "{{ metrics_modules | default('cpu,mem,disk,diskio,net,processes,system', true) }}"
         disk_include_fstypes = "{{ disk_include_fstypes | default('', true) }}"
-        disk_exclude_fstypes = "{{ disk_exclude_fstypes | default('tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32') }}"
+        disk_exclude_fstypes = "{{ disk_exclude_fstypes | default('tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32,cdfs') }}"
         timeout = "{{ timeout | default(60, true) }}"
         instance_id = "{{ instance_id }}"
         instance_type = "{{ instance_type | default('os', true) }}"


### PR DESCRIPTION
## 做了什么

- Host / Host Remote / Windows WMI 新建接入时，`disk_exclude_fstypes` 默认串末尾增加小写 `cdfs`
- 同源串同步：三个 UI.json、三个 child.toml.j2、`DEFAULT_DISK_EXCLUDE_FSTYPES`、stargazer 两处 header fallback
- 中英文提示补「光盘：iso9660、cdfs」

## 没做什么

- 不改已保存实例（无迁移）
- 不改 AIX Host Remote `os_monitor.ksh`
- 不改 disk_filter.py、前端硬编码、metrics.json、K8s sidecar ignore_fs