### PR TITLE
bugfix: 配置对比超预算时停止分配行数乘积矩阵

### DIFF
--- a/web/scripts/config-file-diff-budget-test.ts
+++ b/web/scripts/config-file-diff-budget-test.ts
@@ -1,0 +1,265 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const root = process.cwd();
+const diffUtilsPath = path.join(
+  root,
+  'src/app/cmdb/(pages)/assetData/detail/configFiles/components/diffUtils.ts'
+);
+const compareDrawerPath = path.join(
+  root,
+  'src/app/cmdb/(pages)/assetData/detail/configFiles/components/compareDrawer.tsx'
+);
+const zhLocalePath = path.join(root, 'src/app/cmdb/locales/zh.json');
+const enLocalePath = path.join(root, 'src/app/cmdb/locales/en.json');
+
+interface SlimRow {
+  leftText: string;
+  rightText: string;
+  status: string;
+  leftNumber: number | null;
+  rightNumber: number | null;
+}
+
+const slim = (rows: Array<{
+  leftText: string;
+  rightText: string;
+  status: string;
+  leftNumber: number | null;
+  rightNumber: number | null;
+}>): SlimRow[] => rows.map((row) => ({
+  leftText: row.leftText,
+  rightText: row.rightText,
+  status: row.status,
+  leftNumber: row.leftNumber,
+  rightNumber: row.rightNumber,
+}));
+
+const makeLines = (count: number, prefix: string): string => (
+  Array.from({ length: count }, (_, index) => `${prefix}-${index}`).join('\n')
+);
+
+const expectAligned = (
+  result: { kind?: string; rows?: SlimRow[] },
+  expected: SlimRow[],
+  message: string
+) => {
+  assert.equal(result.kind, 'aligned', message);
+  assert.ok(Array.isArray(result.rows), message);
+  assert.deepEqual(slim(result.rows as SlimRow[]), expected, message);
+};
+
+async function main() {
+  const {
+    buildSideBySideDiffRows,
+    buildInlineSegments,
+    MAX_DIFF_LCS_CELLS,
+  } = await import(pathToFileURL(diffUtilsPath).href);
+
+  assert.equal(
+    MAX_DIFF_LCS_CELLS,
+    1_000_000,
+    'LCS 必须使用命名常量 MAX_DIFF_LCS_CELLS=1000000，按 (n+1)*(m+1) 计'
+  );
+
+  expectAligned(
+    buildSideBySideDiffRows('', ''),
+    [{ leftText: '', rightText: '', status: 'same', leftNumber: 1, rightNumber: 1 }],
+    '空文件应对齐为一行 same'
+  );
+  expectAligned(
+    buildSideBySideDiffRows('', 'a'),
+    [{ leftText: '', rightText: 'a', status: 'changed', leftNumber: 1, rightNumber: 1 }],
+    '空左文件应对齐为 changed'
+  );
+  expectAligned(
+    buildSideBySideDiffRows('a', ''),
+    [{ leftText: 'a', rightText: '', status: 'changed', leftNumber: 1, rightNumber: 1 }],
+    '空右文件应对齐为 changed'
+  );
+  expectAligned(
+    buildSideBySideDiffRows('a\r\nb\r\nc', 'a\nb\nc'),
+    [
+      { leftText: 'a', rightText: 'a', status: 'same', leftNumber: 1, rightNumber: 1 },
+      { leftText: 'b', rightText: 'b', status: 'same', leftNumber: 2, rightNumber: 2 },
+      { leftText: 'c', rightText: 'c', status: 'same', leftNumber: 3, rightNumber: 3 },
+    ],
+    'CRLF 应与 LF 按行对齐'
+  );
+  expectAligned(
+    buildSideBySideDiffRows('a\nc', 'a\nb\nc'),
+    [
+      { leftText: 'a', rightText: 'a', status: 'same', leftNumber: 1, rightNumber: 1 },
+      { leftText: '', rightText: 'b', status: 'added', leftNumber: null, rightNumber: 2 },
+      { leftText: 'c', rightText: 'c', status: 'same', leftNumber: 2, rightNumber: 3 },
+    ],
+    '新增行应对齐为 added'
+  );
+  expectAligned(
+    buildSideBySideDiffRows('a\nb\nc', 'a\nc'),
+    [
+      { leftText: 'a', rightText: 'a', status: 'same', leftNumber: 1, rightNumber: 1 },
+      { leftText: 'b', rightText: '', status: 'removed', leftNumber: 2, rightNumber: null },
+      { leftText: 'c', rightText: 'c', status: 'same', leftNumber: 3, rightNumber: 2 },
+    ],
+    '删除行应对齐为 removed'
+  );
+  expectAligned(
+    buildSideBySideDiffRows('a\nx\nc', 'a\ny\nc'),
+    [
+      { leftText: 'a', rightText: 'a', status: 'same', leftNumber: 1, rightNumber: 1 },
+      { leftText: 'x', rightText: 'y', status: 'changed', leftNumber: 2, rightNumber: 2 },
+      { leftText: 'c', rightText: 'c', status: 'same', leftNumber: 3, rightNumber: 3 },
+    ],
+    '修改行应对齐为 changed'
+  );
+  expectAligned(
+    buildSideBySideDiffRows('a\na\nb', 'a\nb'),
+    [
+      { leftText: 'a', rightText: 'a', status: 'same', leftNumber: 1, rightNumber: 1 },
+      { leftText: 'a', rightText: '', status: 'removed', leftNumber: 2, rightNumber: null },
+      { leftText: 'b', rightText: 'b', status: 'same', leftNumber: 3, rightNumber: 2 },
+    ],
+    '重复行应保持现有 LCS 对齐'
+  );
+
+  assert.deepEqual(
+    buildInlineSegments('hello world', 'hello there'),
+    {
+      left: [{ text: 'hello ', changed: false }, { text: 'world', changed: true }],
+      right: [{ text: 'hello ', changed: false }, { text: 'there', changed: true }],
+    },
+    '行内高亮应保留公共前后缀'
+  );
+  assert.deepEqual(
+    buildInlineSegments('same', 'same'),
+    {
+      left: [{ text: 'same', changed: false }],
+      right: [{ text: 'same', changed: false }],
+    },
+    '相同文本不应标记行内变更'
+  );
+
+  const atBudgetLeft = makeLines(999, 'L');
+  const atBudgetRight = makeLines(999, 'R');
+  const atBudget = buildSideBySideDiffRows(atBudgetLeft, atBudgetRight);
+  assert.equal(
+    atBudget.kind,
+    'aligned',
+    '阈值内 (999+1)*(999+1)=1000000 仍应走 LCS'
+  );
+  assert.ok(Array.isArray(atBudget.rows) && atBudget.rows.length > 0, '阈值内必须返回对齐行');
+
+  const unequalAtBudget = buildSideBySideDiffRows(makeLines(499, 'L'), makeLines(1999, 'R'));
+  assert.equal(
+    unequalAtBudget.kind,
+    'aligned',
+    '阈值内不等长 (499+1)*(1999+1)=1000000 仍应走 LCS'
+  );
+
+  const overBudget = buildSideBySideDiffRows(makeLines(1000, 'L'), makeLines(1000, 'R'));
+  assert.equal(overBudget.kind, 'over_budget', '超过 MAX_DIFF_LCS_CELLS 必须返回 over_budget');
+  assert.ok(
+    typeof overBudget.cellCount === 'number' && overBudget.cellCount > MAX_DIFF_LCS_CELLS,
+    'over_budget 必须给出按 (n+1)*(m+1) 计的 cellCount'
+  );
+  assert.equal('rows' in overBudget, false, '超预算禁止静默返回错误对齐 rows');
+
+  const hugeStart = Date.now();
+  const huge = buildSideBySideDiffRows(makeLines(20000, 'L'), makeLines(20000, 'R'));
+  const hugeElapsed = Date.now() - hugeStart;
+  assert.equal(huge.kind, 'over_budget', '20000x20000 必须返回 over_budget，不得走完整 DP');
+  assert.ok(
+    hugeElapsed < 1000,
+    `20000x20000 必须在 1s 内返回 over_budget，实际 ${hugeElapsed}ms`
+  );
+  assert.equal(
+    huge.cellCount,
+    20001 * 20001,
+    '20000x20000 的 cellCount 必须按 (n+1)*(m+1) 计'
+  );
+
+  const diffUtilsSource = readFileSync(diffUtilsPath, 'utf8');
+  const compareDrawerSource = readFileSync(compareDrawerPath, 'utf8');
+  const zhLocale = JSON.parse(readFileSync(zhLocalePath, 'utf8')) as {
+    ConfigFile: Record<string, string>;
+  };
+  const enLocale = JSON.parse(readFileSync(enLocalePath, 'utf8')) as {
+    ConfigFile: Record<string, string>;
+  };
+
+  assert.match(
+    diffUtilsSource,
+    /export const MAX_DIFF_LCS_CELLS = 1_000_000/,
+    '必须导出命名常量 MAX_DIFF_LCS_CELLS=1000000'
+  );
+  const budgetGuardIndex = diffUtilsSource.search(
+    /if\s*\(\s*cellCount\s*>\s*MAX_DIFF_LCS_CELLS\s*\)/
+  );
+  const matrixIndex = diffUtilsSource.search(
+    /Array\.from\(\{\s*length:\s*leftLength\s*\+\s*1/
+  );
+  assert.ok(budgetGuardIndex >= 0, '超预算必须在分配矩阵前用 cellCount > MAX_DIFF_LCS_CELLS 拦截');
+  assert.ok(matrixIndex > budgetGuardIndex, 'LCS 矩阵只能在预算守卫之后分配');
+  assert.doesNotMatch(
+    diffUtilsSource,
+    /new Worker|worker_threads/,
+    '禁止把完整矩阵搬进 Worker 后继续无上限分配'
+  );
+  assert.match(
+    diffUtilsSource,
+    /菜单「资产」→「配置文件」/,
+    '源码注释必须记录真实菜单文案：资产 → 配置文件'
+  );
+  assert.match(
+    diffUtilsSource,
+    /页头「配置文件列表」/,
+    '源码注释必须记录真实页头：配置文件列表'
+  );
+  assert.match(
+    diffUtilsSource,
+    /按钮「与上版本对比」/,
+    '源码注释必须记录真实按钮：与上版本对比'
+  );
+  assert.doesNotMatch(diffUtilsSource, /与上一版本对比/);
+  assert.match(
+    diffUtilsSource,
+    /抽屉「版本对比」/,
+    '源码注释必须记录真实抽屉标题：版本对比'
+  );
+
+  assert.match(compareDrawerSource, /kind === 'over_budget'|kind !== 'aligned'/);
+  assert.match(compareDrawerSource, /ConfigFile\.diffOverBudgetHint/);
+  assert.match(
+    compareDrawerSource,
+    /leftContent\.split\(|plainLeftLines|overBudgetLeft/,
+    '超预算必须左右纯文本对照，而不是错误 LCS 对齐'
+  );
+  assert.doesNotMatch(compareDrawerSource, /new Worker|worker_threads/);
+
+  assert.equal(zhLocale.ConfigFile.compareWithPrev, '与上版本对比');
+  assert.equal(zhLocale.ConfigFile.title, '配置文件列表');
+  assert.equal(zhLocale.ConfigFile.versionCompare, '版本对比');
+  assert.equal(
+    typeof zhLocale.ConfigFile.diffOverBudgetHint,
+    'string',
+    '抽屉超预算必须有明确中文提示'
+  );
+  assert.match(
+    zhLocale.ConfigFile.diffOverBudgetHint,
+    /无法.*对齐|原文对照/,
+    '中文提示必须说明无法对齐并改为原文对照'
+  );
+  assert.doesNotMatch(zhLocale.ConfigFile.diffOverBudgetHint, /与上一版本对比/);
+  assert.equal(
+    typeof enLocale.ConfigFile.diffOverBudgetHint,
+    'string',
+    '抽屉超预算必须有明确英文提示'
+  );
+
+  console.log('config-file-diff-budget-test OK');
+}
+
+void main();

--- a/web/src/app/cmdb/(pages)/assetData/detail/configFiles/components/compareDrawer.tsx
+++ b/web/src/app/cmdb/(pages)/assetData/detail/configFiles/components/compareDrawer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useRef } from 'react';
-import { Drawer, Flex, Select, Space, Spin, Tag } from 'antd';
+import { Alert, Drawer, Flex, Select, Space, Spin, Tag } from 'antd';
 import type { ConfigFileItem, ConfigFileVersion } from '@/app/cmdb/types/configFile';
 import { useTranslation } from '@/utils/i18n';
 import { buildSideBySideDiffRows, buildInlineSegments, getDiffAccentClassName } from './diffUtils';
@@ -84,10 +84,14 @@ const CompareDrawer = ({
     [rightVersionId, versionList]
   );
 
-  const diffRows = useMemo(
+  const diffResult = useMemo(
     () => buildSideBySideDiffRows(leftContent, rightContent),
     [leftContent, rightContent]
   );
+  const isOverBudget = diffResult.kind === 'over_budget';
+  const diffRows = diffResult.kind === 'aligned' ? diffResult.rows : [];
+  const plainLeftLines = useMemo(() => leftContent.split(/\r?\n/), [leftContent]);
+  const plainRightLines = useMemo(() => rightContent.split(/\r?\n/), [rightContent]);
 
   const diffRowsWithSegments = useMemo(
     () => diffRows.map((row) => ({
@@ -143,19 +147,29 @@ const CompareDrawer = ({
                 allowClear
               />
             </Space>
-            <Space wrap size={8}>
-              <Tag color="gold">
-                {t('ConfigFile.modified')} {diffSummary.changed}
-              </Tag>
-              <Tag color="green">
-                {t('ConfigFile.added')} {diffSummary.added}
-              </Tag>
-              <Tag color="red">
-                {t('ConfigFile.removed')} {diffSummary.removed}
-              </Tag>
-            </Space>
+            {!isOverBudget && (
+              <Space wrap size={8}>
+                <Tag color="gold">
+                  {t('ConfigFile.modified')} {diffSummary.changed}
+                </Tag>
+                <Tag color="green">
+                  {t('ConfigFile.added')} {diffSummary.added}
+                </Tag>
+                <Tag color="red">
+                  {t('ConfigFile.removed')} {diffSummary.removed}
+                </Tag>
+              </Space>
+            )}
           </Flex>
         </div>
+
+        {isOverBudget && (
+          <Alert
+            type="warning"
+            showIcon
+            message={t('ConfigFile.diffOverBudgetHint')}
+          />
+        )}
 
         <Spin spinning={loading}>
           <div className="grid h-[calc(100vh-220px)] grid-cols-2 gap-4">
@@ -176,7 +190,21 @@ const CompareDrawer = ({
                 onScroll={() => syncScroll('left')}
                 className="min-h-0 flex-1 overflow-auto bg-[#0f172a] px-0 py-3"
               >
-                {diffRowsWithSegments.length ? (
+                {isOverBudget ? (
+                  plainLeftLines.map((line, index) => (
+                    <div
+                      key={`plain-left-${index}`}
+                      className="grid grid-cols-[56px_1fr] text-xs leading-6 text-[#e2e8f0]"
+                    >
+                      <div className="px-3 py-1 text-right font-mono text-[#64748b]">
+                        {index + 1}
+                      </div>
+                      <pre className="overflow-x-auto px-3 py-1 whitespace-pre-wrap break-all border-l-2 border-l-transparent">
+                        {line || ' '}
+                      </pre>
+                    </div>
+                  ))
+                ) : diffRowsWithSegments.length ? (
                   diffRowsWithSegments.map((row) => (
                     <div
                       key={`${row.key}-left`}
@@ -228,7 +256,21 @@ const CompareDrawer = ({
                 onScroll={() => syncScroll('right')}
                 className="min-h-0 flex-1 overflow-auto bg-[#0f172a] px-0 py-3"
               >
-                {diffRowsWithSegments.length ? (
+                {isOverBudget ? (
+                  plainRightLines.map((line, index) => (
+                    <div
+                      key={`plain-right-${index}`}
+                      className="grid grid-cols-[56px_1fr] text-xs leading-6 text-[#e2e8f0]"
+                    >
+                      <div className="px-3 py-1 text-right font-mono text-[#64748b]">
+                        {index + 1}
+                      </div>
+                      <pre className="overflow-x-auto px-3 py-1 whitespace-pre-wrap break-all border-l-2 border-l-transparent">
+                        {line || ' '}
+                      </pre>
+                    </div>
+                  ))
+                ) : diffRowsWithSegments.length ? (
                   diffRowsWithSegments.map((row) => (
                     <div
                       key={`${row.key}-right`}

--- a/web/src/app/cmdb/(pages)/assetData/detail/configFiles/components/diffUtils.ts
+++ b/web/src/app/cmdb/(pages)/assetData/detail/configFiles/components/diffUtils.ts
@@ -12,11 +12,38 @@ export interface DiffSegment {
   changed: boolean;
 }
 
-export const buildSideBySideDiffRows = (leftContent: string, rightContent: string): DiffRow[] => {
+export interface AlignedDiffResult {
+  kind: 'aligned';
+  rows: DiffRow[];
+}
+
+export interface OverBudgetDiffResult {
+  kind: 'over_budget';
+  cellCount: number;
+  maxCells: number;
+}
+
+export type SideBySideDiffResult = AlignedDiffResult | OverBudgetDiffResult;
+
+// 页面入口真实文案：菜单「资产」→「配置文件」；页头「配置文件列表」；按钮「与上版本对比」；抽屉「版本对比」。
+export const MAX_DIFF_LCS_CELLS = 1_000_000;
+
+export const buildSideBySideDiffRows = (
+  leftContent: string,
+  rightContent: string
+): SideBySideDiffResult => {
   const leftLines = leftContent.split(/\r?\n/);
   const rightLines = rightContent.split(/\r?\n/);
   const leftLength = leftLines.length;
   const rightLength = rightLines.length;
+  const cellCount = (leftLength + 1) * (rightLength + 1);
+  if (cellCount > MAX_DIFF_LCS_CELLS) {
+    return {
+      kind: 'over_budget',
+      cellCount,
+      maxCells: MAX_DIFF_LCS_CELLS,
+    };
+  }
   const dp = Array.from({ length: leftLength + 1 }, () => Array(rightLength + 1).fill(0));
 
   for (let leftIndex = leftLength - 1; leftIndex >= 0; leftIndex -= 1) {
@@ -120,7 +147,7 @@ export const buildSideBySideDiffRows = (leftContent: string, rightContent: strin
     rightNumber += 1;
   }
 
-  return rows;
+  return { kind: 'aligned', rows };
 };
 
 export const getDiffAccentClassName = (status: DiffRow['status'], side: 'left' | 'right') => {

--- a/web/src/app/cmdb/locales/en.json
+++ b/web/src/app/cmdb/locales/en.json
@@ -1499,6 +1499,7 @@
         "added": "Added",
         "removed": "Removed",
         "selectVersionHint": "Select two versions to compare",
+        "diffOverBudgetHint": "These two versions have too many lines for row-by-row alignment. Showing original text side by side.",
         "versionNumber": "Version",
         "status": "Status",
         "fileSize": "File Size",

--- a/web/src/app/cmdb/locales/zh.json
+++ b/web/src/app/cmdb/locales/zh.json
@@ -1501,6 +1501,7 @@
         "added": "新增",
         "removed": "删除",
         "selectVersionHint": "请选择两个版本进行对比",
+        "diffOverBudgetHint": "当前两个版本行数过多，无法进行逐行对齐对比，已改为左右原文对照。",
         "versionNumber": "版本号",
         "status": "状态",
         "fileSize": "文件大小",


### PR DESCRIPTION
## 复现步骤

前置：账号能打开 CMDB，且当前资产模型会显示 **配置文件** 子菜单。准备两份各约 20,000 行、内容不同的文本配置。

1. 进入 CMDB 左侧菜单 **资产**，打开该资产详情。
2. 点子菜单 **配置文件**。页头是 **配置文件列表**。
3. 点 **手动上传**，为同一合法绝对路径上传第一个成功版本；再上传第二个内容不同的成功版本。
4. 展开该文件的版本列表，点 **与上版本对比**（不是「与上一版本对比」）。
5. 右侧打开抽屉 **版本对比**，确认左右已选中这两个版本。

修复前：抽屉首次计算会同步分配约 `(20001)×(20001)` 的 LCS 矩阵（约 4 亿单元），整个控制台标签页长时间无响应，可能耗尽内存。  
修复后：超过 100 万矩阵单元时不再跑完整 LCS。抽屉顶部提示「当前两个版本行数过多，无法进行逐行对齐对比，已改为左右原文对照。」，左右显示原文。小文件仍走原来的增删改对齐。

## 修复方案

给并排对比加上命名常量 `MAX_DIFF_LCS_CELLS = 1_000_000`，按 `(行数+1)×(行数+1)` 计。

- 未超预算：继续现有 LCS，增删改、CRLF、空文件、重复行、行内高亮不变。
- 超预算：返回明确的 `over_budget`，不分配乘积矩阵，不静默返回错误对齐，也不把完整矩阵丢进 Worker。
- **版本对比** 抽屉展示警告，并左右纯文本对照；修改/新增/删除计数在超预算时不显示，避免假装已对齐。

Fixes #5228

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 约 2 万行 × 2 万行点 **与上版本对比** | 同步分配约 4 亿矩阵单元，标签页卡死 | 1 秒内进入原文对照，有明确提示 |
| 小文件增删改、CRLF、空文件、重复行 | LCS 对齐 | 对齐结果不变 |
| 超预算时的修改/新增/删除标签 | 可能算完才显示，或一直转圈 | 不显示对齐计数，避免误导 |

## 影响面

- **会变**：仅资产详情 **配置文件** → **与上版本对比** → **版本对比**。超预算时不再做逐行对齐高亮。
- **不变**：手动上传、内容拉取、5 MiB 截断、权限、API 字段、历史版本数据。
- **未改**：Storybook 里另有一份 `cmdb-config-file-compare-drawer` 演示组件，不是这条产品入口。
- **不在范围**：配置采集任务、文件内容抽屉、后端 diff。
