### PR TITLE
test(监控): 锁定公共 IF-MIB 无表级 oid 与 v8 对账契约

### DIFF
--- a/server/apps/monitor/tests/test_patch_snmp_interface_filters_pure.py
+++ b/server/apps/monitor/tests/test_patch_snmp_interface_filters_pure.py
@@ -6,15 +6,21 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import pytest
+from django.core.management.base import CommandError
 
 from apps.monitor.constants.snmp_interface import DEFAULT_IFTYPE_EXCLUDE
 from apps.monitor.management.commands.patch_snmp_interface_filters import (
+    CHECKPOINT_VERSION,
+    _load_checkpoint,
+    _reconcile_common_ifmib_fields,
     is_patchable_snmp_child_config,
     patch_child_content_dict,
 )
+from apps.monitor.utils.snmp_interface_template import _load_common_ifmib_table
 
 
 @pytest.mark.unit
@@ -57,6 +63,118 @@ class TestPatchSnmpInterfaceFilterSelection:
             }
         }
         assert patch_child_content_dict(content) is True
+        table = content["config"]["table"][0]
         assert content["config"]["tagexclude"] == ["ifType"]
         assert content["config"]["tagdrop"]["ifType"] == list(DEFAULT_IFTYPE_EXCLUDE)
-        assert any(f.get("name") == "ifType" for f in content["config"]["table"][0]["field"])
+        assert any(f.get("name") == "ifType" for f in table["field"])
+        assert "oid" not in table
+        assert table.get("index_as_tag") is True
+
+
+@pytest.mark.unit
+class TestReconcilePublicIfmibWalkRoot:
+    """v8：存量公共表必须去掉表级 oid，并带上 index_as_tag。"""
+
+    def setup_method(self):
+        _load_common_ifmib_table.cache_clear()
+
+    def test_strips_iftable_walk_root_and_sets_index_as_tag(self):
+        config = {
+            "table": [
+                {
+                    "oid": "1.3.6.1.2.1.2.2",
+                    "name": "interface",
+                    "inherit_tags": ["source"],
+                    "field": [
+                        {
+                            "oid": "1.3.6.1.2.1.2.2.1.2",
+                            "name": "ifDescr",
+                            "is_tag": True,
+                        }
+                    ],
+                }
+            ]
+        }
+
+        assert _reconcile_common_ifmib_fields(config) is True
+        table = config["table"][0]
+        assert "oid" not in table
+        assert table.get("index_as_tag") is True
+        assert table["name"] == "interface"
+
+    def test_strips_stock_ifxtable_walk_root_kept_by_v7(self):
+        config = {
+            "table": [
+                {
+                    "oid": "1.3.6.1.2.1.31.1.1",
+                    "name": "interface",
+                    "inherit_tags": ["source"],
+                    "field": [
+                        {"oid": "1.3.6.1.2.1.31.1.1.1.6", "name": "ifHCInOctets"},
+                        {"oid": "1.3.6.1.2.1.31.1.1.1.10", "name": "ifHCOutOctets"},
+                    ],
+                }
+            ]
+        }
+
+        assert _reconcile_common_ifmib_fields(config) is True
+        table = config["table"][0]
+        names = {field.get("name") for field in table["field"]}
+        assert "oid" not in table
+        assert table.get("index_as_tag") is True
+        assert "ifHCInOctets" in names
+        assert "ifDescr" in names
+
+    def test_patch_child_content_strips_ifxtable_oid(self):
+        content = {
+            "config": {
+                "table": [
+                    {
+                        "oid": "1.3.6.1.2.1.31.1.1",
+                        "name": "interface",
+                        "field": [
+                            {"oid": "1.3.6.1.2.1.2.2.1.2", "name": "ifDescr", "is_tag": True},
+                            {"oid": "1.3.6.1.2.1.31.1.1.1.6", "name": "ifHCInOctets"},
+                        ],
+                    }
+                ]
+            }
+        }
+
+        assert patch_child_content_dict(content) is True
+        table = content["config"]["table"][0]
+        assert "oid" not in table
+        assert table.get("index_as_tag") is True
+
+    def test_v7_checkpoint_is_rejected(self, tmp_path):
+        checkpoint = tmp_path / "checkpoint.json"
+        checkpoint.write_text(
+            json.dumps(
+                {
+                    "version": 7,
+                    "cursor": {"created_at": "2026-01-01T00:00:00+00:00", "id": "cfg-1"},
+                    "overwrite_default": False,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(CommandError, match="Unsupported checkpoint version"):
+            _load_checkpoint(checkpoint, overwrite_default=False)
+
+    def test_v8_checkpoint_loads(self, tmp_path):
+        checkpoint = tmp_path / "checkpoint.json"
+        checkpoint.write_text(
+            json.dumps(
+                {
+                    "version": CHECKPOINT_VERSION,
+                    "cursor": {"created_at": "2026-01-01T00:00:00+00:00", "id": "cfg-1"},
+                    "overwrite_default": False,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        cursor = _load_checkpoint(checkpoint, overwrite_default=False)
+        assert cursor is not None
+        assert cursor[1] == "cfg-1"

--- a/server/apps/monitor/tests/test_snmp_ifmib_table_no_walk_root_pure.py
+++ b/server/apps/monitor/tests/test_snmp_ifmib_table_no_walk_root_pure.py
@@ -1,0 +1,50 @@
+"""公共 IF-MIB 混采表不得带表级 oid，否则 Telegraf 会 MIB 整表展开。"""
+
+from __future__ import annotations
+
+import pytest
+
+from apps.monitor.utils.snmp_interface_template import (
+    _load_common_ifmib_table,
+    ensure_core_network_ifmib_jinja,
+    get_common_ifmib_table,
+    get_common_ifmib_table_block,
+    is_public_ifmib_table,
+    is_public_ifmib_table_block,
+)
+
+
+@pytest.mark.unit
+class TestCommonIfmibTableHasNoWalkRoot:
+    def setup_method(self):
+        _load_common_ifmib_table.cache_clear()
+
+    def test_common_table_uses_explicit_fields_and_index_tag(self):
+        table = get_common_ifmib_table()
+        assert "oid" not in table
+        assert table["name"] == "interface"
+        assert table.get("index_as_tag") is True
+        assert is_public_ifmib_table(table) is True
+
+    def test_common_table_block_has_no_iftable_walk_root(self):
+        block = get_common_ifmib_table_block()
+        assert 'oid = "1.3.6.1.2.1.2.2"' not in block
+        assert "index_as_tag = true" in block
+        assert is_public_ifmib_table_block(block) is True
+
+    def test_render_replaces_legacy_iftable_oid_with_index_as_tag(self):
+        template = """
+[[inputs.snmp]]
+    [[inputs.snmp.table]]
+        oid = "1.3.6.1.2.1.2.2"
+        name = "interface"
+        inherit_tags = ["source"]
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.2.2.1.2"
+        name = "ifDescr"
+        is_tag = true
+"""
+        rendered = ensure_core_network_ifmib_jinja(template, {"ifmib_capable": True})
+        assert 'oid = "1.3.6.1.2.1.2.2"' not in rendered
+        assert "index_as_tag = true" in rendered
+        assert 'oid = "1.3.6.1.2.1.31.1.1.1.6"' in rendered


### PR DESCRIPTION
## Summary
- 补齐 #5206 审查指出的回归缺口：公共 IF-MIB 表不得带表级 `oid`，必须带 `index_as_tag = true`。
- 覆盖存量 ifTable / ifXTable walk 根在 v8 对账时被剥离，以及 v7 断点被拒绝。
- 仅测试文件；产品代码已在 #5206 合入。

## Test plan
- [x] `cd server && DB_ENGINE=sqlite DB_NAME=:memory: SECRET_KEY=cursor-cloud-dev ENABLE_CELERY=true uv run pytest apps/monitor/tests/test_snmp_ifmib_table_no_walk_root_pure.py apps/monitor/tests/test_patch_snmp_interface_filters_pure.py apps/monitor/tests/test_snmp_ifmib_filter_capability_pure.py --no-cov`（15 passed）