### PR TITLE
fix(opspilot): 网关 500 不再误报沙箱，RCA 对象不可见仍出报告

### DIFF
--- a/server/apps/opspilot/metis/llm/agent/tool_execution_planner.py
+++ b/server/apps/opspilot/metis/llm/agent/tool_execution_planner.py
@@ -270,6 +270,47 @@ def is_context_size_error(exc: BaseException | str) -> bool:
     return any(needle in text for needle in needles)
 
 
+_LLM_UPSTREAM_TYPE_NAMES = frozenset(
+    {
+        "internalservererror",
+        "apitimeouterror",
+        "apiconnectionerror",
+        "ratelimiterror",
+        "serviceunavailableerror",
+    }
+)
+_LLM_UPSTREAM_REQUEST_ID_RE = re.compile(r"request id:\s*([A-Za-z0-9]+)", re.IGNORECASE)
+
+
+def is_llm_upstream_error(exc: BaseException | str) -> bool:
+    """识别模型网关/上游失败（如 new_api 500 do_request_failed），不是沙箱白名单拦截。"""
+    if is_context_size_error(exc):
+        return False
+    if isinstance(exc, BaseException) and type(exc).__name__.casefold() in _LLM_UPSTREAM_TYPE_NAMES:
+        return True
+    text = str(exc or "").casefold()
+    needles = (
+        "new_api_error",
+        "do_request_failed",
+        "upstream error: do request failed",
+    )
+    return any(needle in text for needle in needles)
+
+
+def extract_llm_upstream_request_id(exc: BaseException | str) -> str:
+    match = _LLM_UPSTREAM_REQUEST_ID_RE.search(str(exc or ""))
+    if not match:
+        return ""
+    return match.group(1)[:80]
+
+
+def llm_upstream_user_message(exc: BaseException | str) -> str:
+    request_id = extract_llm_upstream_request_id(exc)
+    if request_id:
+        return f"模型服务暂时不可用（上游请求失败），不是本地工具或沙箱命令被拦截。请稍后重试。request_id={request_id}"
+    return "模型服务暂时不可用（上游请求失败），不是本地工具或沙箱命令被拦截。请稍后重试。"
+
+
 def _coerce_positive_int(value: Any) -> int | None:
     try:
         number = int(value)

--- a/server/apps/opspilot/metis/llm/chain/deepagent_assembly.py
+++ b/server/apps/opspilot/metis/llm/chain/deepagent_assembly.py
@@ -181,13 +181,26 @@ class DeepAgentAssemblyMixin:
         return False
 
     @classmethod
-    def _should_skip_planned_summary(cls, messages, *, completed_step_count: int) -> bool:
-        """单步已作答，或多步里已经出现过完整表格时，不再跑总结轮。"""
+    def _should_skip_planned_summary(
+        cls,
+        messages,
+        *,
+        completed_step_count: int,
+        report_mode: str = "default",
+        require_formatted_report: bool = False,
+    ) -> bool:
+        """已有对应终稿时跳过总结轮。告警 RCA / 对象不可见时，调查草稿不算终稿。"""
+        texts = list(cls._iter_planned_assistant_text(messages))
+        if report_mode == "alert_rca":
+            return any(cls._looks_like_complete_rca_report(text) for text in texts)
+        if report_mode == "restart_reason":
+            return any(cls._looks_like_complete_restart_reason_report(text) for text in texts)
+        if require_formatted_report:
+            return any(cls._looks_like_complete_rca_report(text) or cls._looks_like_complete_restart_reason_report(text) for text in texts)
         if not cls._planned_step_already_answered(messages):
             return False
         if completed_step_count <= 1:
             return True
-        texts = list(cls._iter_planned_assistant_text(messages))
         if any(cls._looks_like_complete_rca_report(text) or cls._looks_like_complete_restart_reason_report(text) for text in texts):
             return True
         return cls._planned_output_has_markdown_table(messages)
@@ -312,6 +325,8 @@ class DeepAgentAssemblyMixin:
                 "事件概述、异常对象清单、根因分析、修复建议、待确认项。"
                 "标题之前不要写定位说明、步骤结果或客套话。"
                 "异常对象清单必须是 Markdown 表，列名为：对象、状态/现象、重启次数、关键事件、是否已定位。"
+                "即使 namespace 未解析、lookup_exhausted 或对象在当前集群不可见，也必须输出这份完整报告；"
+                "把无法定位写进根因分析与待确认项，禁止只复述本步工具结果。"
                 "禁止输出「事件描述」「事件总结」「涉及对象清单」「异常对象名单」「链路分析」「数据分析」「调查结论」「诊断结论」。"
                 "禁止改成「日志获取完成」「关键证据确认」这类要点列表。"
                 "已知具体 Pod 的重启原因时，以 diagnose 的 last_state、previous 日志和定点事件为准，不要把当前轮日志当成上一轮死因。"
@@ -345,6 +360,8 @@ class DeepAgentAssemblyMixin:
                 "必须以「# RCA 报告」作为第一行，再按"
                 "「事件概述、异常对象清单、根因分析、修复建议、待确认项」只写一份完整 Markdown 报告，"
                 "异常对象清单表必须保留；标题之前不要写定位说明或步骤结果。"
+                "即使 namespace 未解析、lookup_exhausted 或对象在当前集群不可见，也必须输出完整报告，"
+                "把无法定位写进根因分析与待确认项，禁止只复述步骤结果。"
                 "不要写事件描述、涉及对象清单、链路分析、调查结论；不要重复粘贴多份同类章节。"
                 "禁止改成「日志获取完成」「关键证据确认」要点列表。"
                 "若步骤里已经写过以「# RCA 报告」起笔且未重复粘贴的完整报告，不要重写，最多一两句。"

--- a/server/apps/opspilot/metis/llm/chain/node.py
+++ b/server/apps/opspilot/metis/llm/chain/node.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel as PydanticBaseModel
 from pydantic import Field as PydanticField
 
 from apps.core.logger import opspilot_logger as logger
+from apps.core.logger import safe_exception_info
 from apps.opspilot.metis.llm.chain.approval_tools import ApprovalToolsMixin, _build_approval_tool, _build_choice_tool  # noqa: E402,F401
 from apps.opspilot.metis.llm.chain.deepagent_assembly import (  # noqa: E402,F401
     DeepAgentAssemblyMixin,
@@ -2329,11 +2330,25 @@ class ToolsNodes(
                 ToolPlanningError,
                 classify_tool_failure_kind,
                 drop_k8s_followup_steps_after_unresolved_target,
+                extract_llm_upstream_request_id,
                 is_context_size_error,
+                is_llm_upstream_error,
                 is_non_replanable_tool_failure,
                 is_tool_result_failure,
+                llm_upstream_user_message,
                 merge_replanned_pending_steps,
             )
+
+            def _llm_upstream_failure_result(exc: BaseException, *, failed_stage: str) -> Dict[str, Any]:
+                logger.error(
+                    "event=deepagent_llm_upstream_failed failed_stage=%s error_type=%s request_id=%s",
+                    failed_stage,
+                    type(exc).__name__,
+                    extract_llm_upstream_request_id(exc) or "-",
+                    exc_info=safe_exception_info(exc),
+                )
+                return {"messages": [AIMessage(content=llm_upstream_user_message(exc))]}
+
             from apps.opspilot.metis.llm.tools.kubernetes.data_collection import k8s_target_lookup_exhausted_from_messages
 
             graph_request = config["configurable"]["graph_request"]
@@ -2416,6 +2431,8 @@ class ToolsNodes(
                     )
                     result = await deep_agent.ainvoke({"messages": deep_input_messages}, config=deep_config)
                 except Exception as _await_exc:
+                    if is_llm_upstream_error(_await_exc):
+                        return _llm_upstream_failure_result(_await_exc, failed_stage="legacy_deepagent")
                     try:
                         err_prompt = (
                             f"上一轮工具执行失败(异常 {type(_await_exc).__name__}:"
@@ -2724,6 +2741,7 @@ class ToolsNodes(
                 replan_count = 0
                 total_steps = len(plan.steps)
                 summary_ran = False
+                require_formatted_report = False
                 self._set_hide_planned_step_text(graph_request, True)
 
                 while pending_steps:
@@ -2871,6 +2889,8 @@ class ToolsNodes(
                             )
                         except Exception as step_exc:
                             failure = f"步骤“{step.objective}”执行异常 " f"{type(step_exc).__name__}: {str(step_exc)[:800]}"
+                            if is_llm_upstream_error(step_exc):
+                                raise
                             # 上下文溢出：不带着全量工具目录重规划，但压缩上下文后继续后续步骤。
                             if is_context_size_error(step_exc):
                                 logger.warning(
@@ -2955,6 +2975,7 @@ class ToolsNodes(
                         if k8s_target_lookup_exhausted_from_messages(step_messages):
                             _collect_output_messages(step_messages)
                             remaining_steps = drop_k8s_followup_steps_after_unresolved_target(pending_steps)
+                            require_formatted_report = True
                             logger.info(
                                 "DeepAgent k8s 目标反查已收口，跳过后续需 namespace 步骤 dropped=%s",
                                 len(pending_steps) - len(remaining_steps),
@@ -3064,6 +3085,11 @@ class ToolsNodes(
                 elif self._should_skip_planned_summary(
                     collected_output_messages,
                     completed_step_count=len(completed_steps),
+                    report_mode=self._planned_report_mode(
+                        user_message=planning_question,
+                        agent_system_prompt=str(getattr(graph_request, "system_message_prompt", "") or ""),
+                    ),
+                    require_formatted_report=require_formatted_report,
                 ):
                     # 步骤正文已经给过表格或完整答案。再跑总结轮会换个说法复述。
                     result = {"messages": list(agent_state.get("messages") or [])}
@@ -3096,7 +3122,9 @@ class ToolsNodes(
             except Exception as _await_exc:
                 # deepagent 框架层异常(典型:execute 工具撞 sandbox 命令白名单)会把整
                 # 个 graph 标 ERROR,LLM 没机会拿到 ToolMessage 写 follow-up。
-                # 上下文不足时不要再喂长 system/工具目录给模型“解释失败”，避免二次浪费。
+                # 模型网关 500 / 上下文不足时不要再喂同一上游“解释失败”，避免二次浪费。
+                if is_llm_upstream_error(_await_exc):
+                    return _llm_upstream_failure_result(_await_exc, failed_stage="planned_execution")
                 if is_context_size_error(_await_exc):
                     logger.warning(
                         "DeepAgent 因上下文窗口不足失败，直接返回短提示: %s",

--- a/server/apps/opspilot/tests/test_deepagent_engine_service.py
+++ b/server/apps/opspilot/tests/test_deepagent_engine_service.py
@@ -6,16 +6,20 @@ tools/MCP、knowledge_retrieve 工具、SKILL.md 技能（MinIO backend）、人
 """
 
 import asyncio
+import io
 import json
+import logging
 import os
 import subprocess
 import sys
+import traceback
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from langchain_core.messages import HumanMessage
 
+from apps.core.logger import SafeLogException, opspilot_logger
 from apps.opspilot.metis.llm.chain.node import ToolsNodes
 from apps.opspilot.metis.llm.middleware.tool_runtime import (
     PLANNED_EXECUTION_HIDDEN_DEEPAGENT_TOOLS,
@@ -572,6 +576,111 @@ class TestBuildDeepagentNodes:
         assert "上下文压缩" in captured["ainvoke_joined"][1]
         assert result["messages"][-1].content == "执行结果 3"
 
+    def test_llm_upstream_500_skips_sandbox_whitelist_fallback(self, caplog):
+        node = ToolsNodes()
+        node.all_tools = [
+            _tool("list_kubernetes_events"),
+            _tool("get_kubernetes_pod_logs"),
+        ]
+        req = _request(user_message="告警：Unhealthy startup probe")
+        captured = {}
+
+        gb = _FakeGraphBuilder()
+        name = asyncio.run(node.build_deepagent_nodes(gb, composite_node_name="deep_agent"))
+        wrapper = gb.nodes[name]
+
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        class InternalServerError(Exception):
+            pass
+
+        class _PlannerLLM:
+            async def ainvoke(self, messages, config=None):
+                captured.setdefault("planner_calls", []).append(messages)
+                joined = "\n".join(str(getattr(m, "content", "") or "") for m in messages)
+                if "上一轮工具执行失败" in joined:
+                    captured["fallback_explain"] = True
+                    raise AssertionError("must not re-invoke LLM to explain upstream 500")
+                return AIMessage(
+                    content=json.dumps(
+                        {
+                            "goal": "诊断",
+                            "steps": [
+                                {"objective": "查日志与事件", "tools": ["get_kubernetes_pod_logs", "list_kubernetes_events"]},
+                            ],
+                        },
+                        ensure_ascii=False,
+                    )
+                )
+
+        fake_agent = MagicMock()
+
+        async def _ainvoke(payload, config=None):
+            captured.setdefault("agent_calls", 0)
+            captured["agent_calls"] += 1
+            original = InternalServerError(
+                "Error code: 500 - {'error': {'message': 'upstream error: do request failed "
+                "(request id: 202609051131219225871028268d9d61rWfvQV9)', "
+                "'type': 'new_api_error', 'param': '', 'code': 'do_request_failed'}}"
+            )
+            captured["original"] = original
+            raise original
+
+        fake_agent.ainvoke = _ainvoke
+        caplog.set_level(logging.ERROR, logger="opspilot")
+        log_output = io.StringIO()
+        handler = logging.StreamHandler(log_output)
+        handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+        opspilot_logger.addHandler(handler)
+        try:
+            with patch("apps.opspilot.metis.llm.chain.node.create_deep_agent", return_value=fake_agent), patch.object(
+                ToolsNodes, "get_llm_client", return_value=_PlannerLLM()
+            ), patch.object(ToolsNodes, "_build_knowledge_retrieve_tool", return_value=None), patch.object(
+                ToolsNodes, "_build_skill_backend_and_sources", return_value=(None, [], None)
+            ):
+                result = asyncio.run(
+                    wrapper(
+                        {"messages": [HumanMessage(content="告警：Unhealthy")]},
+                        {"configurable": {"graph_request": req}},
+                    )
+                )
+        finally:
+            opspilot_logger.removeHandler(handler)
+
+        content = result["messages"][-1].content
+        assert "上游请求失败" in content
+        assert "202609051131219225871028268d9d61rWfvQV9" in content
+        assert "uvx" not in content
+        assert "python -m" not in content
+        assert captured["agent_calls"] == 1
+        assert len(captured["planner_calls"]) == 1
+        assert "fallback_explain" not in captured
+
+        owned = [
+            rec
+            for rec in caplog.records
+            if rec.name == "opspilot"
+            and rec.levelno == logging.ERROR
+            and rec.exc_info
+            and rec.msg == "event=deepagent_llm_upstream_failed failed_stage=%s error_type=%s request_id=%s"
+        ]
+        assert len(owned) == 1
+        rec = owned[0]
+        assert rec.args == ("planned_execution", "InternalServerError", "202609051131219225871028268d9d61rWfvQV9")
+        message = rec.getMessage()
+        assert "failed_stage=planned_execution" in message
+        assert "error_type=InternalServerError" in message
+        assert rec.exc_info[0] is SafeLogException
+        assert rec.exc_info[1] is not captured["original"]
+        assert str(rec.exc_info[1]) == "InternalServerError"
+        frame_names = [frame.name for frame in traceback.extract_tb(rec.exc_info[2])]
+        assert "_ainvoke" in frame_names
+        rendered = log_output.getvalue()
+        assert "do_request_failed" not in message
+        assert "do_request_failed" not in rendered
+        traceback_errors = [r for r in caplog.records if r.name == "opspilot" and r.levelno >= logging.ERROR and r.exc_info]
+        assert traceback_errors == owned
+
     def test_successful_step_compacts_history_before_next_step(self):
         node = ToolsNodes()
         node.all_tools = [
@@ -1096,6 +1205,74 @@ class TestBuildDeepagentNodes:
         ]
         assert len(captured["planner_calls"]) == 1
 
+    def test_unresolved_k8s_target_still_runs_alert_rca_summary(self):
+        node = ToolsNodes()
+        node.all_tools = [
+            _tool("resolve_k8s_target_from_alert"),
+            _tool("diagnose_kubernetes_pod_issues"),
+            _tool("get_kubernetes_pod_logs"),
+        ]
+        req = _request(
+            user_message="告警：Unhealthy (kubernetes, bk-lite-k3s, server-fc88f89f4-j2s5z) 检测到异常",
+            system_message_prompt="你是 Kubernetes 集群 RCA 助手。\n## 告警怎么读\n## 输出格式\n# RCA 报告\n",
+        )
+        captured = {}
+        unresolved = json.dumps(
+            {
+                "cluster": "bk-lite-k3s",
+                "namespace": None,
+                "resource_type": "pod",
+                "resource_name": "server-fc88f89f4-j2s5z",
+                "resolved": False,
+                "lookup_exhausted": True,
+                "conclusive": True,
+                "missing_data": ["namespace"],
+                "reason": "Namespace not found for resource server-fc88f89f4-j2s5z via pods/events lookup",
+            },
+            ensure_ascii=False,
+        )
+
+        with patch.object(ToolsNodes, "_build_knowledge_retrieve_tool", return_value=None):
+            self._run_wrapper(
+                node,
+                req,
+                captured,
+                plan_payload={
+                    "goal": "告警 RCA",
+                    "steps": [
+                        {
+                            "objective": "反查命名空间",
+                            "tools": ["resolve_k8s_target_from_alert"],
+                        },
+                        {
+                            "objective": "诊断 Pod",
+                            "tools": ["diagnose_kubernetes_pod_issues"],
+                        },
+                        {
+                            "objective": "拉日志",
+                            "tools": ["get_kubernetes_pod_logs"],
+                        },
+                    ],
+                },
+                failing_agent_calls={
+                    1: {
+                        "content": unresolved,
+                        "status": "success",
+                        "name": "resolve_k8s_target_from_alert",
+                    }
+                },
+                agent_reply=("本步结果：resolve_k8s_target_from_alert 已收口。" "resolved=false，lookup_exhausted=true，无法确定 namespace。" "后续步骤应按对象不可见结束。"),
+            )
+
+        assert captured["visible_tool_calls"] == [
+            ["resolve_k8s_target_from_alert"],
+            [],
+        ]
+        assert len(captured["planner_calls"]) == 1
+        summary_prompt = "\n".join(str(getattr(message, "content", "") or "") for message in captured["ainvoke_messages"][-1])
+        assert "必须以「# RCA 报告」" in summary_prompt
+        assert "对象在当前集群不可见" in summary_prompt
+
     def test_permission_tool_error_aborts_without_replan(self):
         node = ToolsNodes()
         node.all_tools = [
@@ -1489,6 +1666,20 @@ def test_should_skip_planned_summary_for_multi_step_table():
     restart = [AIMessage(content=("## 时间基准\n现在 2026-09-04。\n\n## 对象与结论\nCrashLoop。\n\n" "## 证据\nprevious_tail bind failed。\n\n## 原因\n端口占用。"))]
     assert ToolsNodes._should_skip_planned_summary(restart, completed_step_count=1) is True
     assert ToolsNodes._should_skip_planned_summary(restart, completed_step_count=2) is True
+    rca_prompt_mode = "alert_rca"
+    assert ToolsNodes._should_skip_planned_summary(prose, completed_step_count=1, report_mode=rca_prompt_mode) is False
+    assert ToolsNodes._should_skip_planned_summary(dump, completed_step_count=1, report_mode=rca_prompt_mode) is False
+    complete_rca = [
+        AIMessage(
+            content=(
+                "# RCA 报告\n\n## 事件概述\n对象不可见。\n\n## 异常对象清单\n| 对象 | 状态/现象 | 重启次数 | 关键事件 | 是否已定位 |\n"
+                "| --- | --- | --- | --- | --- |\n| pod/a | 当前集群无匹配 | 未知 | lookup_exhausted | 否 |\n\n"
+                "## 根因分析\n无法定位 namespace。\n\n## 修复建议\n核对集群。\n\n## 待确认项\n对象是否已删除。"
+            )
+        )
+    ]
+    assert ToolsNodes._should_skip_planned_summary(complete_rca, completed_step_count=1, report_mode=rca_prompt_mode) is True
+    assert ToolsNodes._should_skip_planned_summary(prose, completed_step_count=1, require_formatted_report=True) is False
 
 
 def test_select_visible_planned_messages_keeps_last_table_not_cumulative():
@@ -1639,6 +1830,7 @@ def test_planned_tool_step_guidance_alert_rca_keeps_report_template():
     )
     assert "必须以「# RCA 报告」" in last
     assert "事件概述" in last
+    assert "对象在当前集群不可见" in last
     assert "异常对象清单" in last
     assert "根因分析" in last
     assert "修复建议" in last
@@ -1649,6 +1841,7 @@ def test_planned_tool_step_guidance_alert_rca_keeps_report_template():
         agent_system_prompt="你是 Kubernetes 集群 RCA 助手。\n## 告警怎么读\n",
     )
     assert "必须以「# RCA 报告」" in summary
+    assert "对象在当前集群不可见" in summary
 
 
 def test_planned_tool_step_guidance_restart_reason_forbids_rca_template():

--- a/server/apps/opspilot/tests/test_deepagent_runtime_policy.py
+++ b/server/apps/opspilot/tests/test_deepagent_runtime_policy.py
@@ -916,6 +916,32 @@ def test_is_context_size_error_detects_provider_messages():
     assert not is_context_size_error("connection refused")
 
 
+def test_is_llm_upstream_error_detects_gateway_failures():
+    from apps.opspilot.metis.llm.agent.tool_execution_planner import extract_llm_upstream_request_id, is_llm_upstream_error, llm_upstream_user_message
+
+    class InternalServerError(Exception):
+        pass
+
+    class RateLimitError(Exception):
+        pass
+
+    gateway = InternalServerError(
+        "Error code: 500 - {'error': {'message': 'upstream error: do request failed "
+        "(request id: 202609051131219225871028268d9d61rWfvQV9)', "
+        "'type': 'new_api_error', 'param': '', 'code': 'do_request_failed'}}"
+    )
+    assert is_llm_upstream_error(gateway)
+    assert extract_llm_upstream_request_id(gateway) == "202609051131219225871028268d9d61rWfvQV9"
+    text = llm_upstream_user_message(gateway)
+    assert "上游请求失败" in text
+    assert "202609051131219225871028268d9d61rWfvQV9" in text
+    assert "uvx" not in text
+    assert is_llm_upstream_error(RateLimitError("rate limited"))
+    assert not is_llm_upstream_error("connection refused")
+    assert not is_llm_upstream_error("BadRequestError: request exceeds the available context size")
+    assert not is_llm_upstream_error('{"error": "Pod not found", "code": 500}')
+
+
 def test_is_tool_result_failure_detects_json_error_payload():
     from apps.opspilot.metis.llm.agent.tool_execution_planner import is_tool_result_failure
 


### PR DESCRIPTION
上游 InternalServerError 直接提示重试，不再建议 uvx；告警 RCA 在 lookup_exhausted 后仍强制总结轮写出完整报告。