### PR TITLE
bugfix: 端点列表按筛选和并发上限拉取 RED

### DIFF
--- a/web/scripts/apm-endpoint-red-load-test.ts
+++ b/web/scripts/apm-endpoint-red-load-test.ts
@@ -1,0 +1,259 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const webRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const endpointsPage = readFileSync(join(webRoot, 'src/app/apm/explore/endpoints/page.tsx'), 'utf8');
+const redLoadUtilPath = join(webRoot, 'src/app/apm/utils/endpointRedLoad.ts');
+
+assert.doesNotMatch(
+  endpointsPage,
+  /Promise\.allSettled/,
+  '端点页不得对可见服务做无界 Promise.allSettled',
+);
+assert.match(
+  endpointsPage,
+  /selectServicesForEndpointRed/,
+  '端点页必须按服务筛选收窄 RED 请求目标',
+);
+assert.match(
+  endpointsPage,
+  /runEndpointRedSettled/,
+  '端点页必须走带并发上限的 settled 队列',
+);
+assert.match(
+  endpointsPage,
+  /ENDPOINT_RED_CONCURRENCY/,
+  '端点页必须使用固定 RED 并发常量',
+);
+assert.match(
+  endpointsPage,
+  /getServices\(\)/,
+  '端点页必须继续拉取当前环境全部可见服务，不得改成第一页',
+);
+assert.doesNotMatch(
+  endpointsPage,
+  /getServices\(\s*\{[^}]*page_size/,
+  'getServices 不得传 page_size，以免静默漏项',
+);
+assert.doesNotMatch(
+  endpointsPage,
+  /monitor\/dashboards\/shared\/utils\/concurrency/,
+  '端点 RED 队列不得跨模块 import monitor runWithConcurrency',
+);
+assert.equal(existsSync(redLoadUtilPath), true, '必须抽出 apm/utils/endpointRedLoad.ts');
+const redLoadUtil = readFileSync(redLoadUtilPath, 'utf8');
+assert.doesNotMatch(
+  redLoadUtil,
+  /monitor\/dashboards\/shared\/utils\/concurrency/,
+  'apm/utils 必须自建 settled 队列，不得复用 monitor 并发工具',
+);
+assert.match(
+  endpointsPage,
+  /\[authLoading, environment, getServiceRed, getServices, serviceId, timeRange\]/,
+  'load 必须把服务筛选纳入请求目标依赖',
+);
+assert.match(endpointsPage, /t\('apm\.common\.service', '服务'\)/, '筛选文案必须保留「服务」');
+assert.match(endpointsPage, /t\('apm\.common\.allServices', '全部服务'\)/, '筛选文案必须保留「全部服务」');
+assert.match(endpointsPage, /t\('apm\.common\.environment', '环境'\)/, '筛选文案必须保留「环境」');
+assert.match(endpointsPage, /t\('apm\.common\.timeRange', '时间范围'\)/, '筛选文案必须保留「时间范围」');
+assert.match(endpointsPage, /t\('apm\.explore\.refreshEndpoints', '刷新端点'\)/, '筛选文案必须保留「刷新端点」');
+assert.match(endpointsPage, /metricFailureCount/, '部分失败计数不得被关掉');
+assert.match(endpointsPage, /catalogErrorKind\(error\)/, '空结果/无权限路径必须继续走 CatalogState');
+
+interface FakeService {
+  id: string;
+}
+
+const makeServices = (count: number): FakeService[] => (
+  Array.from({ length: count }, (_, index) => ({ id: `svc-${index}` }))
+);
+
+const delay = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+const main = async () => {
+  const {
+    ENDPOINT_RED_CONCURRENCY,
+    runEndpointRedSettled,
+    selectServicesForEndpointRed,
+  } = await import('../src/app/apm/utils/endpointRedLoad.ts');
+
+  assert.equal(ENDPOINT_RED_CONCURRENCY, 6, '全服务视图必须使用固定并发上限 6');
+
+  assert.deepEqual(
+    selectServicesForEndpointRed(makeServices(0), 'all').map((service) => service.id),
+    [],
+    '0 个服务时请求目标应为空',
+  );
+  assert.deepEqual(
+    selectServicesForEndpointRed(makeServices(1), 'all').map((service) => service.id),
+    ['svc-0'],
+    '1 个服务的全部服务视图只覆盖该服务',
+  );
+  assert.equal(
+    selectServicesForEndpointRed(makeServices(200), 'all').length,
+    200,
+    '全部服务视图必须覆盖当前环境全部可见服务，不得只取第一页',
+  );
+  assert.deepEqual(
+    selectServicesForEndpointRed(makeServices(200), 'svc-17').map((service) => service.id),
+    ['svc-17'],
+    '单服务筛选只请求选中 id',
+  );
+
+  const runTracked = async (
+    services: FakeService[],
+    options: {
+      failIds?: Set<string>;
+      isCancelled?: () => boolean;
+      onFulfilled?: (value: { id: string }) => void;
+      hangUntil?: (id: string) => Promise<void>;
+    } = {},
+  ) => {
+    let active = 0;
+    let peak = 0;
+    let started = 0;
+    const requestedIds: string[] = [];
+    const results = await runEndpointRedSettled(
+      services,
+      async (service) => {
+        started += 1;
+        active += 1;
+        peak = Math.max(peak, active);
+        requestedIds.push(service.id);
+        await (options.hangUntil ? options.hangUntil(service.id) : delay());
+        active -= 1;
+        if (options.failIds?.has(service.id)) {
+          throw new Error(`red-failed:${service.id}`);
+        }
+        return { id: service.id };
+      },
+      {
+        concurrency: ENDPOINT_RED_CONCURRENCY,
+        isCancelled: options.isCancelled,
+        onFulfilled: options.onFulfilled,
+      },
+    );
+    return { active, peak, started, requestedIds, results };
+  };
+
+  const emptyRun = await runTracked([]);
+  assert.equal(emptyRun.started, 0, '0 个服务不得发出 RED 请求');
+  assert.equal(emptyRun.results.length, 0, '0 个服务应得到空 settled 结果');
+
+  const singleRun = await runTracked(makeServices(1));
+  assert.equal(singleRun.started, 1, '1 个服务只发出 1 次 RED');
+  assert.equal(singleRun.peak, 1, '1 个服务的在途请求不得超过 1');
+  assert.deepEqual(singleRun.requestedIds, ['svc-0']);
+
+  const largeRun = await runTracked(makeServices(200));
+  assert.equal(largeRun.started, 200, '200 个服务最终必须发出 200 次 RED');
+  assert.ok(
+    largeRun.peak <= ENDPOINT_RED_CONCURRENCY,
+    `200 个服务的最大在途必须 <= ${ENDPOINT_RED_CONCURRENCY}，实际 ${largeRun.peak}`,
+  );
+  assert.equal(largeRun.peak, ENDPOINT_RED_CONCURRENCY, '满负荷批次应打到并发上限');
+  assert.equal(
+    largeRun.results.filter((result) => result.status === 'fulfilled').length,
+    200,
+    '全部成功时最终结果数应等于可见服务全集',
+  );
+
+  const selected = selectServicesForEndpointRed(makeServices(200), 'svc-42');
+  const filteredRun = await runTracked(selected);
+  assert.deepEqual(filteredRun.requestedIds, ['svc-42'], '单服务筛选不得请求其他服务');
+  assert.equal(filteredRun.started, 1, '单服务筛选只请求该 id');
+
+  const failIds = new Set(['svc-3', 'svc-8', 'svc-19']);
+  const partialRun = await runTracked(makeServices(20), { failIds });
+  const partialSuccess = partialRun.results.flatMap((result) => (
+    result.status === 'fulfilled' ? [result.value.id] : []
+  ));
+  const partialFailures = partialRun.results.filter((result) => result.status === 'rejected');
+  assert.equal(partialRun.started, 20, '部分失败不得中断剩余 RED 请求');
+  assert.equal(partialSuccess.length, 17, '部分失败必须保留成功行');
+  assert.equal(partialFailures.length, 3, '部分失败必须计数失败项');
+  assert.equal(partialSuccess.includes('svc-3'), false, '失败服务不得混入成功行');
+
+  let generation = 1;
+  const staleFulfilled: string[] = [];
+  const staleRun = await runTracked(makeServices(20), {
+    isCancelled: () => generation !== 1,
+    onFulfilled: (value) => staleFulfilled.push(value.id),
+    hangUntil: async () => {
+      generation = 2;
+      await delay();
+    },
+  });
+  assert.ok(staleRun.started <= ENDPOINT_RED_CONCURRENCY, '过期批次必须停止继续排队');
+  assert.equal(staleFulfilled.length, 0, '过期批次不得把成功结果写回当前列表');
+  assert.ok(
+    staleRun.results.every((result) => result.status === 'fulfilled' || result.status === 'rejected'),
+    '已启动的过期请求仍应 settled，但不能写回',
+  );
+
+  const writes: Array<{ range: string; ids: string[] }> = [];
+  let releaseStale: () => void = () => undefined;
+  const staleGate = new Promise<void>((resolve) => {
+    releaseStale = resolve;
+  });
+  const loadByRange = async (
+    range: string,
+    batchId: number,
+    current: { id: number },
+    waitFor?: Promise<void>,
+  ) => {
+    const collected: string[] = [];
+    await runEndpointRedSettled(
+      makeServices(12),
+      async (service) => {
+        if (waitFor) await waitFor;
+        await delay();
+        return { id: service.id, range };
+      },
+      {
+        concurrency: ENDPOINT_RED_CONCURRENCY,
+        isCancelled: () => current.id !== batchId,
+        onFulfilled: (value) => {
+          if (current.id !== batchId) return;
+          collected.push(value.id);
+          writes.push({ range, ids: [...collected] });
+        },
+      },
+    );
+    if (current.id !== batchId) return;
+    writes.push({ range, ids: [...collected] });
+  };
+
+  const currentBatch = { id: 1 };
+  const firstLoad = loadByRange('1h', 1, currentBatch, staleGate);
+  await delay();
+  currentBatch.id = 2;
+  const currentLoad = loadByRange('15m', 2, currentBatch);
+  releaseStale();
+  await Promise.all([firstLoad, currentLoad]);
+  assert.equal(
+    writes.every((entry) => entry.range === '15m'),
+    true,
+    '切换时间窗后过期批次不得覆盖当前列表',
+  );
+  assert.ok(writes.length > 0, '当前时间窗批次必须能写回');
+  assert.equal(writes.at(-1)?.ids.length, 12, '最终写回必须覆盖当前批次已取回全集');
+
+  console.log(JSON.stringify({
+    ok: true,
+    concurrency: ENDPOINT_RED_CONCURRENCY,
+    cases: {
+      empty: emptyRun.started,
+      single: singleRun.started,
+      large: { started: largeRun.started, peak: largeRun.peak },
+      filtered: filteredRun.requestedIds,
+      partialFailures: partialFailures.length,
+      staleStarted: staleRun.started,
+      timeRangeWrites: writes.at(-1)?.range,
+    },
+  }));
+};
+
+void main();

--- a/web/src/app/apm/explore/endpoints/page.tsx
+++ b/web/src/app/apm/explore/endpoints/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import Link from 'next/link';
 import { ReloadOutlined, SearchOutlined } from '@ant-design/icons';
 import {
@@ -36,6 +36,11 @@ import {
   isErrorRateDanger,
 } from '@/app/apm/components/metric-format';
 import type { ApmService, ApmServiceRed, ApmTraceSummary } from '@/app/apm/types';
+import {
+  ENDPOINT_RED_CONCURRENCY,
+  runEndpointRedSettled,
+  selectServicesForEndpointRed,
+} from '@/app/apm/utils/endpointRedLoad';
 import EllipsisWithTooltip from '@/components/ellipsis-with-tooltip';
 import SummaryMetricCard from '@/components/summary-metric-card';
 import TimeSeriesComposedChart from '@/components/time-series-composed-chart';
@@ -120,13 +125,16 @@ export default function ApmEndpointsPage() {
   const [samplesLoading, setSamplesLoading] = useState(false);
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(20);
+  const loadGenerationRef = useRef(0);
 
   const load = useCallback(async () => {
     if (authLoading) return;
+    const batchId = ++loadGenerationRef.current;
     setState('loading');
     setMetricFailureCount(0);
     try {
       const serviceItems = await getServices();
+      if (batchId !== loadGenerationRef.current) return;
       setServices(serviceItems);
       const availableEnvironments = Array.from(new Set(
         serviceItems.flatMap((service) => service.environment_views.map((view) => view.environment)),
@@ -137,22 +145,12 @@ export default function ApmEndpointsPage() {
       const visibleServices = serviceItems.filter((service) => (
         service.environment_views.some((view) => view.environment === selectedEnvironment)
       ));
+      const targetServices = selectServicesForEndpointRed(visibleServices, serviceId);
       const endedAt = new Date();
       const startedAt = new Date(endedAt.getTime() - RANGE_MS[timeRange]);
-      const results = await Promise.allSettled(visibleServices.map(async (service) => ({
-        service,
-        red: await getServiceRed(service.id, selectedEnvironment, startedAt.toISOString(), endedAt.toISOString()),
-      })));
-      const successfulResults = results.filter((result) => result.status === 'fulfilled');
-      if (results.length && !successfulResults.length) {
-        const firstFailure = results.find((result) => result.status === 'rejected');
-        throw firstFailure?.reason;
-      }
-      setMetricFailureCount(results.length - successfulResults.length);
-      const endpointRows = results.flatMap((result) => {
-        if (result.status !== 'fulfilled') return [];
-        const { service, red } = result.value;
-        return red.top_endpoints.map((endpoint) => {
+      const collectedRows: EndpointRow[] = [];
+      const toEndpointRows = (service: ApmService, red: ApmServiceRed): EndpointRow[] => (
+        red.top_endpoints.map((endpoint) => {
           const identity = splitEndpoint(endpoint.endpoint);
           return {
             key: `${service.id}:${selectedEnvironment}:${endpoint.endpoint}`,
@@ -169,16 +167,44 @@ export default function ApmEndpointsPage() {
             p99Ms: endpoint.p99_ms,
             lastSeenAt: service.last_seen_at,
           };
-        });
+        })
+      );
+      const results = await runEndpointRedSettled(
+        targetServices,
+        async (service) => ({
+          service,
+          red: await getServiceRed(service.id, selectedEnvironment, startedAt.toISOString(), endedAt.toISOString()),
+        }),
+        {
+          concurrency: ENDPOINT_RED_CONCURRENCY,
+          isCancelled: () => batchId !== loadGenerationRef.current,
+          onFulfilled: ({ service, red }) => {
+            if (batchId !== loadGenerationRef.current) return;
+            collectedRows.push(...toEndpointRows(service, red));
+            setRows([...collectedRows]);
+          },
+        },
+      );
+      if (batchId !== loadGenerationRef.current) return;
+      const successfulResults = results.filter((result) => result.status === 'fulfilled');
+      if (results.length && !successfulResults.length) {
+        const firstFailure = results.find((result) => result.status === 'rejected');
+        throw firstFailure?.reason;
+      }
+      setMetricFailureCount(results.length - successfulResults.length);
+      const endpointRows = results.flatMap((result) => {
+        if (result.status !== 'fulfilled') return [];
+        return toEndpointRows(result.value.service, result.value.red);
       });
       setRows(endpointRows);
       setState(endpointRows.length ? 'ready' : 'empty');
     } catch (error) {
+      if (batchId !== loadGenerationRef.current) return;
       setRows([]);
       setMetricFailureCount(0);
       setState(catalogErrorKind(error));
     }
-  }, [authLoading, environment, getServiceRed, getServices, timeRange]);
+  }, [authLoading, environment, getServiceRed, getServices, serviceId, timeRange]);
 
   useEffect(() => {
     load();

--- a/web/src/app/apm/utils/endpointRedLoad.ts
+++ b/web/src/app/apm/utils/endpointRedLoad.ts
@@ -1,0 +1,55 @@
+export const ENDPOINT_RED_CONCURRENCY = 6;
+
+export const selectServicesForEndpointRed = <T extends { id: string }>(
+  services: readonly T[],
+  serviceId: string,
+): T[] => {
+  if (serviceId === 'all' || !serviceId) {
+    return [...services];
+  }
+  return services.filter((service) => service.id === serviceId);
+};
+
+interface EndpointRedSettledOptions<R> {
+  concurrency?: number;
+  isCancelled?: () => boolean;
+  onFulfilled?: (value: R, index: number) => void;
+}
+
+export const runEndpointRedSettled = async <T, R>(
+  items: readonly T[],
+  worker: (item: T, index: number) => Promise<R>,
+  options: EndpointRedSettledOptions<R> = {},
+): Promise<Array<PromiseSettledResult<R>>> => {
+  const {
+    concurrency = ENDPOINT_RED_CONCURRENCY,
+    isCancelled = () => false,
+    onFulfilled,
+  } = options;
+  if (!items.length) return [];
+
+  const results = new Array<PromiseSettledResult<R>>(items.length);
+  const workerCount = Math.min(Math.max(concurrency, 1), items.length);
+  let cursor = 0;
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (cursor < items.length) {
+        if (isCancelled()) return;
+        const index = cursor;
+        cursor += 1;
+        try {
+          const value = await worker(items[index], index);
+          results[index] = { status: 'fulfilled', value };
+          if (!isCancelled()) {
+            onFulfilled?.(value, index);
+          }
+        } catch (reason) {
+          results[index] = { status: 'rejected', reason };
+        }
+      }
+    }),
+  );
+
+  return results.filter((result) => result !== undefined);
+};


### PR DESCRIPTION
## 复现步骤

前置：账号能打开 APM。当前组织在所选环境里有多个已发现服务（越多越明显）。可用开发者工具看 `/apm/services/{id}/metrics/` 的数量。

1. 进入 APM 左侧菜单 **探索** → **端点**（`/apm/explore/endpoints`）。页头标题是 **端点**，说明是「按服务端点查看吞吐量、错误率与时延，通过查看操作打开详情与样本调用链。」
2. 工具条里 **服务** 保持 **全部服务**，**环境** 选一个有多个服务的环境，**时间范围** 选 `1h`，或点 **刷新端点**。
3. 看 Network：在表格还在 loading 时，是否对每个服务都打了 `metrics`。默认分页是 20 行。
4. 把 **服务** 换成某一个服务，再切 **时间范围**（例如 `15m`）或再点 **刷新端点**。

修复前：**服务** 即使选了单个服务，初次进入和切换时间窗仍会对当前环境每个服务发 RED；表格要等全部 settled 才出结果。分页只切已取回的行。  
修复后：选单个服务时只请求该服务。**全部服务** 仍覆盖当前环境全部可见服务，但同时在途最多 6 个；列表可随成功结果逐步出现。切换时间范围、环境或刷新时，过期批次不再写回。部分失败仍提示「部分服务的端点指标查询失败（N 项）」。

## 修复方案

把请求目标从「先拉全量再本地筛」改成「先按服务筛选，再有界拉取」。

- `selectServicesForEndpointRed`：不是 **全部服务** 时只保留选中 id。
- `runEndpointRedSettled`：固定并发 6，支持取消过期批次，部分失败继续。
- 端点页用 generation 忽略过期写回；`getServices` 仍不传 `page_size`，避免只拿第一页服务而漏项。
- 不改 RED / 服务 API、权限和时间窗校验，不新增批量接口。

Fixes #5225

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| **全部服务** 初次加载 | N 个服务同时发出 N 次 RED，全部结束才出表 | 同时在途最多 6，成功结果可逐步进表，最终仍覆盖当前环境全部可见服务 |
| **服务** 选中某一个 | 仍请求环境内全部服务，再本地过滤 | 只请求该服务 |
| 默认 20 行分页 | 不减少 RED 请求数 | 仍先取回可见服务的端点再分页，不按目录第一页截断服务 |
| 切换 **时间范围** / **刷新端点** | 旧批次后到会盖住新结果 | 过期批次不写回 |
| 部分服务 metrics 失败 | 成功行 + 失败计数 | 不变 |

## 影响面

- **会变**：仅 APM **探索** → **端点** 的 RED 拉取节奏和请求目标。选单个服务时后台压力下降；全服务视图不再无界打满。
- **不变**：`GET /apm/services/`、`GET /apm/services/{id}/metrics/` 契约与权限；组织过滤；时间窗；端点全局排序字段；**搜索路径模板 / 服务** 仍是本地过滤；详情抽屉的趋势和 **样本调用链**。
- **未改**：在途请求仍可能在网上跑完，只是结果被丢掉。未做服务端批量 RED 接口。
- **不在范围**：服务目录其它列表、应用可观测性卡片里的端点入口。

## 验证

- `web/scripts/apm-endpoint-red-load-test.ts`：修复前失败，修复后 `ok`
- 覆盖 0/1/200 服务、并发峰值 6、单服务筛选、部分失败、过期批次与切换时间窗
