### PR TITLE
fix(web): 隔离账号切换的组织上下文

### DIFF
--- a/web/src/app/(core)/auth/signout/page.tsx
+++ b/web/src/app/(core)/auth/signout/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { signOut, useSession } from "next-auth/react";
 import { clearAuthToken } from '@/utils/crossDomainAuth';
 import { resolveThirdLoginFlag } from '@/utils/authRedirect';
+import { clearUserTeamPreference } from '@/utils/userTeamPreference';
 
 export default function SignoutPage() {
   const { data: session, status } = useSession();
@@ -26,6 +27,7 @@ export default function SignoutPage() {
   const handleSignout = async () => {
     try {
       setIsLoading(true);
+      clearUserTeamPreference();
 
       // Call logout API for server-side cleanup
       await fetch("/api/auth/federated-logout", {

--- a/web/src/app/(core)/components/top-menu/user-info/index.tsx
+++ b/web/src/app/(core)/components/top-menu/user-info/index.tsx
@@ -14,6 +14,7 @@ import { clearAuthToken } from '@/utils/crossDomainAuth';
 import Cookies from 'js-cookie';
 import type { Group } from '@/types/index';
 import UserInformation from './userInformation'
+import { clearUserTeamPreference } from '@/utils/userTeamPreference';
 
 // 将 Group 转换为 Tree DataNode
 const convertGroupsToTreeData = (groups: Group[], selectedGroupId: string | undefined): DataNode[] => {
@@ -149,6 +150,7 @@ const UserInfo: React.FC = () => {
 
   const federatedLogout = useCallback(async () => {
     setIsLoading(true);
+    clearUserTeamPreference();
     try {
       // Call logout API for server-side cleanup
       await fetch('/api/auth/federated-logout', {

--- a/web/src/context/__tests__/userInfoAccountSwitch.test.tsx
+++ b/web/src/context/__tests__/userInfoAccountSwitch.test.tsx
@@ -1,0 +1,202 @@
+import React from 'react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import Cookies from 'js-cookie';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { UserInfoProvider, useUserInfoContext } from '@/context/userInfo';
+
+const mocks = vi.hoisted(() => ({
+  getLoginInfo: vi.fn(),
+  sessionUser: {
+    id: 'admin',
+    username: 'admin',
+  },
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({
+    status: 'authenticated',
+    data: { user: mocks.sessionUser },
+  }),
+}));
+
+vi.mock('@/context/auth', () => ({
+  useAuth: () => ({ isCheckingAuth: false }),
+}));
+
+vi.mock('@/utils/request', () => ({
+  default: () => ({ get: mocks.getLoginInfo }),
+}));
+
+const defaultGroup = { id: '1', name: 'Default' };
+const kentGroup = { id: '2', name: 'Kent' };
+
+const loginInfo = (userId: string, username: string, groups = [defaultGroup, kentGroup]) => ({
+  group_list: groups,
+  group_tree: groups,
+  roles: [],
+  is_superuser: true,
+  is_first_login: false,
+  user_id: userId,
+  display_name: username,
+  username,
+});
+
+const Probe = () => {
+  const { loading, selectedGroup, username } = useUserInfoContext();
+
+  return (
+    <>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="selected-group">{selectedGroup?.name || ''}</span>
+      <span data-testid="username">{username}</span>
+    </>
+  );
+};
+
+const renderProvider = () => render(
+  <UserInfoProvider>
+    <Probe />
+  </UserInfoProvider>,
+);
+
+const clearPreferenceCookies = () => {
+  Cookies.remove('current_team');
+  Cookies.remove('current_team_owner');
+};
+
+beforeEach(() => {
+  clearPreferenceCookies();
+  mocks.getLoginInfo.mockReset();
+  mocks.sessionUser.id = 'admin';
+  mocks.sessionUser.username = 'admin';
+});
+
+afterEach(() => {
+  cleanup();
+  clearPreferenceCookies();
+  vi.clearAllMocks();
+});
+
+describe('UserInfoProvider account-scoped current team', () => {
+  it('does not restore the previous account team when the new account can also access it', async () => {
+    Cookies.set('current_team', kentGroup.id);
+    Cookies.set('current_team_owner', 'kent');
+    mocks.getLoginInfo.mockResolvedValue(loginInfo('admin', 'admin'));
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+    expect(screen.getByTestId('username').textContent).toBe('admin');
+    expect(screen.getByTestId('selected-group').textContent).toBe('Default');
+    expect(Cookies.get('current_team')).toBe(defaultGroup.id);
+    expect(Cookies.get('current_team_owner')).toBe('admin');
+  });
+
+  it('restores an accessible team when the preference belongs to the same account', async () => {
+    Cookies.set('current_team', kentGroup.id);
+    Cookies.set('current_team_owner', 'admin');
+    mocks.getLoginInfo.mockResolvedValue(loginInfo('admin', 'admin'));
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+    expect(screen.getByTestId('selected-group').textContent).toBe('Kent');
+    expect(Cookies.get('current_team')).toBe(kentGroup.id);
+    expect(Cookies.get('current_team_owner')).toBe('admin');
+  });
+
+  it('falls back to the default team when the remembered team is no longer accessible', async () => {
+    Cookies.set('current_team', kentGroup.id);
+    Cookies.set('current_team_owner', 'admin');
+    mocks.getLoginInfo.mockResolvedValue(loginInfo('admin', 'admin', [defaultGroup]));
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+    expect(screen.getByTestId('selected-group').textContent).toBe('Default');
+    expect(Cookies.get('current_team')).toBe(defaultGroup.id);
+    expect(Cookies.get('current_team_owner')).toBe('admin');
+  });
+
+  it('reloads and hides the old team while an authenticated session changes account', async () => {
+    Cookies.set('current_team', kentGroup.id);
+    Cookies.set('current_team_owner', 'kent');
+    mocks.sessionUser.id = 'kent';
+    mocks.sessionUser.username = 'kent';
+    mocks.getLoginInfo.mockResolvedValueOnce(loginInfo('kent', 'kent', [kentGroup]));
+
+    const view = renderProvider();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-group').textContent).toBe('Kent');
+    });
+
+    let resolveAdminLoginInfo: ((value: ReturnType<typeof loginInfo>) => void) | undefined;
+    mocks.getLoginInfo.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveAdminLoginInfo = resolve;
+    }));
+    mocks.sessionUser.id = 'admin';
+    mocks.sessionUser.username = 'admin';
+
+    view.rerender(
+      <UserInfoProvider>
+        <Probe />
+      </UserInfoProvider>,
+    );
+
+    expect(screen.getByTestId('loading').textContent).toBe('true');
+    expect(screen.getByTestId('selected-group').textContent).toBe('');
+
+    resolveAdminLoginInfo?.(loginInfo('admin', 'admin'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+    expect(mocks.getLoginInfo).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId('selected-group').textContent).toBe('Default');
+    expect(Cookies.get('current_team_owner')).toBe('admin');
+  });
+
+  it('ignores a late login_info response from the previous account', async () => {
+    mocks.sessionUser.id = 'kent';
+    mocks.sessionUser.username = 'kent';
+    let resolveKentLoginInfo: ((value: ReturnType<typeof loginInfo>) => void) | undefined;
+    mocks.getLoginInfo.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveKentLoginInfo = resolve;
+    }));
+
+    const view = renderProvider();
+
+    await waitFor(() => {
+      expect(mocks.getLoginInfo).toHaveBeenCalledTimes(1);
+    });
+
+    mocks.getLoginInfo.mockResolvedValueOnce(loginInfo('admin', 'admin'));
+    mocks.sessionUser.id = 'admin';
+    mocks.sessionUser.username = 'admin';
+    view.rerender(
+      <UserInfoProvider>
+        <Probe />
+      </UserInfoProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-group').textContent).toBe('Default');
+    });
+
+    resolveKentLoginInfo?.(loginInfo('kent', 'kent', [kentGroup]));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('username').textContent).toBe('admin');
+    });
+    expect(screen.getByTestId('selected-group').textContent).toBe('Default');
+    expect(Cookies.get('current_team_owner')).toBe('admin');
+  });
+});

--- a/web/src/context/userInfo.tsx
+++ b/web/src/context/userInfo.tsx
@@ -1,10 +1,17 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import useApiClient from '@/utils/request';
 import { Group, UserInfoContextType } from '@/types/index'
 import { convertTreeDataToGroupOptions } from '@/utils/index'
 import Cookies from 'js-cookie';
 import { useSession } from 'next-auth/react';
 import { useAuth } from '@/context/auth';
+import {
+  clearUserTeamPreference,
+  CURRENT_TEAM_COOKIE,
+  CURRENT_TEAM_OWNER_COOKIE,
+  persistUserTeamPreference,
+  resolveInitialGroup,
+} from '@/utils/userTeamPreference';
 
 export const UserInfoContext = createContext<UserInfoContextType | undefined>(undefined);
 
@@ -22,6 +29,11 @@ export const UserInfoProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const { get } = useApiClient();
   const { data: session, status } = useSession();
   const { isCheckingAuth } = useAuth(); // 添加 auth context
+  const sessionUser = session?.user as any;
+  const sessionUserIdentity = status === 'authenticated' && sessionUser?.id
+    ? String(sessionUser.id)
+    : '';
+  const sessionUsername = sessionUser?.username;
   const [selectedGroup, setSelectedGroupState] = useState<Group | null>(null);
   const [userId, setUserId] = useState<string>('');
   const [username, setUsername] = useState<string>('');
@@ -36,52 +48,78 @@ export const UserInfoProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const [groupTree, setGroupTree] = useState<Group[]>([]);
   const [isSuperUser, setIsSuperUser] = useState<boolean>(true);
   const [isFirstLogin, setIsFirstLogin] = useState<boolean>(false);
+  const [loadedSessionIdentity, setLoadedSessionIdentity] = useState<string>('');
+  const requestVersionRef = useRef(0);
+  const activeSessionIdentityRef = useRef(sessionUserIdentity);
+  activeSessionIdentityRef.current = sessionUserIdentity;
 
-  const fetchLoginInfo = async () => {
+  const fetchLoginInfo = useCallback(async (expectedSessionIdentity: string) => {
+    const requestVersion = ++requestVersionRef.current;
     setLoading(true);
     try {
       const data = await get('/core/api/login_info/');
+      if (
+        requestVersion !== requestVersionRef.current
+        || activeSessionIdentityRef.current !== expectedSessionIdentity
+      ) {
+        return;
+      }
       if (!data) {
         console.error('Failed to fetch login info: No data received');
-        setLoading(false);
         return;
       }
 
       const { group_list: groupList, group_tree: groupTreeData, roles, is_superuser, is_first_login, user_id, display_name, username } = data;
+      const currentUserId = String(user_id || expectedSessionIdentity);
       setGroups(groupList || []);
       const shouldSkipFilter = username === 'kayla';
-      setGroupTree(is_superuser || shouldSkipFilter ? groupTreeData : filterOpsPilotGuest(groupTreeData || []));
+      setGroupTree(is_superuser || shouldSkipFilter ? (groupTreeData || []) : filterOpsPilotGuest(groupTreeData || []));
       setRoles(roles || []);
       setIsSuperUser(!!is_superuser);
       setIsFirstLogin(!!is_first_login);
-      setUserId(user_id || '');
-      setUsername(username || (session?.user as any)?.username || 'admin');
-      setDisplayName(display_name || (session?.user as any)?.username || 'User');
+      setUserId(currentUserId);
+      setUsername(username || sessionUsername || 'admin');
+      setDisplayName(display_name || sessionUsername || 'User');
 
       if (groupList?.length) {
         const flattenedGroups = convertTreeDataToGroupOptions(groupList);
         setFlatGroups(flattenedGroups);
 
-        const groupIdFromCookie = Cookies.get('current_team');
-        const initialGroup = flattenedGroups.find((group: Group) => String(group.id) === String(groupIdFromCookie));
+        const filteredGroups = is_superuser || shouldSkipFilter
+          ? [...flattenedGroups]
+          : flattenedGroups.filter((group: Group) => group.name !== 'OpsPilotGuest');
+        const initialGroup = resolveInitialGroup({
+          groups: flattenedGroups,
+          defaultGroup: filteredGroups[0],
+          rememberedGroupId: Cookies.get(CURRENT_TEAM_COOKIE),
+          rememberedOwnerId: Cookies.get(CURRENT_TEAM_OWNER_COOKIE),
+          currentUserId,
+        });
 
         if (initialGroup) {
           setSelectedGroupState(initialGroup);
+          persistUserTeamPreference(initialGroup.id, currentUserId);
         } else {
-          const filteredGroups = is_superuser || shouldSkipFilter
-            ? [...flattenedGroups]
-            : flattenedGroups.filter((group: Group) => group.name !== 'OpsPilotGuest');
-          const defaultGroup = filteredGroups[0];
-          setSelectedGroupState(defaultGroup);
-          Cookies.set('current_team', defaultGroup.id);
+          setSelectedGroupState(null);
+          clearUserTeamPreference();
         }
+      } else {
+        setFlatGroups([]);
+        setSelectedGroupState(null);
+        clearUserTeamPreference();
       }
     } catch (err) {
       console.error('Failed to fetch login_info:', err);
     } finally {
-      setLoading(false);
+      if (
+        requestVersion === requestVersionRef.current
+        && activeSessionIdentityRef.current === expectedSessionIdentity
+      ) {
+        setLoadedSessionIdentity(expectedSessionIdentity);
+        setLoading(false);
+      }
     }
-  };
+  }, [get, sessionUsername]);
 
   useEffect(() => {
     // 如果还在检查认证状态，不要进行API调用
@@ -89,22 +127,46 @@ export const UserInfoProvider: React.FC<{ children: React.ReactNode }> = ({ chil
       return;
     }
 
-    if (status === 'authenticated' && session && (session.user as any)?.id) {
-      fetchLoginInfo();
+    if (status === 'authenticated' && sessionUserIdentity) {
+      setSelectedGroupState(null);
+      setGroups([]);
+      setFlatGroups([]);
+      setGroupTree([]);
+      setRoles([]);
+      setUserId('');
+      setUsername('');
+      setDisplayName('');
+      setLoadedSessionIdentity('');
+      void fetchLoginInfo(sessionUserIdentity);
+      return;
     }
-  }, [status, isCheckingAuth]);
+
+    requestVersionRef.current += 1;
+    setSelectedGroupState(null);
+    setLoadedSessionIdentity('');
+    setLoading(status === 'loading');
+  }, [fetchLoginInfo, isCheckingAuth, sessionUserIdentity, status]);
 
   const setSelectedGroup = (group: Group) => {
     setSelectedGroupState(group);
-    Cookies.set('current_team', group.id);
+    persistUserTeamPreference(group.id, userId || sessionUserIdentity);
   };
 
   const refreshUserInfo = async () => {
-    await fetchLoginInfo();
+    if (sessionUserIdentity) {
+      await fetchLoginInfo(sessionUserIdentity);
+    }
   };
 
+  const hasCurrentSessionData = Boolean(
+    sessionUserIdentity && loadedSessionIdentity === sessionUserIdentity,
+  );
+  const isSessionIdentityChanging = Boolean(
+    status === 'authenticated' && sessionUserIdentity && !hasCurrentSessionData,
+  );
+
   return (
-    <UserInfoContext.Provider value={{ loading, roles, groups, groupTree, selectedGroup, flatGroups, isSuperUser, isFirstLogin, userId, username, displayName, setSelectedGroup, refreshUserInfo }}>
+    <UserInfoContext.Provider value={{ loading: loading || isSessionIdentityChanging, roles, groups, groupTree, selectedGroup: hasCurrentSessionData ? selectedGroup : null, flatGroups, isSuperUser, isFirstLogin, userId, username, displayName, setSelectedGroup, refreshUserInfo }}>
       {children}
     </UserInfoContext.Provider>
   );

--- a/web/src/utils/__tests__/userTeamPreference.test.ts
+++ b/web/src/utils/__tests__/userTeamPreference.test.ts
@@ -1,0 +1,35 @@
+import Cookies from 'js-cookie';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  clearUserTeamPreference,
+  CURRENT_TEAM_COOKIE,
+  CURRENT_TEAM_OWNER_COOKIE,
+  persistUserTeamPreference,
+} from '@/utils/userTeamPreference';
+
+afterEach(() => {
+  Cookies.remove(CURRENT_TEAM_COOKIE);
+  Cookies.remove(CURRENT_TEAM_OWNER_COOKIE);
+  Cookies.remove('include_children');
+});
+
+describe('user team preference cookies', () => {
+  it('persists the current team together with its owning account', () => {
+    persistUserTeamPreference('2', 'kent');
+
+    expect(Cookies.get(CURRENT_TEAM_COOKIE)).toBe('2');
+    expect(Cookies.get(CURRENT_TEAM_OWNER_COOKIE)).toBe('kent');
+  });
+
+  it('clears only account-scoped team state during logout', () => {
+    persistUserTeamPreference('2', 'kent');
+    Cookies.set('include_children', '1');
+
+    clearUserTeamPreference();
+
+    expect(Cookies.get(CURRENT_TEAM_COOKIE)).toBeUndefined();
+    expect(Cookies.get(CURRENT_TEAM_OWNER_COOKIE)).toBeUndefined();
+    expect(Cookies.get('include_children')).toBe('1');
+  });
+});

--- a/web/src/utils/forceLogout.ts
+++ b/web/src/utils/forceLogout.ts
@@ -1,6 +1,7 @@
 import { signOut } from 'next-auth/react';
 import { clearAuthToken } from '@/utils/crossDomainAuth';
 import { isAuthPath, resetSessionExpiredState } from '@/utils/sessionExpiry';
+import { clearUserTeamPreference } from '@/utils/userTeamPreference';
 
 let forceLogoutInProgress = false;
 
@@ -19,6 +20,7 @@ export const forceLogoutAndRedirect = async () => {
   }
 
   forceLogoutInProgress = true;
+  clearUserTeamPreference();
 
   try {
     resetSessionExpiredState();

--- a/web/src/utils/userTeamPreference.ts
+++ b/web/src/utils/userTeamPreference.ts
@@ -1,0 +1,38 @@
+import Cookies from 'js-cookie';
+
+import type { Group } from '@/types/index';
+
+export const CURRENT_TEAM_COOKIE = 'current_team';
+export const CURRENT_TEAM_OWNER_COOKIE = 'current_team_owner';
+
+interface ResolveInitialGroupParams {
+  groups: Group[];
+  defaultGroup?: Group;
+  rememberedGroupId?: string;
+  rememberedOwnerId?: string;
+  currentUserId: string;
+}
+
+export const resolveInitialGroup = ({
+  groups,
+  defaultGroup,
+  rememberedGroupId,
+  rememberedOwnerId,
+  currentUserId,
+}: ResolveInitialGroupParams): Group | undefined => {
+  if (rememberedOwnerId === currentUserId) {
+    return groups.find(group => String(group.id) === rememberedGroupId) || defaultGroup;
+  }
+
+  return defaultGroup;
+};
+
+export const persistUserTeamPreference = (groupId: string, userId: string) => {
+  Cookies.set(CURRENT_TEAM_COOKIE, String(groupId));
+  Cookies.set(CURRENT_TEAM_OWNER_COOKIE, String(userId));
+};
+
+export const clearUserTeamPreference = () => {
+  Cookies.remove(CURRENT_TEAM_COOKIE);
+  Cookies.remove(CURRENT_TEAM_OWNER_COOKIE);
+};


### PR DESCRIPTION
## 问题

切换账号后，浏览器中的 current_team 会被新账号直接复用。当两个账号都能访问该组织时，页面会错误保留上一个账号的当前组织；登录信息请求并发返回时也可能覆盖新账号状态。

## 修改

- 将 current_team 与 current_team_owner 绑定，仅为同一账号恢复组织偏好
- 会话账号变化时清空旧账号展示状态并重新加载 login_info
- 忽略上一账号延迟返回的 login_info 响应
- 普通退出、统一退出页和强制退出时清理账号级组织 Cookie
- 补充账号切换、失效组织、竞态响应及 Cookie 清理回归测试

## 验证

- 定向 Vitest：3 个测试文件，10 项全部通过
- TypeScript type-check：通过
- 定向 ESLint：0 error；2 条既有 window.location.href warning
- pre-commit 检查：通过
- wx-test：Linux/x86 镜像构建成功，Web 容器健康，用户已完成账号切换手工验证