### PR TITLE
bugfix: 事故详情筛选后关联改走增量接口

### DIFF
--- a/web/scripts/incident-detail-alert-link-test.ts
+++ b/web/scripts/incident-detail-alert-link-test.ts
@@ -1,0 +1,153 @@
+import * as assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const alarmDir = resolve(here, '../src/app/alarm');
+const pageSource = readFileSync(
+  resolve(alarmDir, '(pages)/incidents/detail/page.tsx'),
+  'utf8'
+);
+
+function extractFunction(source: string, name: string): string {
+  const start = source.indexOf(`const ${name}`);
+  assert.ok(start >= 0, `${name} must exist on the incident detail page`);
+  const nextConst = source.indexOf('\n  const ', start + 1);
+  const nextExport = source.indexOf('\nexport ', start + 1);
+  const end = [nextConst, nextExport].filter((idx) => idx > start).sort((a, b) => a - b)[0];
+  assert.ok(end, `${name} body must be extractable`);
+  return source.slice(start, end);
+}
+
+const handleLinkConfirm = extractFunction(pageSource, 'handleLinkConfirm');
+const handleUnlink = extractFunction(pageSource, 'handleUnlink');
+
+assert.doesNotMatch(
+  handleLinkConfirm,
+  /tableData\.map/,
+  'handleLinkConfirm must not rebuild the full alert set from visible tableData'
+);
+assert.doesNotMatch(
+  handleUnlink,
+  /tableData\.map/,
+  'handleUnlink must not rebuild remaining alerts from visible tableData'
+);
+assert.doesNotMatch(
+  handleLinkConfirm,
+  /modifyIncidentDetail\([\s\S]*alert:/,
+  'handleLinkConfirm must not PATCH alert as a full replacement set'
+);
+assert.doesNotMatch(
+  handleUnlink,
+  /modifyIncidentDetail\([\s\S]*alert:/,
+  'handleUnlink must not PATCH alert as a full replacement set'
+);
+assert.match(
+  pageSource,
+  /addAlertsToIncident,\s*\n\s*removeAlertsFromIncident/,
+  'incident detail must use incremental add/remove APIs'
+);
+assert.match(
+  handleLinkConfirm,
+  /const selectedIds = collectSelectedAlertIds\(selectedKeys\);\s*\n\s*if \(!selectedIds\.length\) return;/,
+  'empty link selection must not send a request'
+);
+assert.match(
+  handleLinkConfirm,
+  /addAlertsToIncident\(rowDetailId,\s*selectedIds\)/,
+  'link must add only the selected alert IDs'
+);
+assert.match(
+  handleUnlink,
+  /const selectedIds = collectSelectedAlertIds\(keys \?\? selectedRowKeys\);\s*\n\s*if \(!selectedIds\.length\) return;/,
+  'empty unlink selection must not send a request'
+);
+assert.match(
+  handleUnlink,
+  /removeAlertsFromIncident\(rowDetailId,\s*selectedIds\)/,
+  'unlink must remove only the selected alert IDs'
+);
+assert.match(
+  handleLinkConfirm,
+  /message\.success\([\s\S]*linkAlert/,
+  'successful link must keep the existing success toast'
+);
+assert.match(
+  handleUnlink,
+  /message\.success\([\s\S]*unlinkAlert/,
+  'successful unlink must keep the existing success toast'
+);
+assert.match(
+  handleLinkConfirm,
+  /fetchAlarmList\(\);\s*\n\s*fetchTimeline\(\);/,
+  'successful link must refresh the filtered list and timeline'
+);
+assert.match(
+  handleUnlink,
+  /fetchAlarmList\(\);\s*\n\s*fetchTimeline\(\);/,
+  'successful unlink must refresh the filtered list and timeline'
+);
+assert.doesNotMatch(
+  handleLinkConfirm.split('} catch')[1] || '',
+  /fetchAlarmList|fetchTimeline|message\.success/,
+  'failed link must not toast success or refresh'
+);
+assert.doesNotMatch(
+  handleUnlink.split('} catch')[1] || '',
+  /fetchAlarmList|fetchTimeline|message\.success/,
+  'failed unlink must not toast success or refresh'
+);
+assert.match(
+  pageSource,
+  /modifyIncidentDetail\(rowDetailId, \{ operator:/,
+  'PATCH replacement remains for other incident fields'
+);
+assert.match(
+  pageSource,
+  /<PermissionWrapper requiredPermissions=\{\['Edit'\]\}>[\s\S]*handleLink\(\)/,
+  'link button must stay behind Edit permission'
+);
+assert.match(
+  pageSource,
+  /<PermissionWrapper requiredPermissions=\{\['Edit'\]\}>[\s\S]*handleUnlink\(\)/,
+  'unlink button must stay behind Edit permission'
+);
+
+async function assertSelectedAlertIds() {
+  const { collectSelectedAlertIds } = await import(
+    '../src/app/alarm/utils/incidentAlertRelations.ts'
+  );
+
+  const visibleTableIds = [101, 202];
+  const hiddenServerIds = [303];
+
+  assert.deepEqual(collectSelectedAlertIds([]), []);
+  assert.deepEqual(collectSelectedAlertIds(undefined), []);
+  assert.deepEqual(collectSelectedAlertIds(null), []);
+
+  const linkIds = collectSelectedAlertIds([404]);
+  assert.deepEqual(linkIds, [404]);
+  assert.equal(
+    linkIds.some((id) => visibleTableIds.includes(id) || hiddenServerIds.includes(id)),
+    false,
+    'link payload must be selected IDs only, never a union with visible or hidden table rows'
+  );
+
+  const unlinkIds = collectSelectedAlertIds([101]);
+  assert.deepEqual(unlinkIds, [101]);
+  assert.notDeepEqual(
+    unlinkIds,
+    visibleTableIds.filter((id) => id !== 101),
+    'unlink payload must not be the remaining visible table IDs'
+  );
+}
+
+assertSelectedAlertIds()
+  .then(() => {
+    console.log('incident detail alert link test passed');
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });

--- a/web/src/app/alarm/(pages)/incidents/detail/page.tsx
+++ b/web/src/app/alarm/(pages)/incidents/detail/page.tsx
@@ -19,6 +19,7 @@ import { useCommon } from '@/app/alarm/context/common';
 import { useTranslation } from '@/utils/i18n';
 import { useSearchParams } from 'next/navigation';
 import { useIncidentsApi } from '@/app/alarm/api/incidents';
+import { collectSelectedAlertIds } from '@/app/alarm/utils/incidentAlertRelations';
 import { message, Spin, Modal, Timeline, Empty } from 'antd';
 import { IncidentTableDataItem } from '@/app/alarm/types/incidents';
 import { useStateMap } from '@/app/alarm/constants/alarm';
@@ -57,7 +58,12 @@ const IncidentDetail: React.FC = () => {
   const [recordLoading, setRecordLoading] = useState<boolean>(false);
   const { levelListIncident, levelMapIncident, userList } = useCommon();
   const { getAlarmList } = useAlarmApi();
-  const { getIncidentDetail, modifyIncidentDetail } = useIncidentsApi();
+  const {
+    getIncidentDetail,
+    modifyIncidentDetail,
+    addAlertsToIncident,
+    removeAlertsFromIncident,
+  } = useIncidentsApi();
   const STATE_MAP = useStateMap();
   const searchParams = useSearchParams();
   const rowDetailId = searchParams.get('id') || '';
@@ -265,12 +271,9 @@ const IncidentDetail: React.FC = () => {
         else setUnlinkLoading(true);
 
         try {
-          const toRemove = keys ?? selectedRowKeys;
-          if (!toRemove.length) return;
-          const remainingIds = tableData
-            .map((i) => i.id)
-            .filter((id) => !toRemove.includes(id));
-          await modifyIncidentDetail(rowDetailId, { alert: remainingIds });
+          const selectedIds = collectSelectedAlertIds(keys ?? selectedRowKeys);
+          if (!selectedIds.length) return;
+          await removeAlertsFromIncident(rowDetailId, selectedIds);
           message.success(
             t('alarmCommon.unlinkAlert') + t('alarmCommon.success')
           );
@@ -292,13 +295,11 @@ const IncidentDetail: React.FC = () => {
   }, []);
 
   const handleLinkConfirm = async (selectedKeys: React.Key[]) => {
+    const selectedIds = collectSelectedAlertIds(selectedKeys);
+    if (!selectedIds.length) return;
     setLinkingLoading(true);
     try {
-      const existingIds = tableData.map((i) => i.id);
-      const newIds = Array.from(
-        new Set([...existingIds, ...(selectedKeys as number[])])
-      );
-      await modifyIncidentDetail(rowDetailId, { alert: newIds });
+      await addAlertsToIncident(rowDetailId, selectedIds);
       message.success(t('alarmCommon.linkAlert') + t('alarmCommon.success'));
       setOperateVisible(false);
       fetchAlarmList();

--- a/web/src/app/alarm/utils/incidentAlertRelations.ts
+++ b/web/src/app/alarm/utils/incidentAlertRelations.ts
@@ -1,0 +1,19 @@
+export function collectSelectedAlertIds(
+  keys: ReadonlyArray<string | number> | null | undefined
+): number[] {
+  if (!keys?.length) {
+    return [];
+  }
+
+  const ids: number[] = [];
+  const seen = new Set<number>();
+  for (const key of keys) {
+    const id = typeof key === 'number' ? key : Number(key);
+    if (!Number.isInteger(id) || seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    ids.push(id);
+  }
+  return ids;
+}


### PR DESCRIPTION
## 复现步骤

前置：账号具备事故查看/编辑权限（详情页「关联告警」「解除告警」包在 Edit 权限里）。准备一条事故，已关联至少两条**告警名称不同**的告警。

1. 进入告警模块左侧菜单 **事故**（`/alarm/incidents`）。
2. 在列表目标行点 **详情**，进入事故详情（`/alarm/incidents/detail?id=…&incident_id=…`）。默认打开 **告警** 页签、**表格** 视图，此时应能看到全部已关联告警。
3. 在表格上方筛选器：左侧下拉从默认的 **告警ID** 改成 **告警名称**，输入其中一条告警名称的可区分片段，回车。表格应只剩这一条。
4. 走下面任一操作：
   - **解除**：点该行操作列 **解除告警**，确认框标题为「解除告警」、内容为「确认解除告警」，点 **确认**。页面提示「解除告警成功」。
   - **再关联**：点右上 **关联告警**，打开标题为「关联告警」的抽屉，勾选一条尚未关联的告警，再点抽屉里的 **关联告警**。页面提示「关联告警成功」。
5. 清空筛选（点输入框清除），回到未筛选的告警表格。

修复前：步骤 5 会发现筛选时没出现的原关联告警已经不在事故里。  
修复后：步骤 5 应仍能看到那些未操作过的原关联告警；解除只少被点的那条，关联只多新选的那条。

## 修复方案

事故详情不再用当前表格可见行拼 `alert` 全集再 `PATCH`。

- **关联告警**：只把本次选中的告警 ID 交给已有 `POST /alerts/api/incident/{id}/alerts/add/`。
- **解除告警**（行内或批量）：只把本次选中的告警 ID 交给已有 `POST /alerts/api/incident/{id}/alerts/remove/`。
- 处理人、备注、团队等其它字段仍走原来的 `PATCH`，后端 `alert.set` 替换语义不改。
- 空选择不发请求；失败不提示成功、不刷新列表。

Fixes #5217

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 筛选后点行内「解除告警」 | 按当前可见行剩余 ID 做 `PATCH alert` 全量替换，筛掉的关联被写成空集或子集 | 只 `remove` 这一条告警 ID，其它关联不动 |
| 筛选后抽屉「关联告警」 | 可见 ID + 新 ID 做 `PATCH alert` 全量替换，筛掉的原关联被丢掉 | 只 `add` 新选中的告警 ID，原关联保留 |
| 未筛选时关联/解除 | 可见列表碰巧等于全集，结果看起来正常 | 同样正确，改为增量接口 |
| 处理人 / 备注 / 团队保存 | `PATCH` 其它字段 | 不变 |
| 后端 `instance.alert.set` | 详情页关联/解除会打到这条替换语义 | 详情页关联/解除不再打这条；替换契约仍留给其它字段 |

## 影响面

- **会变**：仅事故详情 **告警** 页签上的「关联告警」「解除告警」（含行内解除和勾选后批量解除）。筛选后编辑不再覆盖隐藏关联。
- **不变**：告警详情里已有的「加到当前事故」增量入口；事故处理人/备注/团队保存；后端 add/remove/PATCH 契约与权限（仍要 Incidents-Edit，并校验目标告警访问权）。
- **不会自动恢复**：修复前已经被筛掉并替换丢掉的关联，需要从业务记录手工补回。
- **副作用**：不能再靠「先筛掉大部分、再解除剩下可见行」间接清空隐藏关联。那是旧实现的误伤路径，不是产品能力。
- **并发**：另一客户端刚加上的关联，不会再被本页一次筛选后的 PATCH 覆盖。

## 验证

- `web/scripts/incident-detail-alert-link-test.ts`：修复前失败，修复后通过
- `apps/alerts/tests/test_incident_alert_views.py`：30 passed，含 add/remove 与 PATCH 替换回归
