### PR TITLE
bugfix: 配置表格只接受最新列表请求

### DIFF
--- a/web/scripts/settings-table-race-test.ts
+++ b/web/scripts/settings-table-race-test.ts
@@ -1,0 +1,258 @@
+import * as assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createLatestRequestGuard } from '../src/context/latestRequestGuard.ts';
+import type { LatestRequestGuard } from '../src/context/latestRequestGuard.ts';
+
+interface SettingsTableListPayload<T> {
+  items?: T[] | null;
+  count?: number | null;
+}
+
+interface SettingsTableListView<T> {
+  dataList: T[];
+  listCount: number;
+  paginationTotal: number;
+}
+
+interface CommitFns {
+  buildSettingsTableListView: <T>(payload: SettingsTableListPayload<T>) => SettingsTableListView<T>;
+  commitSettingsTableListSuccess: <T>(
+    guard: LatestRequestGuard,
+    requestId: number,
+    payload: SettingsTableListPayload<T>,
+    apply: (next: SettingsTableListView<T>) => void,
+  ) => boolean;
+  commitSettingsTableListFailure: (
+    guard: LatestRequestGuard,
+    requestId: number,
+    reportError: () => void,
+  ) => boolean;
+  commitSettingsTableListSettled: (
+    guard: LatestRequestGuard,
+    requestId: number,
+    settle: () => void,
+  ) => boolean;
+}
+
+interface Row {
+  id: number;
+  name: string;
+}
+
+interface ViewState {
+  dataList: Row[];
+  listCount: number;
+  paginationTotal: number;
+  tableLoading: boolean;
+  error: string | null;
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const hookPath = resolve(here, '../src/app/alarm/hooks/useSettingsTable.ts');
+const utilPath = resolve(here, '../src/app/alarm/utils/settingsTableRequest.ts');
+
+async function loadCommitFns(): Promise<CommitFns> {
+  let loaded: Partial<CommitFns> = {};
+  try {
+    loaded = await import('../src/app/alarm/utils/settingsTableRequest.ts');
+  } catch {
+    // RED：提交函数尚未抽出。
+  }
+
+  assert.equal(typeof loaded.buildSettingsTableListView, 'function', '应抽出 buildSettingsTableListView');
+  assert.equal(typeof loaded.commitSettingsTableListSuccess, 'function', '应抽出 commitSettingsTableListSuccess');
+  assert.equal(typeof loaded.commitSettingsTableListFailure, 'function', '应抽出 commitSettingsTableListFailure');
+  assert.equal(typeof loaded.commitSettingsTableListSettled, 'function', '应抽出 commitSettingsTableListSettled');
+
+  return loaded as CommitFns;
+}
+
+function createListSession(fns: CommitFns) {
+  const guard = createLatestRequestGuard();
+  let state: ViewState = {
+    dataList: [],
+    listCount: 0,
+    paginationTotal: 0,
+    tableLoading: false,
+    error: null,
+  };
+
+  const start = () => {
+    const requestId = guard.begin();
+    state = { ...state, tableLoading: true };
+    return requestId;
+  };
+
+  const succeed = (requestId: number, payload: SettingsTableListPayload<Row>) => {
+    fns.commitSettingsTableListSuccess(guard, requestId, payload, (next) => {
+      state = {
+        ...state,
+        dataList: next.dataList,
+        listCount: next.listCount,
+        paginationTotal: next.paginationTotal,
+      };
+    });
+    fns.commitSettingsTableListSettled(guard, requestId, () => {
+      state = { ...state, tableLoading: false };
+    });
+  };
+
+  const fail = (requestId: number) => {
+    fns.commitSettingsTableListFailure(guard, requestId, () => {
+      state = { ...state, error: 'loadFailed' };
+    });
+    fns.commitSettingsTableListSettled(guard, requestId, () => {
+      state = { ...state, tableLoading: false };
+    });
+  };
+
+  return {
+    getState: () => state,
+    start,
+    succeed,
+    fail,
+    unmount: () => guard.invalidate(),
+  };
+}
+
+function assertHookUsesGeneration(source: string) {
+  assert.match(
+    source,
+    /from ['"]@\/context\/latestRequestGuard['"]/,
+    'hook 必须复用 @/context/latestRequestGuard，不得复制新 guard',
+  );
+  assert.match(source, /createLatestRequestGuard/, 'hook 必须创建 latest request guard');
+  assert.match(source, /requestGuard\.begin\(\)/, 'getTableList 必须按单调序号 begin');
+  assert.match(
+    source,
+    /from ['"]@\/app\/alarm\/utils\/settingsTableRequest['"]/,
+    'hook 必须调用抽出的 settingsTableRequest',
+  );
+  assert.match(source, /commitSettingsTableListSuccess\(/, '成功响应必须经 commitSettingsTableListSuccess 提交');
+  assert.match(source, /commitSettingsTableListFailure\(/, '失败必须经 commitSettingsTableListFailure 提交');
+  assert.match(source, /commitSettingsTableListSettled\(/, '结束 loading 必须经 commitSettingsTableListSettled 提交');
+  assert.match(source, /requestGuard\.invalidate\(\)/, '卸载后必须 invalidate，迟到响应不得写回');
+  assert.match(
+    source,
+    /current:\s*pagination\.current\s*-\s*1/,
+    '删除最后一行后的 current-1 刷新路径必须保留',
+  );
+  assert.doesNotMatch(
+    source,
+    /setDataList\(\s*data\.items/,
+    'getTableList 不得在 await 后无条件写 dataList',
+  );
+  assert.doesNotMatch(
+    source,
+    /function createLatestRequestGuard|const createLatestRequestGuard\s*=/,
+    '不得在 hook 内复制一套序号 guard',
+  );
+}
+
+async function main() {
+  const fns = await loadCommitFns();
+
+  const built = fns.buildSettingsTableListView({ items: [{ id: 1, name: 'a' }], count: 3 });
+  assert.deepEqual(built, {
+    dataList: [{ id: 1, name: 'a' }],
+    listCount: 1,
+    paginationTotal: 3,
+  });
+
+  const search = createListSession(fns);
+  const staleSearch = search.start();
+  const latestSearch = search.start();
+  search.succeed(latestSearch, { items: [{ id: 2, name: 'bar' }], count: 1 });
+  search.succeed(staleSearch, { items: [{ id: 1, name: 'foo' }], count: 5 });
+  assert.deepEqual(search.getState().dataList, [{ id: 2, name: 'bar' }], '搜索乱序：较旧响应不得覆盖较新搜索结果');
+  assert.equal(search.getState().paginationTotal, 1, '搜索乱序：total 必须属于最新查询');
+  assert.equal(search.getState().tableLoading, false);
+
+  const cleared = createListSession(fns);
+  const staleFilter = cleared.start();
+  const latestClear = cleared.start();
+  cleared.succeed(latestClear, {
+    items: [
+      { id: 1, name: 'all-1' },
+      { id: 2, name: 'all-2' },
+    ],
+    count: 2,
+  });
+  cleared.succeed(staleFilter, { items: [{ id: 9, name: 'filtered' }], count: 1 });
+  assert.deepEqual(
+    cleared.getState().dataList.map((row) => row.name),
+    ['all-1', 'all-2'],
+    '清空乱序：较旧搜索结果不得覆盖清空后的全量列表',
+  );
+  assert.equal(cleared.getState().paginationTotal, 2);
+
+  const paging = createListSession(fns);
+  const pageOne = paging.start();
+  const pageTwo = paging.start();
+  paging.succeed(pageTwo, { items: [{ id: 20, name: 'page-2' }], count: 40 });
+  paging.succeed(pageOne, { items: [{ id: 10, name: 'page-1' }], count: 40 });
+  assert.deepEqual(paging.getState().dataList, [{ id: 20, name: 'page-2' }], '翻页乱序：较旧页不得覆盖较新页');
+  assert.equal(paging.getState().listCount, 1);
+
+  const latestFailed = createListSession(fns);
+  const staleSuccess = latestFailed.start();
+  const failedLatest = latestFailed.start();
+  latestFailed.fail(failedLatest);
+  latestFailed.succeed(staleSuccess, { items: [{ id: 3, name: 'stale-ok' }], count: 8 });
+  assert.equal(latestFailed.getState().error, 'loadFailed', '最新失败必须可报错');
+  assert.deepEqual(latestFailed.getState().dataList, [], '旧成功不能在最新失败之后写回列表');
+  assert.equal(latestFailed.getState().paginationTotal, 0);
+  assert.equal(latestFailed.getState().tableLoading, false);
+
+  const inflight = createListSession(fns);
+  const staleFail = inflight.start();
+  inflight.start();
+  inflight.fail(staleFail);
+  assert.equal(inflight.getState().tableLoading, true, '旧失败不得把仍在途的最新请求 loading 清掉');
+  assert.equal(inflight.getState().error, null, '旧失败不得展示为当前错误');
+
+  const unmounted = createListSession(fns);
+  const lateId = unmounted.start();
+  unmounted.unmount();
+  unmounted.succeed(lateId, { items: [{ id: 4, name: 'late' }], count: 1 });
+  unmounted.fail(lateId);
+  assert.deepEqual(unmounted.getState().dataList, [], '卸载后迟到成功不得写回');
+  assert.equal(unmounted.getState().paginationTotal, 0);
+  assert.equal(unmounted.getState().error, null, '卸载后迟到失败不得写回');
+  assert.equal(unmounted.getState().tableLoading, true, '卸载后不得用迟到 finally 收口仍有效的会话状态');
+
+  const afterDelete = createListSession(fns);
+  const pageTwoBeforeDelete = afterDelete.start();
+  afterDelete.succeed(pageTwoBeforeDelete, { items: [{ id: 21, name: 'last-row' }], count: 21 });
+  const pageAfterDelete = afterDelete.start();
+  afterDelete.succeed(pageAfterDelete, { items: [{ id: 11, name: 'prev-page' }], count: 20 });
+  assert.deepEqual(
+    afterDelete.getState().dataList,
+    [{ id: 11, name: 'prev-page' }],
+    '删除最后一行后的 current-1 刷新必须仍能提交',
+  );
+  assert.equal(afterDelete.getState().paginationTotal, 20);
+
+  const hookSource = readFileSync(hookPath, 'utf8');
+  const utilSource = readFileSync(utilPath, 'utf8');
+  assertHookUsesGeneration(hookSource);
+  assert.doesNotMatch(
+    utilSource,
+    /createLatestRequestGuard\s*=|function createLatestRequestGuard/,
+    'settingsTableRequest 不得复制一套序号 guard',
+  );
+  assert.match(
+    hookSource,
+    /patchItem/,
+    '开关 patch 刷新入口必须保留',
+  );
+
+  console.log('settings table race test passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/web/src/app/alarm/hooks/useSettingsTable.ts
+++ b/web/src/app/alarm/hooks/useSettingsTable.ts
@@ -1,6 +1,12 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { message, Modal } from 'antd';
+import { createLatestRequestGuard } from '@/context/latestRequestGuard';
 import { useTranslation } from '@/utils/i18n';
+import {
+  commitSettingsTableListFailure,
+  commitSettingsTableListSettled,
+  commitSettingsTableListSuccess,
+} from '@/app/alarm/utils/settingsTableRequest';
 
 interface Pagination {
   current: number;
@@ -40,6 +46,7 @@ export function useSettingsTable<T>({
 }: UseSettingsTableOptions<T>): UseSettingsTableReturn<T> {
   const { t } = useTranslation();
   const listCount = useRef<number>(0);
+  const [requestGuard] = useState(createLatestRequestGuard);
   const [tableLoading, setTableLoading] = useState<boolean>(false);
   const [loadingIds, setLoadingIds] = useState<Record<number, boolean>>({});
   const [operateVisible, setOperateVisible] = useState<boolean>(false);
@@ -53,8 +60,9 @@ export function useSettingsTable<T>({
   });
 
   const getTableList = useCallback(async (params: { current?: number; pageSize?: number; searchKey?: string } = {}) => {
+    const requestId = requestGuard.begin();
+    setTableLoading(true);
     try {
-      setTableLoading(true);
       const searchVal = params.searchKey !== undefined ? params.searchKey : searchKey;
       const queryParams = {
         page: params.current || pagination.current,
@@ -62,21 +70,28 @@ export function useSettingsTable<T>({
         name: searchVal || undefined,
       };
       const data = await fetchList(queryParams);
-      setDataList(data.items || []);
-      listCount.current = data.items?.length || 0;
-      setPagination((prev) => ({
-        ...prev,
-        total: data.count || 0,
-      }));
+      commitSettingsTableListSuccess(requestGuard, requestId, data, (next) => {
+        setDataList(next.dataList);
+        listCount.current = next.listCount;
+        setPagination((prev) => ({
+          ...prev,
+          total: next.paginationTotal,
+        }));
+      });
     } catch {
-      message.error(t('common.loadFailed'));
+      commitSettingsTableListFailure(requestGuard, requestId, () => {
+        message.error(t('common.loadFailed'));
+      });
     } finally {
-      setTableLoading(false);
+      commitSettingsTableListSettled(requestGuard, requestId, () => {
+        setTableLoading(false);
+      });
     }
-  }, [fetchList, pagination.current, pagination.pageSize, searchKey, t]);
+  }, [fetchList, pagination.current, pagination.pageSize, requestGuard, searchKey, t]);
 
   useEffect(() => {
     getTableList();
+    return () => requestGuard.invalidate();
   }, []);
 
   const handleEdit = useCallback((type: 'add' | 'edit', row?: T) => {

--- a/web/src/app/alarm/utils/settingsTableRequest.ts
+++ b/web/src/app/alarm/utils/settingsTableRequest.ts
@@ -1,0 +1,50 @@
+import type { LatestRequestGuard } from '@/context/latestRequestGuard';
+
+export interface SettingsTableListPayload<T> {
+  items?: T[] | null;
+  count?: number | null;
+}
+
+export interface SettingsTableListView<T> {
+  dataList: T[];
+  listCount: number;
+  paginationTotal: number;
+}
+
+export function buildSettingsTableListView<T>(
+  payload: SettingsTableListPayload<T>,
+): SettingsTableListView<T> {
+  const dataList = payload.items || [];
+  return {
+    dataList,
+    listCount: dataList.length,
+    paginationTotal: payload.count || 0,
+  };
+}
+
+export function commitSettingsTableListSuccess<T>(
+  guard: LatestRequestGuard,
+  requestId: number,
+  payload: SettingsTableListPayload<T>,
+  apply: (next: SettingsTableListView<T>) => void,
+): boolean {
+  return guard.commitIfCurrent(requestId, () => {
+    apply(buildSettingsTableListView(payload));
+  });
+}
+
+export function commitSettingsTableListFailure(
+  guard: LatestRequestGuard,
+  requestId: number,
+  reportError: () => void,
+): boolean {
+  return guard.commitIfCurrent(requestId, reportError);
+}
+
+export function commitSettingsTableListSettled(
+  guard: LatestRequestGuard,
+  requestId: number,
+  settle: () => void,
+): boolean {
+  return guard.commitIfCurrent(requestId, settle);
+}


### PR DESCRIPTION
## 复现步骤

前置：账号能打开告警模块 **配置**。准备至少两条名称不同的告警分派规则，且网络可以乱序返回（慢网或开发者工具把列表接口 Delay 拉大）。

1. 进入告警模块左侧菜单 **配置** → **告警分派**（`/alarm/settings/alertAssign`）。页头标题是 **告警分派**。
2. 在表格上方搜索框（占位 **搜索**）输入第一个关键词，按 Enter。不要等表格 loading 结束。
3. 立刻改成第二个关键词再按 Enter，或点输入框清空。
4. 也可在第一次搜索未返回时点分页，制造页码与关键词交叉。

修复前：搜索框仍显示新关键词，表格行和总数却可能是旧关键词（或旧页）的结果；编辑、开关、删除绑在过期行上。较旧请求结束时还可能把仍在加载的新请求转圈清掉。  
修复后：表格只留下最后一次查询的行和总数。较旧响应不再写列表；较旧失败不会弹出 **加载失败**，也不会清掉新请求的 loading。最新一次失败才提示 **加载失败**。

## 修复方案

在共享 hook `useSettingsTable` 里为每次 `getTableList` 分配单调序号。

- 复用已有 `createLatestRequestGuard`：`begin` / `commitIfCurrent` / 卸载 `invalidate`。
- 只有最新请求可以写入列表、条数、`pagination.total`、报错和结束 loading。
- 列表 API 仍传 `page` / `page_size` / `name`。删除最后一行后的上一页刷新、开关后刷新不改。
- 不靠禁用搜索框来掩盖乱序。

Fixes #5224

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 先搜 A 再搜 B，A 后返回 | 表格变成 A 的行和总数 | 保持 B 的行和总数 |
| 先搜再清空，搜索后返回 | 表格又变回搜索结果 | 保持清空后的全量列表 |
| 先第 1 页再第 2 页，第 1 页后返回 | 行回到第 1 页 | 保持第 2 页 |
| 新请求仍在途，旧请求失败 | loading 被清掉，可能弹出加载失败 | loading 继续，不提示旧失败 |
| 最新请求失败，旧成功后到 | 旧成功写回列表 | 提示加载失败，不写回旧数据 |
| 删除当前页最后一行 | 回到上一页并刷新 | 不变 |

## 影响面

- **会变**：告警 **配置** 下共用该 hook 的四张列表——**告警分派**、**屏蔽策略**、**告警丰富**、**告警处理**。乱序网络下只展示最后一次查询。
- **不变**：各列表 URL、查询参数、权限、分页规格、**新增** / 编辑 / 删除确认 / 开关；删除最后一行后的页码回退。
- **未改**：搜索框仍可在 loading 时继续输入；过期请求仍可能打到后端，只是结果被丢弃。
- **不在范围**：**相关性规则**、**操作日志** 等自建列表请求。

## 验证

- `web/scripts/settings-table-race-test.ts`：修复前失败，修复后 `settings table race test passed`
- 覆盖搜索/清空/翻页乱序、最新失败、旧失败不清新 loading、卸载后不写回、删除后上一页仍能提交
