### PR TITLE
fix(auth): 阻止 legacy 外跳把 JWT 拼进任意 callbackUrl

### DIFF
--- a/server/apps/core/services/legacy_third_login_service.py
+++ b/server/apps/core/services/legacy_third_login_service.py
@@ -1,0 +1,190 @@
+import secrets
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+from django.conf import settings as django_settings
+from django.core.cache import cache
+from django.http import JsonResponse
+from django.utils import timezone
+
+from apps.core.logger import logger
+
+CODE_TTL_SECONDS = 300
+CACHE_KEY_PREFIX = "legacy_third_login_code:"
+ISSUE_RETRY_LIMIT = 5
+GENERIC_EXCHANGE_ERROR = "Invalid or expired code"
+
+
+def get_allowed_callback_hosts() -> set[str]:
+    raw = getattr(django_settings, "LEGACY_THIRD_LOGIN_ALLOWED_CALLBACK_HOSTS", "") or ""
+    if isinstance(raw, (list, tuple, set, frozenset)):
+        parts = raw
+    else:
+        parts = str(raw).split(",")
+    return {str(part).strip().lower() for part in parts if str(part).strip()}
+
+
+def callback_hostname(callback_url: str) -> str | None:
+    try:
+        parsed = urlparse(callback_url)
+    except (TypeError, ValueError):
+        return None
+    hostname = parsed.hostname
+    if not hostname:
+        return None
+    return hostname.lower()
+
+
+def is_safe_legacy_external_callback_url(callback_url: str) -> bool:
+    if not isinstance(callback_url, str) or not callback_url:
+        return False
+    try:
+        parsed = urlparse(callback_url)
+    except (TypeError, ValueError):
+        return False
+    if parsed.scheme not in ("http", "https"):
+        return False
+    hostname = parsed.hostname
+    if not hostname:
+        return False
+    return hostname.lower() in get_allowed_callback_hosts()
+
+
+def origin_hostname(origin: str | None) -> str | None:
+    if not origin:
+        return None
+    try:
+        parsed = urlparse(origin)
+    except (TypeError, ValueError):
+        return None
+    if parsed.scheme not in ("http", "https"):
+        return None
+    hostname = parsed.hostname
+    if not hostname:
+        return None
+    return hostname.lower()
+
+
+def _cache_key(code: str) -> str:
+    return f"{CACHE_KEY_PREFIX}{code}"
+
+
+def issue_legacy_third_login_code(*, token: str, callback_url: str) -> str | None:
+    hostname = callback_hostname(callback_url)
+    if not token or not hostname or not is_safe_legacy_external_callback_url(callback_url):
+        logger.info("event=legacy_third_login_code_issued result=rejected callback_host=%s", hostname or "-")
+        return None
+
+    payload = {
+        "token": token,
+        "callback_host": hostname,
+        "issued_at": timezone.now().isoformat(),
+    }
+    for _ in range(ISSUE_RETRY_LIMIT):
+        code = secrets.token_urlsafe(32)
+        if cache.add(_cache_key(code), payload, CODE_TTL_SECONDS):
+            logger.info("event=legacy_third_login_code_issued result=success callback_host=%s", hostname)
+            return code
+
+    logger.error(
+        "event=legacy_third_login_code_issue_failed failed_stage=cache_add error_type=Collision callback_host=%s",
+        hostname,
+    )
+    return None
+
+
+def build_legacy_redirect_url(callback_url: str, third_login_code: str, bk_lite_code: str) -> str | None:
+    if not third_login_code or not bk_lite_code or not is_safe_legacy_external_callback_url(callback_url):
+        return None
+    try:
+        parsed = urlparse(callback_url)
+    except (TypeError, ValueError):
+        return None
+    query_items = [
+        (key, value)
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        if key not in ("token", "bk_lite_code", "third_login_code")
+    ]
+    query_items.append(("third_login_code", third_login_code))
+    query_items.append(("bk_lite_code", bk_lite_code))
+    return urlunparse(parsed._replace(query=urlencode(query_items)))
+
+
+def authorize_legacy_redirect(*, token: str, callback_url: str, third_login_code: str) -> str | None:
+    hostname = callback_hostname(callback_url)
+    if not third_login_code or not is_safe_legacy_external_callback_url(callback_url):
+        logger.info("event=legacy_third_login_authorized result=rejected callback_host=%s", hostname or "-")
+        return None
+    code = issue_legacy_third_login_code(token=token, callback_url=callback_url)
+    if not code:
+        logger.info("event=legacy_third_login_authorized result=rejected callback_host=%s", hostname or "-")
+        return None
+    redirect_url = build_legacy_redirect_url(callback_url, third_login_code, code)
+    if not redirect_url:
+        logger.info("event=legacy_third_login_authorized result=rejected callback_host=%s", hostname or "-")
+        return None
+    logger.info("event=legacy_third_login_authorized result=success callback_host=%s", hostname)
+    return redirect_url
+
+
+def consume_legacy_third_login_code(code: str, request_origin: str | None) -> dict | None:
+    if not code:
+        logger.info("event=legacy_third_login_exchanged result=rejected reason=invalid")
+        return None
+    key = _cache_key(code)
+    payload = cache.get(key)
+    if not isinstance(payload, dict):
+        logger.info("event=legacy_third_login_exchanged result=rejected reason=invalid")
+        return None
+    request_host = origin_hostname(request_origin)
+    callback_host = payload.get("callback_host")
+    if not request_host or request_host != callback_host:
+        logger.info("event=legacy_third_login_exchanged result=rejected callback_host=%s", callback_host or "-")
+        return None
+    if not cache.delete(key):
+        logger.info("event=legacy_third_login_exchanged result=rejected callback_host=%s", callback_host)
+        return None
+    if not payload.get("token"):
+        logger.info("event=legacy_third_login_exchanged result=rejected callback_host=%s", callback_host)
+        return None
+    logger.info("event=legacy_third_login_exchanged result=success callback_host=%s", callback_host)
+    return payload
+
+
+def cors_origin_for_request(request) -> str | None:
+    origin = request.META.get("HTTP_ORIGIN", "")
+    hostname = origin_hostname(origin)
+    if not hostname or hostname not in get_allowed_callback_hosts():
+        return None
+    try:
+        parsed = urlparse(origin)
+    except (TypeError, ValueError):
+        return None
+    if parsed.scheme not in ("http", "https"):
+        return None
+    return origin
+
+
+def apply_exchange_cors(request, response):
+    origin = cors_origin_for_request(request)
+    if not origin:
+        return response
+    response["Access-Control-Allow-Origin"] = origin
+    response["Access-Control-Allow-Methods"] = "POST, OPTIONS"
+    response["Access-Control-Allow-Headers"] = "Content-Type"
+    response["Access-Control-Max-Age"] = "600"
+    response["Vary"] = "Origin"
+    return response
+
+
+def extract_bearer_token(request) -> str:
+    header = request.META.get(getattr(django_settings, "AUTH_TOKEN_HEADER_NAME", "HTTP_AUTHORIZATION"), "")
+    if not header:
+        header = request.META.get("HTTP_AUTHORIZATION", "")
+    token = str(header).strip()
+    if token.startswith("Bearer "):
+        return token[7:].strip()
+    return token
+
+
+def json_error(message: str, status: int = 400) -> JsonResponse:
+    return JsonResponse({"result": False, "message": message}, status=status)

--- a/server/apps/core/services/login_auth_request_service.py
+++ b/server/apps/core/services/login_auth_request_service.py
@@ -35,8 +35,7 @@ LOGIN_RESULT_ALLOWED_KEYS = {
     "challenge_id",
     "qr_code",
     "need_binding",
-    "legacy_external_callback_url",
-    "legacy_third_login_code",
+    "legacy_redirect_url",
 }
 
 LOGIN_AUTH_CALLBACK_PATH = "/api/v1/core/api/login_auth/callback/"

--- a/server/apps/core/tests/test_legacy_third_login_service.py
+++ b/server/apps/core/tests/test_legacy_third_login_service.py
@@ -1,0 +1,142 @@
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from django.core.cache import cache
+from django.test import override_settings
+
+from apps.core.services import legacy_third_login_service as service
+
+
+WHITELIST = "bklite.ai,bklite.cn"
+TOKEN_SENTINEL = "jwt-token-sentinel-value"
+CODE_SENTINEL = "bk-lite-code-sentinel-value"
+
+
+@pytest.fixture(autouse=True)
+def use_dummy_cache_backend(settings):
+    settings.CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "legacy-third-login-tests",
+        }
+    }
+    from django.core.cache import caches
+
+    caches.close_all()
+    yield
+    caches.close_all()
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def allow_bklite_hosts(settings):
+    settings.LEGACY_THIRD_LOGIN_ALLOWED_CALLBACK_HOSTS = WHITELIST
+
+
+def _issue(callback_url="https://bklite.ai/playground", token=TOKEN_SENTINEL):
+    return service.issue_legacy_third_login_code(token=token, callback_url=callback_url)
+
+
+@pytest.mark.unit
+class TestLegacyCallbackWhitelist:
+    def test_empty_whitelist_rejects_all(self):
+        with override_settings(LEGACY_THIRD_LOGIN_ALLOWED_CALLBACK_HOSTS=""):
+            assert service.is_safe_legacy_external_callback_url("https://bklite.ai/cb") is False
+
+    @pytest.mark.usefixtures("allow_bklite_hosts")
+    @pytest.mark.parametrize(
+        "callback_url, expected",
+        [
+            ("https://bklite.ai/playground", True),
+            ("https://bklite.cn/playground", True),
+            ("HTTPS://BKLITE.AI/playground", True),
+            ("https://bklite.ai:8443/playground", True),
+            ("http://attacker.example/cb?third_login_code=x", False),
+            ("//attacker.com/cb", False),
+            ("https://bklite.ai@attacker.com/cb", False),
+            ("https://bklite.ai.attacker.com/cb", False),
+            ("https://1.2.3.4/cb", False),
+            ("javascript:https://bklite.ai", False),
+        ],
+    )
+    def test_host_matching_vectors(self, callback_url, expected):
+        assert service.is_safe_legacy_external_callback_url(callback_url) is expected
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("allow_bklite_hosts")
+class TestLegacyThirdLoginCodeLifecycle:
+    def test_issue_exchange_once_then_reject(self):
+        code = _issue()
+        assert code
+        payload = service.consume_legacy_third_login_code(code, "https://bklite.ai")
+        assert payload["token"] == TOKEN_SENTINEL
+        assert service.consume_legacy_third_login_code(code, "https://bklite.ai") is None
+
+    def test_expired_or_missing_code_is_rejected(self):
+        code = _issue()
+        cache.delete(f"legacy_third_login_code:{code}")
+        assert service.consume_legacy_third_login_code(code, "https://bklite.ai") is None
+
+    def test_callback_host_mismatch_is_rejected_without_consuming(self):
+        code = _issue()
+        assert service.consume_legacy_third_login_code(code, "https://bklite.cn") is None
+        payload = service.consume_legacy_third_login_code(code, "https://bklite.ai")
+        assert payload["token"] == TOKEN_SENTINEL
+
+    def test_concurrent_exchange_succeeds_once(self):
+        code = _issue()
+
+        def consume():
+            return service.consume_legacy_third_login_code(code, "https://bklite.ai")
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            results = list(pool.map(lambda _: consume(), range(8)))
+
+        successes = [item for item in results if item]
+        assert len(successes) == 1
+        assert successes[0]["token"] == TOKEN_SENTINEL
+
+    def test_redirect_url_has_code_not_token(self):
+        redirect_url = service.authorize_legacy_redirect(
+            token=TOKEN_SENTINEL,
+            callback_url="https://bklite.ai/playground?third_login_code=old&token=leaked",
+            third_login_code="state-code",
+        )
+        parsed = urlparse(redirect_url)
+        query = parse_qs(parsed.query)
+        assert query["third_login_code"] == ["state-code"]
+        assert "bk_lite_code" in query
+        assert "token" not in query
+        assert TOKEN_SENTINEL not in redirect_url
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("allow_bklite_hosts")
+class TestLegacyThirdLoginLogs:
+    def test_logs_omit_code_and_token_sentinels(self, caplog):
+        caplog.set_level(logging.DEBUG, logger="app")
+        redirect_url = service.authorize_legacy_redirect(
+            token=TOKEN_SENTINEL,
+            callback_url="https://bklite.ai/playground",
+            third_login_code=CODE_SENTINEL,
+        )
+        parsed = urlparse(redirect_url)
+        issued_code = parse_qs(parsed.query)["bk_lite_code"][0]
+        service.consume_legacy_third_login_code(issued_code, "https://bklite.ai")
+
+        rendered = "\n".join(record.getMessage() for record in caplog.records)
+        assert TOKEN_SENTINEL not in rendered
+        assert CODE_SENTINEL not in rendered
+        assert issued_code not in rendered
+        assert "https://bklite.ai/playground" not in rendered
+        assert "callback_host=bklite.ai" in rendered
+        assert "result=success" in rendered

--- a/server/apps/core/tests/views/test_legacy_third_login.py
+++ b/server/apps/core/tests/views/test_legacy_third_login.py
@@ -1,0 +1,309 @@
+import json
+from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from django.core.cache import cache
+from django.test import RequestFactory, override_settings
+
+from apps.core.views import index_view
+
+
+WHITELIST = "bklite.ai,bklite.cn"
+TOKEN_SENTINEL = "jwt-token-sentinel-value"
+
+
+def _json(response):
+    return json.loads(response.content)
+
+
+@pytest.fixture(autouse=True)
+def use_dummy_cache_backend(settings):
+    settings.CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "legacy-third-login-view-tests",
+        }
+    }
+    from django.core.cache import caches
+
+    caches.close_all()
+    yield
+    caches.close_all()
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def allow_bklite_hosts(settings):
+    settings.LEGACY_THIRD_LOGIN_ALLOWED_CALLBACK_HOSTS = WHITELIST
+
+
+def _authorize_request(payload, token=TOKEN_SENTINEL):
+    request = RequestFactory().post(
+        "/api/v1/core/api/legacy_third_login/authorize/",
+        data=json.dumps(payload),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+    request.user = MagicMock(is_authenticated=True)
+    return request
+
+
+def _exchange_request(payload, origin="https://bklite.ai"):
+    headers = {"HTTP_ORIGIN": origin} if origin else {}
+    request = RequestFactory().post(
+        "/api/v1/core/api/legacy_third_login/exchange/",
+        data=json.dumps(payload),
+        content_type="application/json",
+        **headers,
+    )
+    return request
+
+
+@pytest.mark.unit
+class TestLegacyThirdLoginAuthorizeView:
+    def test_empty_whitelist_returns_400(self):
+        with override_settings(LEGACY_THIRD_LOGIN_ALLOWED_CALLBACK_HOSTS=""):
+            response = index_view.legacy_third_login_authorize(
+                _authorize_request(
+                    {
+                        "callback_url": "https://bklite.ai/playground",
+                        "third_login_code": "state",
+                    }
+                )
+            )
+        assert response.status_code == 400
+        assert "redirect_url" not in _json(response)
+
+    @pytest.mark.usefixtures("allow_bklite_hosts")
+    def test_whitelisted_hosts_return_redirect_without_token(self):
+        for host in ("bklite.ai", "bklite.cn"):
+            response = index_view.legacy_third_login_authorize(
+                _authorize_request(
+                    {
+                        "callback_url": f"https://{host}/playground?third_login_code=old",
+                        "third_login_code": "state",
+                    }
+                )
+            )
+            assert response.status_code == 200
+            redirect_url = _json(response)["redirect_url"]
+            query = parse_qs(urlparse(redirect_url).query)
+            assert query["third_login_code"] == ["state"]
+            assert query["bk_lite_code"]
+            assert "token" not in query
+            assert TOKEN_SENTINEL not in redirect_url
+
+    @pytest.mark.usefixtures("allow_bklite_hosts")
+    def test_non_whitelisted_host_returns_400(self):
+        response = index_view.legacy_third_login_authorize(
+            _authorize_request(
+                {
+                    "callback_url": "http://attacker.example/cb?third_login_code=x",
+                    "third_login_code": "x",
+                }
+            )
+        )
+        assert response.status_code == 400
+
+    def test_missing_bearer_token_returns_401(self):
+        request = RequestFactory().post(
+            "/api/v1/core/api/legacy_third_login/authorize/",
+            data=json.dumps({"callback_url": "https://bklite.ai/playground", "third_login_code": "state"}),
+            content_type="application/json",
+        )
+        response = index_view.legacy_third_login_authorize(request)
+        assert response.status_code == 401
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("allow_bklite_hosts")
+class TestLegacyThirdLoginExchangeView:
+    def test_exchange_success_then_reuse_fails(self):
+        authorize = index_view.legacy_third_login_authorize(
+            _authorize_request(
+                {
+                    "callback_url": "https://bklite.ai/playground",
+                    "third_login_code": "state",
+                }
+            )
+        )
+        code = parse_qs(urlparse(_json(authorize)["redirect_url"]).query)["bk_lite_code"][0]
+        first = index_view.legacy_third_login_exchange(_exchange_request({"code": code}))
+        assert first.status_code == 200
+        assert _json(first) == {"result": True, "data": {"token": TOKEN_SENTINEL}}
+        second = index_view.legacy_third_login_exchange(_exchange_request({"code": code}))
+        assert second.status_code == 400
+        assert _json(second)["message"] == "Invalid or expired code"
+
+    def test_cors_preflight_allows_both_site_origins(self):
+        for origin in ("https://bklite.ai", "https://bklite.cn"):
+            request = RequestFactory().generic(
+                "OPTIONS",
+                "/api/v1/core/api/legacy_third_login/exchange/",
+                HTTP_ORIGIN=origin,
+            )
+            response = index_view.legacy_third_login_exchange(request)
+            assert response.status_code == 200
+            assert response["Access-Control-Allow-Origin"] == origin
+            assert "POST" in response["Access-Control-Allow-Methods"]
+
+    def test_cors_preflight_rejects_unknown_origin(self):
+        request = RequestFactory().generic(
+            "OPTIONS",
+            "/api/v1/core/api/legacy_third_login/exchange/",
+            HTTP_ORIGIN="https://attacker.example",
+        )
+        response = index_view.legacy_third_login_exchange(request)
+        assert "Access-Control-Allow-Origin" not in response
+
+
+def _bound_auth_request(auth_request_id, extra=None):
+    from apps.core.services.login_auth_request_service import (
+        create_browser_binding_token,
+        _hash_browser_binding_token,
+    )
+
+    origin_token = create_browser_binding_token()
+    auth_request = {
+        "auth_request_id": auth_request_id,
+        "status": "pending",
+        "browser_binding_hash": _hash_browser_binding_token(origin_token),
+        "legacy_external_callback_url": "",
+        "legacy_third_login_code": "",
+    }
+    if extra:
+        auth_request.update(extra)
+    return auth_request, origin_token
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("allow_bklite_hosts")
+class TestLoginAuthCallbackLegacyRedirect:
+    @patch("apps.core.views.index_view.get_auth_request")
+    @patch("apps.core.views.index_view.parse_auth_request_state")
+    @patch("apps.core.views.index_view.SystemMgmt")
+    @patch("apps.core.views.index_view.update_auth_request_status")
+    def test_login_auth_callback_returns_legacy_redirect_url(
+        self,
+        mock_update_status,
+        mock_system_mgmt,
+        mock_parse_state,
+        mock_get_auth_request,
+    ):
+        mock_parse_state.return_value = {
+            "auth_request_id": "auth-legacy",
+            "binding_id": 5,
+            "callback_url": "/",
+        }
+        auth_request, origin_token = _bound_auth_request(
+            "auth-legacy",
+            {
+                "legacy_external_callback_url": "https://bklite.ai/playground?third_login_code=legacy-code",
+                "legacy_third_login_code": "legacy-code",
+            },
+        )
+        mock_get_auth_request.return_value = auth_request
+        mock_system_mgmt.return_value.login_with_binding.return_value = {
+            "result": True,
+            "data": {"id": 9, "username": "legacy-user", "token": "binding-token"},
+        }
+
+        request = RequestFactory().get("/api/v1/core/api/login_auth/callback/?state=signed&code=auth-code")
+        request.COOKIES["bklite_login_auth_browser_auth-legacy"] = origin_token
+        response = index_view.login_auth_callback(request)
+
+        assert response.status_code == 302
+        login_result = mock_update_status.call_args.kwargs["login_result"]
+        redirect_url = login_result["legacy_redirect_url"]
+        query = parse_qs(urlparse(redirect_url).query)
+        assert query["third_login_code"] == ["legacy-code"]
+        assert query["bk_lite_code"]
+        assert "token" not in query
+        assert "binding-token" not in redirect_url
+        assert "legacy_external_callback_url" not in login_result
+        assert "legacy_third_login_code" not in login_result
+
+    @patch("apps.core.views.index_view.get_auth_request")
+    @patch("apps.core.views.index_view.parse_auth_request_state")
+    @patch("apps.core.views.index_view.SystemMgmt")
+    @patch("apps.core.views.index_view.update_auth_request_status")
+    def test_login_auth_callback_ignores_cached_non_whitelisted_legacy_url(
+        self,
+        mock_update_status,
+        mock_system_mgmt,
+        mock_parse_state,
+        mock_get_auth_request,
+    ):
+        mock_parse_state.return_value = {
+            "auth_request_id": "auth-legacy-stale",
+            "binding_id": 5,
+            "callback_url": "/",
+        }
+        auth_request, origin_token = _bound_auth_request(
+            "auth-legacy-stale",
+            {
+                "legacy_external_callback_url": "https://attacker.example/cb?third_login_code=legacy-code",
+                "legacy_third_login_code": "legacy-code",
+            },
+        )
+        mock_get_auth_request.return_value = auth_request
+        mock_system_mgmt.return_value.login_with_binding.return_value = {
+            "result": True,
+            "data": {"id": 9, "username": "legacy-user", "token": "binding-token"},
+        }
+
+        request = RequestFactory().get("/api/v1/core/api/login_auth/callback/?state=signed&code=auth-code")
+        request.COOKIES["bklite_login_auth_browser_auth-legacy-stale"] = origin_token
+        response = index_view.login_auth_callback(request)
+
+        assert response.status_code == 302
+        login_result = mock_update_status.call_args.kwargs["login_result"]
+        assert "legacy_redirect_url" not in login_result
+        assert "legacy_external_callback_url" not in login_result
+
+
+@pytest.mark.unit
+class TestStartLoginAuthLegacyWhitelist:
+    def test_rejects_when_whitelist_empty(self):
+        with override_settings(LEGACY_THIRD_LOGIN_ALLOWED_CALLBACK_HOSTS=""):
+            request = RequestFactory().post(
+                "/api/v1/core/api/start_login_auth/",
+                data=json.dumps(
+                    {
+                        "binding_id": 5,
+                        "callback_url": "/",
+                        "legacy_external_callback_url": "https://bklite.ai/playground?third_login_code=legacy-code",
+                        "legacy_third_login_code": "legacy-code",
+                    }
+                ),
+                content_type="application/json",
+            )
+            response = index_view.start_login_auth(request)
+        assert response.status_code == 400
+        assert _json(response)["message"] == "legacy_external_callback_url is not allowed"
+
+    def test_rejects_non_whitelisted_host(self):
+        with override_settings(LEGACY_THIRD_LOGIN_ALLOWED_CALLBACK_HOSTS=WHITELIST):
+            request = RequestFactory().post(
+                "/api/v1/core/api/start_login_auth/",
+                data=json.dumps(
+                    {
+                        "binding_id": 5,
+                        "callback_url": "/",
+                        "legacy_external_callback_url": "https://attacker.example/cb?third_login_code=x",
+                        "legacy_third_login_code": "x",
+                    }
+                ),
+                content_type="application/json",
+            )
+            response = index_view.start_login_auth(request)
+        assert response.status_code == 400
+        assert _json(response)["message"] == "legacy_external_callback_url is not allowed"
+

--- a/server/apps/core/tests/views/test_login_auth_bindings.py
+++ b/server/apps/core/tests/views/test_login_auth_bindings.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlparse
 
 import pytest
-from django.test import RequestFactory
+from django.test import RequestFactory, override_settings
 
 
 @pytest.mark.unit
@@ -227,6 +227,7 @@ class TestLoginAuthBindingViews:
         assert browser_cookie["samesite"] == "Lax"
         assert mock_create_auth_request.call_args.kwargs["browser_binding_token"] == browser_cookie.value
 
+    @override_settings(LEGACY_THIRD_LOGIN_ALLOWED_CALLBACK_HOSTS="bklite.ai,bklite.cn")
     @patch("apps.core.views.index_view.build_login_auth_redirect")
     @patch("apps.core.views.index_view.create_auth_request")
     @patch("apps.core.views.index_view._get_login_auth_binding_by_id")
@@ -295,6 +296,48 @@ class TestLoginAuthBindingViews:
 
         assert response.status_code == 400
         assert json.loads(response.content)["message"] == "legacy_external_callback_url requires third_login_code"
+
+    def test_start_login_auth_rejects_non_whitelisted_legacy_callback(self):
+        from apps.core.views.index_view import start_login_auth
+
+        with override_settings(LEGACY_THIRD_LOGIN_ALLOWED_CALLBACK_HOSTS="bklite.ai,bklite.cn"):
+            request = RequestFactory().post(
+                "/api/v1/core/api/start_login_auth/",
+                data=json.dumps(
+                    {
+                        "binding_id": 5,
+                        "callback_url": "/",
+                        "legacy_external_callback_url": "https://attacker.example/cb?third_login_code=x",
+                        "legacy_third_login_code": "x",
+                    }
+                ),
+                content_type="application/json",
+            )
+            response = start_login_auth(request)
+
+        assert response.status_code == 400
+        assert json.loads(response.content)["message"] == "legacy_external_callback_url is not allowed"
+
+    def test_start_login_auth_rejects_legacy_callback_when_whitelist_empty(self):
+        from apps.core.views.index_view import start_login_auth
+
+        with override_settings(LEGACY_THIRD_LOGIN_ALLOWED_CALLBACK_HOSTS=""):
+            request = RequestFactory().post(
+                "/api/v1/core/api/start_login_auth/",
+                data=json.dumps(
+                    {
+                        "binding_id": 5,
+                        "callback_url": "/",
+                        "legacy_external_callback_url": "https://bklite.ai/playground?third_login_code=legacy-code",
+                        "legacy_third_login_code": "legacy-code",
+                    }
+                ),
+                content_type="application/json",
+            )
+            response = start_login_auth(request)
+
+        assert response.status_code == 400
+        assert json.loads(response.content)["message"] == "legacy_external_callback_url is not allowed"
 
     @patch("apps.core.views.index_view.build_login_auth_redirect")
     @patch("apps.core.views.index_view.create_auth_request")
@@ -626,11 +669,12 @@ class TestLoginAuthBindingViews:
         mock_update_status.assert_not_called()
         self._assert_callback_redirect(response, "failed", "认证请求与发起浏览器不匹配，请返回原页面重新发起认证。")
 
+    @override_settings(LEGACY_THIRD_LOGIN_ALLOWED_CALLBACK_HOSTS="bklite.ai,bklite.cn")
     @patch("apps.core.views.index_view.get_auth_request")
     @patch("apps.core.views.index_view.parse_auth_request_state")
     @patch("apps.core.views.index_view.SystemMgmt")
     @patch("apps.core.views.index_view.update_auth_request_status")
-    def test_login_auth_callback_returns_legacy_external_callback_data(
+    def test_login_auth_callback_returns_legacy_redirect_url(
         self,
         mock_update_status,
         mock_system_mgmt,
@@ -664,10 +708,56 @@ class TestLoginAuthBindingViews:
 
         assert response.status_code == 302
         login_result = mock_update_status.call_args.kwargs["login_result"]
-        assert login_result["legacy_external_callback_url"] == (
-            "https://bklite.ai/playground?third_login_code=legacy-code"
+        redirect_url = login_result["legacy_redirect_url"]
+        query = parse_qs(urlparse(redirect_url).query)
+        assert query["third_login_code"] == ["legacy-code"]
+        assert query["bk_lite_code"]
+        assert "token" not in query
+        assert "binding-token" not in redirect_url
+        assert "legacy_external_callback_url" not in login_result
+        assert "legacy_third_login_code" not in login_result
+
+    @override_settings(LEGACY_THIRD_LOGIN_ALLOWED_CALLBACK_HOSTS="bklite.ai,bklite.cn")
+    @patch("apps.core.views.index_view.get_auth_request")
+    @patch("apps.core.views.index_view.parse_auth_request_state")
+    @patch("apps.core.views.index_view.SystemMgmt")
+    @patch("apps.core.views.index_view.update_auth_request_status")
+    def test_login_auth_callback_ignores_cached_non_whitelisted_legacy_url(
+        self,
+        mock_update_status,
+        mock_system_mgmt,
+        mock_parse_state,
+        mock_get_auth_request,
+    ):
+        from apps.core.views.index_view import login_auth_callback
+
+        mock_parse_state.return_value = {
+            "auth_request_id": "auth-legacy-stale",
+            "binding_id": 5,
+            "callback_url": "/",
+        }
+        auth_request, origin_browser_token, _other_browser_token = self._make_bound_auth_request()
+        auth_request.update(
+            {
+                "auth_request_id": "auth-legacy-stale",
+                "legacy_external_callback_url": "https://attacker.example/cb?third_login_code=legacy-code",
+                "legacy_third_login_code": "legacy-code",
+            }
         )
-        assert login_result["legacy_third_login_code"] == "legacy-code"
+        mock_get_auth_request.return_value = auth_request
+        mock_system_mgmt.return_value.login_with_binding.return_value = {
+            "result": True,
+            "data": {"id": 9, "username": "legacy-user", "token": "binding-token"},
+        }
+
+        request = RequestFactory().get("/api/v1/core/api/login_auth/callback/?state=signed&code=auth-code")
+        request.COOKIES["bklite_login_auth_browser_auth-legacy-stale"] = origin_browser_token
+        response = login_auth_callback(request)
+
+        assert response.status_code == 302
+        login_result = mock_update_status.call_args.kwargs["login_result"]
+        assert "legacy_redirect_url" not in login_result
+        assert "legacy_external_callback_url" not in login_result
 
     @patch("apps.core.views.index_view.get_auth_request")
     @patch("apps.core.views.index_view.parse_auth_request_state")

--- a/server/apps/core/urls.py
+++ b/server/apps/core/urls.py
@@ -23,6 +23,8 @@ urlpatterns = [
     re_path(r"api/verify_otp_code/", index_view.verify_otp_code),
     re_path(r"api/reset_pwd/", index_view.reset_pwd),
     re_path(r"api/login_info/", index_view.login_info),
+    re_path(r"api/legacy_third_login/authorize/", index_view.legacy_third_login_authorize),
+    re_path(r"api/legacy_third_login/exchange/", index_view.legacy_third_login_exchange),
     re_path(r"api/get_client/", index_view.get_client),
     re_path(r"api/get_my_client/", index_view.get_my_client),
     re_path(r"api/get_client_detail/", index_view.get_client_detail),

--- a/server/apps/core/views/index_view.py
+++ b/server/apps/core/views/index_view.py
@@ -10,6 +10,15 @@ from django.shortcuts import render
 from rest_framework.decorators import api_view
 
 from apps.core.logger import logger, safe_exception_call_chain, safe_exception_info
+from apps.core.services.legacy_third_login_service import (
+    GENERIC_EXCHANGE_ERROR,
+    apply_exchange_cors,
+    authorize_legacy_redirect,
+    consume_legacy_third_login_code,
+    extract_bearer_token,
+    is_safe_legacy_external_callback_url,
+    json_error,
+)
 from apps.core.services.login_auth_request_service import (
     AUTH_REQUEST_TTL,
     build_auth_request_state,
@@ -129,11 +138,7 @@ def _is_safe_relative_callback_url(callback_url: str) -> bool:
 
 
 def _is_safe_legacy_external_callback_url(callback_url: str) -> bool:
-    try:
-        parsed = urlparse(callback_url)
-    except (TypeError, ValueError):
-        return False
-    return parsed.scheme in ("http", "https") and bool(parsed.netloc)
+    return is_safe_legacy_external_callback_url(callback_url)
 
 
 def _build_login_auth_result_redirect(
@@ -970,7 +975,7 @@ def start_login_auth(request):
         if legacy_external_callback_url and not legacy_third_login_code:
             return JsonResponse({"result": False, "message": "legacy_external_callback_url requires third_login_code"}, status=400)
         if legacy_external_callback_url and not _is_safe_legacy_external_callback_url(legacy_external_callback_url):
-            return JsonResponse({"result": False, "message": "legacy_external_callback_url must be an absolute HTTP(S) URL"}, status=400)
+            return JsonResponse({"result": False, "message": "legacy_external_callback_url is not allowed"}, status=400)
         if redirect_origin and not validate_redirect_origin(request, redirect_origin):
             redirect_origin = None
 
@@ -1155,9 +1160,23 @@ def login_auth_callback(request):
 
     login_result = result.get("data", {}) or {}
     login_result.setdefault("redirect_url", state_payload["callback_url"])
-    if auth_request.get("legacy_external_callback_url") and auth_request.get("legacy_third_login_code"):
-        login_result["legacy_external_callback_url"] = auth_request["legacy_external_callback_url"]
-        login_result["legacy_third_login_code"] = auth_request["legacy_third_login_code"]
+    legacy_external_callback_url = auth_request.get("legacy_external_callback_url") or ""
+    legacy_third_login_code = auth_request.get("legacy_third_login_code") or ""
+    login_token = login_result.get("token") or ""
+    if legacy_external_callback_url and legacy_third_login_code and login_token:
+        if not _is_safe_legacy_external_callback_url(legacy_external_callback_url):
+            logger.info(
+                "event=legacy_third_login_auth_callback result=rejected callback_host=%s",
+                urlparse(legacy_external_callback_url).hostname or "-",
+            )
+        else:
+            legacy_redirect_url = authorize_legacy_redirect(
+                token=login_token,
+                callback_url=legacy_external_callback_url,
+                third_login_code=legacy_third_login_code,
+            )
+            if legacy_redirect_url:
+                login_result["legacy_redirect_url"] = legacy_redirect_url
     update_auth_request_status(
         auth_request_id,
         status="success",
@@ -1168,3 +1187,64 @@ def login_auth_callback(request):
     if login_result.get("token"):
         _set_auth_cookie_on_response(response, login_result["token"])
     return response
+
+
+def legacy_third_login_authorize(request):
+    if request.method != "POST":
+        return json_error("Method not allowed", status=405)
+
+    token = extract_bearer_token(request)
+    if not token:
+        return json_error("Authentication required", status=401)
+
+    try:
+        data = _parse_request_data(request)
+        callback_url = (data.get("callback_url") or "").strip()
+        third_login_code = (data.get("third_login_code") or "").strip()
+        redirect_url = authorize_legacy_redirect(
+            token=token,
+            callback_url=callback_url,
+            third_login_code=third_login_code,
+        )
+        if not redirect_url:
+            return json_error("legacy callback is not allowed", status=400)
+        return JsonResponse({"redirect_url": redirect_url})
+    except Exception as error:
+        logger.error(
+            "event=legacy_third_login_authorize_failed failed_stage=authorize error_type=%s call_chain=%s",
+            type(error).__name__,
+            safe_exception_call_chain(error),
+            exc_info=safe_exception_info(error),
+        )
+        return json_error(_get_loader(request).get("error.system_error", "System error occurred"), status=500)
+
+
+@api_exempt
+def legacy_third_login_exchange(request):
+    if request.method == "OPTIONS":
+        return apply_exchange_cors(request, JsonResponse({"result": True}))
+    if request.method != "POST":
+        return apply_exchange_cors(request, json_error("Method not allowed", status=405))
+
+    try:
+        data = _parse_request_data(request)
+        code = (data.get("code") or "").strip()
+        origin = request.META.get("HTTP_ORIGIN", "")
+        payload = consume_legacy_third_login_code(code, origin)
+        if not payload:
+            return apply_exchange_cors(request, json_error(GENERIC_EXCHANGE_ERROR, status=400))
+        return apply_exchange_cors(
+            request,
+            JsonResponse({"result": True, "data": {"token": payload["token"]}}),
+        )
+    except Exception as error:
+        logger.error(
+            "event=legacy_third_login_exchange_failed failed_stage=exchange error_type=%s call_chain=%s",
+            type(error).__name__,
+            safe_exception_call_chain(error),
+            exc_info=safe_exception_info(error),
+        )
+        return apply_exchange_cors(
+            request,
+            json_error(_get_loader(request).get("error.system_error", "System error occurred"), status=500),
+        )

--- a/server/config/components/base.py
+++ b/server/config/components/base.py
@@ -25,5 +25,7 @@ ASGI_APPLICATION = "asgi.application"
 
 DEBUG = os.getenv("DEBUG", "0").lower() in ["1", "true"]
 WEB_BASE_URL = os.getenv("WEB_BASE_URL", "").rstrip("/")
+# 逗号分隔、host 精确匹配。默认空 = 禁用 legacy 外部回调。现网示例：bklite.ai,bklite.cn
+LEGACY_THIRD_LOGIN_ALLOWED_CALLBACK_HOSTS = os.getenv("LEGACY_THIRD_LOGIN_ALLOWED_CALLBACK_HOSTS", "")
 STATIC_URL = "static/"
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles/")

--- a/specs/capabilities/platform-security.md
+++ b/specs/capabilities/platform-security.md
@@ -13,6 +13,7 @@
 
 - 自定义用户模型 `base.User`,多后端(Session / API Secret / 标准)。
 - Web → 后端经 `/api/proxy/core/api/login/`，统一由现行认证辅助函数设置 `bklite_token` cookie；具体函数名以当前代码为准。
+- Legacy 外部站点登录（bklite.ai / bklite.cn playground）：回跳 URL **不得**携带 JWT。服务端按 `LEGACY_THIRD_LOGIN_ALLOWED_CALLBACK_HOSTS`（默认空=禁用）校验回调 host 后签发一次性 `bk_lite_code`，外站再 POST `/api/proxy/core/api/legacy_third_login/exchange/` 兑 token。authorize/exchange 属登录链路，**不走** OpenAPI 网关。
 - `bk_lite_login` 是内部函数,**不暴露为 URL 路由**。
 - 认证源 / SSO 经 NATS 接入，接口规范见 [SSO NATS 接入规格](sso-nats-integration.md)。
 

--- a/specs/changes/legacy-third-login-token-hijack-fix/spec.md
+++ b/specs/changes/legacy-third-login-token-hijack-fix/spec.md
@@ -1,0 +1,172 @@
+# Legacy 第三方登录任意外域 JWT 劫持修复
+
+## 背景
+
+TSRC 报告（2026-09-07，标题「BlueKing Lite平台存在任意账号劫持凭证导致账号接管漏洞」）：
+攻击者构造 `https://<平台>/auth/signin?callbackUrl=http://攻击者主机/cb?third_login_code=<任意值>&thirdLogin=true`
+诱导受害者登录，登录成功后受害者的平台 JWT（约 24h 有效）被完整拼进 `callbackUrl`
+并整页跳转到攻击者服务器，等于账号接管。
+
+代码根因（两条路径都成立）：
+
+- 密码登录路径：`web/src/app/(core)/auth/signin/SigninClient.tsx` 用
+  `getLegacyThirdLoginCode(callbackUrl)` 从**攻击者可控的 URL** 提取 code，即触发 legacy
+  分支；`web/src/utils/authRedirect.ts` 的 `buildLegacyThirdLoginCallbackUrl` **只校验协议是
+  http/https，不做任何域名校验**，把 `token=<JWT>` 拼上后 `window.location.href` 跳转。
+- login-auth v2 路径：`useLoginAuthValidation` 把原始 `callbackUrl` 作为
+  `legacy_external_callback_url` 传给 `start_login_auth`；
+  `server/apps/core/views/index_view.py` 的 `_is_safe_legacy_external_callback_url`
+  同样只校验协议，登录完成后 `login_auth_callback` 原样回填给前端跳转。
+
+合法消费方只有 `bklite-website` 仓库（本机路径 `/Users/lanyu/Work/bklite-website`），
+线上部署为**两个站点**：`bklite.ai`（Cloudflare）与 `bklite.cn`（镜像，Dockerfile 构建时
+将产物中的 `bklite.ai` 文本替换为 `bklite.cn`；`loginBaseUrl`/`loginInfoUrl` 指向的
+`bklite.canway.net` 不受替换影响）。其 `src/lib/playgroundAuth.js` 自生成随机
+`third_login_code` 存
+sessionStorage 作 state，跳平台登录，回跳后校验 state 一致才收 URL 中的 `token`（存入
+非 HttpOnly cookie `bklite_token`，用于 Bearer 直调平台 API，如
+`https://bklite.canway.net/api/proxy/core/api/login_info/`）。该 state 只防 CSRF，
+防不了平台把 token 送给任意外域。
+
+## 目标架构（P0 白名单 + P1 去 token 化，一次修完）
+
+修复后 legacy 外部登录流程：
+
+1. 外部站点（bklite.ai）生成本地 state（沿用现有 `third_login_code` 机制），跳转
+   `/auth/signin?callbackUrl=<外站回调URL>&thirdLogin=true`（参数形态不变，兼容存量链接）。
+2. 用户在平台完成登录（密码 / OTP / login-auth v2 任意方式）。
+3. **由服务端**校验外站回调 host 命中白名单后，签发一次性授权码 `bk_lite_code`，
+   并构建回跳 URL：`<外站回调URL>&third_login_code=<原state>&bk_lite_code=<一次性码>`。
+   **URL 中不再出现 `token`**。白名单未命中：不签发、不外跳，回落站内 `PORTAL_HOME_PATH`。
+4. 外部站点回调页校验本地 state 后，用 `bk_lite_code` POST 平台兑换接口，**token 只经
+   响应体下发**。
+
+### 服务端（server/apps/core）
+
+- **白名单配置**：新增环境变量 `LEGACY_THIRD_LOGIN_ALLOWED_CALLBACK_HOSTS`（逗号分隔，
+  host 精确匹配，不含 scheme/port 归一化按 `urlparse().hostname` 小写比较）。
+  **默认空 = 完全禁用 legacy 外部回调**。现网 bklite.canway.net 部署需配置为
+  `bklite.ai,bklite.cn`（在部署文档/变更说明中登记）。
+- **校验函数**：`_is_safe_legacy_external_callback_url` 升级为「http(s) 绝对 URL 且
+  hostname 命中白名单」；覆盖协议相对 `//`、`user@host`、大小写、IP 直连等变体
+  （统一交给 `urlparse().hostname` 判定，禁止字符串前缀匹配）。
+- **一次性授权码**：
+  - 生成：`secrets.token_urlsafe(32)` 级别熵；存 Django cache，键
+    `legacy_third_login_code:<code>`，值含 `token`、`callback_host`、签发时间；TTL 300s。
+  - 不变量：单次消费（并发重复兑换只能成功一次，兑换实现必须原子判定「取到且删除」）；
+    过期、不存在、`callback_host` 不匹配一律拒绝；日志不得出现 code 或 token 明文。
+- **签发点一：密码登录路径**。新增授权端点（与现有 core 登录端点同模式，`api_exempt`
+  之外需 Bearer 认证）：`POST /api/proxy/core/api/legacy_third_login/authorize/`，
+  body `{callback_url, third_login_code}`，服务端做白名单校验 + 签发 code + 拼接回跳
+  URL，返回 `{redirect_url}`；未命中白名单返回 4xx。**跳转目标由后端决定**（对应报告
+  修复建议 2）。
+- **签发点二：login-auth v2 路径**。`start_login_auth` 对
+  `legacy_external_callback_url` 做白名单校验（未命中返回 400）；`login_auth_callback`
+  成功后由服务端签发 code、构建 `legacy_redirect_url` 写入 `login_result`，
+  `LOGIN_AUTH_RESULT_ALLOWED_FIELDS`（`login_auth_request_service.py`）中
+  `legacy_external_callback_url`/`legacy_third_login_code` 两个字段改为
+  `legacy_redirect_url`；回填前基于缓存中的 auth_request 再做一次白名单校验（防旧缓存
+  绕过）。
+- **兑换端点**：`POST /api/proxy/core/api/legacy_third_login/exchange/`，`api_exempt`
+  （凭 code 本身认证），body `{code}`，成功返回 `{result: true, data: {token}}`；
+  失败（过期/已用/不存在）统一 4xx 且响应不区分具体原因。需允许白名单 origin
+  （`https://bklite.ai` 与 `https://bklite.cn` 两个）的 CORS 预检与跨域 POST
+  （参照现网 `login_info/` 已被两站跨域调用的现状核对 CORS 配置位置）。**该端点属登录链路而非业务 OpenAPI，不走 openapi 网关**，实现前
+  与 `specs/capabilities/openapi-gateway.md` 的边界描述核对一次。
+- 日志遵守仓库红线：稳定模板 + 惰性参数；只记录 host、结果与关联 ID，不记录
+  code/token/完整 URL。
+
+### 平台前端（web/src）
+
+- `SigninClient.tsx`：
+  - 删除「`callbackUrl` query 里出现 `third_login_code` 即触发外跳」的隐式授权。
+    legacy 分支改为：登录成功后携带 Bearer token 调 `legacy_third_login/authorize/`，
+    成功则 `finishAuthentication(响应中的 redirect_url)`，4xx 则回落
+    `PORTAL_HOME_PATH`（正常完成站内登录，不报错阻断）。
+  - login-auth v2 结果改用 `login_result.legacy_redirect_url`。
+- `web/src/utils/authRedirect.ts`：
+  - **删除** `buildLegacyThirdLoginCallbackUrl`（前端不再拼接任何带凭据的外域 URL）。
+  - `getLegacyThirdLoginCode` 仅保留「识别当前是 legacy 流程 + 提取 state 供
+    authorize 请求使用」的职责，不再决定跳转目标。
+- `useLoginAuthValidation.ts`：继续上送 `legacy_external_callback_url`/
+  `legacy_third_login_code`（由服务端校验），透传 `legacy_redirect_url`。
+- 同源 `buildThirdLoginCallbackUrl` 的 `?token=`（浏览器历史/日志残留）**不在本次范围**：
+  它有同源校验、非本漏洞攻击面，且站内消费方（wechat-popup、crossDomainAuth 等）依赖
+  形态未梳理，单独立项跟进，本 spec 记录为已知残留。
+
+### 外部站点（/Users/lanyu/Work/bklite-website）
+
+- `src/lib/playgroundAuth.js`：`verifyLoginCallback` 不再从 URL 读 `token`，改为：
+  校验本地 state 与 URL `third_login_code` 一致 → 读 `bk_lite_code` → POST 平台兑换
+  接口 → 用响应体中的 token 写 `bklite_token` cookie。函数从同步改异步，调用方
+  （`src/pages/playground/index.js`）随之调整；`cleanUrlParams` 增删 `bk_lite_code`。
+- `docusaurus.config.js` `customFields` 新增 `tokenExchangeUrl`
+  （`https://bklite.canway.net/api/proxy/core/api/legacy_third_login/exchange/`）。
+  该 URL 不含 `bklite.ai` 字样，不受 Dockerfile 镜像替换影响，两站共用；如未来配置里
+  出现 `bklite.ai` 域名的新字段，需确认镜像替换后的行为符合预期。
+- 兑换失败展示现有 `callbackErrorMessage` 重新登录引导。
+
+## 兼容与发布顺序
+
+- 平台先发（authorize/exchange 端点 + 白名单 + 前端去 token 化），此时旧版 website
+  的 `verifyLoginCallback` 收不到 `token` 参数会判定登录失败并引导重新登录——**这是
+  可接受的一次性中断**（安全修复优先），website 侧尽快跟发。
+- 白名单默认空即禁用，私有化部署未配置时 legacy 外跳整体失效、站内登录不受影响，
+  符合「非白名单一律拒绝」的安全默认。
+- 回滚只允许回退 website 消费方式，**不得**恢复「URL 携带 token」或去掉白名单校验。
+
+## 测试要求
+
+- server（新增/扩展 `apps/core/tests/`）：
+  - 白名单：未配置一律 400；配置多值（`bklite.ai,bklite.cn`）后两域名均放行、
+    未命中 400；`//attacker.com`、`https://bklite.ai@attacker.com`、`HTTPS://BKLITE.AI`、
+    `bklite.ai.attacker.com`（后缀伪装）、IP 直连、带端口等向量。
+  - code 生命周期：签发→兑换成功一次→二次兑换 4xx；过期 4xx；callback_host 不匹配 4xx。
+  - `login_auth_callback`：白名单命中时 `login_result` 含 `legacy_redirect_url` 且
+    不含 token 参数；缓存中旧 auth_request 携带非白名单 URL 时不回填。
+  - 日志回归：断言日志输出不含 code/token 哨兵值。
+- web：`signin/__tests__/` 与 `web/scripts/auth-callback-url-test.ts` 补攻击向量用例；
+  断言仓库内不再存在把 token 拼入非同源 URL 的代码路径（删除
+  `buildLegacyThirdLoginCallbackUrl` 后其测试同步更新）。
+- website：`verifyLoginCallback` 单测（state 不一致拒绝、兑换失败处理、成功写 cookie）；
+  `pnpm build` 通过。
+
+## 验收（由发起会话执行，实现方需保证以下全部通过）
+
+1. 原始 PoC 复验：构造
+   `/auth/signin?callbackUrl=http://<非白名单主机>/cb?third_login_code=x&thirdLogin=true`，
+   密码登录与 v2 三方登录两条路径完成后均停留站内 `PORTAL_HOME_PATH`，外域收不到
+   任何请求参数中的 token 或 code。
+2. 白名单命中路径（bklite.ai 与 bklite.cn 两个回调 host 分别模拟）端到端可登录：
+   回跳 URL 仅含 `third_login_code` + `bk_lite_code`，兑换接口响应体返回 token，
+   二次兑换失败；兑换接口对两个站点 origin 的 CORS 预检均放行。
+3. `rg -n "searchParams.set\('token'" web/src` 仅剩同源 `buildThirdLoginCallbackUrl`
+   一处（已记录的残留）。
+4. 新增/修改代码测试全绿：
+   `cd server && DB_ENGINE=sqlite DB_NAME=:memory: SECRET_KEY=cursor-cloud-dev ENABLE_CELERY=true uv run pytest apps/core/tests/ --no-cov`；
+   `cd web && pnpm lint && pnpm type-check` 及相关 jest/脚本测试；
+   website 仓库 `pnpm build`。
+5. 不触碰两仓库中与本修复无关的未提交工作（bk-lite 工作区存在进行中的
+   credential-vault 变更，保持原样）。
+6. 运维项（代码外，验收时核对已登记到变更说明）：现网需配置
+   `LEGACY_THIRD_LOGIN_ALLOWED_CALLBACK_HOSTS=bklite.ai,bklite.cn`；修复上线时强制全员会话失效
+   （轮换 JWT 签名密钥），并排查 access log 中外域 `callbackUrl` 带 `third_login_code`
+   的历史请求。
+
+## 变更说明（运维）
+
+- 现网 `bklite.canway.net` 的 **Server** 必须设置
+  `LEGACY_THIRD_LOGIN_ALLOWED_CALLBACK_HOSTS=bklite.ai,bklite.cn`。默认空则
+  legacy 外跳整段禁用，站内登录不受影响。
+- 兑换接口 CORS 由 Server 的 `legacy_third_login/exchange/` 按同一白名单回写
+  `Access-Control-Allow-Origin`。Web `/api/proxy` **只转发该路径的 OPTIONS 预检**，
+  不把整站 proxy 对白名单 origin 放开。私有化未配白名单时预检也没有 ACAO。
+- 上线时轮换 JWT 签名密钥以失效存量会话；并排查历史 access log 中外域
+  `callbackUrl` 且带 `third_login_code` 的请求。
+
+## 实现状态（bk-lite）
+
+- Server authorize/exchange、白名单、一次性码、login-auth v2 `legacy_redirect_url` 已落地。
+- Web 已删除 `buildLegacyThirdLoginCallbackUrl`；登录成功改调 authorize；已登录直跳走
+  `LegacyThirdLoginAuthorizeBridge`。
+- website 仓库消费方已改为 `bk_lite_code` POST 兑换；回跳 URL 不再读取 `token`。

--- a/web/scripts/auth-callback-url-test.ts
+++ b/web/scripts/auth-callback-url-test.ts
@@ -1,64 +1,122 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
-  buildLegacyThirdLoginCallbackUrl,
   getLegacyThirdLoginCode,
   toSafeRelativeCallbackUrl,
 } from '../src/utils/authRedirect';
+import { PORTAL_HOME_PATH } from '../src/utils/route';
+import { requestLegacyThirdLoginAuthorize } from '../src/utils/legacyThirdLogin';
+import { isLegacyThirdLoginExchangePath } from '../src/app/(core)/api/proxy/[...path]/legacyThirdLoginCors';
 
-function run(name: string, fn: () => void) {
-  fn();
-  console.log(`  ✓ ${name}`);
+function run(name: string, fn: () => void | Promise<void>) {
+  return Promise.resolve(fn()).then(() => {
+    console.log(`  ✓ ${name}`);
+  });
 }
 
-run('keeps relative callback paths unchanged', () => {
-  assert.equal(toSafeRelativeCallbackUrl('/monitor/events?tab=detail'), '/monitor/events?tab=detail');
-});
+async function main() {
+  await run('keeps relative callback paths unchanged', () => {
+    assert.equal(toSafeRelativeCallbackUrl('/monitor/events?tab=detail'), '/monitor/events?tab=detail');
+  });
 
-run('converts same-origin absolute callback URL into relative path', () => {
-  assert.equal(
-    toSafeRelativeCallbackUrl('https://bk-lite.example.com/monitor/events?tab=detail#panel', 'https://bk-lite.example.com'),
-    '/monitor/events?tab=detail#panel',
-  );
-});
+  await run('converts same-origin absolute callback URL into relative path', () => {
+    assert.equal(
+      toSafeRelativeCallbackUrl('https://bk-lite.example.com/monitor/events?tab=detail#panel', 'https://bk-lite.example.com'),
+      '/monitor/events?tab=detail#panel',
+    );
+  });
 
-run('rejects cross-origin absolute callback URL', () => {
-  assert.equal(
-    toSafeRelativeCallbackUrl('https://attacker.example.com/steal?token=1', 'https://bk-lite.example.com'),
-    '/',
-  );
-});
+  await run('rejects cross-origin absolute callback URL', () => {
+    assert.equal(
+      toSafeRelativeCallbackUrl('https://attacker.example.com/steal?token=1', 'https://bk-lite.example.com'),
+      PORTAL_HOME_PATH,
+    );
+  });
 
-run('rejects protocol-relative callback URL', () => {
-  assert.equal(toSafeRelativeCallbackUrl('//attacker.example.com/steal'), '/');
-});
+  await run('rejects protocol-relative callback URL', () => {
+    assert.equal(toSafeRelativeCallbackUrl('//attacker.example.com/steal'), PORTAL_HOME_PATH);
+  });
 
-run('builds a legacy external callback URL when third_login_code is present', () => {
-  assert.equal(
-    buildLegacyThirdLoginCallbackUrl(
-      'https://bklite.ai/playground?third_login_code=old-code&token=old-token#console',
-      'new-token',
-      'new-code',
-    ),
-    'https://bklite.ai/playground?third_login_code=new-code&token=new-token#console',
-  );
-});
+  await run('extracts the legacy third login code from an external callback URL', () => {
+    assert.equal(
+      getLegacyThirdLoginCode('http://localhost:3001/playground?third_login_code=legacy-code'),
+      'legacy-code',
+    );
+  });
 
-run('does not enable a legacy external callback without third_login_code', () => {
-  assert.equal(
-    buildLegacyThirdLoginCallbackUrl('https://external.example/playground', 'new-token'),
-    '/',
-  );
-});
+  await run('does not extract a legacy third login code from a relative callback URL', () => {
+    assert.equal(getLegacyThirdLoginCode('/playground?third_login_code=legacy-code'), undefined);
+  });
 
-run('extracts the legacy third login code from an external callback URL', () => {
-  assert.equal(
-    getLegacyThirdLoginCode('http://localhost:3001/playground?third_login_code=legacy-code'),
-    'legacy-code',
-  );
-});
+  await run('authorize helper falls back in-site when the server rejects the callback host', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(JSON.stringify({ result: false, message: 'no' }), { status: 400 })) as typeof fetch;
+    try {
+      const target = await requestLegacyThirdLoginAuthorize({
+        callbackUrl: 'http://attacker.example/cb?third_login_code=x',
+        thirdLoginCode: 'x',
+        token: 'jwt-token-sentinel-value',
+      });
+      assert.equal(target, PORTAL_HOME_PATH);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 
-run('does not extract a legacy third login code from a relative callback URL', () => {
-  assert.equal(getLegacyThirdLoginCode('/playground?third_login_code=legacy-code'), undefined);
-});
+  await run('authorize helper uses server-provided redirect_url without appending token', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(
+      JSON.stringify({ redirect_url: 'https://bklite.ai/playground?third_login_code=state&bk_lite_code=once' }),
+      { status: 200 },
+    )) as typeof fetch;
+    try {
+      const target = await requestLegacyThirdLoginAuthorize({
+        callbackUrl: 'https://bklite.ai/playground?third_login_code=state',
+        thirdLoginCode: 'state',
+        token: 'jwt-token-sentinel-value',
+      });
+      assert.equal(target, 'https://bklite.ai/playground?third_login_code=state&bk_lite_code=once');
+      assert.doesNotMatch(target, /token=/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 
-console.log('All auth callback URL tests passed.');
+  await run('proxy only forwards CORS preflight for the exchange endpoint', () => {
+    assert.equal(
+      isLegacyThirdLoginExchangePath('/api/proxy/core/api/legacy_third_login/exchange/'),
+      true,
+    );
+    assert.equal(
+      isLegacyThirdLoginExchangePath('/api/proxy/core/api/legacy_third_login/exchange'),
+      true,
+    );
+    assert.equal(isLegacyThirdLoginExchangePath('/api/proxy/core/api/login_info/'), false);
+    assert.equal(isLegacyThirdLoginExchangePath('/api/proxy/core/api/login/'), false);
+    const route = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), '..', 'src/app/(core)/api/proxy/[...path]/route.ts'),
+      'utf8',
+    );
+    assert.equal(route.includes('withLegacyThirdLoginCors'), false);
+    assert.match(route, /isLegacyThirdLoginExchangePath/);
+  });
+
+  await run('repository no longer concatenates token onto non-same-origin URLs', () => {
+    const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+    const authRedirect = readFileSync(join(root, 'src/utils/authRedirect.ts'), 'utf8');
+    assert.equal(authRedirect.includes('buildLegacyThirdLoginCallbackUrl'), false);
+    const signinClient = readFileSync(join(root, 'src/app/(core)/auth/signin/SigninClient.tsx'), 'utf8');
+    assert.equal(signinClient.includes('buildLegacyThirdLoginCallbackUrl'), false);
+    const signinPage = readFileSync(join(root, 'src/app/(core)/auth/signin/page.tsx'), 'utf8');
+    assert.equal(signinPage.includes('buildLegacyThirdLoginCallbackUrl'), false);
+  });
+
+  console.log('All auth callback URL tests passed.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/web/src/app/(core)/api/proxy/[...path]/legacyThirdLoginCors.ts
+++ b/web/src/app/(core)/api/proxy/[...path]/legacyThirdLoginCors.ts
@@ -1,0 +1,6 @@
+export const LEGACY_THIRD_LOGIN_EXCHANGE_PATH = '/api/proxy/core/api/legacy_third_login/exchange';
+
+export function isLegacyThirdLoginExchangePath(pathname: string): boolean {
+  const normalized = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+  return normalized === LEGACY_THIRD_LOGIN_EXCHANGE_PATH;
+}

--- a/web/src/app/(core)/api/proxy/[...path]/route.ts
+++ b/web/src/app/(core)/api/proxy/[...path]/route.ts
@@ -1,6 +1,7 @@
 import {NextRequest, NextResponse} from 'next/server';
 import {consumeProxyTimeoutMs, DEFAULT_TIMEOUT_MS, scheduleProxyAbort} from '@/utils/proxyTimeout';
 
+import {isLegacyThirdLoginExchangePath} from './legacyThirdLoginCors';
 import {buildProxyTargets} from './proxyTarget';
 
 const TARGET_SERVER = process.env.NEXTAPI_URL + '/api/v1' || 'http://localhost:3000';
@@ -22,6 +23,13 @@ export async function DELETE(req: NextRequest) {
 }
 
 export async function PATCH(req: NextRequest) {
+  return await handleProxy(req);
+}
+
+export async function OPTIONS(req: NextRequest) {
+  if (!isLegacyThirdLoginExchangePath(req.nextUrl.pathname)) {
+    return new NextResponse(null, { status: 405 });
+  }
   return await handleProxy(req);
 }
 

--- a/web/src/app/(core)/auth/signin/LegacyThirdLoginAuthorizeBridge.tsx
+++ b/web/src/app/(core)/auth/signin/LegacyThirdLoginAuthorizeBridge.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useEffect } from 'react';
+import { requestLegacyThirdLoginAuthorize } from '@/utils/legacyThirdLogin';
+import { PORTAL_HOME_PATH } from '@/utils/route';
+
+interface LegacyThirdLoginAuthorizeBridgeProps {
+  callbackUrl?: string;
+  thirdLoginCode: string;
+  token?: string;
+}
+
+export default function LegacyThirdLoginAuthorizeBridge({
+  callbackUrl,
+  thirdLoginCode,
+  token,
+}: LegacyThirdLoginAuthorizeBridgeProps) {
+  useEffect(() => {
+    let cancelled = false;
+
+    const redirect = async () => {
+      const targetUrl = token
+        ? await requestLegacyThirdLoginAuthorize({
+          callbackUrl: callbackUrl || PORTAL_HOME_PATH,
+          thirdLoginCode,
+          token,
+        })
+        : PORTAL_HOME_PATH;
+      if (!cancelled) {
+        window.location.href = targetUrl;
+      }
+    };
+
+    void redirect();
+    return () => {
+      cancelled = true;
+    };
+  }, [callbackUrl, thirdLoginCode, token]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-6 text-center">
+      <div>
+        <div className="text-lg font-semibold text-(--color-text-1)">登录成功</div>
+        <div className="mt-2 text-sm text-(--color-text-3)">正在返回原页面...</div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(core)/auth/signin/SigninClient.tsx
+++ b/web/src/app/(core)/auth/signin/SigninClient.tsx
@@ -26,10 +26,10 @@ import {
   LOGIN_AUTH_RESULT_RETURN_MESSAGE,
   SIGNIN_WINDOW_NAME,
   buildThirdLoginCallbackUrl,
-  buildLegacyThirdLoginCallbackUrl,
   getLegacyThirdLoginCode,
   resolveThirdLoginFlag
 } from "@/utils/authRedirect";
+import { requestLegacyThirdLoginAuthorize } from "@/utils/legacyThirdLogin";
 import type { LoginAuthLoginResult } from "./login-auth/types";
 import { PORTAL_HOME_PATH } from "@/utils/route";
 
@@ -60,8 +60,7 @@ interface LoginResponse {
   locale?: string;
   timezone?: string;
   redirect_url?: string;
-  legacy_external_callback_url?: string;
-  legacy_third_login_code?: string;
+  legacy_redirect_url?: string;
   password_expiry_reminder?: string;
   // OTP two-phase authentication fields
   require_otp?: boolean;
@@ -158,8 +157,7 @@ export default function SigninClient({
       otp_recommended_apps: otpLoginResult.otp_recommended_apps,
       qr_code: otpLoginResult.qr_code,
       redirect_url: otpLoginResult.redirect_url,
-      legacy_external_callback_url: otpLoginResult.legacy_external_callback_url,
-      legacy_third_login_code: otpLoginResult.legacy_third_login_code,
+      legacy_redirect_url: otpLoginResult.legacy_redirect_url,
     });
     setQrCodeUrl(otpLoginResult.qr_code || "");
     setAuthStep('otp-verification');
@@ -197,8 +195,7 @@ export default function SigninClient({
         enable_otp: loginResult.enable_otp,
         password_expiry_reminder: loginResult.password_expiry_reminder,
         redirect_url: loginResult.redirect_url,
-        legacy_external_callback_url: loginResult.legacy_external_callback_url,
-        legacy_third_login_code: loginResult.legacy_third_login_code,
+        legacy_redirect_url: loginResult.legacy_redirect_url,
       });
 
       if (!success) {
@@ -344,18 +341,20 @@ export default function SigninClient({
           sessionStorage.setItem('password_expiry_reminder', userData.password_expiry_reminder);
         }
 
-        const legacyThirdLoginCode = userData.legacy_third_login_code || thirdLoginCode;
-        const targetUrl = legacyThirdLoginCode
-          ? buildLegacyThirdLoginCallbackUrl(
-            userData.legacy_external_callback_url || userData.redirect_url || callbackUrl,
-            userData.token,
-            legacyThirdLoginCode,
-          )
-          : buildThirdLoginCallbackUrl(
-            userData.redirect_url || callbackUrl || PORTAL_HOME_PATH,
-            userData.token,
-            thirdLoginFlag,
-          );
+        let targetUrl = buildThirdLoginCallbackUrl(
+          userData.redirect_url || callbackUrl || PORTAL_HOME_PATH,
+          userData.token,
+          thirdLoginFlag,
+        );
+        if (userData.legacy_redirect_url) {
+          targetUrl = userData.legacy_redirect_url;
+        } else if (thirdLoginCode && userData.token) {
+          targetUrl = await requestLegacyThirdLoginAuthorize({
+            callbackUrl,
+            thirdLoginCode,
+            token: userData.token,
+          });
+        }
 
         finishAuthentication(targetUrl);
         return true;

--- a/web/src/app/(core)/auth/signin/__tests__/page.test.tsx
+++ b/web/src/app/(core)/auth/signin/__tests__/page.test.tsx
@@ -23,8 +23,8 @@ vi.mock('next/headers', () => ({ headers }));
 vi.mock('next/navigation', () => ({ redirect: vi.fn() }));
 vi.mock('../SigninClient', () => ({ default: () => null }));
 vi.mock('../PopupAuthBridge', () => ({ default: () => null }));
+vi.mock('../LegacyThirdLoginAuthorizeBridge', () => ({ default: () => null }));
 vi.mock('@/utils/authRedirect', () => ({
-  buildLegacyThirdLoginCallbackUrl: vi.fn(),
   buildThirdLoginCallbackUrl: vi.fn(),
   getLegacyThirdLoginCode: vi.fn(() => null),
   resolveThirdLoginFlag: vi.fn(() => false),
@@ -35,6 +35,9 @@ vi.mock('@/utils/userPreferences', () => ({
 }));
 
 import SigninPage from '../page';
+import { redirect } from 'next/navigation';
+import { getLegacyThirdLoginCode } from '@/utils/authRedirect';
+import LegacyThirdLoginAuthorizeBridge from '../LegacyThirdLoginAuthorizeBridge';
 
 describe('SigninPage session configuration', () => {
   beforeEach(() => {
@@ -51,6 +54,23 @@ describe('SigninPage session configuration', () => {
 
     expect(getAuthOptions).not.toHaveBeenCalled();
     expect(getServerSession).toHaveBeenCalledWith(authOptions);
+  });
+
+  it('does not send authenticated users to an external token callback', async () => {
+    vi.mocked(getLegacyThirdLoginCode).mockReturnValue('attacker-state');
+    getServerSession.mockResolvedValueOnce({
+      user: { id: 'u1', token: 'jwt-token-sentinel-value' },
+    });
+
+    const result = await SigninPage({
+      searchParams: Promise.resolve({
+        callbackUrl: 'http://attacker.example/cb?third_login_code=attacker-state',
+        error: '',
+      }),
+    });
+
+    expect(redirect).not.toHaveBeenCalled();
+    expect(result).toEqual(expect.objectContaining({ type: LegacyThirdLoginAuthorizeBridge }));
   });
 
   it('keeps the NextAuth route on the dynamic provider configuration', async () => {

--- a/web/src/app/(core)/auth/signin/login-auth/types.ts
+++ b/web/src/app/(core)/auth/signin/login-auth/types.ts
@@ -47,8 +47,7 @@ export interface LoginAuthLoginResult {
   enable_otp?: boolean;
   password_expiry_reminder?: string;
   redirect_url?: string;
-  legacy_external_callback_url?: string;
-  legacy_third_login_code?: string;
+  legacy_redirect_url?: string;
   require_otp?: boolean;
   challenge_id?: string;
   qr_code?: string;

--- a/web/src/app/(core)/auth/signin/page.tsx
+++ b/web/src/app/(core)/auth/signin/page.tsx
@@ -4,12 +4,12 @@ import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import SigninClient from "./SigninClient";
 import {
-  buildLegacyThirdLoginCallbackUrl,
   buildThirdLoginCallbackUrl,
   getLegacyThirdLoginCode,
   resolveThirdLoginFlag,
 } from "@/utils/authRedirect";
 import PopupAuthBridge from "./PopupAuthBridge";
+import LegacyThirdLoginAuthorizeBridge from "./LegacyThirdLoginAuthorizeBridge";
 
 const signinErrors: Record<string | "default", string> = {
   default: "signin.errors.default",
@@ -72,19 +72,23 @@ export default async function SigninPage({ searchParams }: SignInPageProp) {
       );
     }
 
+    if (thirdLoginCode) {
+      return (
+        <LegacyThirdLoginAuthorizeBridge
+          callbackUrl={resolvedSearchParams.callbackUrl}
+          thirdLoginCode={thirdLoginCode}
+          token={session.user.token}
+        />
+      );
+    }
+
     redirect(
-      thirdLoginCode
-        ? buildLegacyThirdLoginCallbackUrl(
-          resolvedSearchParams.callbackUrl,
-          session.user.token,
-          thirdLoginCode,
-        )
-        : buildThirdLoginCallbackUrl(
-          resolvedSearchParams.callbackUrl,
-          session.user.token,
-          thirdLoginFlag,
-          requestOrigin,
-        ),
+      buildThirdLoginCallbackUrl(
+        resolvedSearchParams.callbackUrl,
+        session.user.token,
+        thirdLoginFlag,
+        requestOrigin,
+      ),
     );
   }
   return <SigninClient searchParams={resolvedSearchParams} signinErrors={signinErrors} />;

--- a/web/src/utils/authRedirect.ts
+++ b/web/src/utils/authRedirect.ts
@@ -124,29 +124,6 @@ export function buildThirdLoginCallbackUrl(
   }
 }
 
-export function buildLegacyThirdLoginCallbackUrl(
-  callbackUrl?: string,
-  token?: string,
-  thirdLoginCode?: string,
-): string {
-  if (!callbackUrl || !token || !thirdLoginCode) {
-    return PORTAL_HOME_PATH;
-  }
-
-  try {
-    const url = new URL(callbackUrl);
-    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-      return PORTAL_HOME_PATH;
-    }
-
-    url.searchParams.set('third_login_code', thirdLoginCode);
-    url.searchParams.set('token', token);
-    return url.toString();
-  } catch {
-    return PORTAL_HOME_PATH;
-  }
-}
-
 export function getLegacyThirdLoginCode(callbackUrl?: string): string | undefined {
   if (!callbackUrl) {
     return undefined;

--- a/web/src/utils/legacyThirdLogin.ts
+++ b/web/src/utils/legacyThirdLogin.ts
@@ -1,0 +1,46 @@
+import { PORTAL_HOME_PATH } from '@/utils/route';
+
+interface AuthorizeLegacyThirdLoginOptions {
+  callbackUrl: string;
+  thirdLoginCode: string;
+  token: string;
+}
+
+export async function requestLegacyThirdLoginAuthorize({
+  callbackUrl,
+  thirdLoginCode,
+  token,
+}: AuthorizeLegacyThirdLoginOptions): Promise<string> {
+  if (!callbackUrl || !thirdLoginCode || !token) {
+    return PORTAL_HOME_PATH;
+  }
+
+  try {
+    const response = await fetch('/api/proxy/core/api/legacy_third_login/authorize/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        callback_url: callbackUrl,
+        third_login_code: thirdLoginCode,
+      }),
+    });
+    if (!response.ok) {
+      return PORTAL_HOME_PATH;
+    }
+
+    const payload: unknown = await response.json();
+    const redirectUrl =
+      payload && typeof payload === 'object' && 'redirect_url' in payload
+        ? (payload as { redirect_url?: unknown }).redirect_url
+        : undefined;
+    if (typeof redirectUrl !== 'string' || !redirectUrl) {
+      return PORTAL_HOME_PATH;
+    }
+    return redirectUrl;
+  } catch {
+    return PORTAL_HOME_PATH;
+  }
+}


### PR DESCRIPTION
回跳改为服务端白名单签发一次性 bk_lite_code，token 只经 exchange 响应体下发。