### PR TITLE
fix(监控): 列表指标 PromQL 聚合保留 instance_id

### DIFF
--- a/server/apps/monitor/support-files/plugins/Kafka-Exporter/exporter/kafka/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Kafka-Exporter/exporter/kafka/metrics.json
@@ -33,7 +33,7 @@
       "unit": "counts",
       "dimensions": [],
       "description": "Number of Kafka Brokers in the cluster.",
-      "query": "sum(kafka_brokers_gauge{__$labels__})"
+      "query": "max by (instance_id) (kafka_brokers_gauge{__$labels__})"
     },
     {
       "metric_group": "Base",
@@ -69,7 +69,7 @@
         }
       ],
       "description": "Number of partitions for a given Kafka topic.",
-      "query": "sum by (topic) (kafka_topic_partitions_gauge{__$labels__})"
+      "query": "sum by (instance_id, topic) (kafka_topic_partitions_gauge{__$labels__})"
     },
     {
       "metric_group": "Topic",

--- a/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/metrics.json
@@ -183,7 +183,7 @@
       "unit": "percent",
       "dimensions": [],
       "description": "Ratio of shared buffer cache hits to total block accesses",
-      "query": "100 * sum(rate(postgresql_blks_hit{__$labels__}[5m])) / clamp_min(sum(rate(postgresql_blks_hit{__$labels__}[5m])) + sum(rate(postgresql_blks_read{__$labels__}[5m])), 1e-6)"
+      "query": "100 * sum without (db) (rate(postgresql_blks_hit{__$labels__}[5m])) / clamp_min(sum without (db) (rate(postgresql_blks_hit{__$labels__}[5m])) + sum without (db) (rate(postgresql_blks_read{__$labels__}[5m])), 1e-6)"
     },
     {
       "metric_group": "Concurrency",

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/rabbitmq/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/rabbitmq/metrics.json
@@ -309,7 +309,7 @@
       "unit": "counts",
       "dimensions": [{"name": "queue", "description": "队列"}, {"name": "vhost", "description": "vhost"}],
       "description": "Total messages in a queue, reflecting queue depth",
-      "query": "sum by (queue, vhost) (rabbitmq_queue_messages{__$labels__})"
+      "query": "sum by (instance_id, queue, vhost) (rabbitmq_queue_messages{__$labels__})"
     },
     {
       "metric_group": "Queue",
@@ -320,7 +320,7 @@
       "unit": "counts",
       "dimensions": [{"name": "queue", "description": "队列"}, {"name": "vhost", "description": "vhost"}],
       "description": "Ready messages waiting for delivery in a queue",
-      "query": "sum by (queue, vhost) (rabbitmq_queue_messages_ready{__$labels__})"
+      "query": "sum by (instance_id, queue, vhost) (rabbitmq_queue_messages_ready{__$labels__})"
     },
     {
       "metric_group": "Queue",
@@ -331,7 +331,7 @@
       "unit": "counts",
       "dimensions": [{"name": "queue", "description": "队列"}, {"name": "vhost", "description": "vhost"}],
       "description": "Delivered but unacknowledged messages in a queue",
-      "query": "sum by (queue, vhost) (rabbitmq_queue_messages_unack{__$labels__})"
+      "query": "sum by (instance_id, queue, vhost) (rabbitmq_queue_messages_unack{__$labels__})"
     },
     {
       "metric_group": "Queue",
@@ -342,7 +342,7 @@
       "unit": "counts",
       "dimensions": [{"name": "queue", "description": "队列"}, {"name": "vhost", "description": "vhost"}],
       "description": "Number of consumers on a queue",
-      "query": "sum by (queue, vhost) (rabbitmq_queue_consumers{__$labels__})"
+      "query": "sum by (instance_id, queue, vhost) (rabbitmq_queue_consumers{__$labels__})"
     },
     {
       "metric_group": "Queue",
@@ -353,7 +353,7 @@
       "unit": "percent",
       "dimensions": [{"name": "queue", "description": "队列"}, {"name": "vhost", "description": "vhost"}],
       "description": "Fraction of time the queue can deliver to consumers, as a percentage",
-      "query": "100 * max by (queue, vhost) (rabbitmq_queue_consumer_utilisation{__$labels__})"
+      "query": "100 * max by (instance_id, queue, vhost) (rabbitmq_queue_consumer_utilisation{__$labels__})"
     },
     {
       "metric_group": "Queue",
@@ -364,7 +364,7 @@
       "unit": "bytes",
       "dimensions": [{"name": "queue", "description": "队列"}, {"name": "vhost", "description": "vhost"}],
       "description": "Memory used by a queue",
-      "query": "sum by (queue, vhost) (rabbitmq_queue_memory{__$labels__})"
+      "query": "sum by (instance_id, queue, vhost) (rabbitmq_queue_memory{__$labels__})"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- 修复 Postgres `postgresql_cache_hit_ratio` 裸 `sum` 丢掉 `instance_id`，导致实例列表「缓存命中率」列为空、详情曲线仍有数据的问题
- 同步修复 Kafka `kafka_brokers_gauge` / `kafka_topic_partition_count`、RabbitMQ 队列 6 条同类聚合缺陷，使列表/告警回填能按实例映射
- 已部署环境需跑一次 `plugin_init` / `migrate_plugin` 以更新库内 `Metric.query`

## Test plan
- [ ] Postgres 监控视图实例列表「缓存命中率」列有数值（非空 Progress）
- [ ] 同一实例详情/全量指标「缓存命中率」曲线仍正常
- [ ] （可选）Kafka Broker 数、RabbitMQ 队列指标全量视图按实例有值
- [ ] 确认提交范围仅 3 个 metrics.json；图标与 merge migration 未纳入