### PR TITLE
bugfix: 调用链查询只接受当前粒度结果

### DIFF
--- a/web/scripts/apm-trace-search-race-test.ts
+++ b/web/scripts/apm-trace-search-race-test.ts
@@ -1,0 +1,271 @@
+import * as assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createLatestRequestGuard } from '../src/context/latestRequestGuard.ts';
+import type { LatestRequestGuard } from '../src/context/latestRequestGuard.ts';
+
+interface SearchItem {
+  id: string;
+}
+
+interface CommitFns {
+  beginTraceSearchRequest: (
+    guard: LatestRequestGuard,
+    currentRequestId: number,
+    cursor?: string,
+  ) => number;
+  commitTraceSearchSuccess: (
+    guard: LatestRequestGuard,
+    requestId: number,
+    apply: () => void,
+  ) => boolean;
+  commitTraceSearchFailure: (
+    guard: LatestRequestGuard,
+    requestId: number,
+    reportError: () => void,
+  ) => boolean;
+  commitTraceSearchSettled: (
+    guard: LatestRequestGuard,
+    requestId: number,
+    settle: () => void,
+  ) => boolean;
+}
+
+interface SearchState {
+  spanItems: SearchItem[];
+  traceItems: SearchItem[];
+  searching: boolean;
+  pageState: 'idle' | 'loading' | 'ready' | 'empty' | 'error';
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pagePath = resolve(here, '../src/app/apm/explore/traces/page.tsx');
+const utilPath = resolve(here, '../src/app/apm/utils/traceSearchRequest.ts');
+const guardPath = resolve(here, '../src/context/latestRequestGuard.ts');
+
+async function loadCommitFns(): Promise<CommitFns> {
+  let loaded: Partial<CommitFns> = {};
+  try {
+    loaded = await import('../src/app/apm/utils/traceSearchRequest.ts');
+  } catch {
+    // RED：提交函数尚未抽出。
+  }
+
+  assert.equal(typeof loaded.beginTraceSearchRequest, 'function', '应抽出 beginTraceSearchRequest');
+  assert.equal(typeof loaded.commitTraceSearchSuccess, 'function', '应抽出 commitTraceSearchSuccess');
+  assert.equal(typeof loaded.commitTraceSearchFailure, 'function', '应抽出 commitTraceSearchFailure');
+  assert.equal(typeof loaded.commitTraceSearchSettled, 'function', '应抽出 commitTraceSearchSettled');
+
+  return loaded as CommitFns;
+}
+
+function createSearchSession(fns: CommitFns) {
+  const guard = createLatestRequestGuard();
+  let currentRequestId = 0;
+  let state: SearchState = {
+    spanItems: [],
+    traceItems: [],
+    searching: false,
+    pageState: 'idle',
+  };
+
+  const start = (cursor?: string) => {
+    const requestId = fns.beginTraceSearchRequest(guard, currentRequestId, cursor);
+    if (!cursor) {
+      currentRequestId = requestId;
+      state = { ...state, searching: true, pageState: 'loading' };
+    } else {
+      state = { ...state, searching: true };
+    }
+    return requestId;
+  };
+
+  const succeedSpans = (requestId: number, items: SearchItem[], cursor?: string) => {
+    fns.commitTraceSearchSuccess(guard, requestId, () => {
+      state = {
+        ...state,
+        spanItems: cursor ? [...state.spanItems, ...items] : items,
+        traceItems: [],
+        pageState: items.length === 0 && !cursor ? 'empty' : 'ready',
+      };
+    });
+    fns.commitTraceSearchSettled(guard, requestId, () => {
+      state = { ...state, searching: false };
+    });
+  };
+
+  const succeedTraces = (requestId: number, items: SearchItem[], cursor?: string) => {
+    fns.commitTraceSearchSuccess(guard, requestId, () => {
+      state = {
+        ...state,
+        traceItems: cursor ? [...state.traceItems, ...items] : items,
+        spanItems: [],
+        pageState: items.length === 0 && !cursor ? 'empty' : 'ready',
+      };
+    });
+    fns.commitTraceSearchSettled(guard, requestId, () => {
+      state = { ...state, searching: false };
+    });
+  };
+
+  const fail = (requestId: number) => {
+    fns.commitTraceSearchFailure(guard, requestId, () => {
+      state = { ...state, pageState: 'error' };
+    });
+    fns.commitTraceSearchSettled(guard, requestId, () => {
+      state = { ...state, searching: false };
+    });
+  };
+
+  return {
+    getState: () => state,
+    getCurrentRequestId: () => currentRequestId,
+    start,
+    succeedSpans,
+    succeedTraces,
+    fail,
+    invalidate: () => guard.invalidate(),
+  };
+}
+
+function assertPageUsesGeneration(source: string) {
+  assert.match(
+    source,
+    /from ['"]@\/context\/latestRequestGuard['"]/,
+    'page 必须复用 @/context/latestRequestGuard，不得复制新 guard',
+  );
+  assert.match(source, /createLatestRequestGuard/, 'page 必须创建 latest request guard');
+  assert.match(
+    source,
+    /from ['"]@\/app\/apm\/utils\/traceSearchRequest['"]/,
+    'page 必须调用抽出的 traceSearchRequest',
+  );
+  assert.match(source, /beginTraceSearchRequest\(/, 'search 无 cursor 时必须 begin，有 cursor 时复用当前代次');
+  assert.match(source, /commitTraceSearchSuccess\(/, '成功响应必须经 commitTraceSearchSuccess 提交');
+  assert.match(source, /commitTraceSearchFailure\(/, '失败必须经 commitTraceSearchFailure 提交');
+  assert.match(source, /commitTraceSearchSettled\(/, '结束 searching 必须经 commitTraceSearchSettled 提交');
+  assert.match(source, /requestGuard\.invalidate\(\)/, '切换粒度、时间窗、清空、卸载必须 invalidate');
+  assert.match(source, /limit:\s*50/, '查询 limit 必须仍为 50');
+  assert.match(
+    source,
+    /searchParams\.get\('entity'\) === 'traces' \? 'traces' : 'spans'/,
+    '默认粒度必须仍为 Spans',
+  );
+  assert.doesNotMatch(
+    source,
+    /function createLatestRequestGuard|const createLatestRequestGuard\s*=/,
+    '不得在 page 内复制一套序号 guard',
+  );
+  assert.doesNotMatch(
+    source,
+    /getSpans\(query\)\s*\.then\(\s*\(page\)\s*=>\s*\{/,
+    'Span then 不得无条件写 items',
+  );
+  assert.doesNotMatch(
+    source,
+    /getTraces\(query\)\s*\.then\(\s*\(page\)\s*=>\s*\{/,
+    'Trace then 不得无条件写 items',
+  );
+  assert.doesNotMatch(
+    source,
+    /disabled=\{searching\}/,
+    '不得把禁用 Segmented 当作唯一修复',
+  );
+}
+
+async function main() {
+  const fns = await loadCommitFns();
+  const guardSource = readFileSync(guardPath, 'utf8');
+  assert.match(guardSource, /export const createLatestRequestGuard/, '必须复用已有 latestRequestGuard');
+
+  const spanThenTrace = createSearchSession(fns);
+  const spanRequest = spanThenTrace.start();
+  const traceRequest = spanThenTrace.start();
+  assert.notEqual(spanRequest, traceRequest, '无 cursor 的新查询必须分配新代次');
+  spanThenTrace.succeedTraces(traceRequest, [{ id: 'trace-latest' }]);
+  spanThenTrace.succeedSpans(spanRequest, [{ id: 'span-stale' }]);
+  assert.deepEqual(
+    spanThenTrace.getState().traceItems,
+    [{ id: 'trace-latest' }],
+    'Span→Trace 逆序：旧 Span 后到不得清空最新 Trace 结果',
+  );
+  assert.deepEqual(spanThenTrace.getState().spanItems, [], 'Span→Trace 逆序：旧 Span 不得写回 spanItems');
+  assert.equal(spanThenTrace.getState().pageState, 'ready');
+  assert.equal(spanThenTrace.getState().searching, false);
+
+  const timeWindow = createSearchSession(fns);
+  const hourWindow = timeWindow.start();
+  const quarterWindow = timeWindow.start();
+  timeWindow.succeedSpans(quarterWindow, [{ id: 'span-15m' }]);
+  timeWindow.succeedSpans(hourWindow, [{ id: 'span-1h' }]);
+  assert.deepEqual(
+    timeWindow.getState().spanItems,
+    [{ id: 'span-15m' }],
+    '同粒度换时间窗：旧查询不得覆盖新结果',
+  );
+  assert.deepEqual(timeWindow.getState().traceItems, []);
+  assert.equal(timeWindow.getState().searching, false);
+
+  const cleared = createSearchSession(fns);
+  const staleBeforeClear = cleared.start();
+  cleared.succeedSpans(staleBeforeClear, [{ id: 'span-before-clear' }]);
+  const inflightAfterClear = cleared.start();
+  cleared.invalidate();
+  cleared.succeedSpans(inflightAfterClear, [{ id: 'span-after-clear' }]);
+  assert.deepEqual(
+    cleared.getState().spanItems,
+    [{ id: 'span-before-clear' }],
+    '清空后旧响应不得写回新结果',
+  );
+  assert.equal(cleared.getState().searching, true, '清空后旧 finally 不得收口仍有效会话');
+
+  const staleError = createSearchSession(fns);
+  const failedOld = staleError.start();
+  staleError.start();
+  staleError.fail(failedOld);
+  assert.equal(staleError.getState().pageState, 'loading', '旧错误晚到不得覆盖最新 loading');
+  assert.equal(staleError.getState().searching, true, '旧错误晚到不得把最新 searching 清掉');
+
+  const staleFinally = createSearchSession(fns);
+  const oldInflight = staleFinally.start();
+  staleFinally.start();
+  staleFinally.succeedSpans(oldInflight, [{ id: 'span-old-finally' }]);
+  assert.equal(staleFinally.getState().searching, true, '旧 finally 不得清掉最新 searching');
+  assert.deepEqual(staleFinally.getState().spanItems, [], '旧成功不得在最新请求仍在途时写回');
+
+  const loadMore = createSearchSession(fns);
+  const firstPage = loadMore.start();
+  loadMore.succeedSpans(firstPage, [{ id: 'span-page-1' }]);
+  const morePage = loadMore.start('cursor-2');
+  assert.equal(morePage, firstPage, '加载更多必须复用当前代次，不得作废首屏');
+  loadMore.succeedSpans(morePage, [{ id: 'span-page-2' }], 'cursor-2');
+  assert.deepEqual(
+    loadMore.getState().spanItems.map((item) => item.id),
+    ['span-page-1', 'span-page-2'],
+    '加载更多必须追加当前代次结果',
+  );
+
+  const pageSource = readFileSync(pagePath, 'utf8');
+  const utilSource = readFileSync(utilPath, 'utf8');
+  assertPageUsesGeneration(pageSource);
+  assert.match(
+    utilSource,
+    /from ['"]@\/context\/latestRequestGuard['"]/,
+    'traceSearchRequest 必须复用 LatestRequestGuard 类型',
+  );
+  assert.doesNotMatch(
+    utilSource,
+    /createLatestRequestGuard\s*=|function createLatestRequestGuard/,
+    'traceSearchRequest 不得复制一套序号 guard',
+  );
+  assert.match(pageSource, /getSpans\(/, '不得改掉 getSpans 查询入口');
+  assert.match(pageSource, /getTraces\(/, '不得改掉 getTraces 查询入口');
+
+  console.log('apm trace search race test passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/web/src/app/apm/explore/traces/page.tsx
+++ b/web/src/app/apm/explore/traces/page.tsx
@@ -26,7 +26,14 @@ import type {
   ApmTraceSearchParams,
   ApmTraceSummary,
 } from '@/app/apm/types';
+import {
+  beginTraceSearchRequest,
+  commitTraceSearchFailure,
+  commitTraceSearchSettled,
+  commitTraceSearchSuccess,
+} from '@/app/apm/utils/traceSearchRequest';
 import FilterToolbar from '@/components/filter-toolbar';
+import { createLatestRequestGuard } from '@/context/latestRequestGuard';
 import { useTranslation } from '@/utils/i18n';
 
 type PageState = CatalogStateKind | 'ready' | 'idle';
@@ -381,6 +388,8 @@ export default function ApmTracesPage() {
   const autoSearched = useRef(false);
   const entityModeReady = useRef(false);
   const servicesLoaded = useRef(false);
+  const currentRequestIdRef = useRef(0);
+  const [requestGuard] = useState(createLatestRequestGuard);
 
   const { serviceName } = filters;
 
@@ -401,6 +410,10 @@ export default function ApmTracesPage() {
   const search = useCallback((cursor?: string, nextFilters?: TraceFilters) => {
     const active = nextFilters ?? filters;
     if (authLoading) return;
+    const requestId = beginTraceSearchRequest(requestGuard, currentRequestIdRef.current, cursor);
+    if (!cursor) {
+      currentRequestIdRef.current = requestId;
+    }
     setSearching(true);
     if (!cursor) {
       setState('loading');
@@ -424,16 +437,20 @@ export default function ApmTracesPage() {
         limit: 50,
       };
       getSpans(query)
-        .then((page) => {
+        .then((page) => commitTraceSearchSuccess(requestGuard, requestId, () => {
           setSpanItems((current) => (cursor ? [...current, ...page.items] : page.items));
           setTraceItems([]);
           setQueryStartedAt(query.started_at);
           setQueryEndedAt(query.ended_at);
           setState(page.items.length === 0 && !cursor && !page.next_cursor ? 'empty' : 'ready');
-        })
-        .catch((error) => setState(catalogErrorKind(error)))
+        }))
+        .catch((error) => commitTraceSearchFailure(requestGuard, requestId, () => {
+          setState(catalogErrorKind(error));
+        }))
         .finally(() => {
-          setSearching(false);
+          commitTraceSearchSettled(requestGuard, requestId, () => {
+            setSearching(false);
+          });
         });
       return;
     }
@@ -450,18 +467,22 @@ export default function ApmTracesPage() {
       limit: 50,
     };
     getTraces(query)
-      .then((page) => {
+      .then((page) => commitTraceSearchSuccess(requestGuard, requestId, () => {
         setTraceItems((current) => (cursor ? [...current, ...page.items] : page.items));
         setSpanItems([]);
         setQueryStartedAt(query.started_at);
         setQueryEndedAt(query.ended_at);
         setState(page.items.length === 0 && !cursor && !page.next_cursor ? 'empty' : 'ready');
-      })
-      .catch((error) => setState(catalogErrorKind(error)))
+      }))
+      .catch((error) => commitTraceSearchFailure(requestGuard, requestId, () => {
+        setState(catalogErrorKind(error));
+      }))
       .finally(() => {
-        setSearching(false);
+        commitTraceSearchSettled(requestGuard, requestId, () => {
+          setSearching(false);
+        });
       });
-  }, [authLoading, entityMode, filters, getSpans, getTraces, timeWindow]);
+  }, [authLoading, entityMode, filters, getSpans, getTraces, requestGuard, timeWindow]);
 
   const commitQueryText = useCallback(() => {
     const next = parseFilters(queryText);
@@ -527,6 +548,10 @@ export default function ApmTracesPage() {
     if (!autoSearched.current || authLoading) return;
     search();
   }, [timeRange]);
+
+  useEffect(() => {
+    return () => requestGuard.invalidate();
+  }, [requestGuard]);
 
   const traceColumns = useMemo<TableProps<ApmTraceSummary>['columns']>(() => [
     {
@@ -863,6 +888,7 @@ export default function ApmTracesPage() {
               value={entityMode}
               onChange={(value) => {
                 if (value !== 'spans' && value !== 'traces') return;
+                requestGuard.invalidate();
                 setEntityMode(value);
                 setResultMode('detail');
                 setTraceItems([]);
@@ -894,8 +920,10 @@ export default function ApmTracesPage() {
                   minDurationMs: null,
                   maxDurationMs: null,
                 };
+                requestGuard.invalidate();
                 applyFilters(cleared);
                 setState('idle');
+                setSearching(false);
                 setTraceItems([]);
                 setSpanItems([]);
               }}
@@ -918,6 +946,7 @@ export default function ApmTracesPage() {
                 value={timeRange}
                 options={['15m', '1h', '4h', '1d', '7d'].map((value) => ({ value, label: value }))}
                 onChange={(value: TimeRange) => {
+                  requestGuard.invalidate();
                   setTimeRange(value);
                   router.replace(`/apm/explore/traces${entityMode === 'spans' ? '?entity=spans' : '?entity=traces'}`);
                 }}

--- a/web/src/app/apm/utils/traceSearchRequest.ts
+++ b/web/src/app/apm/utils/traceSearchRequest.ts
@@ -1,0 +1,36 @@
+import type { LatestRequestGuard } from '@/context/latestRequestGuard';
+
+export function beginTraceSearchRequest(
+  guard: LatestRequestGuard,
+  currentRequestId: number,
+  cursor?: string,
+): number {
+  if (cursor) {
+    return currentRequestId;
+  }
+  return guard.begin();
+}
+
+export function commitTraceSearchSuccess(
+  guard: LatestRequestGuard,
+  requestId: number,
+  apply: () => void,
+): boolean {
+  return guard.commitIfCurrent(requestId, apply);
+}
+
+export function commitTraceSearchFailure(
+  guard: LatestRequestGuard,
+  requestId: number,
+  reportError: () => void,
+): boolean {
+  return guard.commitIfCurrent(requestId, reportError);
+}
+
+export function commitTraceSearchSettled(
+  guard: LatestRequestGuard,
+  requestId: number,
+  settle: () => void,
+): boolean {
+  return guard.commitIfCurrent(requestId, settle);
+}


### PR DESCRIPTION
## 复现步骤

前置：账号能打开 APM。准备当前时间窗内既有 Span 又有 Trace 的数据。可用开发者工具把 `/apm/spans/`、`/apm/traces/` 延迟到乱序返回。

1. 进入 APM 左侧菜单 **探索** → **调用链**（`/apm/explore/traces`）。页头标题是 **调用链**。默认 **调用链查询粒度** 是 **Spans**。
2. 点 **查询**，或等自动查询开始。不要等 loading 结束。
3. 把粒度切到 **Traces**。Segmented 在 searching 时仍可点。
4. 也可保持同一粒度，把 **时间窗** 从 `1h` 改成 `15m`。
5. 或点过滤框清空，看旧响应会不会把列表填回来。

修复前：最新 Trace 已经有行之后，较早的 Span 响应仍会 `setTraceItems([])`，页面还停在 Traces，结果被清空。同粒度换时间窗时，旧窗结果也会盖住新窗。  
修复后：只有当前粒度/时间窗这一代查询能写列表和 **查询** 按钮 loading。旧 Span 不会清掉最新 Trace。清空或离开页面后，迟到响应不写回。

## 修复方案

给 `search` 的成功、失败和 finally 加请求代次。

- 无 cursor 的新查询 `begin`；加载更多复用当前代次，不把首屏作废。
- 复用 `createLatestRequestGuard`。切换 **Spans** / **Traces**、改 **时间窗**、清空过滤、卸载时 invalidate。
- 不改 `getSpans` / `getTraces`、默认 Spans、`limit=50`。不靠禁用 Segmented 当唯一修复。

Fixes #5227

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 查询未完成时从 **Spans** 切到 **Traces**，旧 Span 后到 | 粒度是 Traces，列表被清空 | 保留最新 Trace 结果 |
| 同一粒度改 **时间窗** | 旧窗结果覆盖新窗 | 只保留新窗 |
| 清空过滤后旧响应返回 | 可能把已清空的列表填回 | 不写回 |
| 新查询仍在途，旧查询失败/结束 | **查询** loading 被清掉或变成错误 | loading 仍属于新查询 |

## 影响面

- **会变**：仅 APM **探索** → **调用链** 的查询写回。乱序网络下列表与当前 **Spans** / **Traces**、**时间窗** 一致。
- **不变**：查询参数、默认 Spans、每次 `limit=50`、客户端聚合、权限、接口 URL。
- **未改**：粒度 Segmented 仍可在 loading 时切换；过期请求仍可能打到后端，只是结果被丢弃。
- **不在范围**：调用链详情页、实时尾随（当前禁用）。

## 验证

- `web/scripts/apm-trace-search-race-test.ts`：修复前失败，修复后 `apm trace search race test passed`
- 覆盖 Span→Trace 逆序、换时间窗、清空后旧响应、旧错误/finally、加载更多复用代次
