### PR TITLE
bugfix: 事故列表筛选改用事故等级

### DIFF
--- a/web/scripts/incident-level-filter-test.ts
+++ b/web/scripts/incident-level-filter-test.ts
@@ -1,0 +1,90 @@
+import * as assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const incidentPageSource = readFileSync(
+  resolve(here, '../src/app/alarm/(pages)/incidents/page.tsx'),
+  'utf8'
+);
+
+assert.doesNotMatch(
+  incidentPageSource,
+  /from ['"]@\/app\/alarm\/components\/alarmFilters['"]/,
+  '事故页不得继续引用 camelCase alarmFilters（其内部写死 alert 等级）'
+);
+assert.match(
+  incidentPageSource,
+  /from ['"]@\/app\/alarm\/components\/alarm-filters['"]/,
+  '事故页必须改用接受显式 levelOptions 的 alarm-filters'
+);
+assert.match(
+  incidentPageSource,
+  /toIncidentLevelFilterOptions\(\s*levelListIncident\s*\)/,
+  '事故页必须把 incident 等级列表转成筛选项并传入'
+);
+assert.match(
+  incidentPageSource,
+  /levelOptions=\{toIncidentLevelFilterOptions\(levelListIncident\)\}/,
+  '事故页必须把 incident 筛选项传给 AlarmFilters.levelOptions'
+);
+assert.match(
+  incidentPageSource,
+  /filterSource=\{false\}/,
+  '事故页筛选仍不展示来源'
+);
+assert.match(
+  incidentPageSource,
+  /level:\s*filters\.level\.join\(['"],['"]\)/,
+  '查询参数仍用 filters.level join 后的 level，不改 API'
+);
+
+async function main() {
+  const { toIncidentLevelFilterOptions } = await import(
+    '../src/app/alarm/utils/incidentLevelFilters.ts'
+  );
+
+  const incidentLevels = [
+    {
+      level_id: 1,
+      level_display_name: '事故P1',
+      color: '#ff4d4f',
+    },
+    {
+      level_id: 7,
+      level_display_name: '事故独有',
+      color: '#722ed1',
+    },
+  ];
+
+  const options = toIncidentLevelFilterOptions(incidentLevels);
+  const byValue = new Map(options.map((item) => [item.value, item]));
+
+  assert.equal(typeof options[0]?.value, 'string');
+  assert.ok(
+    byValue.has('7'),
+    '仅属于 incident 的 level_id 必须出现在筛选项'
+  );
+  assert.equal(byValue.get('7')?.label, '事故独有');
+  assert.equal(byValue.get('7')?.color, '#722ed1');
+
+  assert.ok(
+    !byValue.has('99'),
+    '仅属于 alert 的等级不得进入事故筛选项'
+  );
+
+  const shared = byValue.get('1');
+  assert.ok(shared, '同 ID 的事故等级必须出现在筛选项');
+  assert.equal(
+    shared?.label,
+    '事故P1',
+    '同 ID 不同名称时必须使用 incident 显示名'
+  );
+  assert.notEqual(shared?.label, '告警P1');
+  assert.equal(shared?.value, String(1));
+
+  console.log('incident level filter test passed');
+}
+
+main();

--- a/web/src/app/alarm/(pages)/incidents/page.tsx
+++ b/web/src/app/alarm/(pages)/incidents/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import LevelIcon from '@/app/alarm/components/levelIcon';
-import AlarmFilters from '@/app/alarm/components/alarmFilters';
+import AlarmFilters from '@/app/alarm/components/alarm-filters';
 import CustomTable from '@/components/custom-table';
 import alertStyle from './index.module.scss';
 import TimeSelector from '@/components/time-selector';
@@ -17,6 +17,7 @@ import { useTranslation } from '@/utils/i18n';
 import { incidentStates } from '@/app/alarm/constants/alarm';
 import { useRouter } from 'next/navigation';
 import { useCommon } from '@/app/alarm/context/common';
+import { toIncidentLevelFilterOptions } from '@/app/alarm/utils/incidentLevelFilters';
 import { KeepAlive, useActivate } from 'react-activation';
 
 const IncidentsPage: React.FC = () => {
@@ -209,6 +210,7 @@ const IncidentsPage: React.FC = () => {
         <AlarmFilters
           filterSource={false}
           stateOptions={stateOptions}
+          levelOptions={toIncidentLevelFilterOptions(levelListIncident)}
           filters={filters}
           onFilterChange={onFilterChange}
           clearFilters={clearFilters}

--- a/web/src/app/alarm/utils/incidentLevelFilters.ts
+++ b/web/src/app/alarm/utils/incidentLevelFilters.ts
@@ -1,0 +1,21 @@
+export interface IncidentLevelFilterSource {
+  level_id: number;
+  level_display_name: string;
+  color?: string;
+}
+
+export interface IncidentLevelFilterOption {
+  value: string;
+  label: string;
+  color?: string;
+}
+
+export function toIncidentLevelFilterOptions(
+  levelListIncident: IncidentLevelFilterSource[]
+): IncidentLevelFilterOption[] {
+  return (levelListIncident || []).map((item) => ({
+    value: String(item.level_id),
+    label: item.level_display_name,
+    color: item.color,
+  }));
+}


### PR DESCRIPTION
## 复现步骤

前置：账号能打开告警模块。准备一个只属于 Incident、不属于 Alert 的等级（例如显示名可区分的独立等级）。

1. 进入告警模块左侧菜单 **配置** → **全局配置**（`/alarm/settings/globalConfig`）。
2. 在页面 **告警等级管理** 中找到 **Incident 事件等级**，点 **新增等级**。弹窗标题是 **新增告警等级**。填显示名、颜色后保存。
3. 进入 **告警**（`/alarm/alarms`），勾选一条未关联事故的告警，点 **升级为事故**。弹窗里选 **创建事故**，在表单项 **级别** 勾选刚保存的 Incident 等级，填事故名称和处理人后提交。
4. 进入左侧菜单 **事故**（`/alarm/incidents`）。表格 **级别** 列应能看到该事故等级。
5. 看左侧 **过滤项** → **级别** 勾选项，再勾选该等级观察列表。

修复前：表格行能显示该 Incident 等级，但左侧 **级别** 筛选项来自 Alert 告警等级。独立 Incident 等级勾不到；同 ID 不同名称时筛选项文案还是告警侧的。  
修复后：左侧 **级别** 与表格同源，展示 Incident 事件等级。勾选后请求参数仍是 `level`（逗号分隔 ID），列表按该事故等级过滤。

## 修复方案

事故列表不再使用内部写死 Alert 等级的 camelCase `alarmFilters`。

- 改用已有的 kebab `alarm-filters`，显式传入 `toIncidentLevelFilterOptions(levelListIncident)`。
- 筛选项 `value` 为 `String(level_id)`，显示名和颜色来自 Incident 等级。
- 查询仍是 `filters.level.join(',')` 作为 `level`，不改事故列表 API。
- 告警列表继续走 Alert 等级，camelCase 组件不改。

Fixes #5219

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 事故页左侧 **级别** | 展示 Alert 告警等级 | 展示 Incident 事件等级 |
| 仅属于 Incident 的等级 | 表格看得到，筛选项没有 | 筛选项与表格都能看到 |
| 同 ID、Alert/Incident 显示名不同 | 筛选项用告警显示名 | 筛选项用事故显示名 |
| 勾选后请求 | `level` 为勾选 ID 的逗号拼接 | 不变 |
| 告警列表筛选 | Alert 等级 | 不变 |

## 影响面

- **会变**：仅告警模块 **事故** 列表左侧 **过滤项** → **级别** 的候选和色条来源。
- **不变**：事故列表/详情表格、升级为事故、全局配置里的三类等级维护、告警列表筛选、事故 API 的 `level` / `status` 契约与权限。
- **兼容**：勾选值从旧组件可能传入的数字 ID，改为字符串 ID；`join` 后请求体仍是逗号分隔等级值。
- **未改**：事故详情页其它筛选、告警页 camelCase `alarmFilters`。

## 验证

- `web/scripts/incident-level-filter-test.ts`：修复前失败，修复后 `incident level filter test passed`
- 覆盖 Incident 独有等级进入筛选项、Alert 独有等级不进入、同 ID 使用事故显示名、事故页改用 `alarm-filters` 并传入 `levelListIncident`
