### PR TITLE
fix(采集): 去掉未使用的 raw decode，并补 AIX JSON wrap 回归测试

### DIFF
--- a/agents/ansible-executor/tests/test_ansible_runner.py
+++ b/agents/ansible-executor/tests/test_ansible_runner.py
@@ -13,6 +13,8 @@ from service.ansible_runner import (
     _redact_cli_command,
     _safe_extract_zip,
     _safe_workspace_path,
+    build_adhoc_command,
+    encode_adhoc_module_args,
     parse_ansible_output_per_host,
     parse_playbook_recap,
     prepare_adhoc_execution,
@@ -27,6 +29,33 @@ def test_redact_cli_command_hides_extra_vars_values():
 
     assert _redact_cli_command(command) == ["ansible-playbook", "playbook.yml", "--extra-vars", "***"]
     assert command[-1] != "***"
+
+
+def test_encode_adhoc_module_args_json_wraps_raw_heredoc_with_unbalanced_quotes():
+    command = "/usr/bin/ksh -c '. /dev/stdin' <<'STARGAZER_AIX_COLLECT_EOF'\nawk '{print $1}'\nSTARGAZER_AIX_COLLECT_EOF\n"
+
+    encoded = encode_adhoc_module_args("raw", command)
+
+    parsed = json.loads(encoded)
+    assert parsed["_raw_params"] == command
+    assert encode_adhoc_module_args("raw", encoded) == encoded
+    assert encode_adhoc_module_args("shell", command) == command
+
+
+def test_build_adhoc_command_passes_raw_module_args_as_json():
+    command = "LC_ALL=C LANG=C /usr/bin/ksh <<'EOF'\n'unbalanced\nEOF\n"
+    cmd = build_adhoc_command(
+        AdhocRequest(
+            inventory="/tmp/inventory.ini",
+            hosts="all",
+            module="raw",
+            module_args=command,
+        )
+    )
+
+    args_index = cmd.index("-a")
+    encoded = cmd[args_index + 1]
+    assert json.loads(encoded)["_raw_params"] == command
 
 
 def test_to_adhoc_request_accepts_windows_stream_type():

--- a/agents/stargazer/tasks/collectors/aix_os_monitor.py
+++ b/agents/stargazer/tasks/collectors/aix_os_monitor.py
@@ -30,8 +30,8 @@ def _append_gauge(lines: list[str], name: str, labels: str, value: Any, timestam
 
 AIX_SCRIPT_PATH = Path(__file__).parent / "scripts" / "aix" / "os_monitor.ksh"
 AIX_COLLECT_EOF = "STARGAZER_AIX_COLLECT_EOF"
-# 与 Linux 采集一致：quoted heredoc。不要再用 `ksh -c '. /dev/stdin'`，
-# 嵌套单引号会被 Ansible adhoc `-a` 的 split_args 判成 unbalanced quotes。
+# 与 Linux 采集一致：quoted heredoc。Ansible adhoc `-a` 的引号拆分由
+# encode_ansible_raw_module_args 的 JSON `_raw_params` 绕过。
 AIX_KSH_PREFIX = "LC_ALL=C LANG=C /usr/bin/ksh"
 
 COMMAND_EXECUTE_TIMEOUT = int(os.getenv("COMMAND_EXECUTE_TIMEOUT", "900"))

--- a/agents/stargazer/tasks/collectors/host_collector.py
+++ b/agents/stargazer/tasks/collectors/host_collector.py
@@ -54,22 +54,6 @@ def encode_ansible_raw_module_args(command: str) -> str:
     return json.dumps({"_raw_params": command}, ensure_ascii=False)
 
 
-def decode_ansible_raw_module_args(module_args: str) -> str:
-    """还原 encode_ansible_raw_module_args 的命令正文；非 JSON 则原样返回。"""
-    text = str(module_args or "")
-    stripped = text.strip()
-    if stripped.startswith("{") and stripped.endswith("}"):
-        try:
-            parsed = json.loads(stripped)
-        except json.JSONDecodeError:
-            return text
-        if isinstance(parsed, dict):
-            raw_params = parsed.get("_raw_params")
-            if isinstance(raw_params, str):
-                return raw_params
-    return text
-
-
 def _url_decode_secret(value: Any, credential_encoding: Any = "url") -> str:
     """还原前端对 encrypted 字段做的 encodeURIComponent。
 

--- a/agents/stargazer/tests/test_host_collector.py
+++ b/agents/stargazer/tests/test_host_collector.py
@@ -36,6 +36,7 @@ from tasks.collectors.host_collector import (  # noqa: E402
     _extract_json_payload,
     build_script,
     classify_ansible_failure,
+    encode_ansible_raw_module_args,
     extract_ansible_failure_summary,
     parse_metrics_to_prometheus,
 )
@@ -308,6 +309,16 @@ class TestBuildScript:
         assert script.endswith(f"{LINUX_SCRIPT_WRAPPER_EOF}\n")
         assert "--noprofile --norc" in script
         assert "LC_ALL=C" in script
+
+    def test_aix_script_is_wrapped_with_ksh_heredoc(self):
+        from tasks.collectors.aix_os_monitor import AIX_COLLECT_EOF, AIX_KSH_PREFIX
+
+        script = build_script("aix", ["cpu"])
+
+        assert script.startswith(f"{AIX_KSH_PREFIX} <<'{AIX_COLLECT_EOF}'\n")
+        assert script.endswith(f"{AIX_COLLECT_EOF}\n")
+        assert "ksh -c" not in script
+        assert "PAGE_SIZE" in script
 
     def test_windows_all_modules(self):
         script = build_script("windows", ["cpu", "mem", "disk", "net"])
@@ -1107,6 +1118,16 @@ class TestHostCollectorHelpers:
 
         assert _escape_prometheus_label_value(value) == 'foo\\"bar\\\\baz\\nqux'
 
+    def test_encode_ansible_raw_module_args_wraps_aix_heredoc_as_json_raw_params(self):
+        command = build_script("aix", ["cpu"])
+        encoded = encode_ansible_raw_module_args(command)
+
+        assert encoded.startswith("{")
+        assert encoded.endswith("}")
+        parsed = json.loads(encoded)
+        assert parsed["_raw_params"] == command
+        assert "ksh -c" not in command
+
 
 class TestHostCollectorCredentialDecoding:
     """前端对 encrypted 字段做了 encodeURIComponent，后端需在送往 SSH/WinRM 前解码还原。"""
@@ -1125,6 +1146,26 @@ class TestHostCollectorCredentialDecoding:
         config = collector._resolve_execution_config()
 
         assert config["host_credentials"][0]["password"] == "CW@roger1117!@#"
+        assert json.loads(config["module_args"])["_raw_params"].startswith(f"{LINUX_SCRIPT_WRAPPER_PREFIX} <<'{LINUX_SCRIPT_WRAPPER_EOF}'\n")
+
+    def test_aix_password_is_url_decoded(self):
+        collector = HostCollector(
+            {
+                "host": "10.53.0.150",
+                "os_type": "aix",
+                "username": "root",
+                "password": "aix%40pass2021",
+                "ansible_node_id": "node1",
+            }
+        )
+
+        config = collector._resolve_execution_config()
+
+        assert config["host_credentials"][0]["password"] == "aix@pass2021"
+        assert config["module"] == "raw"
+        encoded_args = json.loads(config["module_args"])
+        assert encoded_args["_raw_params"].startswith("LC_ALL=C LANG=C /usr/bin/ksh <<'")
+        assert "ksh -c" not in encoded_args["_raw_params"]
 
     def test_windows_password_is_url_decoded(self):
         collector = HostCollector(
@@ -2124,7 +2165,7 @@ class TestHostCollectorCollect:
         assert "host_cpu_usage_percent" in result
         assert "25.0" in result
 
-    @patch("core.ansible_rpc.ansible_adhoc", new_callable=AsyncMock)
+    @patch("core.infra.ansible_rpc.ansible_adhoc", new_callable=AsyncMock)
     async def test_successful_collect_linux_uses_bash_wrapped_script(self, mock_adhoc):
         mock_adhoc.return_value = {
             "success": True,
@@ -2164,7 +2205,7 @@ class TestHostCollectorCollect:
         await collector.collect()
 
         call_kwargs = mock_adhoc.call_args[1]
-        assert call_kwargs["module_args"].startswith(f"{LINUX_SCRIPT_WRAPPER_PREFIX} <<'{LINUX_SCRIPT_WRAPPER_EOF}'\n")
+        assert json.loads(call_kwargs["module_args"])["_raw_params"].startswith(f"{LINUX_SCRIPT_WRAPPER_PREFIX} <<'{LINUX_SCRIPT_WRAPPER_EOF}'\n")
 
     @patch("core.ansible_rpc.ansible_adhoc", new_callable=AsyncMock)
     async def test_default_modules_when_invalid(self, mock_adhoc):
@@ -2583,11 +2624,7 @@ class TestHostRemoteProcessWorker:
         assert "Connection refused" in collector_records[0].getMessage()
         assert sentinel_password not in collector_records[0].getMessage()
 
-        handler_records = [
-            item
-            for item in caplog.records
-            if isinstance(item.msg, str) and "event=callback_process_failed" in item.msg
-        ]
+        handler_records = [item for item in caplog.records if isinstance(item.msg, str) and "event=callback_process_failed" in item.msg]
         assert len(handler_records) == 1
         handler_record = handler_records[0]
         assert handler_record.exc_info is None


### PR DESCRIPTION
## Summary
- 跟进 #5204 审查：生产路径删除未使用的 `decode_ansible_raw_module_args`。
- 补回归测试：AIX quoted heredoc、SSH/AIX `module_args` JSON `_raw_params`、AIX 密码 URL 解码、executor `raw` 不二次包装。
- Linux collect 用例的 mock 改为 `core.infra.ansible_rpc.ansible_adhoc`，才能真正锁住 JSON wrap。

## Test plan
- [x] `cd agents/stargazer && uv run pytest tests/test_host_collector.py::TestBuildScript tests/test_host_collector.py::TestHostCollectorHelpers tests/test_host_collector.py::TestHostCollectorCredentialDecoding tests/test_host_collector.py::TestHostCollectorCollect::test_successful_collect_linux_uses_bash_wrapped_script`
- [x] `cd agents/ansible-executor && PYTHONPATH=. uv run pytest tests/test_ansible_runner.py`