### PR TITLE
feat(node_mgmt): 新增 APM 区域 Collector 采集器定义

### DIFF
--- a/server/apps/node_mgmt/constants/collector.py
+++ b/server/apps/node_mgmt/constants/collector.py
@@ -14,6 +14,7 @@ class CollectorConstants:
         "monitor": {"is_app": True, "name": "Monitor"},
         "log": {"is_app": True, "name": "Log"},
         "cmdb": {"is_app": True, "name": "CMDB"},
+        "apm": {"is_app": True, "name": "APM"},
         "linux": {"is_app": False, "name": "Linux"},
         "windows": {"is_app": False, "name": "Windows"},
         "jmx": {"is_app": False, "name": "JMX"},
@@ -22,7 +23,7 @@ class CollectorConstants:
     }
 
     # 容器节点才会默认初始化的采集器配置
-    DEFAULT_CONTAINER_COLLECTOR_CONFIGS = ["Snmptrapd", "Ansible-Executor"]
+    DEFAULT_CONTAINER_COLLECTOR_CONFIGS = ["Snmptrapd", "Ansible-Executor", "OTel-Collector"]
 
     IGNORE_ERROR_COLLECTORS = ["Metricbeat", "Auditbeat", "Filebeat", "Packetbeat", "Winlogbeat"]
     IGNORE_ERROR_COLLECTORS_MESSAGES = [

--- a/server/apps/node_mgmt/support-files/collectors/OTel-Collector.json
+++ b/server/apps/node_mgmt/support-files/collectors/OTel-Collector.json
@@ -1,0 +1,48 @@
+[
+  {
+    "id": "otelcollector_linux",
+    "name": "OTel-Collector",
+    "controller_default_run": true,
+    "icon": "caijixinxi",
+    "node_operating_system": "linux",
+    "service_type": "exec",
+    "executable_path": "/opt/fusion-collectors/bin/bklite-otelcol",
+    "execute_parameters": "--config %s",
+    "validation_parameters": "",
+    "default_template": "",
+    "introduction": "BK-Lite APM regional collector. Receives OTLP traces from application probes on 4317/gRPC and 4318/HTTP, sanitizes them with trace_guard, and publishes them to the NATS JetStream subject apm.traces.<cloud_region_id> for the system collector to write into VictoriaTraces.",
+    "default_config": {
+      "nats": "extensions:\n  health_check:\n    endpoint: 0.0.0.0:13133\n  file_storage:\n    directory: /opt/fusion-collectors/cache/apm-queue\n    create_directory: true\n    timeout: 1s\n    compaction:\n      directory: /opt/fusion-collectors/cache/apm-queue\n      on_start: true\n\nreceivers:\n  otlp:\n    protocols:\n      grpc:\n        endpoint: 0.0.0.0:4317\n        max_recv_msg_size_mib: 8\n        include_metadata: true\n      http:\n        endpoint: 0.0.0.0:4318\n        include_metadata: true\n        max_request_body_size: 8388608\n\nprocessors:\n  memory_limiter:\n    check_interval: 1s\n    limit_mib: 384\n    spike_limit_mib: 96\n  trace_guard:\n    cloud_region_id: \"${node.cloud_region}\"\n    max_resource_attributes: 64\n    max_scope_attributes: 32\n    max_span_attributes: 100\n    max_event_attributes: 32\n    max_link_attributes: 32\n    max_attribute_runes: 4096\n  batch/traces:\n    timeout: 2s\n    send_batch_size: 256\n    send_batch_max_size: 512\n\nexporters:\n  nats_jetstream:\n    urls: [\"${NATS_PROTOCOL}://${NATS_USERNAME}:${NATS_PASSWORD}@${NATS_SERVERS}\"]\n    subject: apm.traces.${node.cloud_region}\n    connect_timeout: 5s\n    timeout: 10s\n    max_message_bytes: 8388608\n{% if NATS_PROTOCOL == \"tls\" %}\n    tls:\n      ca_file: \"${NATS_TLS_CA_FILE}\"\n      insecure_skip_verify: false\n{% endif %}\n    sending_queue:\n      enabled: true\n      sizer: bytes\n      queue_size: 1073741824\n      num_consumers: 4\n      block_on_overflow: false\n      storage: file_storage\n    retry_on_failure:\n      enabled: true\n      initial_interval: 1s\n      max_interval: 30s\n      max_elapsed_time: 0s\n\nservice:\n  extensions: [health_check, file_storage]\n  telemetry:\n    metrics:\n      level: normal\n      readers:\n        - pull:\n            exporter:\n              prometheus:\n                host: 0.0.0.0\n                port: 8888\n  pipelines:\n    traces:\n      receivers: [otlp]\n      processors:\n        - memory_limiter\n        - trace_guard\n        - batch/traces\n      exporters: [nats_jetstream]\n"
+    },
+    "tags": [
+      "linux",
+      "apm",
+      "x86_64"
+    ],
+    "package_name": "bklite-otelcol",
+    "cpu_architecture": "x86_64"
+  },
+  {
+    "id": "otelcollector_linux_arm64",
+    "name": "OTel-Collector",
+    "controller_default_run": true,
+    "icon": "caijixinxi",
+    "node_operating_system": "linux",
+    "service_type": "exec",
+    "executable_path": "/opt/fusion-collectors/bin/bklite-otelcol",
+    "execute_parameters": "--config %s",
+    "validation_parameters": "",
+    "default_template": "",
+    "introduction": "BK-Lite APM regional collector. Receives OTLP traces from application probes on 4317/gRPC and 4318/HTTP, sanitizes them with trace_guard, and publishes them to the NATS JetStream subject apm.traces.<cloud_region_id> for the system collector to write into VictoriaTraces.",
+    "default_config": {
+      "nats": "extensions:\n  health_check:\n    endpoint: 0.0.0.0:13133\n  file_storage:\n    directory: /opt/fusion-collectors/cache/apm-queue\n    create_directory: true\n    timeout: 1s\n    compaction:\n      directory: /opt/fusion-collectors/cache/apm-queue\n      on_start: true\n\nreceivers:\n  otlp:\n    protocols:\n      grpc:\n        endpoint: 0.0.0.0:4317\n        max_recv_msg_size_mib: 8\n        include_metadata: true\n      http:\n        endpoint: 0.0.0.0:4318\n        include_metadata: true\n        max_request_body_size: 8388608\n\nprocessors:\n  memory_limiter:\n    check_interval: 1s\n    limit_mib: 384\n    spike_limit_mib: 96\n  trace_guard:\n    cloud_region_id: \"${node.cloud_region}\"\n    max_resource_attributes: 64\n    max_scope_attributes: 32\n    max_span_attributes: 100\n    max_event_attributes: 32\n    max_link_attributes: 32\n    max_attribute_runes: 4096\n  batch/traces:\n    timeout: 2s\n    send_batch_size: 256\n    send_batch_max_size: 512\n\nexporters:\n  nats_jetstream:\n    urls: [\"${NATS_PROTOCOL}://${NATS_USERNAME}:${NATS_PASSWORD}@${NATS_SERVERS}\"]\n    subject: apm.traces.${node.cloud_region}\n    connect_timeout: 5s\n    timeout: 10s\n    max_message_bytes: 8388608\n{% if NATS_PROTOCOL == \"tls\" %}\n    tls:\n      ca_file: \"${NATS_TLS_CA_FILE}\"\n      insecure_skip_verify: false\n{% endif %}\n    sending_queue:\n      enabled: true\n      sizer: bytes\n      queue_size: 1073741824\n      num_consumers: 4\n      block_on_overflow: false\n      storage: file_storage\n    retry_on_failure:\n      enabled: true\n      initial_interval: 1s\n      max_interval: 30s\n      max_elapsed_time: 0s\n\nservice:\n  extensions: [health_check, file_storage]\n  telemetry:\n    metrics:\n      level: normal\n      readers:\n        - pull:\n            exporter:\n              prometheus:\n                host: 0.0.0.0\n                port: 8888\n  pipelines:\n    traces:\n      receivers: [otlp]\n      processors:\n        - memory_limiter\n        - trace_guard\n        - batch/traces\n      exporters: [nats_jetstream]\n"
+    },
+    "tags": [
+      "linux",
+      "apm",
+      "arm64"
+    ],
+    "package_name": "bklite-otelcol",
+    "cpu_architecture": "arm64"
+  }
+]


### PR DESCRIPTION
## 背景

`deploy/apm/collector` 已经交付了 BK-Lite 自研的 `bklite-otelcol` 发行版（`nats_jetstream` exporter/receiver + `trace_guard` processor），`deploy/apm/README.md` 也写明正式链路是：

```
OTel SDK/Agent → 区域 Collector(4317/4318) → NATS JetStream apm.traces.<region> → 系统级 Collector → VictoriaTraces
```

但节点管理侧一直没有对应的采集器定义。实测现象是：部署完成后宿主机 `ss -lntp | grep 4318` 无任何监听——即使把二进制随 fusion-collector 分发下去，sidecar 也没有可下发的采集器和配置模板，探针无处上报。

本 PR 补齐这一环。部署侧（打包、端口映射、`collector_package_init` 注册）与 CI 侧（`bklite-otelcol` 二进制构建）改动在各自仓库/流水线单独进行。

## 改动

- **新增 `OTel-Collector.json`**（linux x86_64 / arm64 两条）。`default_config.nats` 由 `deploy/apm/otel/regional.yaml` 改写而来：OTLP 4317/4318 收端、`trace_guard` 清洗、`file_storage` 落盘队列（`/opt/fusion-collectors/cache/apm-queue`）、`nats_jetstream` 发布到 `apm.traces.${node.cloud_region}`。契约配置里的 `${env:...}` 全部换成 server 侧模板变量，TLS 块按 `NATS_PROTOCOL` 条件生成。
- **`OTel-Collector` 加入 `DEFAULT_CONTAINER_COLLECTOR_CONFIGS`**。区域入口的 4318 端口映射在 fusion-collector 容器上，所以只在容器节点生成默认配置，与 `Snmptrapd` / `Ansible-Executor` 同构。
- **`TAG_ENUM` 补 `apm` 应用标签**，否则该采集器在 UI 上会落到 `other` 分组。

## 验证

- JSON 字段集与 `Snmptrapd.json` 完全一致。
- 模板在 `NATS_PROTOCOL=tls` 与 `nats` 两种取值下渲染后均为合法 YAML，`subject`、`urls`、`cloud_region_id`、TLS 块的有无都符合预期。
- 未跑 pytest：本地缺 MINIO 等必需环境变量，`django.setup()` 起不来。改动不含运行期逻辑，主要风险在模板渲染，已按上面的方式单独冒烟。

## 待确认

`executable_path` 取 `/opt/fusion-collectors/bin/bklite-otelcol`、`package_name` 取 `bklite-otelcol`，需与部署侧 `collector_package_init --object OTel-Collector` 的注册路径保持一致。Windows 暂不提供（当前只构建 Linux 双架构二进制）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)