### PR TITLE
bugfix: 告警事件切换只接受当前事件证据

### DIFF
--- a/web/scripts/apm-alert-event-race-test.ts
+++ b/web/scripts/apm-alert-event-race-test.ts
@@ -1,0 +1,282 @@
+import * as assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createLatestRequestGuard } from '../src/context/latestRequestGuard.ts';
+import type { LatestRequestGuard } from '../src/context/latestRequestGuard.ts';
+import type { ApmAlertEvent, ApmEventSnapshot, ApmNotificationDelivery } from '../src/app/apm/types.ts';
+
+interface AlertEventRequestKey {
+  alertId: string;
+  eventId: string;
+}
+
+interface AlertEventCommitFns {
+  commitAlertEventEvidenceSuccess: (
+    guard: LatestRequestGuard,
+    requestId: number,
+    requested: AlertEventRequestKey,
+    snapshots: ApmEventSnapshot[],
+    deliveries: ApmNotificationDelivery[],
+    apply: (evidence: ApmEventSnapshot | null, deliveries: ApmNotificationDelivery[]) => void,
+  ) => boolean;
+  commitAlertEventEvidenceSettled: (
+    guard: LatestRequestGuard,
+    requestId: number,
+    settle: () => void,
+  ) => boolean;
+  canRetryAlertEventDelivery: (
+    delivery: ApmNotificationDelivery | undefined,
+    selectedEvent: Pick<ApmAlertEvent, 'event_id'> | null,
+  ) => boolean;
+}
+
+interface EventViewState {
+  selectedEventId: string | null;
+  evidence: ApmEventSnapshot | null;
+  deliveries: ApmNotificationDelivery[];
+  loading: boolean;
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pagePath = resolve(here, '../src/app/apm/events/alerts/page.tsx');
+const utilPath = resolve(here, '../src/app/apm/utils/alertEventRequest.ts');
+
+function snapshot(eventId: string): ApmEventSnapshot {
+  return {
+    id: `snap-${eventId}`,
+    event_id: eventId,
+    schema_version: 1,
+    action: 'triggered',
+    occurred_at: '2026-09-09T00:00:00Z',
+    policy_snapshot: {},
+    object_snapshot: {},
+    evaluation_snapshot: { value: '1', data_state: 'available' },
+    trace_context: { trace_id: `trace-${eventId}` },
+    payload_status: 'available',
+    payload_error_code: '',
+    payload: null,
+    retention_expires_at: '2026-09-16T00:00:00Z',
+  };
+}
+
+function delivery(id: string, eventId: string): ApmNotificationDelivery {
+  return {
+    id,
+    event_id: eventId,
+    channel_id: 1,
+    channel_name: `channel-${eventId}`,
+    channel_type: 'slack',
+    delivery_mode: 'message',
+    recipients: ['sre'],
+    status: 'failed',
+    attempts: 1,
+    next_retry_at: null,
+    last_error_code: 'provider_unavailable',
+    last_error_message: 'down',
+    delivered_at: null,
+    failed_at: '2026-09-09T00:00:00Z',
+  };
+}
+
+async function loadCommitFns(): Promise<AlertEventCommitFns> {
+  let loaded: Partial<AlertEventCommitFns> = {};
+  try {
+    loaded = await import('../src/app/apm/utils/alertEventRequest.ts');
+  } catch {
+    // RED：提交函数尚未抽出。
+  }
+
+  assert.equal(typeof loaded.commitAlertEventEvidenceSuccess, 'function', '应抽出 commitAlertEventEvidenceSuccess');
+  assert.equal(typeof loaded.commitAlertEventEvidenceSettled, 'function', '应抽出 commitAlertEventEvidenceSettled');
+  assert.equal(typeof loaded.canRetryAlertEventDelivery, 'function', '应抽出 canRetryAlertEventDelivery');
+
+  return loaded as AlertEventCommitFns;
+}
+
+function createEventSession(fns: AlertEventCommitFns) {
+  const guard = createLatestRequestGuard();
+  let state: EventViewState = {
+    selectedEventId: null,
+    evidence: null,
+    deliveries: [],
+    loading: false,
+  };
+
+  const choose = (alertId: string, eventId: string) => {
+    const requestId = guard.begin();
+    state = {
+      selectedEventId: eventId,
+      evidence: null,
+      deliveries: [],
+      loading: true,
+    };
+    return { requestId, alertId, eventId };
+  };
+
+  const succeed = (req: AlertEventRequestKey & { requestId: number }, evidence: ApmEventSnapshot, items: ApmNotificationDelivery[]) => {
+    fns.commitAlertEventEvidenceSuccess(
+      guard,
+      req.requestId,
+      { alertId: req.alertId, eventId: req.eventId },
+      [evidence],
+      items,
+      (nextEvidence, nextDeliveries) => {
+        state = {
+          ...state,
+          evidence: nextEvidence,
+          deliveries: nextDeliveries,
+        };
+      },
+    );
+    fns.commitAlertEventEvidenceSettled(guard, req.requestId, () => {
+      state = { ...state, loading: false };
+    });
+  };
+
+  const fail = (req: { requestId: number }) => {
+    fns.commitAlertEventEvidenceSettled(guard, req.requestId, () => {
+      state = { ...state, loading: false };
+    });
+  };
+
+  const close = () => {
+    guard.invalidate();
+    state = {
+      selectedEventId: null,
+      evidence: null,
+      deliveries: [],
+      loading: false,
+    };
+  };
+
+  return {
+    getState: () => state,
+    choose,
+    succeed,
+    fail,
+    close,
+  };
+}
+
+function assertPageUsesGeneration(source: string) {
+  assert.match(
+    source,
+    /from ['"]@\/context\/latestRequestGuard['"]/,
+    'page 必须复用 @/context/latestRequestGuard，不得复制新 guard',
+  );
+  assert.match(source, /createLatestRequestGuard/, 'page 必须创建 latest request guard');
+  assert.match(source, /\.begin\(\)/, 'chooseEvent 必须按单调序号 begin');
+  assert.match(
+    source,
+    /from ['"]@\/app\/apm\/utils\/alertEventRequest['"]/,
+    'page 必须调用抽出的 alertEventRequest',
+  );
+  assert.match(source, /commitAlertEventEvidenceSuccess\(/, 'chooseEvent 成功必须经序号提交证据和投递');
+  assert.match(source, /commitAlertEventEvidenceSettled\(/, 'chooseEvent 结束 loading 必须经序号提交');
+  assert.match(source, /\.invalidate\(\)/, '关闭抽屉、换事件或重开告警必须 invalidate');
+  assert.match(source, /canRetryAlertEventDelivery\(/, '重投前必须校验 delivery.event_id');
+  assert.match(source, /snapshotLoadSequence/, '指标快照序号逻辑必须保持');
+  assert.match(
+    source,
+    /snapshotSequence !== snapshotLoadSequence\.current/,
+    '指标快照仍按原序号提交',
+  );
+  assert.doesNotMatch(
+    source,
+    /setEventEvidence\(snapshots\[0\]/,
+    'chooseEvent 不得在 Promise.then 无条件写 evidence',
+  );
+  assert.doesNotMatch(
+    source,
+    /\.finally\(\(\) => setEventEvidenceLoading\(false\)\)/,
+    'chooseEvent 不得在 finally 无条件清 loading',
+  );
+  assert.doesNotMatch(
+    source,
+    /function createLatestRequestGuard|const createLatestRequestGuard\s*=/,
+    '不得在 page 内复制一套序号 guard',
+  );
+}
+
+async function main() {
+  const fns = await loadCommitFns();
+
+  const race = createEventSession(fns);
+  const requestA = race.choose('alert-1', 'evt-A');
+  const requestB = race.choose('alert-1', 'evt-B');
+  race.succeed(requestB, snapshot('evt-B'), [delivery('d-B', 'evt-B')]);
+  race.succeed(requestA, snapshot('evt-A'), [delivery('d-A', 'evt-A')]);
+  assert.equal(race.getState().selectedEventId, 'evt-B', 'A→B 选择后高亮必须停在 B');
+  assert.equal(race.getState().evidence?.event_id, 'evt-B', 'B→A 完成时证据不得回写成 A');
+  assert.deepEqual(
+    race.getState().deliveries.map((item) => item.id),
+    ['d-B'],
+    'B→A 完成时投递列表不得回写成 A',
+  );
+  assert.equal(race.getState().loading, false);
+
+  const closed = createEventSession(fns);
+  const lateAfterClose = closed.choose('alert-1', 'evt-A');
+  closed.close();
+  closed.succeed(lateAfterClose, snapshot('evt-A'), [delivery('d-late', 'evt-A')]);
+  assert.equal(closed.getState().selectedEventId, null, '关闭抽屉后所选事件必须清空');
+  assert.equal(closed.getState().evidence, null, '关闭抽屉后迟到证据不得写回');
+  assert.deepEqual(closed.getState().deliveries, [], '关闭抽屉后迟到投递不得写回');
+
+  const inflight = createEventSession(fns);
+  const staleFail = inflight.choose('alert-1', 'evt-A');
+  inflight.choose('alert-1', 'evt-B');
+  inflight.fail(staleFail);
+  assert.equal(inflight.getState().selectedEventId, 'evt-B', '换事件后高亮必须是最新事件');
+  assert.equal(inflight.getState().loading, true, '旧失败不得把仍在途的最新请求 loading 清掉');
+  assert.equal(inflight.getState().evidence, null, '旧失败不得写回证据');
+
+  const selectedB: Pick<ApmAlertEvent, 'event_id'> = { event_id: 'evt-B' };
+  assert.equal(
+    fns.canRetryAlertEventDelivery(delivery('d-B', 'evt-B'), selectedB),
+    true,
+    '当前事件的失败投递必须允许重投',
+  );
+  assert.equal(
+    fns.canRetryAlertEventDelivery(delivery('d-A', 'evt-A'), selectedB),
+    false,
+    'event_id 与所选事件不一致时必须拒绝重投',
+  );
+  assert.equal(
+    fns.canRetryAlertEventDelivery(delivery('d-null', ''), selectedB),
+    false,
+    '缺少 event_id 的投递不得重投',
+  );
+  assert.equal(
+    fns.canRetryAlertEventDelivery(undefined, selectedB),
+    false,
+    '当前列表找不到的投递不得重投',
+  );
+  assert.equal(
+    fns.canRetryAlertEventDelivery(delivery('d-B', 'evt-B'), null),
+    false,
+    '未选中事件时不得重投',
+  );
+
+  const pageSource = readFileSync(pagePath, 'utf8');
+  const utilSource = readFileSync(utilPath, 'utf8');
+  assertPageUsesGeneration(pageSource);
+  assert.doesNotMatch(
+    utilSource,
+    /createLatestRequestGuard\s*=|function createLatestRequestGuard/,
+    'alertEventRequest 不得复制一套序号 guard',
+  );
+  assert.match(
+    utilSource,
+    /alertId|eventId/,
+    '提交函数必须绑定 alert.id + event.event_id',
+  );
+
+  console.log('apm alert event race test passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/web/src/app/apm/events/alerts/page.tsx
+++ b/web/src/app/apm/events/alerts/page.tsx
@@ -19,6 +19,12 @@ import {
   type TableColumnsType,
 } from 'antd';
 import useApmApi from '@/app/apm/api';
+import {
+  canRetryAlertEventDelivery,
+  commitAlertEventEvidenceSettled,
+  commitAlertEventEvidenceSuccess,
+} from '@/app/apm/utils/alertEventRequest';
+import { createLatestRequestGuard } from '@/context/latestRequestGuard';
 import ApmDataTable, { APM_TABLE_COLUMN_WIDTHS } from '@/app/apm/components/apm-data-table';
 import ApmRouteShell, { ApmSurface } from '@/app/apm/components/apm-route-shell';
 import CatalogState, { catalogErrorKind, type CatalogStateKind } from '@/app/apm/components/catalog-state';
@@ -110,6 +116,7 @@ export default function ApmAlertsPage() {
   const [eventEvidenceLoading, setEventEvidenceLoading] = useState(false);
   const loadSequence = useRef(0);
   const snapshotLoadSequence = useRef(0);
+  const [eventRequestGuard] = useState(createLatestRequestGuard);
 
   const load = useCallback(() => {
     if (authLoading) return;
@@ -161,6 +168,7 @@ export default function ApmAlertsPage() {
 
   const chooseEvent = useCallback(
     (alert: ApmAlert, event: ApmAlertEvent) => {
+      const requestId = eventRequestGuard.begin();
       setSelectedEvent(event);
       setEventEvidence(null);
       setDeliveries([]);
@@ -170,16 +178,30 @@ export default function ApmAlertsPage() {
         getNotificationDeliveries({ event_id: event.event_id }),
       ])
         .then(([snapshots, deliveryItems]) => {
-          setEventEvidence(snapshots[0] ?? null);
-          setDeliveries(deliveryItems);
+          commitAlertEventEvidenceSuccess(
+            eventRequestGuard,
+            requestId,
+            { alertId: alert.id, eventId: event.event_id },
+            snapshots,
+            deliveryItems,
+            (evidence, items) => {
+              setEventEvidence(evidence);
+              setDeliveries(items);
+            },
+          );
         })
-        .finally(() => setEventEvidenceLoading(false));
+        .finally(() => {
+          commitAlertEventEvidenceSettled(eventRequestGuard, requestId, () => {
+            setEventEvidenceLoading(false);
+          });
+        });
     },
-    [getEventEvidence, getNotificationDeliveries],
+    [eventRequestGuard, getEventEvidence, getNotificationDeliveries],
   );
 
   const resetDrawerState = useCallback(() => {
     snapshotLoadSequence.current += 1;
+    eventRequestGuard.invalidate();
     setSelected(null);
     setSelectedEvent(null);
     setEventEvidence(null);
@@ -189,11 +211,12 @@ export default function ApmAlertsPage() {
     setEventEvidenceLoading(false);
     setDeliveries([]);
     setRetryingDeliveryId(null);
-  }, []);
+  }, [eventRequestGuard]);
 
   const openDrawer = (alert: ApmAlert) => {
     const snapshotSequence = snapshotLoadSequence.current + 1;
     snapshotLoadSequence.current = snapshotSequence;
+    eventRequestGuard.invalidate();
     setSelected(alert);
     setMetricSnapshot(null);
     setMetricSnapshotError(null);
@@ -216,9 +239,13 @@ export default function ApmAlertsPage() {
   };
 
   const handleRetryDelivery = async (deliveryId: string) => {
-    setRetryingDeliveryId(deliveryId);
+    const delivery = deliveries.find((item) => item.id === deliveryId);
+    if (!canRetryAlertEventDelivery(delivery, selectedEvent)) {
+      return;
+    }
+    setRetryingDeliveryId(delivery.id);
     try {
-      await retryNotificationDelivery(deliveryId);
+      await retryNotificationDelivery(delivery.id);
       message.success(t('apm.alerts.retrySuccess', '已重新投递'));
       if (selected && selectedEvent) chooseEvent(selected, selectedEvent);
     } catch {

--- a/web/src/app/apm/utils/alertEventRequest.ts
+++ b/web/src/app/apm/utils/alertEventRequest.ts
@@ -1,0 +1,51 @@
+import type { LatestRequestGuard } from '@/context/latestRequestGuard';
+import type { ApmAlertEvent, ApmEventSnapshot, ApmNotificationDelivery } from '@/app/apm/types';
+
+export interface AlertEventRequestKey {
+  alertId: string;
+  eventId: string;
+}
+
+export function pickAlertEventEvidence(
+  snapshots: ApmEventSnapshot[],
+  eventId: string,
+): ApmEventSnapshot | null {
+  return snapshots.find((item) => item.event_id === eventId) ?? null;
+}
+
+export function commitAlertEventEvidenceSuccess(
+  guard: LatestRequestGuard,
+  requestId: number,
+  requested: AlertEventRequestKey,
+  snapshots: ApmEventSnapshot[],
+  deliveries: ApmNotificationDelivery[],
+  apply: (evidence: ApmEventSnapshot | null, deliveries: ApmNotificationDelivery[]) => void,
+): boolean {
+  return guard.commitIfCurrent(requestId, () => {
+    const evidence = pickAlertEventEvidence(snapshots, requested.eventId);
+    const scopedDeliveries = deliveries.filter(
+      (item) => !item.event_id || item.event_id === requested.eventId,
+    );
+    apply(evidence, scopedDeliveries);
+  });
+}
+
+export function commitAlertEventEvidenceSettled(
+  guard: LatestRequestGuard,
+  requestId: number,
+  settle: () => void,
+): boolean {
+  return guard.commitIfCurrent(requestId, settle);
+}
+
+export function canRetryAlertEventDelivery(
+  delivery: ApmNotificationDelivery | undefined,
+  selectedEvent: Pick<ApmAlertEvent, 'event_id'> | null,
+): delivery is ApmNotificationDelivery {
+  return Boolean(
+    delivery
+    && selectedEvent?.event_id
+    && delivery.event_id
+    && delivery.event_id === selectedEvent.event_id,
+  );
+}


### PR DESCRIPTION
## 复现步骤

前置：账号能打开 APM。准备一条含多个生命周期事件、且至少两个事件都有事件证据和通知投递的告警。可用开发者工具把 `event-evidence` / `notification-deliveries` 延迟到乱序返回。

1. 进入 APM 左侧菜单 **事件** → **告警**（`/apm/events/alerts`）。页头标题是 **告警**。
2. 在 **活跃告警** 或 **历史告警** 表格中点某条告警的 **详情**，打开抽屉。
3. 在 **事件流(按时间倒序 · 共 N 条)** 里先点事件 A，再立刻点事件 B。事件行会高亮。不要等 loading 结束。
4. 看高亮行旁的 **查看当时调用链**，以及下方 **通知投递**。若 B 的投递显示 **失败**，点 **重投**。
5. 点抽屉底部 **取消** 关闭后再打开另一条告警，确认不会闪回旧证据。

修复前：高亮停在 B，但调用链链接和投递记录可能是 A；若 A 投递失败，在 B 的上下文点 **重投** 会提交 A 的 delivery id。  
修复后：证据、调用链链接和投递列表只来自当前选中事件。过期请求不写回，也不清掉新事件的 loading。**重投** 只提交当前事件且 `event_id` 匹配的记录。

## 修复方案

给事件证据和投递记录单独加请求序号，并绑 `alert.id` + `event.event_id`。

- 复用 `createLatestRequestGuard`：换事件、关闭抽屉、重开告警时作废旧请求。
- 只有最新请求可以写证据、投递和 loading。
- **重投** 前用 `canRetryAlertEventDelivery` 核对 `delivery.event_id`。
- 指标快照仍走原来的 `snapshotLoadSequence`。通知 retry API 不变。

Fixes #5226

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 先点事件 A 再点 B，A 后返回 | 高亮是 B，证据/调用链/投递可能是 A | 证据、调用链、投递保持 B |
| 新事件仍在加载，旧请求失败 | loading 被清掉 | 新事件继续 loading |
| 点 **取消** 后旧请求返回 | 可能写回已关闭抽屉 | 不写回 |
| 在 B 上下文点 A 的 **重投** | 提交 A 的 delivery id | 拒绝，不发请求 |
| 指标趋势快照 | 已有序号 | 不变 |

## 影响面

- **会变**：仅 APM **事件** → **告警** 详情抽屉里，切换 **事件流** 后的证据、**查看当时调用链** 和 **通知投递** / **重投**。
- **不变**：告警列表、关闭告警、指标快照、`event-evidence` / `notification-deliveries` / retry 接口与权限、投递幂等。
- **未改**：事件流按钮仍可在 loading 时点击；过期请求仍可能打到后端，只是结果被丢弃。
- **兼容**：`event_id` 为空的投递仍可能出现在列表中，但 **重投** 会拒绝，避免投错事件。

## 验证

- `web/scripts/apm-alert-event-race-test.ts`：修复前失败，修复后 `apm alert event race test passed`
- 覆盖事件逆序响应、关闭作废、旧失败不清新 loading、重投归属
