### PR TITLE
fix: 修正代理 NATS 外部端口映射

### DIFF
--- a/agents/webhookd/infra/proxy/docker-compose.yaml
+++ b/agents/webhookd/infra/proxy/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       - ./conf/certs:/etc/nats/certs:ro
       - nats:/nats
     ports:
-      - "4223:4222"
+      - "4222:4222"
     command:
       - "-c"
       - "/etc/nats/nats.conf"

--- a/agents/webhookd/infra/tests/test_proxy_certificate_san.py
+++ b/agents/webhookd/infra/tests/test_proxy_certificate_san.py
@@ -135,6 +135,13 @@ def test_proxy_compose_injects_zone_instance_id_for_region_services(
     assert stargazer["restart"] == "always"
 
 
+def test_proxy_bundle_publishes_platform_nats_port(certificate_authority):
+    with _generate_proxy_archive("10.0.0.8", certificate_authority) as archive:
+        compose_config = yaml.safe_load(archive.extractfile("./docker-compose.yaml").read().decode())
+
+    assert compose_config["services"]["nats"]["ports"] == ["4222:4222"]
+
+
 def test_bootstrap_uses_rendered_nats_admin_user(certificate_authority):
     """bootstrap.sh 必须用 .env 渲染出的管理员账号连 NATS，不能写死 admin。"""
     with _generate_proxy_archive("10.0.0.8", certificate_authority) as archive:


### PR DESCRIPTION
## 变更说明

- 将云区域代理 NATS 宿主机映射从 4223:4222 修正为 4222:4222，与平台提示及下发的 NATS 地址保持一致
- 新增最终代理安装包回归测试，锁定对外发布端口契约

## 问题影响

修复前，客户端按代理地址的 4222 端口连接，但代理 Compose 实际只发布宿主机 4223，可能导致区域节点连接 NATS 失败。容器内部仍继续使用 nats:4222。

## 验证

- DB_ENGINE=sqlite DB_NAME=:memory: SECRET_KEY=cursor-cloud-dev ENABLE_CELERY=true uv run pytest ../agents/webhookd/infra/tests -q --no-cov
- 106 passed