### PR TITLE
fix(监控): 修复 K8s 集群看板命名空间内存与工作负载可用度空数据

### DIFF
--- a/agents/webhookd/bk-lite-metric-collector.yaml
+++ b/agents/webhookd/bk-lite-metric-collector.yaml
@@ -647,8 +647,12 @@ data:
           target_label: pod
           regex: (.+)
           action: replace
-        # id(cgroup 路径)/name/image 超长且无查询消费；pod_name 已复制为 pod
-        - regex: id|name|image|container_label_io_kubernetes_pod_name
+        - source_labels: [container_label_io_kubernetes_pod_namespace]
+          target_label: namespace
+          regex: (.+)
+          action: replace
+        # id(cgroup 路径)/name/image 超长且无查询消费；docker label 已复制为 pod/namespace
+        - regex: id|name|image|container_label_io_kubernetes_pod_name|container_label_io_kubernetes_pod_namespace
           action: labeldrop
       - job_name: 'kubernetes-kube-state-metrics'
         kubernetes_sd_configs:

--- a/deploy/dist/bk-lite-kubernetes-collector/bk-lite-metric-collector.yaml
+++ b/deploy/dist/bk-lite-kubernetes-collector/bk-lite-metric-collector.yaml
@@ -666,8 +666,12 @@ data:
           target_label: pod
           regex: (.+)
           action: replace
-        # id(cgroup 路径)/name/image 超长且无查询消费；pod_name 已复制为 pod
-        - regex: id|name|image|container_label_io_kubernetes_pod_name
+        - source_labels: [container_label_io_kubernetes_pod_namespace]
+          target_label: namespace
+          regex: (.+)
+          action: replace
+        # id(cgroup 路径)/name/image 超长且无查询消费；docker label 已复制为 pod/namespace
+        - regex: id|name|image|container_label_io_kubernetes_pod_name|container_label_io_kubernetes_pod_namespace
           action: labeldrop
       - job_name: 'kubernetes-kube-state-metrics'
         kubernetes_sd_configs:

--- a/server/apps/monitor/support-files/dashboard_query_capabilities.json
+++ b/server/apps/monitor/support-files/dashboard_query_capabilities.json
@@ -191,13 +191,6 @@
       "template": "rate(elasticsearch_http_total_opened{__$labels__}[__$window__])"
     },
     {
-      "id": "dashboard:v1:06e5913a",
-      "object_names": [
-        "MSSQL"
-      ],
-      "template": "rate(sqlserver_waitstats_signal_wait_time_ms_rate{__$labels__}[__$window__])"
-    },
-    {
       "id": "dashboard:v1:077cf7a3",
       "object_names": [
         "Ping"
@@ -786,13 +779,6 @@
         "Mysql"
       ],
       "template": "mysql_variables_max_connections{__$labels__}"
-    },
-    {
-      "id": "dashboard:v1:1d08f9aa",
-      "object_names": [
-        "Host"
-      ],
-      "template": "max by (instance_id) (disk_used_percent{instance_type=\"os\", __$labels__} or host_disk_used_percent_gauge{instance_type=\"os\", __$labels__} or disk_used_percent_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__} or disk_used_percent_gauge{instance_type=\"os\", config_type=\"host_aix_remote\", __$labels__})"
     },
     {
       "id": "dashboard:v1:1d131c0f",
@@ -2286,6 +2272,13 @@
       "template": "sum(rate(docker_container_net_rx_bytes{__$labels__}[__$window__])) by (instance_id)"
     },
     {
+      "id": "dashboard:v1:5ac524f2",
+      "object_names": [
+        "Host"
+      ],
+      "template": "mem_used_percent{instance_type=\"os\", __$labels__} or host_mem_used_percent_gauge{instance_type=\"os\", __$labels__} or mem_used_percent_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}"
+    },
+    {
       "id": "dashboard:v1:5addc434",
       "object_names": [
         "Cluster"
@@ -2854,20 +2847,6 @@
       "template": "clamp_max(100 * (docker_n_containers_stopped{__$labels__} / clamp_min(docker_n_containers{__$labels__}, 1)), 100)"
     },
     {
-      "id": "dashboard:v1:75766335",
-      "object_names": [
-        "Host"
-      ],
-      "template": "sum by (instance_id) (rate(diskio_write_bytes{instance_type=\"os\", __$labels__}[__$window__]) or rate(diskio_write_bytes_total_gauge{instance_type=\"os\", config_type!~\"host_aix.*\", __$labels__}[__$window__]) or rate(diskio_write_bytes_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}[__$window__]) or diskio_write_bytes_gauge{instance_type=\"os\", config_type=\"host_aix_remote\", __$labels__})"
-    },
-    {
-      "id": "dashboard:v1:75cd4c37",
-      "object_names": [
-        "Host"
-      ],
-      "template": "sum by (instance_id) (rate(diskio_read_bytes{instance_type=\"os\", __$labels__}[__$window__]) or rate(diskio_read_bytes_total_gauge{instance_type=\"os\", config_type!~\"host_aix.*\", __$labels__}[__$window__]) or rate(diskio_read_bytes_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}[__$window__]) or diskio_read_bytes_gauge{instance_type=\"os\", config_type=\"host_aix_remote\", __$labels__})"
-    },
-    {
       "id": "dashboard:v1:76ff4618",
       "object_names": [
         "Exchange"
@@ -3359,6 +3338,13 @@
         "Mysql"
       ],
       "template": "rate(mysql_queries{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:8ab7d7ad",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "rate(sqlserver_waitstats_signal_wait_time_ms{__$labels__}[__$window__])"
     },
     {
       "id": "dashboard:v1:8ae3b991",
@@ -3958,6 +3944,13 @@
       "template": "zookeeper_max_latency{__$labels__}"
     },
     {
+      "id": "dashboard:v1:a5c1faa5",
+      "object_names": [
+        "Host"
+      ],
+      "template": "sum by (instance_id) (rate(diskio_read_bytes{instance_type=\"os\", __$labels__}[__$window__]) or rate(diskio_read_bytes_total_gauge{instance_type=\"os\", __$labels__}[__$window__]) or rate(diskio_read_bytes_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}[__$window__]))"
+    },
+    {
       "id": "dashboard:v1:a6041c1a",
       "object_names": [
         "Firewall"
@@ -4226,13 +4219,6 @@
       "template": "rate(mysql_com_select{__$labels__}[__$window__])"
     },
     {
-      "id": "dashboard:v1:b4e40a82",
-      "object_names": [
-        "Host"
-      ],
-      "template": "mem_used_percent{instance_type=\"os\", __$labels__} or host_mem_used_percent_gauge{instance_type=\"os\", __$labels__} or mem_used_percent_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__} or mem_used_percent_gauge{instance_type=\"os\", config_type=\"host_aix_remote\", __$labels__}"
-    },
-    {
       "id": "dashboard:v1:b5430b18",
       "object_names": [
         "Minio"
@@ -4336,6 +4322,13 @@
         "Cluster"
       ],
       "template": "sum(prometheus_remote_write_kube_pod_status_phase{instance_type=\"k8s\",__$labels__}) by (phase)"
+    },
+    {
+      "id": "dashboard:v1:b8277ee6",
+      "object_names": [
+        "Host"
+      ],
+      "template": "(100 - cpu_usage_idle{cpu=\"cpu-total\", instance_type=\"os\", __$labels__}) or host_cpu_usage_percent_gauge{instance_type=\"os\", __$labels__} or cpu_usage_total_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}"
     },
     {
       "id": "dashboard:v1:b8440293",
@@ -4891,13 +4884,6 @@
       "template": "100 * mysql_innodb_buffer_pool_pages_dirty{__$labels__} / clamp_min(mysql_innodb_buffer_pool_pages_total{__$labels__}, 1)"
     },
     {
-      "id": "dashboard:v1:cf22232a",
-      "object_names": [
-        "Host"
-      ],
-      "template": "(100 - cpu_usage_idle{cpu=\"cpu-total\", instance_type=\"os\", __$labels__}) or host_cpu_usage_percent_gauge{instance_type=\"os\", __$labels__} or cpu_usage_total_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__} or cpu_usage_total_gauge{instance_type=\"os\", config_type=\"host_aix_remote\", __$labels__}"
-    },
-    {
       "id": "dashboard:v1:cf85f24a",
       "object_names": [
         "Docker"
@@ -5353,11 +5339,25 @@
       "template": "sum(rate(interface_ifInErrors{__$labels__}[__$window__])) by (instance_id)"
     },
     {
+      "id": "dashboard:v1:e4e0cd2a",
+      "object_names": [
+        "Host"
+      ],
+      "template": "max by (instance_id) (disk_used_percent{instance_type=\"os\", __$labels__} or host_disk_used_percent_gauge{instance_type=\"os\", __$labels__} or disk_used_percent_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__})"
+    },
+    {
       "id": "dashboard:v1:e54bf04a",
       "object_names": [
         "Website"
       ],
       "template": "avg(http_response_result_code{__$labels__} == bool 2) * 100"
+    },
+    {
+      "id": "dashboard:v1:e5c19424",
+      "object_names": [
+        "Host"
+      ],
+      "template": "sum by (instance_id) (rate(diskio_write_bytes{instance_type=\"os\", __$labels__}[__$window__]) or rate(diskio_write_bytes_total_gauge{instance_type=\"os\", __$labels__}[__$window__]) or rate(diskio_write_bytes_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}[__$window__]))"
     },
     {
       "id": "dashboard:v1:e5e98cdd",

--- a/server/apps/monitor/support-files/dashboard_query_capabilities.json
+++ b/server/apps/monitor/support-files/dashboard_query_capabilities.json
@@ -886,6 +886,13 @@
       "template": "rate(mongodb_net_in_bytes_count{__$labels__}[__$window__])"
     },
     {
+      "id": "dashboard:v1:1fc6119c",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "topk(5, sum by (namespace) (label_replace(prometheus_remote_write_container_memory_working_set_bytes{instance_type=\"k8s\",__$labels__}, \"namespace\", \"$1\", \"container_label_io_kubernetes_pod_namespace\", \"(.+)\")))"
+    },
+    {
       "id": "dashboard:v1:20114010",
       "object_names": [
         "VLLM"
@@ -1378,13 +1385,6 @@
         "Switch"
       ],
       "template": "max(device_psu_state{__$labels__}) by (instance_id)"
-    },
-    {
-      "id": "dashboard:v1:3674f24d",
-      "object_names": [
-        "Cluster"
-      ],
-      "template": "topk(5, sum by (namespace) (sum by (instance_id, pod) (prometheus_remote_write_container_memory_working_set_bytes{instance_type=\"k8s\",__$labels__}) * on (instance_id, pod) group_left (namespace) topk by (instance_id, pod) (1, prometheus_remote_write_kube_pod_info{instance_type=\"k8s\",__$labels__})))"
     },
     {
       "id": "dashboard:v1:36951148",

--- a/server/apps/monitor/support-files/dashboard_query_capabilities.json
+++ b/server/apps/monitor/support-files/dashboard_query_capabilities.json
@@ -184,18 +184,18 @@
       "template": "clamp_max(100 * sum by (instance_id) (consul_health_checks_passing{__$labels__}) / clamp_min(count by (instance_id) (consul_health_checks_status{__$labels__}), 1), 100)"
     },
     {
-      "id": "dashboard:v1:065a8dde",
-      "object_names": [
-        "Cluster"
-      ],
-      "template": "100 * sum(prometheus_remote_write_kube_deployment_status_replicas_available{instance_type=\"k8s\",__$labels__}) / clamp_min(sum(prometheus_remote_write_kube_deployment_spec_replicas{instance_type=\"k8s\",__$labels__}),1)"
-    },
-    {
       "id": "dashboard:v1:069588ce",
       "object_names": [
         "ElasticSearch"
       ],
       "template": "rate(elasticsearch_http_total_opened{__$labels__}[__$window__])"
+    },
+    {
+      "id": "dashboard:v1:06e5913a",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "rate(sqlserver_waitstats_signal_wait_time_ms_rate{__$labels__}[__$window__])"
     },
     {
       "id": "dashboard:v1:077cf7a3",
@@ -786,6 +786,13 @@
         "Mysql"
       ],
       "template": "mysql_variables_max_connections{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:1d08f9aa",
+      "object_names": [
+        "Host"
+      ],
+      "template": "max by (instance_id) (disk_used_percent{instance_type=\"os\", __$labels__} or host_disk_used_percent_gauge{instance_type=\"os\", __$labels__} or disk_used_percent_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__} or disk_used_percent_gauge{instance_type=\"os\", config_type=\"host_aix_remote\", __$labels__})"
     },
     {
       "id": "dashboard:v1:1d131c0f",
@@ -1387,6 +1394,13 @@
       "template": "max(device_psu_state{__$labels__}) by (instance_id)"
     },
     {
+      "id": "dashboard:v1:3674f24d",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "topk(5, sum by (namespace) (sum by (instance_id, pod) (prometheus_remote_write_container_memory_working_set_bytes{instance_type=\"k8s\",__$labels__}) * on (instance_id, pod) group_left (namespace) topk by (instance_id, pod) (1, prometheus_remote_write_kube_pod_info{instance_type=\"k8s\",__$labels__})))"
+    },
+    {
       "id": "dashboard:v1:36951148",
       "object_names": [
         "Website"
@@ -1774,13 +1788,6 @@
       "template": "mongodb_connections_current{__$labels__}"
     },
     {
-      "id": "dashboard:v1:46d0f9ce",
-      "object_names": [
-        "K3SCluster"
-      ],
-      "template": "100 * sum(prometheus_remote_write_kube_deployment_status_replicas_available{instance_type=\"k3s\",__$labels__}) / clamp_min(sum(prometheus_remote_write_kube_deployment_spec_replicas{instance_type=\"k3s\",__$labels__}),1)"
-    },
-    {
       "id": "dashboard:v1:46e96889",
       "object_names": [
         "Redis"
@@ -2010,6 +2017,13 @@
         "Exchange"
       ],
       "template": "win_exchange_transport_queues_Poison_Queue_Length{instance_type=\"exchange\", __$labels__}"
+    },
+    {
+      "id": "dashboard:v1:50110358",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "100 * clamp_min(sum(prometheus_remote_write_kube_daemonset_status_desired_number_scheduled{instance_type=\"k3s\",__$labels__}) - (sum(prometheus_remote_write_kube_daemonset_status_number_unavailable{instance_type=\"k3s\",__$labels__}) or vector(0)), 0) / clamp_min(sum(prometheus_remote_write_kube_daemonset_status_desired_number_scheduled{instance_type=\"k3s\",__$labels__}),1)"
     },
     {
       "id": "dashboard:v1:501b0278",
@@ -2270,13 +2284,6 @@
         "Docker"
       ],
       "template": "sum(rate(docker_container_net_rx_bytes{__$labels__}[__$window__])) by (instance_id)"
-    },
-    {
-      "id": "dashboard:v1:5ac524f2",
-      "object_names": [
-        "Host"
-      ],
-      "template": "mem_used_percent{instance_type=\"os\", __$labels__} or host_mem_used_percent_gauge{instance_type=\"os\", __$labels__} or mem_used_percent_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}"
     },
     {
       "id": "dashboard:v1:5addc434",
@@ -2847,6 +2854,20 @@
       "template": "clamp_max(100 * (docker_n_containers_stopped{__$labels__} / clamp_min(docker_n_containers{__$labels__}, 1)), 100)"
     },
     {
+      "id": "dashboard:v1:75766335",
+      "object_names": [
+        "Host"
+      ],
+      "template": "sum by (instance_id) (rate(diskio_write_bytes{instance_type=\"os\", __$labels__}[__$window__]) or rate(diskio_write_bytes_total_gauge{instance_type=\"os\", config_type!~\"host_aix.*\", __$labels__}[__$window__]) or rate(diskio_write_bytes_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}[__$window__]) or diskio_write_bytes_gauge{instance_type=\"os\", config_type=\"host_aix_remote\", __$labels__})"
+    },
+    {
+      "id": "dashboard:v1:75cd4c37",
+      "object_names": [
+        "Host"
+      ],
+      "template": "sum by (instance_id) (rate(diskio_read_bytes{instance_type=\"os\", __$labels__}[__$window__]) or rate(diskio_read_bytes_total_gauge{instance_type=\"os\", config_type!~\"host_aix.*\", __$labels__}[__$window__]) or rate(diskio_read_bytes_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}[__$window__]) or diskio_read_bytes_gauge{instance_type=\"os\", config_type=\"host_aix_remote\", __$labels__})"
+    },
+    {
       "id": "dashboard:v1:76ff4618",
       "object_names": [
         "Exchange"
@@ -3340,13 +3361,6 @@
       "template": "rate(mysql_queries{__$labels__}[__$window__])"
     },
     {
-      "id": "dashboard:v1:8ab7d7ad",
-      "object_names": [
-        "MSSQL"
-      ],
-      "template": "rate(sqlserver_waitstats_signal_wait_time_ms{__$labels__}[__$window__])"
-    },
-    {
       "id": "dashboard:v1:8ae3b991",
       "object_names": [
         "RabbitMQ"
@@ -3401,6 +3415,13 @@
         "JVM"
       ],
       "template": "jvm_memory_usage_used_value{type=\"Heap\",__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:8d5f975a",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "100 * clamp_min(sum(prometheus_remote_write_kube_deployment_spec_replicas{instance_type=\"k8s\",__$labels__}) - (sum(prometheus_remote_write_kube_deployment_status_replicas_unavailable{instance_type=\"k8s\",__$labels__}) or vector(0)), 0) / clamp_min(sum(prometheus_remote_write_kube_deployment_spec_replicas{instance_type=\"k8s\",__$labels__}),1)"
     },
     {
       "id": "dashboard:v1:8ebd3e28",
@@ -3783,13 +3804,6 @@
       "template": "clamp_min(rate(mysql_created_tmp_tables{__$labels__}[__$window__]) - rate(mysql_created_tmp_disk_tables{__$labels__}[__$window__]), 0)"
     },
     {
-      "id": "dashboard:v1:9ed2014d",
-      "object_names": [
-        "Cluster"
-      ],
-      "template": "topk(5, sum by (container_label_io_kubernetes_pod_namespace) (prometheus_remote_write_container_memory_working_set_bytes{instance_type=\"k8s\",__$labels__}))"
-    },
-    {
       "id": "dashboard:v1:9ef6dee8",
       "object_names": [
         "Mysql"
@@ -3942,13 +3956,6 @@
         "Zookeeper"
       ],
       "template": "zookeeper_max_latency{__$labels__}"
-    },
-    {
-      "id": "dashboard:v1:a5c1faa5",
-      "object_names": [
-        "Host"
-      ],
-      "template": "sum by (instance_id) (rate(diskio_read_bytes{instance_type=\"os\", __$labels__}[__$window__]) or rate(diskio_read_bytes_total_gauge{instance_type=\"os\", __$labels__}[__$window__]) or rate(diskio_read_bytes_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}[__$window__]))"
     },
     {
       "id": "dashboard:v1:a6041c1a",
@@ -4219,6 +4226,13 @@
       "template": "rate(mysql_com_select{__$labels__}[__$window__])"
     },
     {
+      "id": "dashboard:v1:b4e40a82",
+      "object_names": [
+        "Host"
+      ],
+      "template": "mem_used_percent{instance_type=\"os\", __$labels__} or host_mem_used_percent_gauge{instance_type=\"os\", __$labels__} or mem_used_percent_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__} or mem_used_percent_gauge{instance_type=\"os\", config_type=\"host_aix_remote\", __$labels__}"
+    },
+    {
       "id": "dashboard:v1:b5430b18",
       "object_names": [
         "Minio"
@@ -4322,13 +4336,6 @@
         "Cluster"
       ],
       "template": "sum(prometheus_remote_write_kube_pod_status_phase{instance_type=\"k8s\",__$labels__}) by (phase)"
-    },
-    {
-      "id": "dashboard:v1:b8277ee6",
-      "object_names": [
-        "Host"
-      ],
-      "template": "(100 - cpu_usage_idle{cpu=\"cpu-total\", instance_type=\"os\", __$labels__}) or host_cpu_usage_percent_gauge{instance_type=\"os\", __$labels__} or cpu_usage_total_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}"
     },
     {
       "id": "dashboard:v1:b8440293",
@@ -4884,6 +4891,13 @@
       "template": "100 * mysql_innodb_buffer_pool_pages_dirty{__$labels__} / clamp_min(mysql_innodb_buffer_pool_pages_total{__$labels__}, 1)"
     },
     {
+      "id": "dashboard:v1:cf22232a",
+      "object_names": [
+        "Host"
+      ],
+      "template": "(100 - cpu_usage_idle{cpu=\"cpu-total\", instance_type=\"os\", __$labels__}) or host_cpu_usage_percent_gauge{instance_type=\"os\", __$labels__} or cpu_usage_total_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__} or cpu_usage_total_gauge{instance_type=\"os\", config_type=\"host_aix_remote\", __$labels__}"
+    },
+    {
       "id": "dashboard:v1:cf85f24a",
       "object_names": [
         "Docker"
@@ -4994,6 +5008,13 @@
         "Mongodb"
       ],
       "template": "mongodb_cursor_timed_out_count{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:d55dbd27",
+      "object_names": [
+        "K3SCluster"
+      ],
+      "template": "100 * clamp_min(sum(prometheus_remote_write_kube_deployment_spec_replicas{instance_type=\"k3s\",__$labels__}) - (sum(prometheus_remote_write_kube_deployment_status_replicas_unavailable{instance_type=\"k3s\",__$labels__}) or vector(0)), 0) / clamp_min(sum(prometheus_remote_write_kube_deployment_spec_replicas{instance_type=\"k3s\",__$labels__}),1)"
     },
     {
       "id": "dashboard:v1:d5eb0490",
@@ -5120,13 +5141,6 @@
         "Exchange"
       ],
       "template": "win_exchange_transport_queues_Submission_Queue_Length{instance_type=\"exchange\", __$labels__}"
-    },
-    {
-      "id": "dashboard:v1:dcbef466",
-      "object_names": [
-        "Cluster"
-      ],
-      "template": "100 * sum(prometheus_remote_write_kube_daemonset_status_number_available{instance_type=\"k8s\",__$labels__}) / clamp_min(sum(prometheus_remote_write_kube_daemonset_status_desired_number_scheduled{instance_type=\"k8s\",__$labels__}),1)"
     },
     {
       "id": "dashboard:v1:dcc35767",
@@ -5339,25 +5353,11 @@
       "template": "sum(rate(interface_ifInErrors{__$labels__}[__$window__])) by (instance_id)"
     },
     {
-      "id": "dashboard:v1:e4e0cd2a",
-      "object_names": [
-        "Host"
-      ],
-      "template": "max by (instance_id) (disk_used_percent{instance_type=\"os\", __$labels__} or host_disk_used_percent_gauge{instance_type=\"os\", __$labels__} or disk_used_percent_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__})"
-    },
-    {
       "id": "dashboard:v1:e54bf04a",
       "object_names": [
         "Website"
       ],
       "template": "avg(http_response_result_code{__$labels__} == bool 2) * 100"
-    },
-    {
-      "id": "dashboard:v1:e5c19424",
-      "object_names": [
-        "Host"
-      ],
-      "template": "sum by (instance_id) (rate(diskio_write_bytes{instance_type=\"os\", __$labels__}[__$window__]) or rate(diskio_write_bytes_total_gauge{instance_type=\"os\", __$labels__}[__$window__]) or rate(diskio_write_bytes_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}[__$window__]))"
     },
     {
       "id": "dashboard:v1:e5e98cdd",
@@ -5724,13 +5724,6 @@
       "template": "apache_CacheCurrentEntries{__$labels__}"
     },
     {
-      "id": "dashboard:v1:f6edc87c",
-      "object_names": [
-        "K3SCluster"
-      ],
-      "template": "100 * sum(prometheus_remote_write_kube_daemonset_status_number_available{instance_type=\"k3s\",__$labels__}) / clamp_min(sum(prometheus_remote_write_kube_daemonset_status_desired_number_scheduled{instance_type=\"k3s\",__$labels__}),1)"
-    },
-    {
       "id": "dashboard:v1:f73d2940",
       "object_names": [
         "K3SCluster"
@@ -5743,6 +5736,13 @@
         "Router"
       ],
       "template": "count({instance_type='router', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:f8bf91af",
+      "object_names": [
+        "Cluster"
+      ],
+      "template": "100 * clamp_min(sum(prometheus_remote_write_kube_daemonset_status_desired_number_scheduled{instance_type=\"k8s\",__$labels__}) - (sum(prometheus_remote_write_kube_daemonset_status_number_unavailable{instance_type=\"k8s\",__$labels__}) or vector(0)), 0) / clamp_min(sum(prometheus_remote_write_kube_daemonset_status_desired_number_scheduled{instance_type=\"k8s\",__$labels__}),1)"
     },
     {
       "id": "dashboard:v1:f8f30032",

--- a/web/src/app/monitor/dashboards/objects/k3s-cluster/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k3s-cluster/dashboard.tsx
@@ -63,6 +63,7 @@ import {
 } from '../../shared/utils/display-mode-route';
 import {
   latestScalar,
+  latestScalarOrNull,
   seriesLatestByLabel,
   phaseCount,
   saturationColor,
@@ -392,7 +393,8 @@ export default function K3sClusterDashboardPage() {
   // 工作负载可用度条
   const workloadBars = useMemo(() => {
     const mk = (label: string, key: string, color: string) => {
-      const v = latestScalar(raw[key]);
+      const v = latestScalarOrNull(raw[key]);
+      if (v === null) return { label, value: 0, display: '--', color, max: 100 };
       return { label, value: v, display: pct(v), color, max: 100 };
     };
     return [
@@ -683,6 +685,7 @@ export default function K3sClusterDashboardPage() {
                   guide={guide('Top 命名空间 · 内存', '内存占用最高的命名空间。')}
                   items={topNsMemBars}
                   tiered
+                  isEmpty={topNsMemBars.length === 0}
                   className={styles.span4}
                   styles={styles}
                 />
@@ -690,6 +693,7 @@ export default function K3sClusterDashboardPage() {
                   title="工作负载可用度"
                   guide={guide('工作负载可用度', '各类工作负载可用副本占期望副本的比例。')}
                   items={workloadBars}
+                  isEmpty={workloadBars.every((item) => item.display === '--')}
                   className={styles.span4}
                   styles={styles}
                 />

--- a/web/src/app/monitor/dashboards/objects/k3s-cluster/parse.ts
+++ b/web/src/app/monitor/dashboards/objects/k3s-cluster/parse.ts
@@ -4,10 +4,17 @@ import { TOP_N } from './queries';
 
 type QueryResult = { data?: { result?: Array<{ metric?: Record<string, string>; values?: Array<[number, string | number | null]> }> } } | null;
 
-/** 取单序列结果的最新标量(无数据 → 0)。 */
+/** 取单序列结果的最新标量(无数据 → 0)。KPI 计数用；百分比条请用 latestScalarOrNull。 */
 export const latestScalar = (result: QueryResult): number => {
   const series = result?.data?.result;
   if (!series || series.length === 0) return 0;
+  return latestFiniteValue(series[0].values);
+};
+
+/** 无序列时返回 null，避免把查空画成 0%。 */
+export const latestScalarOrNull = (result: QueryResult): number | null => {
+  const series = result?.data?.result;
+  if (!series || series.length === 0) return null;
   return latestFiniteValue(series[0].values);
 };
 
@@ -54,7 +61,7 @@ export interface TopBarItem { label: string; value: number; display: string; col
 /** 由 topk 结果按某 label 构建排行 bar items(降序、取前 TOP_N、max 取本卡最大值)。 */
 export const buildTopBars = (
   result: Parameters<typeof seriesLatestByLabel>[0],
-  label: string,
+  label: string | string[],
   color: string,
   format: (n: number) => string
 ): TopBarItem[] => {

--- a/web/src/app/monitor/dashboards/objects/k3s-cluster/queries.ts
+++ b/web/src/app/monitor/dashboards/objects/k3s-cluster/queries.ts
@@ -42,9 +42,9 @@ export const QUERIES: Record<string, ClusterQuery> = {
   crashloop: { query: `count(prometheus_remote_write_kube_pod_container_status_waiting_reason{instance_type="k3s",reason="CrashLoopBackOff",__$labels__} > 0)`, unit: 'none' },
   restarts1h: { query: `sum(increase(prometheus_remote_write_kube_pod_container_status_restarts_total${L}[1h]))`, unit: 'counts' },
 
-  deployPct: { query: `100 * sum(prometheus_remote_write_kube_deployment_status_replicas_available${L}) / clamp_min(sum(prometheus_remote_write_kube_deployment_spec_replicas${L}),1)`, unit: 'percent' },
+  deployPct: { query: `100 * clamp_min(sum(prometheus_remote_write_kube_deployment_spec_replicas${L}) - (sum(prometheus_remote_write_kube_deployment_status_replicas_unavailable${L}) or vector(0)), 0) / clamp_min(sum(prometheus_remote_write_kube_deployment_spec_replicas${L}),1)`, unit: 'percent' },
   stsPct: { query: `100 * sum(prometheus_remote_write_kube_statefulset_status_replicas_ready${L}) / clamp_min(sum(prometheus_remote_write_kube_statefulset_replicas${L}),1)`, unit: 'percent' },
-  dsPct: { query: `100 * sum(prometheus_remote_write_kube_daemonset_status_number_available${L}) / clamp_min(sum(prometheus_remote_write_kube_daemonset_status_desired_number_scheduled${L}),1)`, unit: 'percent' },
+  dsPct: { query: `100 * clamp_min(sum(prometheus_remote_write_kube_daemonset_status_desired_number_scheduled${L}) - (sum(prometheus_remote_write_kube_daemonset_status_number_unavailable${L}) or vector(0)), 0) / clamp_min(sum(prometheus_remote_write_kube_daemonset_status_desired_number_scheduled${L}),1)`, unit: 'percent' },
 
   cpuAllocatable: { query: `sum(prometheus_remote_write_kube_node_status_allocatable{instance_type="k3s",resource="cpu", __$labels__})`, unit: 'none' },
   cpuRequests: { query: `sum(prometheus_remote_write_kube_pod_container_resource_requests{instance_type="k3s",resource="cpu", __$labels__})`, unit: 'none' },

--- a/web/src/app/monitor/dashboards/objects/k8s-cluster/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k8s-cluster/dashboard.tsx
@@ -53,8 +53,7 @@ import {
   NEUTRAL_BLUE,
   NEUTRAL_INK,
   RING_REST,
-  RING_DONE,
-  NS_LABEL
+  RING_DONE
 } from './queries';
 import {
   DashboardDisplayMode,
@@ -63,6 +62,7 @@ import {
 } from '../../shared/utils/display-mode-route';
 import {
   latestScalar,
+  latestScalarOrNull,
   seriesLatestByLabel,
   phaseCount,
   saturationColor,
@@ -392,7 +392,8 @@ export default function K8sClusterDashboardPage() {
   // 工作负载可用度条
   const workloadBars = useMemo(() => {
     const mk = (label: string, key: string, color: string) => {
-      const v = latestScalar(raw[key]);
+      const v = latestScalarOrNull(raw[key]);
+      if (v === null) return { label, value: 0, display: '--', color, max: 100 };
       return { label, value: v, display: pct(v), color, max: 100 };
     };
     return [
@@ -444,7 +445,10 @@ export default function K8sClusterDashboardPage() {
   // 资源消耗 Top-N
   const topPodCpuBars = useMemo(() => buildTopBars(raw.topPodCpu, 'pod', '#9254de', coresDisplay), [raw.topPodCpu]);
   const topPodMemBars = useMemo(() => buildTopBars(raw.topPodMem, 'pod', '#13c2c2', bytesDisplay), [raw.topPodMem]);
-  const topNsMemBars = useMemo(() => buildTopBars(raw.topNsMem, NS_LABEL, '#13c2c2', bytesDisplay), [raw.topNsMem]);
+  const topNsMemBars = useMemo(
+    () => buildTopBars(raw.topNsMem, ['namespace', 'container_label_io_kubernetes_pod_namespace'], '#13c2c2', bytesDisplay),
+    [raw.topNsMem]
+  );
 
   // ── 事件 ──
   const onTimeChange = (vals: number[], originValue: number | null) => {
@@ -683,6 +687,7 @@ export default function K8sClusterDashboardPage() {
                   guide={guide('Top 命名空间 · 内存', '内存占用最高的命名空间。')}
                   items={topNsMemBars}
                   tiered
+                  isEmpty={topNsMemBars.length === 0}
                   className={styles.span4}
                   styles={styles}
                 />
@@ -690,6 +695,7 @@ export default function K8sClusterDashboardPage() {
                   title="工作负载可用度"
                   guide={guide('工作负载可用度', '各类工作负载可用副本占期望副本的比例。')}
                   items={workloadBars}
+                  isEmpty={workloadBars.every((item) => item.display === '--')}
                   className={styles.span4}
                   styles={styles}
                 />

--- a/web/src/app/monitor/dashboards/objects/k8s-cluster/parse.ts
+++ b/web/src/app/monitor/dashboards/objects/k8s-cluster/parse.ts
@@ -4,10 +4,17 @@ import { TOP_N } from './queries';
 
 type QueryResult = { data?: { result?: Array<{ metric?: Record<string, string>; values?: Array<[number, string | number | null]> }> } } | null;
 
-/** 取单序列结果的最新标量(无数据 → 0)。 */
+/** 取单序列结果的最新标量(无数据 → 0)。KPI 计数用；百分比条请用 latestScalarOrNull。 */
 export const latestScalar = (result: QueryResult): number => {
   const series = result?.data?.result;
   if (!series || series.length === 0) return 0;
+  return latestFiniteValue(series[0].values);
+};
+
+/** 无序列时返回 null，避免把查空画成 0%。 */
+export const latestScalarOrNull = (result: QueryResult): number | null => {
+  const series = result?.data?.result;
+  if (!series || series.length === 0) return null;
   return latestFiniteValue(series[0].values);
 };
 
@@ -54,7 +61,7 @@ export interface TopBarItem { label: string; value: number; display: string; col
 /** 由 topk 结果按某 label 构建排行 bar items(降序、取前 TOP_N、max 取本卡最大值)。 */
 export const buildTopBars = (
   result: Parameters<typeof seriesLatestByLabel>[0],
-  label: string,
+  label: string | string[],
   color: string,
   format: (n: number) => string
 ): TopBarItem[] => {

--- a/web/src/app/monitor/dashboards/objects/k8s-cluster/queries.ts
+++ b/web/src/app/monitor/dashboards/objects/k8s-cluster/queries.ts
@@ -59,8 +59,8 @@ export const QUERIES: Record<string, ClusterQuery> = {
 
   topPodCpu: { query: `topk(${TOP_N}, sum by (pod) (rate(prometheus_remote_write_container_cpu_usage_seconds_total${L}[__$window__])))`, unit: 'none' },
   topPodMem: { query: `topk(${TOP_N}, sum by (pod) (prometheus_remote_write_container_memory_working_set_bytes${L}))`, unit: 'bytes' },
-  // cadvisor 序列常只有 pod；用 kube_pod_info 补 namespace，不依赖 docker 长 label。
-  topNsMem: { query: `topk(${TOP_N}, sum by (namespace) (sum by (instance_id, pod) (prometheus_remote_write_container_memory_working_set_bytes${L}) * on (instance_id, pod) group_left (namespace) topk by (instance_id, pod) (1, prometheus_remote_write_kube_pod_info${L})))`, unit: 'bytes' },
+  // 按 namespace 聚合：relabel 后已有短标签；未滚动采集器时把 docker 长 label 写成 namespace。不用 pod 名 join，避免跨 ns 同名叠在一起。
+  topNsMem: { query: `topk(${TOP_N}, sum by (namespace) (label_replace(prometheus_remote_write_container_memory_working_set_bytes${L}, "namespace", "$1", "container_label_io_kubernetes_pod_namespace", "(.+)")))`, unit: 'bytes' },
 
   memPct: { query: `100 * sum(prometheus_remote_write_mem_used${L}) / sum(prometheus_remote_write_mem_total${L})`, unit: 'percent' },
   cpuPct: { query: `100 - avg(prometheus_remote_write_cpu_usage_idle{instance_type="k8s",cpu="cpu-total",__$labels__})`, unit: 'percent' },

--- a/web/src/app/monitor/dashboards/objects/k8s-cluster/queries.ts
+++ b/web/src/app/monitor/dashboards/objects/k8s-cluster/queries.ts
@@ -42,9 +42,10 @@ export const QUERIES: Record<string, ClusterQuery> = {
   crashloop: { query: `count(prometheus_remote_write_kube_pod_container_status_waiting_reason{instance_type="k8s",reason="CrashLoopBackOff",__$labels__} > 0)`, unit: 'none' },
   restarts1h: { query: `sum(increase(prometheus_remote_write_kube_pod_container_status_restarts_total${L}[1h]))`, unit: 'counts' },
 
-  deployPct: { query: `100 * sum(prometheus_remote_write_kube_deployment_status_replicas_available${L}) / clamp_min(sum(prometheus_remote_write_kube_deployment_spec_replicas${L}),1)`, unit: 'percent' },
+  // 用 spec - unavailable：unavailable=0 时 KSM 仍出数，避免 sum(available) 为空导致整式空向量被画成 0.0%。
+  deployPct: { query: `100 * clamp_min(sum(prometheus_remote_write_kube_deployment_spec_replicas${L}) - (sum(prometheus_remote_write_kube_deployment_status_replicas_unavailable${L}) or vector(0)), 0) / clamp_min(sum(prometheus_remote_write_kube_deployment_spec_replicas${L}),1)`, unit: 'percent' },
   stsPct: { query: `100 * sum(prometheus_remote_write_kube_statefulset_status_replicas_ready${L}) / clamp_min(sum(prometheus_remote_write_kube_statefulset_replicas${L}),1)`, unit: 'percent' },
-  dsPct: { query: `100 * sum(prometheus_remote_write_kube_daemonset_status_number_available${L}) / clamp_min(sum(prometheus_remote_write_kube_daemonset_status_desired_number_scheduled${L}),1)`, unit: 'percent' },
+  dsPct: { query: `100 * clamp_min(sum(prometheus_remote_write_kube_daemonset_status_desired_number_scheduled${L}) - (sum(prometheus_remote_write_kube_daemonset_status_number_unavailable${L}) or vector(0)), 0) / clamp_min(sum(prometheus_remote_write_kube_daemonset_status_desired_number_scheduled${L}),1)`, unit: 'percent' },
 
   cpuAllocatable: { query: `sum(prometheus_remote_write_kube_node_status_allocatable{instance_type="k8s",resource="cpu", __$labels__})`, unit: 'none' },
   cpuRequests: { query: `sum(prometheus_remote_write_kube_pod_container_resource_requests{instance_type="k8s",resource="cpu", __$labels__})`, unit: 'none' },
@@ -58,7 +59,8 @@ export const QUERIES: Record<string, ClusterQuery> = {
 
   topPodCpu: { query: `topk(${TOP_N}, sum by (pod) (rate(prometheus_remote_write_container_cpu_usage_seconds_total${L}[__$window__])))`, unit: 'none' },
   topPodMem: { query: `topk(${TOP_N}, sum by (pod) (prometheus_remote_write_container_memory_working_set_bytes${L}))`, unit: 'bytes' },
-  topNsMem: { query: `topk(${TOP_N}, sum by (container_label_io_kubernetes_pod_namespace) (prometheus_remote_write_container_memory_working_set_bytes${L}))`, unit: 'bytes' },
+  // cadvisor 序列常只有 pod；用 kube_pod_info 补 namespace，不依赖 docker 长 label。
+  topNsMem: { query: `topk(${TOP_N}, sum by (namespace) (sum by (instance_id, pod) (prometheus_remote_write_container_memory_working_set_bytes${L}) * on (instance_id, pod) group_left (namespace) topk by (instance_id, pod) (1, prometheus_remote_write_kube_pod_info${L})))`, unit: 'bytes' },
 
   memPct: { query: `100 * sum(prometheus_remote_write_mem_used${L}) / sum(prometheus_remote_write_mem_total${L})`, unit: 'percent' },
   cpuPct: { query: `100 - avg(prometheus_remote_write_cpu_usage_idle{instance_type="k8s",cpu="cpu-total",__$labels__})`, unit: 'percent' },
@@ -79,4 +81,4 @@ export const QUERY_GROUPS: Record<string, string[]> = {
   panels: ['deployPct', 'stsPct', 'dsPct', 'cpuAllocatable', 'cpuRequests', 'cpuUsedCores', 'memAllocatable', 'memRequests', 'memUsedBytes', 'nodeMemTop', 'restartTop', 'topPodCpu', 'topPodMem', 'topNsMem']
 };
 
-export const NS_LABEL = 'container_label_io_kubernetes_pod_namespace';
+export const NS_LABEL = 'namespace';


### PR DESCRIPTION
## Summary

- 修复 K8s/K3s 集群看板「Top 命名空间 · 内存」空白：cadvisor 序列常缺 `namespace`，查询改为用 `kube_pod_info` 按 `(instance_id, pod)` join 补维度；采集模板同步把 docker label `container_label_io_kubernetes_pod_namespace` 复制为 `namespace`。
- 修复「工作负载可用度」Deployment/DaemonSet 被画成 `0.0%`：不再用可能为空的 `sum(available)`，改为 `spec - (unavailable or vector(0))`；无数据时展示 `--` 并走空态，而不是当成 0%。
- 已重生 `dashboard_query_capabilities.json`，与内置看板查询清单对齐。

## 提交范围

已核对暂存区与相对 `master` 的 diff：仅包含采集模板、K8s/K3s 集群看板查询/解析/展示，以及 query capabilities 清单。未纳入测试文件、Storybook mock、腾讯云地域相关 WIP、图标与 migration。

## Test plan

- [x] `pnpm exec tsx scripts/k8s-cluster-dashboard-cards-test.ts`（本地验证，测试文件未提交）
- [x] `pnpm exec tsx scripts/generate-monitor-query-capabilities.ts --check`
- [ ] 在已接入 K8s 集群的环境打开集群看板：命名空间内存排行有数据；工作负载可用度与 hero KPI 一致，缺数时为 `--` 而非 `0.0%`
- [ ] 采集器滚动更新后，cadvisor 指标带 `namespace` 短标签（不依赖本次查询 join 也能按 namespace 聚合）