### PR TITLE
feat(监控): NetFlow Top 会话支持搜索与分页

### DIFF
--- a/server/apps/monitor/services/authorized_metric_query.py
+++ b/server/apps/monitor/services/authorized_metric_query.py
@@ -344,6 +344,9 @@ class AuthorizedMetricQueryService:
             card_budget=prepared.card_budget,
         )
 
+    def prepare(self, payload: dict) -> AuthorizedMetricQuery:
+        return self._prepare(payload)
+
     def query_instant(self, payload: dict) -> dict:
-        prepared = self._prepare(payload)
+        prepared = self.prepare(payload)
         return Metrics.get_metrics(prepared.query, time=prepared.end / 1000.0)

--- a/server/apps/monitor/services/flow_conversations.py
+++ b/server/apps/monitor/services/flow_conversations.py
@@ -1,0 +1,114 @@
+"""Full Flow conversation list: keyword on src/dst, then paginate.
+
+The professional dashboard used to query a TopN capability. This service unwraps
+topk/bottomk/limitk, keeps the full 5-tuple aggregation, filters by source or
+destination address, and returns one page. Top protocol ranking stays unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from apps.monitor.services.authorized_metric_query import AuthorizedMetricQueryError, AuthorizedMetricQueryService
+from apps.monitor.services.metric_series import fold_instant_rows, unwrap_limiting_query
+from apps.monitor.services.metrics import Metrics
+from apps.monitor.utils.pagination import parse_page_params
+
+DEFAULT_PAGE_SIZE = 10
+MAX_PAGE_SIZE = 100
+MAX_KEYWORD_LENGTH = 256
+CONVERSATION_DIMENSIONS = ["src", "src_port", "dst", "dst_port", "protocol"]
+
+
+def normalize_conversation_keyword(value) -> str:
+    text = str(value or "").strip()
+    if len(text) > MAX_KEYWORD_LENGTH:
+        raise AuthorizedMetricQueryError("keyword 过长", code="keyword_invalid")
+    return text
+
+
+def parse_conversation_page(payload: dict[str, Any]) -> tuple[int, int]:
+    page, page_size = parse_page_params(payload, default_page=1, default_page_size=DEFAULT_PAGE_SIZE)
+    return page, min(page_size, MAX_PAGE_SIZE)
+
+
+def is_conversation_query(query: str) -> bool:
+    text = str(query or "")
+    has_src = "src_ip" in text or re.search(r"\bsrc\b", text) is not None
+    has_dst = "dst_ip" in text or re.search(r"\bdst\b", text) is not None
+    has_ports = "src_port" in text and "dst_port" in text
+    has_protocol = "protocol" in text
+    return has_src and has_dst and has_ports and has_protocol
+
+
+def conversation_matches_keyword(row: dict[str, Any], keyword: str) -> bool:
+    if not keyword:
+        return True
+    needle = keyword.casefold()
+    src = str(row.get("src") or "").casefold()
+    dst = str(row.get("dst") or "").casefold()
+    return needle in src or needle in dst
+
+
+def parse_conversation_rows(vm_result: dict[str, Any] | None) -> list[dict[str, Any]]:
+    series = ((vm_result or {}).get("data") or {}).get("result") or []
+    if not isinstance(series, list):
+        return []
+    rows = fold_instant_rows(series, CONVERSATION_DIMENSIONS, limit=max(len(series), 1))
+    return [row for row in rows if row.get("src") or row.get("dst")]
+
+
+def serialize_conversation_page(
+    rows: list[dict[str, Any]],
+    *,
+    keyword: str,
+    page: int,
+    page_size: int,
+) -> dict[str, Any]:
+    filtered = [row for row in rows if conversation_matches_keyword(row, keyword)]
+    count = len(filtered)
+    start = (page - 1) * page_size
+    page_rows = filtered[start : start + page_size]
+    items = []
+    for offset, row in enumerate(page_rows):
+        items.append(
+            {
+                "src_ip": row.get("src") or "--",
+                "dst_ip": row.get("dst") or "--",
+                "src_port": row.get("src_port") or "--",
+                "dst_port": row.get("dst_port") or "--",
+                "protocol": row.get("protocol") or "--",
+                "bytes_rate": float(row.get("value") or 0),
+                "rank": start + offset + 1,
+            }
+        )
+    return {
+        "count": count,
+        "page": page,
+        "page_size": page_size,
+        "items": items,
+    }
+
+
+def query_flow_conversation_page(
+    *,
+    authorized_service: AuthorizedMetricQueryService,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    keyword = normalize_conversation_keyword(payload.get("keyword") or payload.get("ip"))
+    page, page_size = parse_conversation_page(payload)
+    prepared = authorized_service.prepare(payload)
+    query = unwrap_limiting_query(prepared.query)
+    if not is_conversation_query(query):
+        raise AuthorizedMetricQueryError("查询能力不支持会话列表", code="capability_not_conversation")
+
+    vm_result = Metrics.get_metrics(query, time=prepared.end / 1000.0)
+    if not isinstance(vm_result, dict) or vm_result.get("status") != "success":
+        raise AuthorizedMetricQueryError("指标查询失败", code="metric_query_failed")
+    return serialize_conversation_page(
+        parse_conversation_rows(vm_result),
+        keyword=keyword,
+        page=page,
+        page_size=page_size,
+    )

--- a/server/apps/monitor/views/metrics_instance.py
+++ b/server/apps/monitor/views/metrics_instance.py
@@ -12,6 +12,7 @@ from apps.monitor.constants.permission import PermissionConstants
 from apps.monitor.models import MonitorInstance
 from apps.monitor.models.monitor_metrics import Metric
 from apps.monitor.services.authorized_metric_query import AuthorizedMetricQueryError, AuthorizedMetricQueryService
+from apps.monitor.services.flow_conversations import query_flow_conversation_page
 from apps.monitor.services.metrics import Metrics as MetricsService
 from apps.monitor.services.metrics import MetricsQueryBudgetExceeded
 from apps.monitor.utils.unit_converter import UnitConverter
@@ -79,6 +80,19 @@ class MetricsInstanceViewSet(viewsets.ViewSet):
                 data = self._apply_unit_conversion(data, source_unit, target_unit)
             elif auto_convert:
                 data = self._apply_unit_conversion(data, source_unit)
+        return WebUtils.response_success(data)
+
+    @action(methods=["post"], detail=False, url_path="query_flow_conversations")
+    def query_flow_conversations(self, request):
+        """全量 Flow 会话列表：按源/目的地址关键字过滤后分页，不截断为 TopN。"""
+        payload = request.data if isinstance(request.data, dict) else {}
+        try:
+            data = query_flow_conversation_page(
+                authorized_service=self._authorized_query_service(request),
+                payload=payload,
+            )
+        except AuthorizedMetricQueryError as exc:
+            self._raise_authorized_query_error(exc)
         return WebUtils.response_success(data)
 
     @staticmethod

--- a/web/src/app/monitor/api/view.ts
+++ b/web/src/app/monitor/api/view.ts
@@ -47,6 +47,20 @@ const useViewApi = () => {
     [post]
   );
 
+  const queryFlowConversations = useCallback(
+    async (params: SearchParams, config?: RequestConfig) => {
+      return await post(
+        `/monitor/api/metrics_instance/query_flow_conversations/`,
+        params,
+        {
+          ...METRIC_QUERY_REQUEST_CONFIG,
+          ...config,
+        }
+      );
+    },
+    [post]
+  );
+
   const getInstanceSearch = useCallback(
     async (
       objectId: React.Key,
@@ -117,6 +131,7 @@ const useViewApi = () => {
   return {
     getInstanceQuery,
     getInstanceInstantQuery,
+    queryFlowConversations,
     getInstanceSearch,
     getInstanceQueryParams,
     getMetricsInstanceQuery,

--- a/web/src/app/monitor/dashboards/objects/flow-common/conversation-table.tsx
+++ b/web/src/app/monitor/dashboards/objects/flow-common/conversation-table.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import { Input, Pagination, Spin } from 'antd';
+import { SearchOutlined } from '@ant-design/icons';
 import useViewApi from '@/app/monitor/api/view';
 import ChartEmptyState from '@/components/chart-empty-state';
 import { DashboardPanel } from '../../shared/widgets';
@@ -155,14 +156,15 @@ export function FlowConversationTable({
       styles={styles}
     >
       <Spin spinning={loading}>
-        <div className="mb-2 flex items-center">
+        <div className="mb-2.5 flex items-center justify-between gap-2">
           <Input
             allowClear
             size="small"
+            prefix={<SearchOutlined className="text-gray-400" />}
             value={keywordInput}
             placeholder="搜索源/目的地址"
             onChange={(event) => setKeywordInput(event.target.value)}
-            className="max-w-[240px]"
+            className="w-60"
           />
         </div>
         {!loading && rows.length === 0 ? (
@@ -237,7 +239,7 @@ export function FlowConversationTable({
           </div>
         )}
         {count > 0 ? (
-          <div className="mt-2 flex justify-end">
+          <div className="mt-3 flex items-center justify-end">
             <Pagination
               size="small"
               current={page}
@@ -245,8 +247,9 @@ export function FlowConversationTable({
               total={count}
               showSizeChanger
               pageSizeOptions={['10', '20', '50']}
+              showTotal={(total) => `共 ${total} 条会话`}
               onChange={(nextPage, nextPageSize) => {
-                setPage(nextPage);
+                setPage(nextPageSize === pageSize ? nextPage : 1);
                 setPageSize(nextPageSize);
               }}
             />

--- a/web/src/app/monitor/dashboards/objects/flow-common/conversation-table.tsx
+++ b/web/src/app/monitor/dashboards/objects/flow-common/conversation-table.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import React, { useEffect, useMemo, useState } from 'react';
-import { Spin } from 'antd';
-import { useSearchParams } from 'next/navigation';
+import { Input, Pagination, Spin } from 'antd';
 import useViewApi from '@/app/monitor/api/view';
 import ChartEmptyState from '@/components/chart-empty-state';
 import { DashboardPanel } from '../../shared/widgets';
@@ -10,7 +9,7 @@ import { buildSearchParams, formatMetricValue } from '../../shared/utils';
 import { useSimpleDashboardData } from '../common/simple-dashboard-core';
 import type { FlowProtocol } from './constants';
 import { buildConversationTopQuery } from './queries';
-import { parseConversationRows, type FlowConversationRow } from './parse-conversation-rows';
+import { mapConversationPageItems, type FlowConversationPage, type FlowConversationRow } from './parse-conversation-rows';
 import { formatProtocolShortName } from './protocol-labels';
 import { resolveFlowRankClass } from './rank-class';
 
@@ -21,9 +20,12 @@ interface FlowConversationTableProps {
   styles: Record<string, string>;
 }
 
+const DEFAULT_PAGE_SIZE = 10;
+const SEARCH_DEBOUNCE_MS = 300;
+
 const CONVERSATION_GUIDE = [{
   label: 'Top 会话',
-  detail: '所选时间窗内平均流量速率最高的 10 组会话，按源/目的地址、端口与协议聚合展示。',
+  detail: '所选时间窗内的全量会话，按源/目的地址、端口与协议聚合，并按平均流量速率排序。可按源或目的地址关键字过滤后分页查看。',
 }];
 
 const formatBytesRate = (value: number | null) => {
@@ -52,12 +54,12 @@ export function FlowConversationTable({
   instanceType,
   styles,
 }: FlowConversationTableProps) {
-  const { getInstanceInstantQuery } = useViewApi();
-  const searchParams = useSearchParams();
-  const instanceIdKeys = useMemo(
-    () => (searchParams.get('instance_id_keys') || 'instance_id').split(',').filter(Boolean),
-    [searchParams],
-  );
+  const { queryFlowConversations } = useViewApi();
+  const [keywordInput, setKeywordInput] = useState('');
+  const [keyword, setKeyword] = useState('');
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+  const [count, setCount] = useState(0);
   const [rows, setRows] = useState<FlowConversationRow[]>([]);
   const [loading, setLoading] = useState(false);
   const conversationQuery = useMemo(
@@ -66,8 +68,19 @@ export function FlowConversationTable({
   );
 
   useEffect(() => {
+    const timer = window.setTimeout(() => {
+      const nextKeyword = keywordInput.trim();
+      if (nextKeyword === keyword) return;
+      setKeyword(nextKeyword);
+      setPage(1);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(timer);
+  }, [keyword, keywordInput]);
+
+  useEffect(() => {
     if (!dashboard.isDashboardMode || !instanceType || !dashboard.idValues.length) {
       setRows([]);
+      setCount(0);
       setLoading(false);
       return;
     }
@@ -76,22 +89,29 @@ export function FlowConversationTable({
     setLoading(true);
 
     const load = async () => {
-      const result = await getInstanceInstantQuery(
-        buildSearchParams(
+      const result = await queryFlowConversations({
+        ...buildSearchParams(
           conversationQuery,
           'byteps',
           dashboard.idValues,
-          instanceIdKeys,
+          ['instance_id'],
           dashboard.timeValues,
           undefined,
           false,
           dashboard.currentInstanceInterval,
           { monitorObjectId: dashboard.monitorObjectId, instanceId: dashboard.instanceId },
         ),
-      ).catch(() => null);
+        keyword,
+        page,
+        page_size: pageSize,
+      }).catch(() => null) as FlowConversationPage | null;
 
       if (!active) return;
-      setRows(parseConversationRows(result, protocol));
+      const nextCount = Number(result?.count) || 0;
+      setRows(mapConversationPageItems(result?.items));
+      setCount(nextCount);
+      const maxPage = Math.max(1, Math.ceil(nextCount / pageSize) || 1);
+      if (page > maxPage) setPage(maxPage);
       setLoading(false);
     };
 
@@ -104,13 +124,16 @@ export function FlowConversationTable({
     conversationQuery,
     dashboard.currentInstanceInterval,
     dashboard.idValues,
+    dashboard.instanceId,
     dashboard.isDashboardMode,
     dashboard.loadTick,
+    dashboard.monitorObjectId,
     dashboard.timeValues,
-    getInstanceInstantQuery,
-    instanceIdKeys,
     instanceType,
-    protocol,
+    keyword,
+    page,
+    pageSize,
+    queryFlowConversations,
   ]);
 
   const peakRate = useMemo(
@@ -118,19 +141,33 @@ export function FlowConversationTable({
     [rows],
   );
 
+  const emptyDescription = keyword
+    ? '未找到匹配的 Flow 会话'
+    : '所选时间窗内无 Flow 会话数据';
+
   return (
     <DashboardPanel
       title="Top 会话"
-      subtitle="Top 10 会话 · 按源/目的地址、端口与协议聚合"
+      subtitle="全量会话 · 按源/目的地址、端口与协议聚合，支持搜索与分页"
       guide={CONVERSATION_GUIDE}
       className={`${styles.span8} ${styles.flowConversationPanel}`}
       bodyClassName={styles.flowConversationBody}
       styles={styles}
     >
       <Spin spinning={loading}>
+        <div className="mb-2 flex items-center">
+          <Input
+            allowClear
+            size="small"
+            value={keywordInput}
+            placeholder="搜索源/目的地址"
+            onChange={(event) => setKeywordInput(event.target.value)}
+            className="max-w-[240px]"
+          />
+        </div>
         {!loading && rows.length === 0 ? (
           <div className={styles.flowConversationEmpty}>
-            <ChartEmptyState description="所选时间窗内无 Flow 会话数据" compact />
+            <ChartEmptyState description={emptyDescription} compact />
           </div>
         ) : (
           <div
@@ -161,12 +198,13 @@ export function FlowConversationTable({
                 </tr>
               </thead>
               <tbody>
-                {rows.map((row, index) => {
+                {rows.map((row) => {
+                  const rank = row.rank ?? 0;
                   const share = peakRate > 0 ? (row.bytesRate / peakRate) * 100 : 0;
                   return (
-                    <tr key={row.rowKey} className={resolveFlowRankClass(index, styles)}>
+                    <tr key={row.rowKey} className={resolveFlowRankClass(Math.max(rank - 1, 0), styles)}>
                       <td className={styles.flowCellRank}>
-                        <span className={styles.flowProtocolRankMark}>{index + 1}</span>
+                        <span className={styles.flowProtocolRankMark}>{rank || '--'}</span>
                       </td>
                       <td className={styles.flowCellIp} title={row.srcIp}>{row.srcIp}</td>
                       <td className={styles.flowCellIp} title={row.dstIp}>{row.dstIp}</td>
@@ -198,6 +236,22 @@ export function FlowConversationTable({
             </table>
           </div>
         )}
+        {count > 0 ? (
+          <div className="mt-2 flex justify-end">
+            <Pagination
+              size="small"
+              current={page}
+              pageSize={pageSize}
+              total={count}
+              showSizeChanger
+              pageSizeOptions={['10', '20', '50']}
+              onChange={(nextPage, nextPageSize) => {
+                setPage(nextPage);
+                setPageSize(nextPageSize);
+              }}
+            />
+          </div>
+        ) : null}
       </Spin>
     </DashboardPanel>
   );

--- a/web/src/app/monitor/dashboards/objects/flow-common/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/flow-common/index.module.scss
@@ -138,7 +138,7 @@
 }
 
 .flowColProtocol {
-  width: 12%;
+  width: 76px;
 }
 
 .flowColTraffic {
@@ -160,6 +160,8 @@
 .flowConversationTable tbody td.flowCellProtocol {
   padding-left: 8px;
   padding-right: 8px;
+  text-align: left;
+  vertical-align: middle;
 }
 
 .flowConversationTable thead th.flowColTraffic,
@@ -199,7 +201,7 @@
 }
 
 .flowCellProtocol {
-  text-align: center;
+  text-align: left;
   white-space: nowrap;
 }
 

--- a/web/src/app/monitor/dashboards/objects/flow-common/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/flow-common/index.module.scss
@@ -130,19 +130,19 @@
 }
 
 .flowColIp {
-  width: 18%;
+  width: 22%;
 }
 
 .flowColPort {
-  width: 10%;
+  width: 9%;
 }
 
 .flowColProtocol {
-  width: 76px;
+  width: 92px;
 }
 
 .flowColTraffic {
-  width: 27%;
+  width: 20%;
 }
 
 .flowConversationTable thead th.flowColRank {
@@ -158,7 +158,7 @@
 
 .flowConversationTable thead th.flowColProtocol,
 .flowConversationTable tbody td.flowCellProtocol {
-  padding-left: 8px;
+  padding-left: 16px;
   padding-right: 8px;
   text-align: left;
   vertical-align: middle;

--- a/web/src/app/monitor/dashboards/objects/flow-common/parse-conversation-rows.ts
+++ b/web/src/app/monitor/dashboards/objects/flow-common/parse-conversation-rows.ts
@@ -19,6 +19,24 @@ export interface FlowConversationRow {
   protocol: string;
   bytesRate: number;
   rowKey: string;
+  rank?: number;
+}
+
+export interface FlowConversationPageItem {
+  src_ip?: string;
+  dst_ip?: string;
+  src_port?: string;
+  dst_port?: string;
+  protocol?: string;
+  bytes_rate?: number;
+  rank?: number;
+}
+
+export interface FlowConversationPage {
+  count?: number;
+  page?: number;
+  page_size?: number;
+  items?: FlowConversationPageItem[];
 }
 
 const latestValue = (series: RawSeries): number | null => {
@@ -100,4 +118,27 @@ export const parseConversationRows = (
   }
 
   return rows.sort((left, right) => right.bytesRate - left.bytesRate);
+};
+
+export const mapConversationPageItems = (
+  items: FlowConversationPageItem[] | null | undefined,
+): FlowConversationRow[] => {
+  if (!items?.length) return [];
+  return items.map((item, index) => {
+    const srcIp = item.src_ip || '--';
+    const dstIp = item.dst_ip || '--';
+    const srcPort = normalizePort(item.src_port);
+    const dstPort = normalizePort(item.dst_port);
+    const protocol = item.protocol || '';
+    return {
+      srcIp,
+      srcPort,
+      dstIp,
+      dstPort,
+      protocol,
+      bytesRate: Number(item.bytes_rate),
+      rank: item.rank ?? index + 1,
+      rowKey: [srcIp, srcPort, dstIp, protocol, dstPort, String(item.rank ?? index)].join('\u0000'),
+    };
+  }).filter((row) => Number.isFinite(row.bytesRate));
 };

--- a/web/src/app/monitor/types/search.ts
+++ b/web/src/app/monitor/types/search.ts
@@ -51,6 +51,10 @@ export interface SearchParams {
   detect_gaps?: boolean;
   collection_interval?: number;
   card_budget?: boolean;
+  keyword?: string;
+  ip?: string;
+  page?: number;
+  page_size?: number;
 }
 
 export interface QueryGroup {


### PR DESCRIPTION
## 做了什么

- 「Top 会话」改为后端全量会话列表 + 搜索 + 分页，不再只能看 TopN
- 搜索匹配源地址或目的地址；空搜=全量分页；有词先过滤再分页
- 新接口 `POST /monitor/api/metrics_instance/query_flow_conversations/`（`keyword`/`ip` + `page`/`page_size`）

## 没做什么

- 「Top 协议」仍为 TopN，未改
- 不做前端假分页