### PR TITLE
feat(监控): 视图资产抽屉展示绑定的监控策略

### DIFF
--- a/server/apps/monitor/filters/monitor_policy.py
+++ b/server/apps/monitor/filters/monitor_policy.py
@@ -1,8 +1,6 @@
-from django.db.models import Q
 from django_filters import CharFilter, FilterSet
 
 from apps.monitor.filters.id_filters import filter_positive_int_field
-from apps.monitor.models.monitor_object import MonitorInstanceOrganization
 from apps.monitor.models.monitor_policy import MonitorPolicy
 from apps.monitor.utils.dimension import normalize_instance_identity
 
@@ -38,43 +36,29 @@ def _normalized_source_values(values) -> set:
             continue
         normalized.add(item)
         normalized.add(str(item))
-        text = str(item).strip()
-        if text.isdigit():
-            normalized.add(int(text))
     return normalized
 
 
-def source_covers_instance(source, instance_ids, org_ids) -> bool:
-    """判断策略 source 是否覆盖当前实例（显式实例或所属组织）。"""
+def source_covers_instance(source, instance_ids) -> bool:
+    """仅匹配显式绑定当前实例的策略，不含组织范围策略。"""
     if not isinstance(source, dict):
         return False
-    source_type = source.get("type")
+    if source.get("type") != "instance":
+        return False
     value_set = _normalized_source_values(source.get("values"))
-    if source_type == "instance":
-        return bool(value_set.intersection(instance_ids))
-    if source_type == "organization":
-        org_value_set = set(org_ids)
-        org_value_set.update(str(item) for item in org_ids)
-        return bool(value_set.intersection(org_value_set))
-    return False
+    return bool(value_set.intersection(instance_ids))
 
 
 def filter_policy_queryset_by_instance(queryset, instance_id):
-    """按实例绑定过滤策略。不依赖 JSON contains，SQLite / PostgreSQL 均可。"""
+    """按实例显式绑定过滤策略。不依赖 JSON contains，SQLite / PostgreSQL 均可。"""
     instance_ids = set(policy_instance_id_candidates(instance_id))
     if not instance_ids:
         return queryset.none()
 
-    org_ids = set(
-        MonitorInstanceOrganization.objects.filter(monitor_instance_id__in=instance_ids).values_list(
-            "organization",
-            flat=True,
-        )
-    )
     matched_ids = [
         policy_id
-        for policy_id, source in queryset.filter(Q(source__type="instance") | Q(source__type="organization")).values_list("id", "source")
-        if source_covers_instance(source, instance_ids, org_ids)
+        for policy_id, source in queryset.filter(source__type="instance").values_list("id", "source")
+        if source_covers_instance(source, instance_ids)
     ]
     return queryset.filter(id__in=matched_ids)
 

--- a/server/apps/monitor/filters/monitor_policy.py
+++ b/server/apps/monitor/filters/monitor_policy.py
@@ -1,17 +1,102 @@
+from django.db.models import Q
 from django_filters import CharFilter, FilterSet
 
 from apps.monitor.filters.id_filters import filter_positive_int_field
+from apps.monitor.models.monitor_object import MonitorInstanceOrganization
 from apps.monitor.models.monitor_policy import MonitorPolicy
+from apps.monitor.utils.dimension import normalize_instance_identity
+
+
+def policy_instance_id_candidates(value) -> list[str]:
+    """兼容裸实例 ID 与存储用 tuple 串，供策略 source 过滤使用。"""
+    text = str(value or "").strip()
+    if not text:
+        return []
+    candidates = {text}
+    try:
+        identity = normalize_instance_identity(text)
+    except ValueError:
+        return [text]
+    storage_key = identity.get("storage_instance_key")
+    logical_value = identity.get("logical_instance_value")
+    raw_input = identity.get("raw_input")
+    if storage_key not in (None, ""):
+        candidates.add(str(storage_key))
+    if logical_value not in (None, ""):
+        candidates.add(str(logical_value))
+    if raw_input not in (None, ""):
+        candidates.add(str(raw_input))
+    return [item for item in candidates if item]
+
+
+def _normalized_source_values(values) -> set:
+    if not isinstance(values, list):
+        return set()
+    normalized = set()
+    for item in values:
+        if item in (None, ""):
+            continue
+        normalized.add(item)
+        normalized.add(str(item))
+        text = str(item).strip()
+        if text.isdigit():
+            normalized.add(int(text))
+    return normalized
+
+
+def source_covers_instance(source, instance_ids, org_ids) -> bool:
+    """判断策略 source 是否覆盖当前实例（显式实例或所属组织）。"""
+    if not isinstance(source, dict):
+        return False
+    source_type = source.get("type")
+    value_set = _normalized_source_values(source.get("values"))
+    if source_type == "instance":
+        return bool(value_set.intersection(instance_ids))
+    if source_type == "organization":
+        org_value_set = set(org_ids)
+        org_value_set.update(str(item) for item in org_ids)
+        return bool(value_set.intersection(org_value_set))
+    return False
+
+
+def filter_policy_queryset_by_instance(queryset, instance_id):
+    """按实例绑定过滤策略。不依赖 JSON contains，SQLite / PostgreSQL 均可。"""
+    instance_ids = set(policy_instance_id_candidates(instance_id))
+    if not instance_ids:
+        return queryset.none()
+
+    org_ids = set(
+        MonitorInstanceOrganization.objects.filter(monitor_instance_id__in=instance_ids).values_list(
+            "organization",
+            flat=True,
+        )
+    )
+    matched_ids = [
+        policy_id
+        for policy_id, source in queryset.filter(Q(source__type="instance") | Q(source__type="organization")).values_list("id", "source")
+        if source_covers_instance(source, instance_ids, org_ids)
+    ]
+    return queryset.filter(id__in=matched_ids)
 
 
 class MonitorPolicyFilter(FilterSet):
     monitor_object_id = CharFilter(field_name="monitor_object", lookup_expr="exact", label="监控对象", method="filter_monitor_object_id")
     name = CharFilter(field_name="name", lookup_expr="icontains", label="策略名称")
+    monitor_instance_id = CharFilter(method="filter_monitor_instance_id", label="监控实例ID")
 
     @staticmethod
     def filter_monitor_object_id(queryset, _name, value):
         return filter_positive_int_field(queryset, "monitor_object", value)
 
+    @staticmethod
+    def filter_monitor_instance_id(queryset, _name, value):
+        if value in (None, ""):
+            return queryset
+        text = str(value).strip()
+        if not text:
+            return queryset
+        return filter_policy_queryset_by_instance(queryset, text)
+
     class Meta:
         model = MonitorPolicy
-        fields = ["monitor_object_id", "name"]
+        fields = ["monitor_object_id", "name", "monitor_instance_id"]

--- a/web/src/app/monitor/(pages)/view/monitorPolicy.tsx
+++ b/web/src/app/monitor/(pages)/view/monitorPolicy.tsx
@@ -3,6 +3,8 @@ import React, { useEffect, useState, useRef } from 'react';
 import { Button, Tag } from 'antd';
 import { useRouter } from 'next/navigation';
 import useApiClient from '@/utils/request';
+import useMonitorApi from '@/app/monitor/api';
+import { fetchAllMonitorMetrics } from '@/app/monitor/api/fetchMetricCatalogPages';
 import useEventApi from '@/app/monitor/api/event';
 import { useTranslation } from '@/utils/i18n';
 import { ColumnItem, Pagination, TableDataItem } from '@/app/monitor/types';
@@ -11,7 +13,10 @@ import CustomTable from '@/components/custom-table';
 import { useLocalizedTime } from '@/hooks/useLocalizedTime';
 import { INIT_VIEW_MODAL_FORM } from '@/app/monitor/constants/view';
 import { buildMonitorStrategyDetailUrl } from '@/app/monitor/utils/policyRouteUtils';
-import { getPolicyMetricContext } from '@/app/monitor/utils/policyDisplayName';
+import {
+  PolicyMetricCatalogItem,
+  resolvePolicyMetricDisplayName
+} from '@/app/monitor/utils/policyDisplayName';
 
 const MonitorPolicy: React.FC<ViewModalProps> = ({
   monitorObject,
@@ -19,14 +24,20 @@ const MonitorPolicy: React.FC<ViewModalProps> = ({
   form = INIT_VIEW_MODAL_FORM
 }) => {
   const { isLoading } = useApiClient();
+  const { getMonitorMetrics } = useMonitorApi();
   const { getMonitorPolicy } = useEventApi();
   const { t } = useTranslation();
   const router = useRouter();
   const { convertToLocalizedTime } = useLocalizedTime();
   const abortControllerRef = useRef<AbortController | null>(null);
   const requestIdRef = useRef<number>(0);
+  const getMonitorMetricsRef = useRef(getMonitorMetrics);
+  getMonitorMetricsRef.current = getMonitorMetrics;
   const [tableLoading, setTableLoading] = useState<boolean>(false);
   const [tableData, setTableData] = useState<TableDataItem[]>([]);
+  const [metricCatalog, setMetricCatalog] = useState<PolicyMetricCatalogItem[]>(
+    []
+  );
   const [pagination, setPagination] = useState<Pagination>({
     current: 1,
     total: 0,
@@ -60,10 +71,9 @@ const MonitorPolicy: React.FC<ViewModalProps> = ({
       title: t('monitor.events.policyMetric'),
       dataIndex: 'query_condition',
       key: 'query_condition',
-      render: (_, record) => {
-        const metric = getPolicyMetricContext(record);
-        return <>{metric || record.alert_name || '--'}</>;
-      }
+      render: (_, record) => (
+        <>{resolvePolicyMetricDisplayName(record, metricCatalog) || '--'}</>
+      )
     },
     {
       title: t('monitor.events.alertName'),
@@ -86,6 +96,28 @@ const MonitorPolicy: React.FC<ViewModalProps> = ({
     if (isLoading) return;
     getBoundPolicies();
   }, [isLoading, pagination.current, pagination.pageSize, form.instance_id, monitorObject]);
+
+  useEffect(() => {
+    if (isLoading || !monitorObject) {
+      setMetricCatalog([]);
+      return;
+    }
+    const abortController = new AbortController();
+    fetchAllMonitorMetrics(
+      getMonitorMetricsRef.current,
+      { monitor_object_id: monitorObject },
+      { signal: abortController.signal }
+    )
+      .then((data) => {
+        if (abortController.signal.aborted) return;
+        setMetricCatalog(data.items || []);
+      })
+      .catch(() => {
+        if (abortController.signal.aborted) return;
+        setMetricCatalog([]);
+      });
+    return () => abortController.abort();
+  }, [isLoading, monitorObject]);
 
   useEffect(() => {
     return () => {

--- a/web/src/app/monitor/(pages)/view/monitorPolicy.tsx
+++ b/web/src/app/monitor/(pages)/view/monitorPolicy.tsx
@@ -1,0 +1,164 @@
+'use client';
+import React, { useEffect, useState, useRef } from 'react';
+import { Button, Tag } from 'antd';
+import { useRouter } from 'next/navigation';
+import useApiClient from '@/utils/request';
+import useEventApi from '@/app/monitor/api/event';
+import { useTranslation } from '@/utils/i18n';
+import { ColumnItem, Pagination, TableDataItem } from '@/app/monitor/types';
+import { ViewModalProps } from '@/app/monitor/types/view';
+import CustomTable from '@/components/custom-table';
+import { useLocalizedTime } from '@/hooks/useLocalizedTime';
+import { INIT_VIEW_MODAL_FORM } from '@/app/monitor/constants/view';
+import { buildMonitorStrategyDetailUrl } from '@/app/monitor/utils/policyRouteUtils';
+import { getPolicyMetricContext } from '@/app/monitor/utils/policyDisplayName';
+
+const MonitorPolicy: React.FC<ViewModalProps> = ({
+  monitorObject,
+  monitorName,
+  form = INIT_VIEW_MODAL_FORM
+}) => {
+  const { isLoading } = useApiClient();
+  const { getMonitorPolicy } = useEventApi();
+  const { t } = useTranslation();
+  const router = useRouter();
+  const { convertToLocalizedTime } = useLocalizedTime();
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const requestIdRef = useRef<number>(0);
+  const [tableLoading, setTableLoading] = useState<boolean>(false);
+  const [tableData, setTableData] = useState<TableDataItem[]>([]);
+  const [pagination, setPagination] = useState<Pagination>({
+    current: 1,
+    total: 0,
+    pageSize: 20
+  });
+
+  const columns: ColumnItem[] = [
+    {
+      title: t('common.name'),
+      dataIndex: 'name',
+      key: 'name',
+      render: (_, record) => (
+        <Button type="link" className="px-0" onClick={() => linkToStrategyDetail(record)}>
+          {record.name || '--'}
+        </Button>
+      )
+    },
+    {
+      title: t('monitor.events.enableStatus'),
+      dataIndex: 'enable',
+      key: 'enable',
+      width: 110,
+      render: (_, { enable }) =>
+        enable ? (
+          <Tag color="success">{t('monitor.events.turnedOn')}</Tag>
+        ) : (
+          <Tag>{t('monitor.events.inactive')}</Tag>
+        )
+    },
+    {
+      title: t('monitor.events.policyMetric'),
+      dataIndex: 'query_condition',
+      key: 'query_condition',
+      render: (_, record) => {
+        const metric = getPolicyMetricContext(record);
+        return <>{metric || record.alert_name || '--'}</>;
+      }
+    },
+    {
+      title: t('monitor.events.alertName'),
+      dataIndex: 'alert_name',
+      key: 'alert_name',
+      render: (_, { alert_name }) => <>{alert_name || '--'}</>
+    },
+    {
+      title: t('monitor.events.executionTime'),
+      dataIndex: 'last_run_time',
+      key: 'last_run_time',
+      width: 170,
+      render: (_, { last_run_time }) => (
+        <>{last_run_time ? convertToLocalizedTime(last_run_time) : '--'}</>
+      )
+    }
+  ];
+
+  useEffect(() => {
+    if (isLoading) return;
+    getBoundPolicies();
+  }, [isLoading, pagination.current, pagination.pageSize, form.instance_id, monitorObject]);
+
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
+
+  const linkToStrategyDetail = (record: TableDataItem) => {
+    router.push(
+      buildMonitorStrategyDetailUrl('edit', {
+        monitorObjId: String(monitorObject),
+        monitorName,
+        id: record.id as string | number,
+        name: String(record.name || '')
+      })
+    );
+  };
+
+  const handleTableChange = (nextPagination: Pagination) => {
+    setPagination(nextPagination);
+  };
+
+  const getBoundPolicies = async () => {
+    abortControllerRef.current?.abort();
+    const abortController = new AbortController();
+    abortControllerRef.current = abortController;
+    const currentRequestId = ++requestIdRef.current;
+    const instanceId = String(form.instance_id || '').trim();
+    if (!instanceId || !monitorObject) {
+      setTableData([]);
+      setPagination((pre) => ({ ...pre, total: 0 }));
+      setTableLoading(false);
+      return;
+    }
+    try {
+      setTableLoading(true);
+      const data = await getMonitorPolicy(
+        '',
+        {
+          page: pagination.current,
+          page_size: pagination.pageSize,
+          monitor_object_id: monitorObject,
+          monitor_instance_id: instanceId
+        },
+        { signal: abortController.signal }
+      );
+      if (currentRequestId !== requestIdRef.current) return;
+      setTableData(data.items || []);
+      setPagination((pre) => ({
+        ...pre,
+        total: data.count || 0
+      }));
+    } finally {
+      if (currentRequestId === requestIdRef.current) {
+        setTableLoading(false);
+      }
+    }
+  };
+
+  return (
+    <div className="w-full">
+      <CustomTable
+        scroll={{ y: 'calc(100vh - 360px)', x: 890 }}
+        columns={columns}
+        dataSource={tableData}
+        pagination={pagination}
+        loading={tableLoading}
+        rowKey="id"
+        locale={{ emptyText: t('monitor.views.noBoundPolicy') }}
+        onChange={handleTableChange}
+      />
+    </div>
+  );
+};
+
+export default MonitorPolicy;

--- a/web/src/app/monitor/(pages)/view/viewModal.tsx
+++ b/web/src/app/monitor/(pages)/view/viewModal.tsx
@@ -9,6 +9,7 @@ import { ViewModalProps } from '@/app/monitor/types/view';
 import { useTranslation } from '@/utils/i18n';
 import MonitorView from './monitorView';
 import MonitorAlarm from './monitorAlarm';
+import MonitorPolicy from './monitorPolicy';
 import { OBJECT_DEFAULT_ICON } from '@/app/monitor/constants';
 import { INIT_VIEW_MODAL_FORM } from '@/app/monitor/constants/view';
 import { resolveDashboardUrl } from '@/app/monitor/dashboards/registry';
@@ -32,6 +33,10 @@ const ViewModal = forwardRef<ModalRef, ViewModalProps>(
       {
         label: t('monitor.views.alertList'),
         key: 'alertList',
+      },
+      {
+        label: t('monitor.views.monitoringPolicy'),
+        key: 'monitorPolicy',
       },
     ];
     const [currentTab, setCurrentTab] = useState<string>('monitorView');
@@ -127,13 +132,21 @@ const ViewModal = forwardRef<ModalRef, ViewModalProps>(
               plugins={plugins}
               form={viewConfig}
             />
-          ) : (
+          ) : currentTab === 'alertList' ? (
             <MonitorAlarm
               monitorObject={monitorObject}
               monitorName={monitorName}
               plugins={plugins}
               form={viewConfig}
               metrics={metrics}
+              objects={objects}
+            />
+          ) : (
+            <MonitorPolicy
+              monitorObject={monitorObject}
+              monitorName={monitorName}
+              plugins={plugins}
+              form={viewConfig}
               objects={objects}
             />
           )}

--- a/web/src/app/monitor/api/event.ts
+++ b/web/src/app/monitor/api/event.ts
@@ -28,6 +28,7 @@ const useEventApi = () => {
       page?: number;
       page_size?: number;
       monitor_object_id?: React.Key;
+      monitor_instance_id?: string;
     } = {},
     config?: AxiosRequestConfig
   ) => {

--- a/web/src/app/monitor/locales/en.json
+++ b/web/src/app/monitor/locales/en.json
@@ -326,6 +326,8 @@
       "node": "Node",
       "clickhouse_asynchronous_metrics_load_average1": "Load Average (1m)",
       "alertList": "Alert List",
+      "monitoringPolicy": "Monitoring Policy",
+      "noBoundPolicy": "No monitoring policies are bound to this asset",
       "postgresql_numbackends": "Active DB Connections",
       "postgresql_blks_read_rate": "Disk Block Read Rate",
       "postgresql_temp_files_rate": "Temporary Files Creation Rate",

--- a/web/src/app/monitor/locales/zh.json
+++ b/web/src/app/monitor/locales/zh.json
@@ -326,6 +326,8 @@
       "node": "节点",
       "clickhouse_asynchronous_metrics_load_average1": "系统负载（1分钟）",
       "alertList": "告警列表",
+      "monitoringPolicy": "监控策略",
+      "noBoundPolicy": "该资产暂无绑定的监控策略",
       "postgresql_numbackends": "当前活跃数据库连接数",
       "postgresql_blks_read_rate": "磁盘数据块读取速率",
       "postgresql_temp_files_rate": "临时文件创建速率",

--- a/web/src/app/monitor/utils/policyDisplayName.ts
+++ b/web/src/app/monitor/utils/policyDisplayName.ts
@@ -8,15 +8,26 @@ export interface PolicyNameSource {
   alert_name?: string;
   query_condition?: {
     type?: string;
+    metric_id?: string | number;
     metric_name?: string;
     result_name?: string;
     expression?: string;
-    queries?: Array<{ ref?: string; metric_name?: string }>;
+    queries?: Array<{
+      ref?: string;
+      metric_id?: string | number;
+      metric_name?: string;
+    }>;
     [key: string]: unknown;
   } | null;
   monitor_object_name?: string;
   monitor_object_display_name?: string;
   [key: string]: unknown;
+}
+
+export interface PolicyMetricCatalogItem {
+  id?: string | number;
+  name?: string;
+  display_name?: string;
 }
 
 /** 从策略配置提取用于区分同名的短上下文（指标优先；公式展开为指标名）。 */
@@ -54,6 +65,75 @@ export const getPolicyMetricContext = (policy?: PolicyNameSource | null): string
   const metricName = String(query.metric_name || '').trim();
   if (metricName) return metricName;
   return '';
+};
+
+const metricCatalogLabel = (metric?: PolicyMetricCatalogItem | null): string =>
+  String(metric?.display_name || metric?.name || '').trim();
+
+const lookupCatalogMetric = (
+  byId: Map<string, PolicyMetricCatalogItem>,
+  byName: Map<string, PolicyMetricCatalogItem>,
+  metricId?: string | number,
+  metricName?: string
+): PolicyMetricCatalogItem | undefined => {
+  if (metricId !== undefined && metricId !== null && metricId !== '') {
+    const hit = byId.get(String(metricId));
+    if (hit) return hit;
+  }
+  const name = String(metricName || '').trim();
+  if (name) return byName.get(name);
+  return undefined;
+};
+
+/**
+ * 策略指标列：目录 display_name 优先；有 metric_name/公式上下文时回落到 getPolicyMetricContext。
+ * 不使用 alert_name。
+ */
+export const resolvePolicyMetricDisplayName = (
+  policy?: PolicyNameSource | null,
+  metrics: PolicyMetricCatalogItem[] = []
+): string => {
+  if (!policy) return '';
+  const query = policy.query_condition || {};
+  const byId = new Map<string, PolicyMetricCatalogItem>();
+  const byName = new Map<string, PolicyMetricCatalogItem>();
+  metrics.forEach((item) => {
+    if (item.id !== undefined && item.id !== null && item.id !== '') {
+      byId.set(String(item.id), item);
+    }
+    const name = String(item.name || '').trim();
+    if (name) byName.set(name, item);
+  });
+
+  if (query.type === 'formula' && Array.isArray(query.queries)) {
+    const enrichedQueries = query.queries.map((item) => {
+      const label = metricCatalogLabel(
+        lookupCatalogMetric(byId, byName, item?.metric_id, item?.metric_name)
+      );
+      return {
+        ...item,
+        metric_name: label || String(item?.metric_name || '').trim()
+      };
+    });
+    const hasNamedMetric = enrichedQueries.some((item) =>
+      Boolean(String(item.metric_name || '').trim())
+    );
+    if (!hasNamedMetric) return '';
+    return getPolicyMetricContext({
+      ...policy,
+      query_condition: { ...query, queries: enrichedQueries }
+    });
+  }
+
+  const catalogHit = lookupCatalogMetric(
+    byId,
+    byName,
+    query.metric_id,
+    query.metric_name
+  );
+  const catalogLabel = metricCatalogLabel(catalogHit);
+  if (catalogLabel) return catalogLabel;
+  return getPolicyMetricContext(policy);
 };
 
 export const getPolicySecondaryContext = (


### PR DESCRIPTION
## Summary
- 监控视图点开资产后的右侧抽屉增加只读「监控策略」Tab
- 仅列出 `source.type=instance` 且显式绑定当前实例的策略（不串组织级/其他实例）
- 策略指标列按指标目录展示 `display_name`（如「内存碎片率」），告警名称保留 `${resource_name}` 模板
- 点名称跳转现有策略编辑页；抽屉内不做 CRUD/启用开关

## Test plan
- [ ] 打开资产抽屉「监控策略」：有绑定策略列表 / 无策略空态
- [ ] 两台不同实例对照：不出现只绑在另一台上的策略
- [ ] 策略指标列为真实指标名，告警名称可含 `${resource_name}`
- [ ] 点策略名称进入现有策略详情/编辑页