### PR TITLE
fix(采集): 将 AIX/SSH raw 参数编码为 JSON，避免 Ansible 引号拆分失败

### DIFF
--- a/agents/ansible-executor/service/ansible_runner.py
+++ b/agents/ansible-executor/service/ansible_runner.py
@@ -42,6 +42,22 @@ _SENSITIVE_INVENTORY_PATTERNS = (
 
 _SSH_KNOWN_HOSTS_FILE_ENV = "SSH_KNOWN_HOSTS_FILE"
 _LEGACY_PASSWORD_SSH_COMMON_ARGS = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+_RAW_ADHOC_MODULES = {"raw"}
+
+
+def encode_adhoc_module_args(module: str, module_args: str) -> str:
+    """raw 模块的 `-a` 用 JSON `_raw_params`，避免 Ansible split_args 被引号/heredoc 拆失败。"""
+    if str(module or "").strip() not in _RAW_ADHOC_MODULES or not module_args:
+        return module_args
+    stripped = module_args.strip()
+    if stripped.startswith("{") and stripped.endswith("}"):
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, dict) and isinstance(parsed.get("_raw_params"), str):
+            return module_args
+    return json.dumps({"_raw_params": module_args}, ensure_ascii=False)
 
 
 def _redact_cli_command(args: list[str]) -> list[str]:
@@ -977,7 +993,7 @@ def build_adhoc_command(payload: AdhocRequest) -> list[str]:
         payload.module,
     ]
     if payload.module_args:
-        cli_args.extend(["-a", payload.module_args])
+        cli_args.extend(["-a", encode_adhoc_module_args(payload.module, payload.module_args)])
     if payload.extra_vars_file:
         cli_args.extend(["--extra-vars", f"@{payload.extra_vars_file}"])
     elif extra_vars:

--- a/agents/stargazer/tasks/collectors/aix_os_monitor.py
+++ b/agents/stargazer/tasks/collectors/aix_os_monitor.py
@@ -30,7 +30,9 @@ def _append_gauge(lines: list[str], name: str, labels: str, value: Any, timestam
 
 AIX_SCRIPT_PATH = Path(__file__).parent / "scripts" / "aix" / "os_monitor.ksh"
 AIX_COLLECT_EOF = "STARGAZER_AIX_COLLECT_EOF"
-AIX_KSH_C_PREFIX = "/usr/bin/ksh -c '. /dev/stdin'"
+# 与 Linux 采集一致：quoted heredoc。不要再用 `ksh -c '. /dev/stdin'`，
+# 嵌套单引号会被 Ansible adhoc `-a` 的 split_args 判成 unbalanced quotes。
+AIX_KSH_PREFIX = "LC_ALL=C LANG=C /usr/bin/ksh"
 
 COMMAND_EXECUTE_TIMEOUT = int(os.getenv("COMMAND_EXECUTE_TIMEOUT", "900"))
 
@@ -41,7 +43,7 @@ def load_aix_monitor_script() -> str:
 
 def wrap_ksh_collect(script_body: str | None = None) -> str:
     body = script_body if script_body is not None else load_aix_monitor_script()
-    return f"{AIX_KSH_C_PREFIX} <<'{AIX_COLLECT_EOF}'\n{body.rstrip()}\n{AIX_COLLECT_EOF}\n"
+    return f"{AIX_KSH_PREFIX} <<'{AIX_COLLECT_EOF}'\n{body.rstrip()}\n{AIX_COLLECT_EOF}\n"
 
 
 def _as_float(value: Any, default: float = 0.0) -> float:

--- a/agents/stargazer/tasks/collectors/host_collector.py
+++ b/agents/stargazer/tasks/collectors/host_collector.py
@@ -21,10 +21,7 @@ ANSIBLE_ADHOC_FAILED_LOG_TEMPLATE = (
     "host_status=%s exit_code=%s stderr=%s stderr_missing=%s "
     "failed_stage=callback_process error_type=%s"
 )
-_SECRET_ASSIGNMENT_RE = re.compile(
-    r"(?i)\b(password|passwd|secret|token|authorization|passphrase|"
-    r"private_key(?:_content)?)\s*[:=]\s*\S+"
-)
+_SECRET_ASSIGNMENT_RE = re.compile(r"(?i)\b(password|passwd|secret|token|authorization|passphrase|" r"private_key(?:_content)?)\s*[:=]\s*\S+")
 _PEM_BLOCK_RE = re.compile(
     r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
     re.DOTALL,
@@ -43,6 +40,34 @@ _UNREACHABLE_MARKERS = (
     "no route to host",
     "name or service not known",
 )
+
+
+def encode_ansible_raw_module_args(command: str) -> str:
+    """把 raw 命令编码成 Ansible adhoc `-a` 可安全解析的 JSON。
+
+    AdHocCLI 对非 JSON 的 `-a` 会走 ``parse_kv`` / ``split_args``。AIX ksh
+    heredoc 和脚本正文里的引号会触发
+    ``failed at splitting arguments, either an unbalanced jinja2 block or quotes``
+    （进程退出码 4），SSH 根本不会发生。JSON ``{"_raw_params": "..."}`` 走
+    ``from_yaml(..., json_only=True)``，跳过引号拆分。
+    """
+    return json.dumps({"_raw_params": command}, ensure_ascii=False)
+
+
+def decode_ansible_raw_module_args(module_args: str) -> str:
+    """还原 encode_ansible_raw_module_args 的命令正文；非 JSON 则原样返回。"""
+    text = str(module_args or "")
+    stripped = text.strip()
+    if stripped.startswith("{") and stripped.endswith("}"):
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            return text
+        if isinstance(parsed, dict):
+            raw_params = parsed.get("_raw_params")
+            if isinstance(raw_params, str):
+                return raw_params
+    return text
 
 
 def _url_decode_secret(value: Any, credential_encoding: Any = "url") -> str:
@@ -73,9 +98,7 @@ LINUX_SCRIPT_WRAPPER_PREFIX = "LC_ALL=C LANG=C bash --noprofile --norc"
 SUPPORTED_OS_TYPES = {"linux", "windows", "aix"}
 
 
-def sanitize_ansible_failure_text(
-    value: Any, *, max_length: int = ANSIBLE_FAILURE_TEXT_MAX_CHARS
-) -> str:
+def sanitize_ansible_failure_text(value: Any, *, max_length: int = ANSIBLE_FAILURE_TEXT_MAX_CHARS) -> str:
     text = _PEM_BLOCK_RE.sub("[omitted]", str(value or ""))
     text = _SECRET_ASSIGNMENT_RE.sub(r"\1=[omitted]", text)
     return safe_log_value(text, max_length=max_length)
@@ -110,21 +133,11 @@ def extract_ansible_failure_summary(result: Dict[str, Any], host: str) -> Dict[s
     summary_meta = payload.get("result_summary")
     if not isinstance(summary_meta, dict):
         summary_meta = {}
-    raw_status = str(
-        host_result.get("raw_status")
-        or summary_meta.get("failure_status")
-        or host_result.get("status")
-        or ""
-    )
+    raw_status = str(host_result.get("raw_status") or summary_meta.get("failure_status") or host_result.get("status") or "")
     exit_code = host_result.get("exit_code")
     if exit_code is None:
         exit_code = host_result.get("rc", summary_meta.get("failure_exit_code"))
-    stderr = str(
-        host_result.get("stderr")
-        or host_result.get("error_message")
-        or summary_meta.get("failure_stderr")
-        or ""
-    )
+    stderr = str(host_result.get("stderr") or host_result.get("error_message") or summary_meta.get("failure_stderr") or "")
     sanitized_stderr = sanitize_ansible_failure_text(stderr)
     return {
         "error": sanitize_ansible_failure_text(error),
@@ -137,9 +150,7 @@ def extract_ansible_failure_summary(result: Dict[str, Any], host: str) -> Dict[s
 
 def classify_ansible_failure(summary: Dict[str, Any]) -> str:
     host_status = str(summary.get("host_status") or "").upper()
-    text = " ".join(
-        str(summary.get(key) or "") for key in ("error", "stderr", "host_status")
-    ).lower()
+    text = " ".join(str(summary.get(key) or "") for key in ("error", "stderr", "host_status")).lower()
     if host_status.startswith("UNREACHABLE"):
         return "target_unreachable"
     if any(marker in text for marker in _AUTH_FAILURE_MARKERS):
@@ -484,6 +495,7 @@ class HostCollector(BaseCollector):
 
         connection = "ssh" if ssh_like else "winrm"
         module = "raw" if ssh_like else "win_shell"
+        module_args = encode_ansible_raw_module_args(script) if ssh_like else script
 
         host_credential = {
             "host": host,
@@ -519,7 +531,7 @@ class HostCollector(BaseCollector):
             "ansible_node_id": ansible_node_id,
             "host_credentials": host_credentials,
             "module": module,
-            "module_args": script,
+            "module_args": module_args,
             "execute_timeout": execute_timeout,
         }
 


### PR DESCRIPTION
## Summary
- AIX 远程采集把整份 ksh 脚本经 Ansible `raw` 的 `-a` 下发。AdHocCLI 对非 JSON 参数走 `split_args`，heredoc 和脚本引号会被判成 unbalanced quotes（exit 4），SSH 根本不会发生。
- Stargazer 将 Linux/AIX 的 `module_args` 编码为 `{"_raw_params": "..."}`，让 Ansible 走 JSON 解析；AIX 包装改为与 Linux 一致的 quoted heredoc。
- ansible-executor 对 `raw` 做同样防御包装（已是 `_raw_params` JSON 则不二次包装）。发新 Stargazer 即可恢复采集，不必先换现场 executor。

## Test plan
- [x] `cd agents/stargazer && uv run pytest tests/test_host_collector.py::TestBuildScript tests/test_host_collector.py::TestHostCollectorHelpers tests/test_host_collector.py::TestHostCollectorCredentialDecoding tests/test_host_collector.py::TestAnsibleFailureSummary`
- [x] `cd agents/ansible-executor && PYTHONPATH=. uv run pytest tests/test_ansible_runner.py`
- [ ] 发新 Stargazer 后，对原先失败的 AIX 主机重跑采集，确认不再出现 `failed at splitting arguments`
- [ ] 密码含 `@` 的实例确认 SSH 认证使用解码后的明文（依赖已有 URL 解码，随新 Stargazer 生效）