### PR TITLE
fix(监控): 腾讯云地域必填误报修复并支持多选

### DIFF
--- a/server/apps/monitor/support-files/plugins/Telegraf/http/qcloud/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/qcloud/UI.json
@@ -43,17 +43,21 @@
       "editable": true,
       "options_key": "region_option",
       "options": [],
-      "description": "填写 SecretId / SecretKey 后会自动拉取可用地域；也可点击右侧刷新图标手动更新。仅采集所选地域的资源与监控指标。",
-      "description_en": "Available regions load automatically after SecretId / SecretKey are filled; use the refresh icon to reload. Only the selected region is collected.",
+      "description": "填写 SecretId / SecretKey 后会自动拉取可用地域；也可点击右侧刷新图标手动更新。可多选，将采集所选全部地域的资源与监控指标。",
+      "description_en": "Available regions load automatically after SecretId / SecretKey are filled; use the refresh icon to reload. Multiple regions can be selected and will all be collected.",
       "widget_props": {
-        "placeholder": "请选择腾讯云地域",
-        "placeholder_en": "Select a Tencent Cloud region",
+        "placeholder": "请选择腾讯云地域（可多选）",
+        "placeholder_en": "Select Tencent Cloud regions",
+        "mode": "multiple",
+        "maxTagCount": "responsive",
         "showSearch": true,
         "optionFilterProp": "label",
         "show_refresh": true
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.http_headers.region"
+        "origin_path": "child.content.config.http_headers.region",
+        "to_form": { "split": "," },
+        "to_api": { "join": "," }
       },
       "label_en": "Tencent Cloud Region"
     }

--- a/server/apps/monitor/utils/plugin_controller.py
+++ b/server/apps/monitor/utils/plugin_controller.py
@@ -211,6 +211,15 @@ def ensure_qcloud_region_jinja(template_content: str) -> str:
     return text[: password_line.end()] + "\n" + insertion + text[password_line.end() :]
 
 
+def _normalize_qcloud_region(value) -> str:
+    """表单多选为列表，Telegraf header 为逗号串；空值回落广州。"""
+    if isinstance(value, (list, tuple)):
+        parts = [str(item).strip() for item in value if str(item).strip()]
+    else:
+        parts = [item.strip() for item in str(value or "").split(",") if item.strip()]
+    return ",".join(parts) or "ap-guangzhou"
+
+
 def _normalize_template_context(context: dict) -> dict:
     normalized = {**context}
     metrics_modules = normalized.get("metrics_modules")
@@ -227,11 +236,9 @@ def _normalize_template_context(context: dict) -> dict:
         normalized["url"] = normalize_rabbitmq_management_url(normalized.get("url"))
     # 腾讯云地域：表单未填时回落广州，与 Stargazer 采集缺省一致。
     if str(normalized.get("instance_type") or normalized.get("config_type") or "").lower() == "qcloud":
-        region = str(normalized.get("region") or "").strip()
-        normalized["region"] = region or "ap-guangzhou"
+        normalized["region"] = _normalize_qcloud_region(normalized.get("region"))
     elif str(normalized.get("type") or "").lower() == "qcloud":
-        region = str(normalized.get("region") or "").strip()
-        normalized["region"] = region or "ap-guangzhou"
+        normalized["region"] = _normalize_qcloud_region(normalized.get("region"))
     return normalized
 
 

--- a/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
+++ b/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
@@ -33,6 +33,44 @@ export type FormFieldOptionControls = Record<
   }
 >;
 
+type SelectWithRefreshProps = React.ComponentProps<typeof Select> & {
+  onRefresh: () => void;
+  refreshLabel: string;
+  refreshTip: string;
+  regionLoading?: boolean;
+};
+
+// Form.Item 只把 value/onChange 注入直接子节点。刷新按钮必须放在转发包装里，
+// 否则选中地域只改 Select 内部展示，表单仍为空，必填校验会误报。
+const SelectWithRefresh = React.forwardRef<any, SelectWithRefreshProps>(
+  function SelectWithRefresh(
+    { onRefresh, refreshLabel, refreshTip, regionLoading, ...selectProps },
+    ref
+  ) {
+    return (
+      <div className="mr-[10px] inline-flex items-center gap-1">
+        <Select ref={ref} {...selectProps} />
+        <Tooltip title={refreshTip}>
+          <Button
+            type="text"
+            aria-label={refreshLabel}
+            disabled={Boolean(regionLoading)}
+            className="!inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[var(--color-text-3)] hover:!bg-[var(--color-fill-2)] hover:!text-[var(--color-primary)]"
+            icon={
+              <SyncOutlined
+                spin={Boolean(regionLoading)}
+                className="text-[14px]"
+                aria-hidden
+              />
+            }
+            onClick={onRefresh}
+          />
+        </Tooltip>
+      </div>
+    );
+  }
+);
+
 const mutexValuesEqual = (left: any, right: any) => {
   if (left === right) return true;
   if (Array.isArray(left) || Array.isArray(right)) {
@@ -426,60 +464,44 @@ export const useConfigRenderer = () => {
           ));
           if (shouldShowRegionRefresh && optionControl?.onRefresh) {
             const regionLoading = Boolean(optionControl.loading);
-            const refreshLabel = t(
-              'monitor.integrations.fetchQcloudRegions',
-              '获取地域'
-            );
-            const refreshTip = t(
-              'monitor.integrations.refreshQcloudRegionsTip',
-              '根据 SecretId / SecretKey 刷新可用地域'
-            );
             return (
-              <div className="mr-[10px] inline-flex items-center gap-1">
-                <Select
-                  {...selectProps}
-                  placeholder={
-                    selectProps.placeholder ||
-                    t('monitor.integrations.selectQcloudRegion', '请选择腾讯云地域')
-                  }
-                  notFoundContent={
-                    regionLoading ? (
-                      <div className="flex items-center justify-center gap-2 py-3 text-[var(--color-text-3)]">
-                        <Spin size="small" />
-                        <span>
-                          {t(
-                            'monitor.integrations.fetchingQcloudRegions',
-                            '正在获取地域…'
-                          )}
-                        </span>
-                      </div>
-                    ) : (
-                      t(
-                        'monitor.integrations.qcloudRegionNoOptions',
-                        '暂无地域，请先填写密钥后点击刷新'
-                      )
+              <SelectWithRefresh
+                {...selectProps}
+                placeholder={
+                  selectProps.placeholder ||
+                  t('monitor.integrations.selectQcloudRegion', '请选择腾讯云地域')
+                }
+                notFoundContent={
+                  regionLoading ? (
+                    <div className="flex items-center justify-center gap-2 py-3 text-[var(--color-text-3)]">
+                      <Spin size="small" />
+                      <span>
+                        {t(
+                          'monitor.integrations.fetchingQcloudRegions',
+                          '正在获取地域…'
+                        )}
+                      </span>
+                    </div>
+                  ) : (
+                    t(
+                      'monitor.integrations.qcloudRegionNoOptions',
+                      '暂无地域，请先填写密钥后点击刷新'
                     )
-                  }
-                >
-                  {optionNodes}
-                </Select>
-                <Tooltip title={refreshTip}>
-                  <Button
-                    type="text"
-                    aria-label={refreshLabel}
-                    disabled={regionLoading}
-                    className="!inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[var(--color-text-3)] hover:!bg-[var(--color-fill-2)] hover:!text-[var(--color-primary)]"
-                    icon={
-                      <SyncOutlined
-                        spin={regionLoading}
-                        className="text-[14px]"
-                        aria-hidden
-                      />
-                    }
-                    onClick={optionControl.onRefresh}
-                  />
-                </Tooltip>
-              </div>
+                  )
+                }
+                onRefresh={optionControl.onRefresh}
+                refreshLabel={t(
+                  'monitor.integrations.fetchQcloudRegions',
+                  '获取地域'
+                )}
+                refreshTip={t(
+                  'monitor.integrations.refreshQcloudRegionsTip',
+                  '根据 SecretId / SecretKey 刷新可用地域'
+                )}
+                regionLoading={regionLoading}
+              >
+                {optionNodes}
+              </SelectWithRefresh>
             );
           }
           return (

--- a/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
+++ b/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
@@ -455,6 +455,10 @@ export const useConfigRenderer = () => {
               : widget_props.placeholder || label,
             showSearch: true as const,
             optionFilterProp: 'label' as const,
+            maxTagCount:
+              widget_props.mode === 'multiple'
+                ? widget_props.maxTagCount || 'responsive'
+                : widget_props.maxTagCount,
             style: formWidgetWidthStyle(widgetStyle),
           };
           const optionNodes = options.map((option: any) => (

--- a/web/src/app/monitor/hooks/integration/useDataMapper.ts
+++ b/web/src/app/monitor/hooks/integration/useDataMapper.ts
@@ -77,6 +77,18 @@ export class DataMapper {
           const match = processedValue.match(new RegExp(to_form.regex));
           processedValue = match ? match[1] || match[0] : processedValue;
         }
+        // 逗号串拆成数组（腾讯云地域多选回显）
+        if (to_form.split) {
+          const sep = typeof to_form.split === 'string' ? to_form.split : ',';
+          if (typeof processedValue === 'string') {
+            processedValue = processedValue
+              .split(sep)
+              .map((item: string) => item.trim())
+              .filter(Boolean);
+          } else if (processedValue == null || processedValue === '') {
+            processedValue = [];
+          }
+        }
         // 数组用分隔符拼成字符串（SNMP ifDescr 黑白名单回显）
         if (to_form.array_join) {
           const sep = typeof to_form.array_join === 'string' ? to_form.array_join : ',';
@@ -200,6 +212,18 @@ export class DataMapper {
         processedValue !== null
       ) {
         processedValue = String(processedValue) + to_api.suffix;
+      }
+      // 多选数组拼成逗号串（腾讯云地域提交）
+      if (to_api.join) {
+        const sep = typeof to_api.join === 'string' ? to_api.join : ',';
+        if (Array.isArray(processedValue)) {
+          processedValue = processedValue
+            .map((item) => String(item).trim())
+            .filter(Boolean)
+            .join(sep);
+        } else if (processedValue == null) {
+          processedValue = '';
+        }
       }
       // 字符串按分隔符拆成数组（SNMP ifDescr 黑白名单提交）
       if (to_api.split) {

--- a/web/src/app/monitor/hooks/integration/useQcloudRegionOptions.ts
+++ b/web/src/app/monitor/hooks/integration/useQcloudRegionOptions.ts
@@ -18,6 +18,16 @@ function isUsableSecret(value: unknown): value is string {
   return true;
 }
 
+function regionSelection(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item).trim()).filter(Boolean);
+  }
+  if (typeof value === 'string' && value.trim()) {
+    return value.split(',').map((item) => item.trim()).filter(Boolean);
+  }
+  return [];
+}
+
 /**
  * 腾讯云监控接入：密钥齐全后按账号动态拉取可用地域。
  */
@@ -69,13 +79,13 @@ export function useQcloudRegionOptions(options: {
           .filter((item) => item.value);
         setRegionOptions(next);
 
-        const currentRegion = form.getFieldValue('region');
-        if (
-          currentRegion &&
-          next.length > 0 &&
-          !next.some((item) => item.value === currentRegion)
-        ) {
-          form.setFieldsValue({ region: undefined });
+        const selected = regionSelection(form.getFieldValue('region'));
+        if (selected.length > 0 && next.length > 0) {
+          const allowed = new Set(next.map((item) => item.value));
+          const kept = selected.filter((item) => allowed.has(item));
+          if (kept.length !== selected.length) {
+            form.setFieldsValue({ region: kept.length ? kept : undefined });
+          }
         }
 
         if (next.length === 0) {
@@ -118,13 +128,18 @@ export function useQcloudRegionOptions(options: {
       return;
     }
     if (!isUsableSecret(username) || !isUsableSecret(password)) {
-      const currentRegion = form.getFieldValue('region');
-      if (typeof currentRegion === 'string' && currentRegion.trim()) {
+      const selected = regionSelection(form.getFieldValue('region'));
+      if (selected.length > 0) {
         setRegionOptions((prev) => {
-          if (prev.some((item) => item.value === currentRegion)) {
+          const existing = new Set(prev.map((item) => item.value));
+          const missing = selected.filter((item) => !existing.has(item));
+          if (missing.length === 0) {
             return prev;
           }
-          return [{ label: currentRegion, value: currentRegion }];
+          return [
+            ...prev,
+            ...missing.map((item) => ({ label: item, value: item })),
+          ];
         });
       }
       return;


### PR DESCRIPTION
## Summary
- 修复腾讯云接入地域已选仍报「必填项」：刷新按钮把 `Select` 包进普通 `div`，`Form.Item` 的 `value`/`onChange` 未注入下拉框；改为 `SelectWithRefresh` 转发包装。
- 地域支持多选：UI `mode=multiple`，提交/渲染为逗号串写入 Telegraf `region` header，编辑再拆回多选回显；后端 `_normalize_qcloud_region` 避免 Jinja 渲染出 Python list 字符串。

## Test plan
- [ ] 填写密钥并选择地域后，「必填项」消失，可提交；不选仍提示必填；刷新按钮可用
- [ ] 多选多个地域后保存，子配置 `http_headers.region` 为逗号串
- [ ] 编辑回显为多选标签；去掉无效地域时保留仍有效的选中项

## 提交范围
`useConfigRenderer.tsx`、`useDataMapper.ts`、`useQcloudRegionOptions.ts`、`qcloud/UI.json`、`plugin_controller.py`。测试文件按仓库规则未纳入。