### PR TITLE
feat(监控): 腾讯云接入选地域并打通采集与连接状态

### DIFF
--- a/agents/stargazer/api/monitor.py
+++ b/agents/stargazer/api/monitor.py
@@ -245,11 +245,14 @@ async def qcloud_metrics(request):
     def build_params(req):
         minutes = req.args.get("minutes", 5)
         username = req.headers.get("username")
-        logger.info("Request: Minutes=%s", minutes)
+        # 未传 region 时保持历史默认 ap-guangzhou，避免旧配置行为突变。
+        region = (req.headers.get("region") or "").strip() or "ap-guangzhou"
+        logger.info("Request: Minutes=%s Region=%s", minutes, region)
         return {
             "monitor_type": "qcloud",
             "username": username,
             "password": req.headers.get("password"),
+            "region": region,
             "minutes": int(minutes),
             "tags": _standard_tags(req),
         }

--- a/agents/stargazer/common/cmp/cloud_apis/resource_apis/resource_format/qcloud/qcloud_constant.py
+++ b/agents/stargazer/common/cmp/cloud_apis/resource_apis/resource_format/qcloud/qcloud_constant.py
@@ -47,6 +47,7 @@ class QCloudVMChargeType(Enum):
     PREPAID = "PREPAID"  # 包年包月
     POSTPAID_BY_HOUR = "POSTPAID_BY_HOUR"  # 按量计费
     CDHPAID = "CDHPAID"  # CDH计费 只对CDH计费，不对CDH上的实例计费
+    CDCPAID = "CDCPAID"  # 专用集群 CDC 上的实例，集群侧计费
     SPOTPAID = "SPOTPAID"  # 竞价实例付费
 
 

--- a/agents/stargazer/common/cmp/cloud_apis/resource_apis/resource_format/qcloud/qcloud_format_utils.py
+++ b/agents/stargazer/common/cmp/cloud_apis/resource_apis/resource_format/qcloud/qcloud_format_utils.py
@@ -115,7 +115,11 @@ def format_qcloud_vm_status(status):
 
 
 def format_qcloud_vm_charge_type(charge_type):
-    if charge_type in [QCloudVMChargeType.PREPAID.value, QCloudVMChargeType.CDHPAID.value]:
+    if charge_type in [
+        QCloudVMChargeType.PREPAID.value,
+        QCloudVMChargeType.CDHPAID.value,
+        QCloudVMChargeType.CDCPAID.value,
+    ]:
         return VMChargeType.PREPAID.value
     elif charge_type in [QCloudVMChargeType.POSTPAID_BY_HOUR.value, QCloudVMChargeType.SPOTPAID.value]:
         return VMChargeType.POSTPAID_BY_HOUR.value
@@ -127,9 +131,7 @@ def format_qcloud_tag(tags):
     if not tags:
         return []
     # return [{i.Key: i.Value} for i in tags]
-    return [
-        {getattr(i, "TagKey"): getattr(i, "TagValue")} for i in tags if hasattr(i, "TagKey") and hasattr(i, "TagValue")
-    ]
+    return [{getattr(i, "TagKey"): getattr(i, "TagValue")} for i in tags if hasattr(i, "TagKey") and hasattr(i, "TagValue")]
 
 
 # ******************************* 磁盘 disk

--- a/agents/stargazer/core/collection/yaml_target_policy.py
+++ b/agents/stargazer/core/collection/yaml_target_policy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any, Mapping
 
+from core.collection.constants import CLOUD_TYPES
 from core.collection.runtime import CollectionRequest
 from core.logger import logger, safe_log_value
 from core.plugin.yaml_reader import PluginYamlReader, yaml_reader
@@ -32,13 +33,11 @@ def apply_yaml_target_policy(
 
     一次 run 调用一次即可；yaml 解析有缓存。
     yaml 有声明时覆盖 request_builder 兜底猜测；无声明则保留原 params。
-    监控采集若已显式设置 preflight_kind（或 plugin_family=monitor），
+    监控采集若已显式设置 preflight_kind，或非云 SDK 的 plugin_family=monitor，
     不得用同名 CMDB plugin.yml 的 tls/443 覆盖，否则 SNMP 存储会被 HTTPS
-    预检挡死。
+    预检挡死。腾讯云/阿里云等 SDK 监控仍需套用 cloud_endpoint 受信域名。
     """
-    if str(request.params.get("plugin_family") or "") == "monitor":
-        return request
-    if str(request.params.get("preflight_kind") or "").strip() and request.params.get("preflight_kind_explicit"):
+    if _skip_yaml_target_policy(request):
         return request
     plugin_name = _plugin_name(request)
     executor_type = str(request.params.get("executor_type") or "").strip()
@@ -76,9 +75,7 @@ async def apply_yaml_target_policy_async(
     reader: PluginYamlReader | None = None,
 ) -> CollectionRequest:
     """异步 Run 入口；通过 reader 自身的锁避免并行首次读取同一 YAML。"""
-    if str(request.params.get("plugin_family") or "") == "monitor":
-        return request
-    if str(request.params.get("preflight_kind") or "").strip() and request.params.get("preflight_kind_explicit"):
+    if _skip_yaml_target_policy(request):
         return request
     selected_reader = reader or yaml_reader
     plugin_name = _plugin_name(request)
@@ -124,9 +121,7 @@ def apply_executor_target_policy(
 ) -> CollectionRequest:
     """使用 fallback 后的最终执行器配置覆盖目标策略。"""
 
-    if str(request.params.get("plugin_family") or "") == "monitor":
-        return request
-    if str(request.params.get("preflight_kind") or "").strip() and request.params.get("preflight_kind_explicit"):
+    if _skip_yaml_target_policy(request):
         return request
     plugin_name = plugin_name or _plugin_name(request)
     executor_type = executor_type or str(request.params.get("executor_type") or "").strip()
@@ -167,6 +162,7 @@ def apply_executor_target_policy(
         targets=request.targets,
         credentials=request.credentials,
         params=params,
+        workload_class=request.workload_class,
     )
 
 
@@ -184,6 +180,19 @@ def _refine_pc_preflight(params: dict[str, Any], plugin_name: str) -> None:
     params["preflight_kind"] = "remote"
     if params.get("port") in (None, ""):
         params["port"] = 22
+
+
+def _skip_yaml_target_policy(request: CollectionRequest) -> bool:
+    """监控路径默认不套用 CMDB yaml 的 tls/443，避免 SNMP 存储被 HTTPS 预检挡死。
+
+    云 SDK 采集例外：必须带上 plugin.yml 的 cloud_endpoint 受信域名，
+    否则逻辑 instance_id 会被出站策略当成主机名拒绝。
+    """
+    if str(request.params.get("preflight_kind") or "").strip() and request.params.get("preflight_kind_explicit"):
+        return True
+    if str(request.params.get("plugin_family") or "") != "monitor":
+        return False
+    return _plugin_name(request) not in CLOUD_TYPES
 
 
 def _plugin_name(request: CollectionRequest) -> str:

--- a/agents/stargazer/tasks/collectors/qcloud_collector.py
+++ b/agents/stargazer/tasks/collectors/qcloud_collector.py
@@ -116,8 +116,12 @@ class QCloudCollector(BaseCollector):
             try:
                 all_resources = driver.list_all_resources()
             except Exception as e:
-                logger.error("[QCloud Collector] Resource fetch failed Region=%s error_type=%s", region, type(e).__name__)
-                raise
+                logger.exception(
+                    "event=qcloud_collect_failed Region=%s failed_stage=list_all_resources error_type=%s",
+                    region,
+                    type(e).__name__,
+                )
+                continue
 
             listed_ok = True
             if not all_resources.get("data"):

--- a/agents/stargazer/tasks/collectors/qcloud_collector.py
+++ b/agents/stargazer/tasks/collectors/qcloud_collector.py
@@ -7,6 +7,7 @@ QCloud 监控数据采集器
 """
 import asyncio
 import datetime
+import time
 
 from sanic.log import logger
 
@@ -51,6 +52,15 @@ def _cvm_resource_ip_map(resources):
     return mapping
 
 
+def _parse_qcloud_regions(value):
+    """表单多选为列表，Telegraf header 为逗号串；空值回落广州。"""
+    if isinstance(value, (list, tuple)):
+        parts = [str(item).strip() for item in value if str(item).strip()]
+    else:
+        parts = [item.strip() for item in str(value or "").split(",") if item.strip()]
+    return parts or ["ap-guangzhou"]
+
+
 def _attach_ip_dimension(metrics, ip):
     """把 resource_ip 写成 convert_to_prometheus 已支持的维度，不改公共转换层。"""
     ip_dim = ("resource_ip", ip)
@@ -85,9 +95,9 @@ class QCloudCollector(BaseCollector):
         password = self.params["password"]
         minutes = self.params.get("minutes", 5)
         # 与 API 缺省一致：旧配置未传地域时仍采广州，避免无数据行为突变。
-        region = str(self.params.get("region") or "").strip() or "ap-guangzhou"
+        regions = _parse_qcloud_regions(self.params.get("region"))
 
-        logger.info("[QCloud Collector] Minutes=%s Region=%s", minutes, region)
+        logger.info("[QCloud Collector] Minutes=%s Region=%s", minutes, ",".join(regions))
 
         # 获取时间范围
         end_time = datetime.datetime.now()
@@ -95,66 +105,107 @@ class QCloudCollector(BaseCollector):
         start_time_str = start_time.strftime("%Y-%m-%d %H:%M") + ":00"
         end_time_str = end_time.strftime("%Y-%m-%d %H:%M") + ":00"
 
-        logger.info(f"[QCloud Collector] Time range: {start_time_str} to {end_time_str}")
-
-        driver = CMPDriver(username, password, "qcloud", region=region)
-
-        try:
-            all_resources = driver.list_all_resources()
-
-            if not all_resources.get("data"):
-                logger.warning("[QCloud Collector] No resources found")
-                return ""
-
-            total_resource_count = sum(len(resources) if resources else 0 for resources in all_resources.get("data", {}).values())
-            logger.info(f"[QCloud Collector] Connected: {len(all_resources.get('data', {}))} object types, {total_resource_count} total resources")
-
-        except Exception as e:
-            logger.error(f"[QCloud Collector] Resource fetch failed: {str(e)}")
-            raise
+        logger.info("[QCloud Collector] Time range: %s to %s", start_time_str, end_time_str)
 
         metric_dict = {}
         total_resources_processed = 0
+        listed_ok = False
 
-        for object_id, resources in all_resources.get("data", {}).items():
-            if not resources:
+        for region in regions:
+            driver = CMPDriver(username, password, "qcloud", region=region)
+            try:
+                all_resources = driver.list_all_resources()
+            except Exception as e:
+                logger.error("[QCloud Collector] Resource fetch failed Region=%s error_type=%s", region, type(e).__name__)
+                raise
+
+            listed_ok = True
+            if not all_resources.get("data"):
+                logger.warning("[QCloud Collector] No resources found Region=%s", region)
                 continue
 
-            resource_ids = [resource["resource_id"] for resource in resources]
-            ip_by_resource = _cvm_resource_ip_map(resources) if object_id == QCLOUD_CVM_OBJECT_ID else {}
-            logger.info(f"[QCloud Collector] Processing '{object_id}': {len(resource_ids)} resources")
+            total_resource_count = sum(len(resources) if resources else 0 for resources in all_resources.get("data", {}).values())
+            logger.info(
+                "[QCloud Collector] Connected Region=%s object_types=%s resources=%s",
+                region,
+                len(all_resources.get("data", {})),
+                total_resource_count,
+            )
 
-            try:
-                data = driver.get_weops_monitor_data(
-                    resourceId=",".join(resource_ids),
-                    StartTime=start_time_str,
-                    EndTime=end_time_str,
-                    Period=300,
-                    Metrics=[],
-                    context={"resources": [{"bk_obj_id": object_id}]},
-                )
-
-                if not data["result"]:
-                    logger.error(f"[QCloud Collector] Monitor data failed for '{object_id}': {data.get('message')}")
+            for object_id, resources in all_resources.get("data", {}).items():
+                if not resources:
                     continue
 
-                for resource_id, metrics in data["data"].items():
-                    ip = ip_by_resource.get(resource_id)
-                    if ip:
-                        metrics = _attach_ip_dimension(metrics, ip)
-                    metric_dict[(resource_id, object_id)] = metrics
+                resource_ids = [resource.get("resource_id") for resource in resources if resource.get("resource_id")]
+                if not resource_ids:
+                    logger.warning(
+                        "[QCloud Collector] Skip object without resource_id Region=%s object=%s",
+                        region,
+                        object_id,
+                    )
+                    continue
+                ip_by_resource = _cvm_resource_ip_map(resources) if object_id == QCLOUD_CVM_OBJECT_ID else {}
+                logger.info("[QCloud Collector] Processing Region=%s object=%s count=%s", region, object_id, len(resource_ids))
 
-                total_resources_processed += len(data["data"])
-                logger.info(f"[QCloud Collector] '{object_id}' processed: {len(data['data'])} resources")
+                try:
+                    data = driver.get_weops_monitor_data(
+                        resourceId=",".join(resource_ids),
+                        StartTime=start_time_str,
+                        EndTime=end_time_str,
+                        Period=300,
+                        Metrics=[],
+                        context={"resources": [{"bk_obj_id": object_id}]},
+                    )
 
-            except Exception as e:
-                logger.error(f"[QCloud Collector] Error processing '{object_id}': {str(e)}")
-                continue
+                    if not data["result"]:
+                        logger.error("[QCloud Collector] Monitor data failed Region=%s object=%s", region, object_id)
+                        continue
 
-        # 转换为 Prometheus 格式
-        metric_list = convert_to_prometheus(metric_dict)
-        influxdb_data = "\n".join(metric_list) + "\n"
+                    for resource_id, metrics in data["data"].items():
+                        ip = ip_by_resource.get(resource_id)
+                        if ip:
+                            metrics = _attach_ip_dimension(metrics, ip)
+                        metric_dict[(resource_id, object_id)] = metrics
 
-        logger.info(f"[QCloud Collector] Completed: {total_resources_processed} resources, {len(influxdb_data)} bytes")
+                    total_resources_processed += len(data["data"])
+                    logger.info(
+                        "[QCloud Collector] Processed Region=%s object=%s count=%s",
+                        region,
+                        object_id,
+                        len(data["data"]),
+                    )
+
+                except Exception as e:
+                    logger.error(
+                        "[QCloud Collector] Error processing Region=%s object=%s error_type=%s",
+                        region,
+                        object_id,
+                        type(e).__name__,
+                    )
+                    continue
+
+        metric_list = convert_to_prometheus(metric_dict) if metric_dict else []
+        connect_lines = self._connect_status_lines(connected=listed_ok)
+        influxdb_data = "\n".join(connect_lines + metric_list) + "\n"
+
+        logger.info(
+            "[QCloud Collector] Completed resources=%s bytes=%s connected=%s",
+            total_resources_processed,
+            len(influxdb_data),
+            listed_ok,
+        )
 
         return influxdb_data
+
+    def _connect_status_lines(self, *, connected: bool) -> list[str]:
+        """账号级连通性。NATS 会把 Prometheus gauge 写成 ConnectStatus_gauge。"""
+        tags = self.params.get("tags") if isinstance(self.params.get("tags"), dict) else {}
+        instance_id = tags.get("instance_id") or self.params.get("instance_id") or "qcloud"
+        safe_instance_id = str(instance_id).replace("\\", "\\\\").replace('"', '\\"').replace("\n", " ")
+        value = 1 if connected else 0
+        timestamp_ms = int(time.time() * 1000)
+        return [
+            "# HELP ConnectStatus QCloud API connectivity",
+            "# TYPE ConnectStatus gauge",
+            (f'ConnectStatus{{instance_id="{safe_instance_id}",' f'instance_type="qcloud"}} {value} {timestamp_ms}'),
+        ]

--- a/agents/stargazer/tasks/collectors/qcloud_collector.py
+++ b/agents/stargazer/tasks/collectors/qcloud_collector.py
@@ -84,8 +84,10 @@ class QCloudCollector(BaseCollector):
         username = self.params["username"]
         password = self.params["password"]
         minutes = self.params.get("minutes", 5)
+        # 与 API 缺省一致：旧配置未传地域时仍采广州，避免无数据行为突变。
+        region = str(self.params.get("region") or "").strip() or "ap-guangzhou"
 
-        logger.info(f"[QCloud Collector] Minutes={minutes}")
+        logger.info("[QCloud Collector] Minutes=%s Region=%s", minutes, region)
 
         # 获取时间范围
         end_time = datetime.datetime.now()
@@ -95,7 +97,7 @@ class QCloudCollector(BaseCollector):
 
         logger.info(f"[QCloud Collector] Time range: {start_time_str} to {end_time_str}")
 
-        driver = CMPDriver(username, password, "qcloud")
+        driver = CMPDriver(username, password, "qcloud", region=region)
 
         try:
             all_resources = driver.list_all_resources()

--- a/server/apps/monitor/services/qcloud_regions.py
+++ b/server/apps/monitor/services/qcloud_regions.py
@@ -1,0 +1,124 @@
+"""腾讯云监控接入：按账号密钥动态查询可用地域。"""
+
+from __future__ import annotations
+
+from apps.core.exceptions.base_app_exception import ValidationAppException
+from apps.core.logger import monitor_logger as logger
+from apps.rpc.node_mgmt import NodeMgmt
+from apps.rpc.stargazer import Stargazer
+
+
+def _normalize_qcloud_regions(regions: list) -> list[dict]:
+    normalized = []
+    for region in regions or []:
+        if not isinstance(region, dict):
+            continue
+        resource_id = region.get("resource_id") or region.get("Region") or region.get("RegionName") or ""
+        resource_name = region.get("resource_name") or region.get("RegionName") or region.get("Region") or resource_id
+        resource_id = str(resource_id or "").strip()
+        if not resource_id:
+            continue
+        # DescribeRegions 可能带 RegionState；仅保留可用区，避免选后无数据。
+        state = str(region.get("RegionState") or region.get("region_state") or "").strip().upper()
+        if state and state != "AVAILABLE":
+            continue
+        normalized.append(
+            {
+                "label": str(resource_name or resource_id),
+                "value": resource_id,
+                "resource_id": resource_id,
+                "resource_name": str(resource_name or resource_id),
+            }
+        )
+    return normalized
+
+
+def _resolve_stargazer_cloud_name(cloud_region_id=None) -> str:
+    """解析 Stargazer NATS 命名空间用的云区域名（{name}_stargazer）。"""
+    cloud_list = NodeMgmt().cloud_region_list() or []
+    if cloud_region_id not in (None, ""):
+        for item in cloud_list:
+            if not isinstance(item, dict):
+                continue
+            if str(item.get("id")) == str(cloud_region_id):
+                name = str(item.get("name") or "").strip()
+                if name:
+                    return name
+                break
+        raise ValidationAppException("cloud_region_id 不存在")
+
+    for item in cloud_list:
+        if not isinstance(item, dict):
+            continue
+        if item.get("id") == 1:
+            name = str(item.get("name") or "").strip()
+            if name:
+                return name
+    for item in cloud_list:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or "").strip()
+        if name.lower() == "default":
+            return name
+    if cloud_list and isinstance(cloud_list[0], dict):
+        name = str(cloud_list[0].get("name") or "").strip()
+        if name:
+            return name
+    return "default"
+
+
+class QCloudRegionService:
+    @classmethod
+    def list_regions(
+        cls,
+        *,
+        username: str,
+        password: str,
+        cloud_region_id=None,
+    ) -> list[dict]:
+        secret_id = str(username or "").strip()
+        secret_key = str(password or "").strip()
+        if not secret_id or not secret_key:
+            raise ValidationAppException("SecretId 与 SecretKey 均必填")
+
+        cloud_name = _resolve_stargazer_cloud_name(cloud_region_id)
+        instance_id = f"{cloud_name}_stargazer"
+        credential = {
+            "model_id": "qcloud",
+            "secret_id": secret_id,
+            "secret_key": secret_key,
+        }
+
+        try:
+            result = Stargazer(instance_id=instance_id).list_regions(credential)
+        except Exception as exc:
+            logger.error(
+                "event=qcloud_list_regions_rpc_failed failed_stage=stargazer_list_regions " "cloud_name=%s error_type=%s",
+                cloud_name,
+                type(exc).__name__,
+                exc_info=True,
+            )
+            raise ValidationAppException("获取腾讯云地域失败，请检查 Stargazer 是否就绪") from exc
+
+        if not isinstance(result, dict):
+            raise ValidationAppException("获取腾讯云地域失败")
+
+        if result.get("success") is False:
+            message = result.get("error") or result.get("message") or "获取腾讯云地域失败"
+            raise ValidationAppException(str(message))
+
+        regions_payload = result.get("regions") or {}
+        if not isinstance(regions_payload, dict):
+            # 兼容偶发直接返回 region 列表
+            if isinstance(regions_payload, list):
+                return _normalize_qcloud_regions(regions_payload)
+            raise ValidationAppException("获取腾讯云地域失败")
+
+        if regions_payload.get("success") is False:
+            message = regions_payload.get("message") or result.get("error") or "获取腾讯云地域失败"
+            raise ValidationAppException(str(message))
+
+        raw_regions = regions_payload.get("result")
+        if raw_regions is None and isinstance(result.get("result"), list):
+            raw_regions = result.get("result")
+        return _normalize_qcloud_regions(raw_regions or [])

--- a/server/apps/monitor/services/qcloud_ui_overlay.py
+++ b/server/apps/monitor/services/qcloud_ui_overlay.py
@@ -1,0 +1,76 @@
+"""腾讯云监控 UI：从磁盘 UI.json 热同步地域等字段。
+
+已部署环境的 DB 模板可能仍缺 region；通过接口读模板时补齐，避免必须重跑 plugin_init。
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+_QCLOUD_FILE_OVERLAY_FIELD_KEYS = (
+    "label",
+    "label_en",
+    "type",
+    "required",
+    "editable",
+    "default_value",
+    "description",
+    "description_en",
+    "options",
+    "options_key",
+    "widget_props",
+    "transform_on_edit",
+)
+
+
+def is_qcloud_ui_template(file_ui: dict | None, content: dict | None = None) -> bool:
+    """判断是否为腾讯云监控插件 UI（磁盘或 DB 模板）。"""
+    for candidate in (file_ui, content):
+        if not isinstance(candidate, dict):
+            continue
+        if candidate.get("instance_type") == "qcloud":
+            return True
+        config_type = candidate.get("config_type") or []
+        if isinstance(config_type, str):
+            config_type = [config_type]
+        if "qcloud" in config_type:
+            return True
+    return False
+
+
+def merge_qcloud_ui_from_file(enriched: dict | None, file_ui: dict | None) -> dict | None:
+    """从磁盘 UI.json 热同步腾讯云地域等字段。"""
+    if not isinstance(enriched, dict) or not isinstance(file_ui, dict):
+        return enriched
+    if not is_qcloud_ui_template(file_ui, enriched):
+        return enriched
+
+    instance_id = file_ui.get("instance_id")
+    if isinstance(instance_id, str) and instance_id.strip():
+        enriched["instance_id"] = instance_id
+
+    file_fields = [field for field in (file_ui.get("form_fields") or []) if isinstance(field, dict) and field.get("name")]
+    if not file_fields:
+        return enriched
+
+    form_fields = enriched.get("form_fields")
+    if not isinstance(form_fields, list):
+        enriched["form_fields"] = deepcopy(file_fields)
+        return enriched
+
+    existing_by_name = {str(field.get("name")): field for field in form_fields if isinstance(field, dict) and field.get("name")}
+    for source in file_fields:
+        name = str(source.get("name"))
+        target = existing_by_name.get(name)
+        if target is None:
+            form_fields.append(deepcopy(source))
+            existing_by_name[name] = form_fields[-1]
+            continue
+        for key in _QCLOUD_FILE_OVERLAY_FIELD_KEYS:
+            if key not in source:
+                continue
+            value = source.get(key)
+            if value in (None, ""):
+                continue
+            target[key] = deepcopy(value)
+    return enriched

--- a/server/apps/monitor/services/ui_form_field_overlay.py
+++ b/server/apps/monitor/services/ui_form_field_overlay.py
@@ -52,11 +52,16 @@ def overlay_form_field_help_from_plugin_files(content: dict | None, plugin: Moni
     if not isinstance(file_ui, dict):
         return content
 
+    enriched = deepcopy(content)
+    from apps.monitor.services.qcloud_ui_overlay import merge_qcloud_ui_from_file
+
+    # 腾讯云：补齐磁盘上的 region / instance_id 等结构字段（不限于帮助文案）。
+    enriched = merge_qcloud_ui_from_file(enriched, file_ui) or enriched
+
     file_fields = _named_items(file_ui.get("form_fields"))
     if not file_fields:
-        return content
+        return enriched
 
-    enriched = deepcopy(content)
     form_fields = enriched.get("form_fields")
     if not isinstance(form_fields, list):
         return enriched

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/qcloud/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/qcloud/UI.json
@@ -6,30 +6,56 @@
     "qcloud"
   ],
   "collector": "Telegraf",
-  "instance_id": "{{cloud_region}}_qcloud_{{username}}",
+  "instance_id": "{{cloud_region}}_qcloud_{{username}}_{{region}}",
   "form_fields": [
     {
       "name": "username",
-      "label": "用户名",
+      "label": "SecretId",
       "type": "input",
       "required": true,
       "editable": false,
+      "description": "腾讯云 API 密钥 SecretId。填写后与 SecretKey 一起用于拉取可用地域。",
+      "description_en": "Tencent Cloud API SecretId. Used with SecretKey to load available regions.",
       "transform_on_edit": {
         "origin_path": "child.content.config.http_headers.username"
       },
-      "label_en": "Username"
+      "label_en": "SecretId"
     },
     {
       "name": "ENV_PASSWORD",
-      "label": "密码",
+      "label": "SecretKey",
       "type": "password",
       "required": true,
       "editable": false,
       "encrypted": true,
+      "description": "腾讯云 API 密钥 SecretKey。填写后与 SecretId 一起用于拉取可用地域。",
+      "description_en": "Tencent Cloud API SecretKey. Used with SecretId to load available regions.",
       "transform_on_edit": {
         "origin_path": "child.env_config.PASSWORD__{{config_id}}"
       },
-      "label_en": "Password"
+      "label_en": "SecretKey"
+    },
+    {
+      "name": "region",
+      "label": "腾讯云地域",
+      "type": "select",
+      "required": true,
+      "editable": true,
+      "options_key": "region_option",
+      "options": [],
+      "description": "填写 SecretId / SecretKey 后会自动拉取可用地域；也可点击右侧刷新图标手动更新。仅采集所选地域的资源与监控指标。",
+      "description_en": "Available regions load automatically after SecretId / SecretKey are filled; use the refresh icon to reload. Only the selected region is collected.",
+      "widget_props": {
+        "placeholder": "请选择腾讯云地域",
+        "placeholder_en": "Select a Tencent Cloud region",
+        "showSearch": true,
+        "optionFilterProp": "label",
+        "show_refresh": true
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.http_headers.region"
+      },
+      "label_en": "Tencent Cloud Region"
     }
   ],
   "table_columns": [

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/qcloud/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/qcloud/metrics.json
@@ -27,7 +27,7 @@
           "unit": "[{\"name\":\"异常\",\"id\":0,\"color\":\"#ff4d4f\"},{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"}]",
           "dimensions": [],
           "description": "This metric reflects the availability of cloud APIs, the validity of account credentials, and the overall health of the data collection pipeline.",
-          "query": "ConnectStatus{__$labels__}"
+          "query": "ConnectStatus_gauge{__$labels__} or ConnectStatus{__$labels__}"
         }
       ]
     },

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/qcloud/qcloud.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/qcloud/qcloud.child.toml.j2
@@ -8,6 +8,7 @@
     [inputs.prometheus.http_headers]
         username = "{{ username }}"
         password = "${PASSWORD__{{ config_id }}}"
+        region = "{{ region }}"
         instance_id = "{{ instance_id }}"
         instance_type = "{{ instance_type }}"
         collect_type = "http"

--- a/server/apps/monitor/utils/plugin_controller.py
+++ b/server/apps/monitor/utils/plugin_controller.py
@@ -1,3 +1,4 @@
+import re
 import uuid
 from urllib.parse import urlsplit, urlunsplit
 
@@ -93,6 +94,7 @@ _MONITOR_TEMPLATE_ALLOWED_VARIABLES = {
     "response_timeout",
     "response_status_code",
     "response_string_match",
+    "region",
     "follow_redirects",
     "gather_binary_logs",
     "gather_global_variables",
@@ -189,6 +191,26 @@ def _is_rabbitmq_collect_config(config: dict) -> bool:
     return str(config.get("type") or config.get("instance_type") or "").lower() == "rabbitmq"
 
 
+def ensure_qcloud_region_jinja(template_content: str) -> str:
+    """确保腾讯云 Telegraf 子配置带有 region 请求头（兼容 DB 中旧模板）。"""
+    text = template_content or ""
+    if 'config_type = "qcloud"' not in text and "config_type = 'qcloud'" not in text:
+        return text
+    if re.search(r"(?m)^\s*region\s*=", text):
+        return text
+
+    password_line = re.search(
+        r'(?m)^(?P<indent>\s*)password\s*=\s*"[^"]*"\s*$',
+        text,
+    )
+    if not password_line:
+        return text
+
+    indent = password_line.group("indent")
+    insertion = f'{indent}region = "{{{{ region }}}}"\n'
+    return text[: password_line.end()] + "\n" + insertion + text[password_line.end() :]
+
+
 def _normalize_template_context(context: dict) -> dict:
     normalized = {**context}
     metrics_modules = normalized.get("metrics_modules")
@@ -203,6 +225,13 @@ def _normalize_template_context(context: dict) -> dict:
     normalized["ports"] = normalize_filter_list(normalized.get("ports"))
     if _is_rabbitmq_collect_config(normalized) and normalized.get("url") not in (None, ""):
         normalized["url"] = normalize_rabbitmq_management_url(normalized.get("url"))
+    # 腾讯云地域：表单未填时回落广州，与 Stargazer 采集缺省一致。
+    if str(normalized.get("instance_type") or normalized.get("config_type") or "").lower() == "qcloud":
+        region = str(normalized.get("region") or "").strip()
+        normalized["region"] = region or "ap-guangzhou"
+    elif str(normalized.get("type") or "").lower() == "qcloud":
+        region = str(normalized.get("region") or "").strip()
+        normalized["region"] = region or "ap-guangzhou"
     return normalized
 
 
@@ -311,6 +340,9 @@ class Controller:
         # 即使模板含 ifDescr，也不得静默注入默认 ifType 排除。
         if is_ifmib_capable_render_context(_context) and needs_snmp_interface_filter_jinja(template_content):
             template_content = ensure_snmp_interface_filter_jinja(template_content)
+        template_content = ensure_qcloud_region_jinja(template_content)
+        if 'region = "{{ region }}"' in template_content and not str(_context.get("region") or "").strip():
+            _context["region"] = "ap-guangzhou"
 
         safe_context = sanitize_template_context(_context)
         if escape_toml_strings:

--- a/server/apps/monitor/views/plugin.py
+++ b/server/apps/monitor/views/plugin.py
@@ -4,7 +4,7 @@ from rest_framework import status, viewsets
 from rest_framework.decorators import action
 
 from apps.core.decorators.api_permission import HasPermission
-from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.exceptions.base_app_exception import BaseAppException, ValidationAppException
 from apps.core.utils.loader import LanguageLoader
 from apps.core.utils.web_utils import WebUtils
 from apps.monitor.constants.language import LanguageConstants
@@ -15,6 +15,7 @@ from apps.monitor.serializers.plugin import MonitorPluginListSerializer, Monitor
 from apps.monitor.services.custom_snmp_plugin import CustomSnmpPluginService
 from apps.monitor.services.plugin import MonitorPluginService
 from apps.monitor.services.plugin_guide import PluginGuideService
+from apps.monitor.services.qcloud_regions import QCloudRegionService
 from apps.monitor.services.template_access_guide import TemplateAccessGuideService
 from apps.monitor.utils.pagination import parse_page_params
 from config.drf.pagination import CustomPageNumberPagination
@@ -370,6 +371,26 @@ class MonitorPluginViewSet(viewsets.ModelViewSet):
         ui_template["ui_template"] = localize_ui_template(content or {}, locale) if content else content
         ui_template["support_collect_detect"] = resolve_support_collect_detect(plugin, fallback=bool(ui_template.get("support_collect_detect")))
         return WebUtils.response_success(ui_template)
+
+    @action(methods=["post"], detail=False, url_path="qcloud_regions")
+    @HasPermission("integration_configure-Add,integration_list-View")
+    def qcloud_regions(self, request):
+        """按腾讯云账号密钥动态拉取可用地域（DescribeRegions）。"""
+        payload = request.data if isinstance(request.data, dict) else {}
+        username = payload.get("username") or payload.get("secret_id") or ""
+        password = payload.get("password") or payload.get("ENV_PASSWORD") or payload.get("secret_key") or ""
+        cloud_region_id = payload.get("cloud_region_id")
+        try:
+            regions = QCloudRegionService.list_regions(
+                username=username,
+                password=password,
+                cloud_region_id=cloud_region_id,
+            )
+        except ValidationAppException as exc:
+            return WebUtils.response_error(error_message=str(exc), status_code=400)
+        except BaseAppException as exc:
+            return WebUtils.response_error(error_message=str(exc), status_code=400)
+        return WebUtils.response_success(regions)
 
     @HasPermission("integration_collect-View,integration_configure-Add")
     def _get_collect_template(self, request, pk=None):

--- a/web/src/app/monitor/(pages)/integration/asset/updateConfig.tsx
+++ b/web/src/app/monitor/(pages)/integration/asset/updateConfig.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from '@/utils/i18n';
 import OperateModal from '@/components/operate-modal';
 import useApiClient from '@/utils/request';
 import { usePluginFromJson } from '@/app/monitor/hooks/integration/usePluginFromJson';
+import { useQcloudRegionOptions } from '@/app/monitor/hooks/integration/useQcloudRegionOptions';
 import {
   getSnmpFilterMutexConflicts,
   trackSnmpFilterMutexLastChanged
@@ -27,10 +28,13 @@ interface PluginFormField {
   type?: string;
   editable?: boolean;
   default_value?: unknown;
+  options_key?: string;
 }
 
 interface PluginConfig {
   form_fields?: PluginFormField[];
+  instance_type?: string;
+  config_type?: string[];
 }
 
 const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
@@ -78,6 +82,24 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
   }));
 
   // 获取配置信息
+  const isQcloudPlugin =
+    currentConfig?.instance_type === 'qcloud' ||
+    (Array.isArray(currentConfig?.config_type) &&
+      currentConfig.config_type.includes('qcloud')) ||
+    Boolean(
+      currentConfig?.form_fields?.some(
+        (field) => field?.options_key === 'region_option' || field?.name === 'region'
+      )
+    );
+  const {
+    regionOptions,
+    loadingRegions,
+    refreshRegions,
+  } = useQcloudRegionOptions({
+    enabled: Boolean(isQcloudPlugin && modalVisible),
+    form,
+  });
+
   const configsInfo = useMemo(() => {
     if (configLoading || !currentConfig || !pluginId) {
       return {
@@ -89,8 +111,26 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
     return jsonConfig.buildPluginUI(pluginId, {
       mode: 'edit',
       form,
+      externalOptions: {
+        region_option: regionOptions,
+      },
+      optionControls: {
+        region_option: {
+          loading: loadingRegions,
+          onRefresh: refreshRegions,
+        },
+      },
     });
-  }, [configLoading, currentConfig, pluginId, form, jsonConfig.buildPluginUI]);
+  }, [
+    configLoading,
+    currentConfig,
+    pluginId,
+    form,
+    regionOptions,
+    loadingRegions,
+    refreshRegions,
+    jsonConfig.buildPluginUI,
+  ]);
 
   const formItems = useMemo(() => {
     return configsInfo.formItems;

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
@@ -41,6 +41,7 @@ import Permission from '@/components/permission';
 import { cloneDeep } from 'lodash';
 import { usePluginFromJson } from '@/app/monitor/hooks/integration/usePluginFromJson';
 import { useConfigRenderer } from '@/app/monitor/hooks/integration/useConfigRenderer';
+import { useQcloudRegionOptions } from '@/app/monitor/hooks/integration/useQcloudRegionOptions';
 import {
   getSnmpFilterMutexConflicts,
   trackSnmpFilterMutexLastChanged
@@ -233,6 +234,25 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
     return currentConfig;
   }, [configLoading, currentConfig]);
 
+  const isQcloudPlugin =
+    baseConfig?.instance_type === 'qcloud' ||
+    (Array.isArray(baseConfig?.config_type) &&
+      baseConfig.config_type.includes('qcloud')) ||
+    Boolean(
+      baseConfig?.form_fields?.some(
+        (field: { name?: string; options_key?: string }) =>
+          field?.options_key === 'region_option' || field?.name === 'region'
+      )
+    );
+  const {
+    regionOptions,
+    loadingRegions,
+    refreshRegions,
+  } = useQcloudRegionOptions({
+    enabled: Boolean(isQcloudPlugin),
+    form,
+  });
+
   // 获取表单配置
   const formConfig = useMemo(() => {
     if (!baseConfig || !pluginId) {
@@ -244,15 +264,31 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
       onTableDataChange,
       form,
       externalOptions: {
-        node_ids_option: nodeList
-      }
+        node_ids_option: nodeList,
+        region_option: regionOptions,
+      },
+      optionControls: {
+        region_option: {
+          loading: loadingRegions,
+          onRefresh: refreshRegions,
+        },
+      },
     });
     return {
       formItems: cfg.formItems,
       defaultForm: cfg.defaultForm,
       initTableItems: cfg.initTableItems
     };
-  }, [baseConfig, pluginId, form, nodeList, jsonConfig.buildPluginUI]);
+  }, [
+    baseConfig,
+    pluginId,
+    form,
+    nodeList,
+    regionOptions,
+    loadingRegions,
+    refreshRegions,
+    jsonConfig.buildPluginUI,
+  ]);
 
   // 获取动态配置（依赖 dataSource）
   const configsInfo = useMemo(() => {

--- a/web/src/app/monitor/api/integration.ts
+++ b/web/src/app/monitor/api/integration.ts
@@ -276,6 +276,13 @@ const useIntegrationApi = () => {
       getCollectDetectTask: async (taskId: React.Key) => {
         return await get(`/monitor/api/collect_detect/${String(taskId)}/`);
       },
+      listQcloudRegions: async (data: {
+        username: string;
+        password: string;
+        cloud_region_id?: number | string;
+      }) => {
+        return await post('/monitor/api/monitor_plugin/qcloud_regions/', data);
+      },
     } satisfies FlowIntegrationApi),
     [del, get, post, put]
   );

--- a/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
+++ b/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
@@ -8,9 +8,10 @@ import {
   Button,
   Tooltip,
   Switch,
-  Segmented
+  Segmented,
+  Spin,
 } from 'antd';
-import { ExclamationCircleFilled, MinusCircleOutlined, PlusOutlined } from '@ant-design/icons';
+import { ExclamationCircleFilled, MinusCircleOutlined, PlusOutlined, SyncOutlined } from '@ant-design/icons';
 import Password from '@/components/password';
 import GroupTreeSelector from '@/components/group-tree-select';
 import { useTranslation } from '@/utils/i18n';
@@ -23,6 +24,14 @@ import {
   normalizeIfTypeTags,
   normalizeMutexValues
 } from './snmpFilterMutex';
+
+export type FormFieldOptionControls = Record<
+  string,
+  {
+    loading?: boolean;
+    onRefresh?: () => void;
+  }
+>;
 
 const mutexValuesEqual = (left: any, right: any) => {
   if (left === right) return true;
@@ -50,7 +59,12 @@ export const useConfigRenderer = () => {
   });
   const fieldGuideTitle = t('monitor.integrations.fieldGuideTip');
 
-  const renderFormField = (fieldConfig: any, mode?: string) => {
+  const renderFormField = (
+    fieldConfig: any,
+    mode?: string,
+    externalOptions?: Record<string, any[]>,
+    optionControls?: FormFieldOptionControls
+  ) => {
     const {
       name,
       label,
@@ -58,7 +72,8 @@ export const useConfigRenderer = () => {
       required = false,
       default_value,
       widget_props = {},
-      options = [],
+      options: staticOptions = [],
+      options_key,
       dependency,
       rules = [],
       description,
@@ -66,6 +81,20 @@ export const useConfigRenderer = () => {
       guide_short,
       tooltip
     } = fieldConfig;
+    let options = staticOptions || [];
+    const resolvedOptionsKey =
+      options_key || (name === 'region' ? 'region_option' : undefined);
+    // 空数组 [] 在 JS 中为 falsy，必须用 `in` 判断，否则动态 options 永远回落静态列表。
+    if (
+      resolvedOptionsKey &&
+      externalOptions &&
+      Object.prototype.hasOwnProperty.call(externalOptions, resolvedOptionsKey)
+    ) {
+      options = externalOptions[resolvedOptionsKey] || [];
+    }
+    const optionControl = resolvedOptionsKey
+      ? optionControls?.[resolvedOptionsKey]
+      : undefined;
     // 帮助文案只使用当前插件字段自身的 description/tooltip/guide_short，
     // 禁止按 name === "username" 去套 monitor.integrations.usernameDes 或 WMI 文案。
     const guideTip = guide_short || tooltip || description;
@@ -363,33 +392,99 @@ export const useConfigRenderer = () => {
         case 'select': {
           const allowCustomTags =
             name === 'iftype_exclude' || name === 'iftype_include';
-          const { style: widgetStyle, ...restSelectProps } = widget_props;
+          const {
+            style: widgetStyle,
+            show_refresh: showRefresh,
+            ...restSelectProps
+          } = widget_props;
+          // 腾讯云地域：即使 UI.json 未带 show_refresh / options_key，也展示刷新按钮。
+          const shouldShowRegionRefresh =
+            Boolean(optionControl?.onRefresh) &&
+            (Boolean(showRefresh) ||
+              resolvedOptionsKey === 'region_option' ||
+              name === 'region');
+          const selectProps = {
+            ...restSelectProps,
+            mode: allowCustomTags ? ('tags' as const) : widget_props.mode,
+            tokenSeparators: allowCustomTags
+              ? widget_props.tokenSeparators || [',']
+              : widget_props.tokenSeparators,
+            disabled: Boolean(locked || widget_props.disabled),
+            loading: Boolean(optionControl?.loading),
+            placeholder: allowCustomTags
+              ? widget_props.placeholder ||
+                t('monitor.integrations.filterIfTypeTagsPlaceholder')
+              : widget_props.placeholder || label,
+            showSearch: true as const,
+            optionFilterProp: 'label' as const,
+            style: formWidgetWidthStyle(widgetStyle),
+          };
+          const optionNodes = options.map((option: any) => (
+            <Select.Option key={option.value} value={option.value} label={option.label}>
+              {option.label}
+            </Select.Option>
+          ));
+          if (shouldShowRegionRefresh && optionControl?.onRefresh) {
+            const regionLoading = Boolean(optionControl.loading);
+            const refreshLabel = t(
+              'monitor.integrations.fetchQcloudRegions',
+              '获取地域'
+            );
+            const refreshTip = t(
+              'monitor.integrations.refreshQcloudRegionsTip',
+              '根据 SecretId / SecretKey 刷新可用地域'
+            );
+            return (
+              <div className="mr-[10px] inline-flex items-center gap-1">
+                <Select
+                  {...selectProps}
+                  placeholder={
+                    selectProps.placeholder ||
+                    t('monitor.integrations.selectQcloudRegion', '请选择腾讯云地域')
+                  }
+                  notFoundContent={
+                    regionLoading ? (
+                      <div className="flex items-center justify-center gap-2 py-3 text-[var(--color-text-3)]">
+                        <Spin size="small" />
+                        <span>
+                          {t(
+                            'monitor.integrations.fetchingQcloudRegions',
+                            '正在获取地域…'
+                          )}
+                        </span>
+                      </div>
+                    ) : (
+                      t(
+                        'monitor.integrations.qcloudRegionNoOptions',
+                        '暂无地域，请先填写密钥后点击刷新'
+                      )
+                    )
+                  }
+                >
+                  {optionNodes}
+                </Select>
+                <Tooltip title={refreshTip}>
+                  <Button
+                    type="text"
+                    aria-label={refreshLabel}
+                    disabled={regionLoading}
+                    className="!inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[var(--color-text-3)] hover:!bg-[var(--color-fill-2)] hover:!text-[var(--color-primary)]"
+                    icon={
+                      <SyncOutlined
+                        spin={regionLoading}
+                        className="text-[14px]"
+                        aria-hidden
+                      />
+                    }
+                    onClick={optionControl.onRefresh}
+                  />
+                </Tooltip>
+              </div>
+            );
+          }
           return (
-            <Select
-              {...restSelectProps}
-              mode={allowCustomTags ? 'tags' : widget_props.mode}
-              tokenSeparators={
-                allowCustomTags
-                  ? widget_props.tokenSeparators || [',']
-                  : widget_props.tokenSeparators
-              }
-              disabled={Boolean(locked || widget_props.disabled)}
-              placeholder={
-                allowCustomTags
-                  ? widget_props.placeholder ||
-                    t('monitor.integrations.filterIfTypeTagsPlaceholder')
-                  : widget_props.placeholder || label
-              }
-              showSearch
-              optionFilterProp="label"
-              className="mr-[10px]"
-              style={formWidgetWidthStyle(widgetStyle)}
-            >
-              {options.map((option: any) => (
-                <Select.Option key={option.value} value={option.value} label={option.label}>
-                  {option.label}
-                </Select.Option>
-              ))}
+            <Select {...selectProps} className="mr-[10px]">
+              {optionNodes}
             </Select>
           );
         }

--- a/web/src/app/monitor/hooks/integration/useDataMapper.ts
+++ b/web/src/app/monitor/hooks/integration/useDataMapper.ts
@@ -383,11 +383,17 @@ export class DataMapper {
       // 普通模板继续使用既有哈希编码。
       let instance_id = row.instance_id;
       if (!instance_id && context.instance_id) {
+        // form_fields（如 qcloud 的 username/region）在顶层表单，不在表格行；
+        // 生成 instance_id 时需合并，否则 {{username}}/{{region}} 无法替换。
         instance_id =
           context.instance_id === '{{uuid}}'
             ? String(row.key).replaceAll('-', '').toLowerCase()
             : this.hashInstanceId(
-              this.applyTemplate(context.instance_id, row, context)
+              this.applyTemplate(
+                context.instance_id,
+                { ...processedFormData, ...row },
+                context
+              )
             );
       }
       // 过滤掉 key 字段和所有 _error 字段，并处理加密字段

--- a/web/src/app/monitor/hooks/integration/usePluginFromJson.tsx
+++ b/web/src/app/monitor/hooks/integration/usePluginFromJson.tsx
@@ -240,6 +240,13 @@ export const usePluginFromJson = () => {
         onTableDataChange?: (data: any[]) => void;
         form?: any;
         externalOptions?: Record<string, any[]>;
+        optionControls?: Record<
+          string,
+          {
+            loading?: boolean;
+            onRefresh?: () => void;
+          }
+        >;
       }
     ) => {
       // 如果当前没有配置或 pluginId 不匹配，返回空配置
@@ -300,7 +307,14 @@ export const usePluginFromJson = () => {
       const renderAdvancedFieldGroups = (fields: any[]) => {
         const hasSections = fields.some((field) => field.section);
         if (!hasSections) {
-          return fields.map((fieldConfig: any) => renderFormField(fieldConfig, extra.mode));
+          return fields.map((fieldConfig: any) =>
+            renderFormField(
+              fieldConfig,
+              extra.mode,
+              extra.externalOptions,
+              extra.optionControls
+            )
+          );
         }
 
         const sectionMap = new Map<string, any[]>();
@@ -331,7 +345,12 @@ export const usePluginFromJson = () => {
                 )}
                 <div className="space-y-1">
                   {(sectionMap.get(section) || []).map((fieldConfig: any) =>
-                    renderFormField(fieldConfig, extra.mode)
+                    renderFormField(
+                      fieldConfig,
+                      extra.mode,
+                      extra.externalOptions,
+                      extra.optionControls
+                    )
                   )}
                 </div>
               </section>
@@ -343,7 +362,12 @@ export const usePluginFromJson = () => {
       const formItems = (
         <>
           {basicFields.map((fieldConfig: any) =>
-            renderFormField(fieldConfig, extra.mode)
+            renderFormField(
+              fieldConfig,
+              extra.mode,
+              extra.externalOptions,
+              extra.optionControls
+            )
           )}
           {advancedFields.length > 0 && (() => {
             // Ant Design：函数子节点的 Form.Item 必须带 truthy 的 shouldUpdate/dependencies，

--- a/web/src/app/monitor/hooks/integration/useQcloudRegionOptions.ts
+++ b/web/src/app/monitor/hooks/integration/useQcloudRegionOptions.ts
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Form, FormInstance, message } from 'antd';
+import { useTranslation } from '@/utils/i18n';
+import useIntegrationApi from '@/app/monitor/api/integration';
+
+const MASKED_PASSWORD_RE = /^\*+$/;
+
+export interface RegionOption {
+  label: string;
+  value: string;
+}
+
+function isUsableSecret(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  if (MASKED_PASSWORD_RE.test(trimmed)) return false;
+  return true;
+}
+
+/**
+ * 腾讯云监控接入：密钥齐全后按账号动态拉取可用地域。
+ */
+export function useQcloudRegionOptions(options: {
+  enabled: boolean;
+  form: FormInstance;
+  cloudRegionId?: number | string;
+}) {
+  const { enabled, form, cloudRegionId } = options;
+  const { t } = useTranslation();
+  const { listQcloudRegions } = useIntegrationApi();
+  const [regionOptions, setRegionOptions] = useState<RegionOption[]>([]);
+  const [loadingRegions, setLoadingRegions] = useState(false);
+  const requestSeq = useRef(0);
+  const lastAutoKey = useRef('');
+
+  const username = Form.useWatch('username', form);
+  const password = Form.useWatch('ENV_PASSWORD', form);
+
+  const fetchRegions = useCallback(
+    async (opts?: { silent?: boolean }) => {
+      if (!enabled) return;
+      if (!isUsableSecret(username) || !isUsableSecret(password)) {
+        if (!opts?.silent) {
+          message.warning(
+            t(
+              'monitor.integrations.qcloudRegionNeedCredentials',
+              '请先填写 SecretId 与 SecretKey，再获取地域'
+            )
+          );
+        }
+        return;
+      }
+
+      const seq = ++requestSeq.current;
+      setLoadingRegions(true);
+      try {
+        const data = await listQcloudRegions({
+          username: username.trim(),
+          password: password.trim(),
+          cloud_region_id: cloudRegionId,
+        });
+        if (seq !== requestSeq.current) return;
+        const next = (Array.isArray(data) ? data : [])
+          .map((item: any) => ({
+            label: String(item?.label || item?.resource_name || item?.value || item?.resource_id || ''),
+            value: String(item?.value || item?.resource_id || ''),
+          }))
+          .filter((item) => item.value);
+        setRegionOptions(next);
+
+        const currentRegion = form.getFieldValue('region');
+        if (
+          currentRegion &&
+          next.length > 0 &&
+          !next.some((item) => item.value === currentRegion)
+        ) {
+          form.setFieldsValue({ region: undefined });
+        }
+
+        if (next.length === 0) {
+          message.warning(
+            t(
+              'monitor.integrations.qcloudRegionEmpty',
+              '未获取到可用腾讯云地域，请确认密钥权限是否包含 CVM DescribeRegions'
+            )
+          );
+          return;
+        }
+        if (!opts?.silent) {
+          message.success(
+            t('monitor.integrations.qcloudRegionFetched', '已获取 {count} 个地域', {
+              count: next.length,
+            })
+          );
+        }
+      } catch (error: any) {
+        if (seq !== requestSeq.current) return;
+        setRegionOptions([]);
+        // 自动拉取失败也要提示，避免「填了密钥却无回应」。
+        message.error(
+          error?.message ||
+            t('monitor.integrations.qcloudRegionFetchFailed', '获取腾讯云地域失败')
+        );
+      } finally {
+        if (seq === requestSeq.current) {
+          setLoadingRegions(false);
+        }
+      }
+    },
+    [cloudRegionId, enabled, form, listQcloudRegions, password, t, username]
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      setRegionOptions([]);
+      lastAutoKey.current = '';
+      return;
+    }
+    if (!isUsableSecret(username) || !isUsableSecret(password)) {
+      const currentRegion = form.getFieldValue('region');
+      if (typeof currentRegion === 'string' && currentRegion.trim()) {
+        setRegionOptions((prev) => {
+          if (prev.some((item) => item.value === currentRegion)) {
+            return prev;
+          }
+          return [{ label: currentRegion, value: currentRegion }];
+        });
+      }
+      return;
+    }
+    const autoKey = `${username.trim()}::${password.trim()}::${cloudRegionId ?? ''}`;
+    if (lastAutoKey.current === autoKey) {
+      return;
+    }
+    lastAutoKey.current = autoKey;
+    void fetchRegions({ silent: true });
+  }, [enabled, username, password, cloudRegionId, fetchRegions, form]);
+
+  return {
+    regionOptions,
+    loadingRegions,
+    refreshRegions: () => fetchRegions({ silent: false }),
+  };
+}


### PR DESCRIPTION
## Summary
- 腾讯云监控接入增加地域选择：填写 SecretId/SecretKey 后经 Stargazer `DescribeRegions` 动态拉取可用地域，不再写死广州；采集与 `instance_id` 透传所选 `region`。
- 云监控套用 `plugin.yml` 的 `cloud_endpoint` 受信域名，逻辑 `instance_id` 不再被出站策略当成主机名拒绝。
- 采集识别 `CDCPAID`、跳过无 `resource_id` 的对象，并写出账号级 `ConnectStatus`；父对象查询对齐 NATS 转换后的 `ConnectStatus_gauge`。

## Test plan
- [ ] 重启 Server + Stargazer 后打开腾讯云接入页，确认地域下拉与刷新图标可用
- [ ] 填密钥后自动/手动拉取地域成功；成功文案为「已获取 N 个地域」（无花括号）
- [ ] 选择非 `ap-guangzhou` 地域保存后，采集配置 http_headers 含对应 `region`
- [ ] 真实腾讯云采集能过出站策略，CVM CPU/内存/内网流量入库
- [ ] 父对象「腾讯云」连接状态图有数据，列表上报时间与连接状态正常
- [ ] 含 CDC 计费 CVM 的账号 `list_all_resources` 不再因 `CDCPAID` 整轮失败

## 提交范围说明
已检查暂存区与相对 `master` 的完整 diff。本 PR 不含测试文件、Storybook/运行时 mock、无关 icons、重复 merge migration；相关单测仅本地验证，仍留在工作区未提交。