### PR TITLE
feat(监控): K8s Pod 视图内置 Namespace 列并支持筛选

### DIFF
--- a/server/apps/monitor/services/monitor_instance.py
+++ b/server/apps/monitor/services/monitor_instance.py
@@ -613,7 +613,7 @@ class InstanceSearch:
 
     @staticmethod
     def role_display_field_bindings(monitor_object_id):
-        """取该对象带 role 的字段展示列绑定（当前为云平台子对象 IP）。
+        """取该对象带 role 的字段展示列绑定（云平台子对象 IP、K8s Pod Namespace）。
 
         只认 role 列：普通字段展示列由用户自由配置，不承诺筛选能力。
         """

--- a/server/apps/monitor/support-files/plugins/unknown/k8s/k8s/language/en.yaml
+++ b/server/apps/monitor/support-files/plugins/unknown/k8s/k8s/language/en.yaml
@@ -44,7 +44,7 @@ monitor_object_metric:
   Pod:
     pod_info:
       name: Pod Info
-      desc: Pod metadata from kube_pod_info, used as the carrier metric for the IP display column.
+      desc: Pod metadata from kube_pod_info, used as the carrier metric for the IP and Namespace display columns.
     pod_status_phase:
       name: Pod Phase
       desc: Lifecycle phase: 0 Pending / 1 Running / 2 Succeeded / 3 Failed / 4 Unknown.

--- a/server/apps/monitor/support-files/plugins/unknown/k8s/k8s/language/zh-Hans.yaml
+++ b/server/apps/monitor/support-files/plugins/unknown/k8s/k8s/language/zh-Hans.yaml
@@ -42,7 +42,7 @@ monitor_object_metric:
   Pod:
     pod_info:
       name: Pod 信息
-      desc: 来自 kube_pod_info 的 Pod 元数据，用作 IP 展示列的载体指标。
+      desc: 来自 kube_pod_info 的 Pod 元数据，用作 IP 与 Namespace 展示列的载体指标。
     pod_status_phase:
       name: Pod 阶段
       desc: 生命周期阶段：0 Pending / 1 Running / 2 Succeeded / 3 Failed / 4 Unknown。

--- a/server/apps/monitor/support-files/plugins/unknown/k8s/k8s/metrics.json
+++ b/server/apps/monitor/support-files/plugins/unknown/k8s/k8s/metrics.json
@@ -73,7 +73,7 @@
       "default_metric": "prometheus_remote_write_kube_pod_info",
       "instance_id_keys": ["instance_id", "pod"],
       "supplementary_indicators": ["pod_status_phase", "pod_cpu_utilization", "pod_memory_utilization"],
-      "display_fields": [{"name": "IP 地址", "type": "field", "role": "resource_ip", "variable_id": "vm_ip", "sort_order": 0, "metrics": [{"plugin": "K8S", "metric": "pod_info", "field": "pod_ip"}]}, {"name": "Pod Status", "sort_order": 1, "metrics": [{"plugin": "K8S", "metric": "pod_status_phase"}]}, {"name": "CPU Utilization", "sort_order": 2, "metrics": [{"plugin": "K8S", "metric": "pod_cpu_utilization"}]}, {"name": "Memory Utilization", "sort_order": 3, "metrics": [{"plugin": "K8S", "metric": "pod_memory_utilization"}]}],
+      "display_fields": [{"name": "IP 地址", "type": "field", "role": "resource_ip", "variable_id": "vm_ip", "sort_order": 0, "metrics": [{"plugin": "K8S", "metric": "pod_info", "field": "pod_ip"}]}, {"name": "Namespace", "type": "field", "role": "namespace", "sort_order": 1, "metrics": [{"plugin": "K8S", "metric": "pod_info", "field": "namespace"}]}, {"name": "Pod Status", "sort_order": 2, "metrics": [{"plugin": "K8S", "metric": "pod_status_phase"}]}, {"name": "CPU Utilization", "sort_order": 3, "metrics": [{"plugin": "K8S", "metric": "pod_cpu_utilization"}]}, {"name": "Memory Utilization", "sort_order": 4, "metrics": [{"plugin": "K8S", "metric": "pod_memory_utilization"}]}],
       "metrics": [
         {
           "metric_group": "Status",
@@ -83,7 +83,7 @@
           "data_type": "Number",
           "unit": "counts",
           "dimensions": [],
-          "description": "Pod metadata from kube_pod_info, used as the carrier metric for the IP display column.",
+          "description": "Pod metadata from kube_pod_info, used as the carrier metric for the IP and Namespace display columns.",
           "query": "prometheus_remote_write_kube_pod_info{instance_type=\"k8s\",__$labels__}"
         },
         {

--- a/server/apps/monitor/utils/display_fields.py
+++ b/server/apps/monitor/utils/display_fields.py
@@ -3,16 +3,14 @@ import json
 
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.monitor.models.monitor_metrics import Metric
-from apps.monitor.utils.alert_name_variables import (
-    normalize_variable_id,
-    validate_variable_id,
-)
+from apps.monitor.utils.alert_name_variables import normalize_variable_id, validate_variable_id
 
 DISPLAY_FIELD_TYPES = {"metric", "field"}
 
 # 展示列语义角色。云平台子对象的 IP 来自指标 label，与基础对象的 asset.ip 摘要列是两套机制；
-# 打上 role 后页面按内置 IP 列渲染，各平台上报的 label 名（resource_ip / ip）无需统一。
-DISPLAY_FIELD_ROLES = {"resource_ip"}
+# 打上 role 后页面按内置列渲染并承诺列头筛选。各平台上报的 label 名（resource_ip / ip）无需统一。
+# namespace：K8s Pod 的命名空间，来自 kube_pod_info.namespace。
+DISPLAY_FIELD_ROLES = {"resource_ip", "namespace"}
 
 
 def build_display_column_key(display_field):
@@ -24,11 +22,7 @@ def build_display_column_key(display_field):
             {
                 "plugin": binding.get("plugin") or "",
                 "metric": binding.get("metric") or "",
-                **(
-                    {"field": binding.get("field") or ""}
-                    if column_type == "field"
-                    else {}
-                ),
+                **({"field": binding.get("field") or ""} if column_type == "field" else {}),
             }
             for binding in display_field.get("metrics") or []
         ],
@@ -44,8 +38,7 @@ def validate_display_fields(monitor_object, display_fields):
         raise BaseAppException("display_fields must be a list")
 
     existing = {
-        (m["monitor_plugin__name"], m["name"])
-        for m in Metric.objects.filter(monitor_object=monitor_object).values("monitor_plugin__name", "name")
+        (m["monitor_plugin__name"], m["name"]) for m in Metric.objects.filter(monitor_object=monitor_object).values("monitor_plugin__name", "name")
     }
 
     normalized = []

--- a/web/src/app/monitor/(pages)/integration/object/types.ts
+++ b/web/src/app/monitor/(pages)/integration/object/types.ts
@@ -94,8 +94,8 @@ export interface DisplayMetricBinding {
 export interface DisplayColumn {
   name: string;
   type?: 'metric' | 'field';
-  // 语义列标记，如云平台子对象 IP；由内置种子写入，用户编辑时原样保留
-  role?: 'resource_ip';
+  // 语义列标记，如云平台子对象 IP、K8s Pod Namespace；由内置种子写入，用户编辑时原样保留
+  role?: 'resource_ip' | 'namespace';
   sort_order: number;
   variable_id?: string;
   metrics: DisplayMetricBinding[];

--- a/web/src/app/monitor/(pages)/view/instanceViewColumns.tsx
+++ b/web/src/app/monitor/(pages)/view/instanceViewColumns.tsx
@@ -29,12 +29,25 @@ export const INSTANCE_VIEW_ACTION_KEY = 'action';
 // 云平台子对象的 IP 由采集 label 提供，走展示字段列；标记为该 role 后按内置 IP 列渲染，
 // 与基础对象的 asset.ip 摘要列保持同一列头与位置。
 export const RESOURCE_IP_ROLE = 'resource_ip';
+export const NAMESPACE_ROLE = 'namespace';
 
 // 字段展示列的筛选参数键，与主机 asset.ip 的筛选参数互不影响（后端 FIELD_PARAM_PREFIX）。
 export const displayFieldParamKey = (field?: string) => `field:${field ?? ''}`;
 
 const isResourceIpColumn = (col: DisplayCol) =>
   col.type === 'field' && col.role === RESOURCE_IP_ROLE;
+
+const isNamespaceColumn = (col: DisplayCol) =>
+  col.type === 'field' && col.role === NAMESPACE_ROLE;
+
+const isRoleFieldColumn = (col: DisplayCol) =>
+  col.type === 'field' && Boolean(col.role);
+
+const fieldColumnTitle = (col: DisplayCol, t?: (key: string) => string) => {
+  if (isResourceIpColumn(col) && t) return t('monitor.views.assetIp');
+  if (isNamespaceColumn(col) && t) return t('monitor.views.namespace');
+  return col.name;
+};
 
 export const displayFieldKey = (
   plugin?: string,
@@ -158,17 +171,15 @@ export const buildDisplayFieldColumns = ({
       activeSort?.key === dataKey ? activeSort.order : null;
 
     if (col.type === 'field') {
-      const isResourceIp = isResourceIpColumn(col);
       const filterParam = displayFieldParamKey(col.metrics?.[0]?.field);
       const fieldFilters = (fieldFilterOptions?.[filterParam] || []).map(
         (value) => ({ text: value, value })
       );
       return {
-        title:
-          isResourceIp && t ? t('monitor.views.assetIp') : col.name,
-        ...(isResourceIp
+        title: fieldColumnTitle(col, t),
+        ...(isRoleFieldColumn(col)
           ? {
-            role: RESOURCE_IP_ROLE,
+            role: col.role,
             filterMultiple: true,
             filterSearch: true,
             filterParam,
@@ -340,12 +351,17 @@ export const buildInstanceViewColumns = ({
     fieldFilterOptions,
     activeSort
   });
-  // 内置 IP 列紧跟基础列，与基础对象的 asset.ip 摘要列同位置；其余展示列排在上报时间之后。
+  // 命名空间紧跟集群列；内置 IP 列再跟其后，与基础对象的 asset.ip 摘要列同位置；
+  // 其余展示列排在上报时间之后。
+  const namespaceColumns = displayColumns.filter(
+    (column) => column.role === NAMESPACE_ROLE
+  );
   const resourceIpColumns = displayColumns.filter(
     (column) => column.role === RESOURCE_IP_ROLE
   );
   const restDisplayColumns = displayColumns.filter(
-    (column) => column.role !== RESOURCE_IP_ROLE
+    (column) =>
+      column.role !== RESOURCE_IP_ROLE && column.role !== NAMESPACE_ROLE
   );
   return [
     ...getBaseInstanceColumn({
@@ -355,6 +371,7 @@ export const buildInstanceViewColumns = ({
       queryData,
       ipFilterOptions
     }),
+    ...namespaceColumns,
     ...resourceIpColumns,
     buildReportTimeColumn({
       t,

--- a/web/src/app/monitor/(pages)/view/viewList.tsx
+++ b/web/src/app/monitor/(pages)/view/viewList.tsx
@@ -37,7 +37,6 @@ import {
 } from './viewColumnPreference';
 import {
   INSTANCE_VIEW_ACTION_KEY,
-  RESOURCE_IP_ROLE,
   buildInstanceViewColumns,
   buildReportTimeColumn,
   displayFieldKey,
@@ -216,10 +215,10 @@ const ViewList: React.FC<ViewListProps> = ({
     return summaryColumns.some((column) => column.fact === 'asset.ip');
   }, [objects, objectId]);
 
-  // 云平台子对象的内置 IP 列（role=resource_ip）：候选值需要后端下发，走同一个枚举接口。
+  // 带 role 的字段展示列（云平台子对象 IP、K8s Pod Namespace）：候选值需要后端下发。
   const roleFieldColumns = useMemo(() => {
     return (findByMonitorId(objects, objectId)?.display_fields || []).filter(
-      (column) => column.type === 'field' && column.role === RESOURCE_IP_ROLE
+      (column) => column.type === 'field' && Boolean(column.role)
     );
   }, [objects, objectId]);
 
@@ -336,7 +335,10 @@ const ViewList: React.FC<ViewListProps> = ({
           filters: assetIpFilters.length ? assetIpFilters : undefined
         };
       }
-      if (col.role === RESOURCE_IP_ROLE) {
+      if (
+        col.filterParam &&
+        String(col.filterParam).startsWith('field:')
+      ) {
         const options = fieldFilters[String(col.filterParam)] || [];
         next = {
           ...next,

--- a/web/src/app/monitor/types/index.ts
+++ b/web/src/app/monitor/types/index.ts
@@ -254,7 +254,7 @@ export interface ObjectItem {
     column_key?: string;
     name: string;
     type?: 'metric' | 'field';
-    role?: 'resource_ip';
+    role?: 'resource_ip' | 'namespace';
     sort_order: number;
     variable_id?: string;
     metrics: { plugin: string; metric: string; field?: string }[];


### PR DESCRIPTION
## Summary
- K8s Pod 监控视图将 Namespace 作为内置展示列（`role=namespace`），从 `kube_pod_info.namespace` 取值。
- 列头支持多选/搜索过滤，位置在集群列与 IP 列之间。
- 已有环境需重新导入 K8S 插件，或对未自定义展示列的对象执行 `refresh_display_fields --only Pod --apply`。

## Test plan
- [ ] 重新导入 K8S 插件后打开 Pod 监控视图，确认出现「命名空间」列且可按 namespace 筛选。
- [ ] 确认 IP、Pod 阶段、CPU/内存列与筛选行为未回归。
- [ ] 若该视图曾保存列偏好，在齿轮中勾选「命名空间」后列可见。

## 提交范围
已检查暂存区与相对 `master` 的 diff：仅包含本次 Pod Namespace 列相关产品代码（插件种子、展示列 role、视图列渲染与筛选）。测试文件、Storybook mock、图标与其它本地文件未纳入本次 PR。