### PR TITLE
feat(监控): 主机监控选节点时已接入主机在数据源侧沉底

### DIFF
--- a/server/apps/monitor/services/host_deployment.py
+++ b/server/apps/monitor/services/host_deployment.py
@@ -13,16 +13,15 @@ class HostDeploymentStatus:
 
     @classmethod
     def applies_to(cls, monitor_object_name, collector, collect_type):
-        return (
-            monitor_object_name == cls.MONITOR_OBJECT_NAME
-            and collector == cls.COLLECTOR
-            and collect_type == cls.COLLECT_TYPE
-        )
+        return monitor_object_name == cls.MONITOR_OBJECT_NAME and collector == cls.COLLECTOR and collect_type == cls.COLLECT_TYPE
+
+    @classmethod
+    def sink_child_config(cls):
+        """节点列表在数据源侧将已接入主机监控的节点整块沉底。"""
+        return {"collector": cls.COLLECTOR, "collect_type": cls.COLLECT_TYPE}
 
     def get_configured_node_ids(self, node_ids):
-        normalized_node_ids = list(
-            dict.fromkeys(str(node_id) for node_id in node_ids if node_id not in (None, ""))
-        )
+        normalized_node_ids = list(dict.fromkeys(str(node_id) for node_id in node_ids if node_id not in (None, "")))
         if not normalized_node_ids:
             return set()
 

--- a/server/apps/monitor/views/node_mgmt.py
+++ b/server/apps/monitor/views/node_mgmt.py
@@ -48,6 +48,7 @@ class NodeMgmtView(ViewSet):
             is_active=request.data.get("is_active"),
             is_manual=request.data.get("is_manual"),
             is_container=request.data.get("is_container"),
+            keyword=request.data.get("keyword"),
             permission_data={
                 "username": request.user.username,
                 "domain": request.user.domain,
@@ -59,11 +60,13 @@ class NodeMgmtView(ViewSet):
         if monitor_plugin_id and hasattr(InstanceConfigService, "_get_plugin_node_selector"):
             node_selector = InstanceConfigService._get_plugin_node_selector(monitor_plugin_id)
             query_data = merge_node_query_with_selector(query_data, node_selector)
-        data = NodeMgmt().node_list(query_data)
         plugin = MonitorPlugin.objects.filter(id=monitor_plugin_id).prefetch_related("monitor_object").first() if monitor_plugin_id else None
         is_host_monitoring_plugin = bool(
             plugin and any(HostDeploymentStatus.applies_to(obj.name, plugin.collector, plugin.collect_type) for obj in plugin.monitor_object.all())
         )
+        if is_host_monitoring_plugin:
+            query_data["sink_child_config"] = HostDeploymentStatus.sink_child_config()
+        data = NodeMgmt().node_list(query_data)
         if is_host_monitoring_plugin:
             nodes = data.get("nodes", [])
             try:

--- a/server/apps/node_mgmt/nats/node.py
+++ b/server/apps/node_mgmt/nats/node.py
@@ -4,10 +4,9 @@ from collections import defaultdict
 
 from django.db import IntegrityError, connection, transaction
 from django.db.models import F
-
-import nats_client
 from rest_framework.exceptions import ValidationError as DRFValidationError
 
+import nats_client
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.logger import node_logger as logger
 from apps.core.utils.crypto.aes_crypto import AESCryptor
@@ -834,6 +833,8 @@ def node_list(query_data: dict):
     is_container = query_data.get("is_container")
     permission_data = query_data.get("permission_data", {})
     skip_permission = query_data.get("skip_permission", False)
+    keyword = query_data.get("keyword")
+    sink_child_config = query_data.get("sink_child_config")
     if skip_permission:
         declared_callsite = query_data.get("legacy_callsite")
         if not isinstance(declared_callsite, str) or declared_callsite not in LEGACY_NODE_LIST_CALLSITES:
@@ -852,6 +853,8 @@ def node_list(query_data: dict):
         is_container,
         permission_data,
         skip_permission,
+        keyword=keyword,
+        sink_child_config=sink_child_config,
     )
 
 

--- a/server/apps/node_mgmt/services/node.py
+++ b/server/apps/node_mgmt/services/node.py
@@ -2,6 +2,7 @@ import ipaddress
 import os
 from datetime import datetime, timedelta, timezone
 
+from django.db.models import Exists, OuterRef, Q
 from django.utils import timezone as dj_timezone
 
 from apps.core.exceptions.base_app_exception import BaseAppException
@@ -430,6 +431,8 @@ class NodeService:
         is_container,
         permission_data={},
         skip_permission=False,
+        keyword=None,
+        sink_child_config=None,
     ):
         """获取节点列表"""
         if permission_data:
@@ -463,6 +466,9 @@ class NodeService:
             qs = qs.filter(name__icontains=name)
         if ip:
             qs = qs.filter(ip__icontains=ip)
+        keyword = NodeService._normalize_keyword(keyword)
+        if keyword:
+            qs = qs.filter(Q(name__icontains=keyword) | Q(ip__icontains=keyword))
         if os:
             qs = qs.filter(operating_system__icontains=os)
 
@@ -487,6 +493,8 @@ class NodeService:
             qs = qs.filter(updated_at__gte=one_minute_ago)
         elif is_active is False:
             qs = qs.filter(updated_at__lt=one_minute_ago)
+
+        qs = NodeService._apply_configured_sink_order(qs, sink_child_config)
 
         count = qs.count()
         page = NodeService._normalize_page(page)
@@ -576,6 +584,43 @@ class NodeService:
             collect_type=collect_type,
         ).values_list("collector_config__nodes__id", flat=True)
         return sorted(set(configured_node_ids))
+
+    @staticmethod
+    def _normalize_keyword(keyword):
+        if keyword in (None, ""):
+            return None
+        if not isinstance(keyword, str):
+            raise BaseAppException("keyword 必须是字符串")
+        keyword = keyword.strip()
+        return keyword or None
+
+    @staticmethod
+    def _normalize_sink_child_config(sink_child_config):
+        if sink_child_config in (None, ""):
+            return None
+        if not isinstance(sink_child_config, dict):
+            raise BaseAppException("sink_child_config 必须是对象")
+        collector = sink_child_config.get("collector")
+        collect_type = sink_child_config.get("collect_type")
+        if not isinstance(collector, str) or not collector.strip():
+            raise BaseAppException("sink_child_config.collector 非法")
+        if not isinstance(collect_type, str) or not collect_type.strip():
+            raise BaseAppException("sink_child_config.collect_type 非法")
+        return collector.strip(), collect_type.strip()
+
+    @staticmethod
+    def _apply_configured_sink_order(qs, sink_child_config):
+        """将已绑定指定子配置的节点整块沉到过滤结果末尾，再交给分页。"""
+        normalized = NodeService._normalize_sink_child_config(sink_child_config)
+        if normalized is None:
+            return qs
+        collector, collect_type = normalized
+        configured = ChildConfig.objects.filter(
+            collector_config__collector__name=collector,
+            collect_type=collect_type,
+            collector_config__nodes__id=OuterRef("pk"),
+        )
+        return qs.annotate(_sink_configured=Exists(configured)).order_by("_sink_configured", "id")
 
     @staticmethod
     def _normalize_page(page):


### PR DESCRIPTION
## Summary
- CTeam p398_634：加主机监控选节点时，未接入在前、已接入整段沉底；已接入仍灰显保留，不从列表删除。
- 在节点列表数据源侧（过滤后、分页前）按是否已绑 Telegraf/host 子配置排序，远程搜索/分页也保持该顺序。
- 不做默认隐藏已接入；前端未改假排序。

## Files
- `server/apps/node_mgmt/services/node.py`
- `server/apps/node_mgmt/nats/node.py`
- `server/apps/monitor/views/node_mgmt.py`
- `server/apps/monitor/services/host_deployment.py`

## Test plan
- [ ] 加主机监控选节点：未接入在前，已接入整段沉底且灰显「已接入主机监控」
- [ ] 搜索关键字可命中已接入，结果仍未接入优先
- [ ] 翻页/远程搜索顺序稳定（非仅前端单页假排）