### PR TITLE
fix(监控): 恢复主机仪表盘 KPI 查询能力清单

### DIFF
--- a/server/apps/monitor/support-files/dashboard_query_capabilities.json
+++ b/server/apps/monitor/support-files/dashboard_query_capabilities.json
@@ -191,6 +191,13 @@
       "template": "rate(elasticsearch_http_total_opened{__$labels__}[__$window__])"
     },
     {
+      "id": "dashboard:v1:06e5913a",
+      "object_names": [
+        "MSSQL"
+      ],
+      "template": "rate(sqlserver_waitstats_signal_wait_time_ms_rate{__$labels__}[__$window__])"
+    },
+    {
       "id": "dashboard:v1:077cf7a3",
       "object_names": [
         "Ping"
@@ -779,6 +786,13 @@
         "Mysql"
       ],
       "template": "mysql_variables_max_connections{__$labels__}"
+    },
+    {
+      "id": "dashboard:v1:1d08f9aa",
+      "object_names": [
+        "Host"
+      ],
+      "template": "max by (instance_id) (disk_used_percent{instance_type=\"os\", __$labels__} or host_disk_used_percent_gauge{instance_type=\"os\", __$labels__} or disk_used_percent_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__} or disk_used_percent_gauge{instance_type=\"os\", config_type=\"host_aix_remote\", __$labels__})"
     },
     {
       "id": "dashboard:v1:1d131c0f",
@@ -2272,13 +2286,6 @@
       "template": "sum(rate(docker_container_net_rx_bytes{__$labels__}[__$window__])) by (instance_id)"
     },
     {
-      "id": "dashboard:v1:5ac524f2",
-      "object_names": [
-        "Host"
-      ],
-      "template": "mem_used_percent{instance_type=\"os\", __$labels__} or host_mem_used_percent_gauge{instance_type=\"os\", __$labels__} or mem_used_percent_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}"
-    },
-    {
       "id": "dashboard:v1:5addc434",
       "object_names": [
         "Cluster"
@@ -2847,6 +2854,20 @@
       "template": "clamp_max(100 * (docker_n_containers_stopped{__$labels__} / clamp_min(docker_n_containers{__$labels__}, 1)), 100)"
     },
     {
+      "id": "dashboard:v1:75766335",
+      "object_names": [
+        "Host"
+      ],
+      "template": "sum by (instance_id) (rate(diskio_write_bytes{instance_type=\"os\", __$labels__}[__$window__]) or rate(diskio_write_bytes_total_gauge{instance_type=\"os\", config_type!~\"host_aix.*\", __$labels__}[__$window__]) or rate(diskio_write_bytes_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}[__$window__]) or diskio_write_bytes_gauge{instance_type=\"os\", config_type=\"host_aix_remote\", __$labels__})"
+    },
+    {
+      "id": "dashboard:v1:75cd4c37",
+      "object_names": [
+        "Host"
+      ],
+      "template": "sum by (instance_id) (rate(diskio_read_bytes{instance_type=\"os\", __$labels__}[__$window__]) or rate(diskio_read_bytes_total_gauge{instance_type=\"os\", config_type!~\"host_aix.*\", __$labels__}[__$window__]) or rate(diskio_read_bytes_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}[__$window__]) or diskio_read_bytes_gauge{instance_type=\"os\", config_type=\"host_aix_remote\", __$labels__})"
+    },
+    {
       "id": "dashboard:v1:76ff4618",
       "object_names": [
         "Exchange"
@@ -3338,13 +3359,6 @@
         "Mysql"
       ],
       "template": "rate(mysql_queries{__$labels__}[__$window__])"
-    },
-    {
-      "id": "dashboard:v1:8ab7d7ad",
-      "object_names": [
-        "MSSQL"
-      ],
-      "template": "rate(sqlserver_waitstats_signal_wait_time_ms{__$labels__}[__$window__])"
     },
     {
       "id": "dashboard:v1:8ae3b991",
@@ -3944,13 +3958,6 @@
       "template": "zookeeper_max_latency{__$labels__}"
     },
     {
-      "id": "dashboard:v1:a5c1faa5",
-      "object_names": [
-        "Host"
-      ],
-      "template": "sum by (instance_id) (rate(diskio_read_bytes{instance_type=\"os\", __$labels__}[__$window__]) or rate(diskio_read_bytes_total_gauge{instance_type=\"os\", __$labels__}[__$window__]) or rate(diskio_read_bytes_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}[__$window__]))"
-    },
-    {
       "id": "dashboard:v1:a6041c1a",
       "object_names": [
         "Firewall"
@@ -4219,6 +4226,13 @@
       "template": "rate(mysql_com_select{__$labels__}[__$window__])"
     },
     {
+      "id": "dashboard:v1:b4e40a82",
+      "object_names": [
+        "Host"
+      ],
+      "template": "mem_used_percent{instance_type=\"os\", __$labels__} or host_mem_used_percent_gauge{instance_type=\"os\", __$labels__} or mem_used_percent_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__} or mem_used_percent_gauge{instance_type=\"os\", config_type=\"host_aix_remote\", __$labels__}"
+    },
+    {
       "id": "dashboard:v1:b5430b18",
       "object_names": [
         "Minio"
@@ -4322,13 +4336,6 @@
         "Cluster"
       ],
       "template": "sum(prometheus_remote_write_kube_pod_status_phase{instance_type=\"k8s\",__$labels__}) by (phase)"
-    },
-    {
-      "id": "dashboard:v1:b8277ee6",
-      "object_names": [
-        "Host"
-      ],
-      "template": "(100 - cpu_usage_idle{cpu=\"cpu-total\", instance_type=\"os\", __$labels__}) or host_cpu_usage_percent_gauge{instance_type=\"os\", __$labels__} or cpu_usage_total_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}"
     },
     {
       "id": "dashboard:v1:b8440293",
@@ -4884,6 +4891,13 @@
       "template": "100 * mysql_innodb_buffer_pool_pages_dirty{__$labels__} / clamp_min(mysql_innodb_buffer_pool_pages_total{__$labels__}, 1)"
     },
     {
+      "id": "dashboard:v1:cf22232a",
+      "object_names": [
+        "Host"
+      ],
+      "template": "(100 - cpu_usage_idle{cpu=\"cpu-total\", instance_type=\"os\", __$labels__}) or host_cpu_usage_percent_gauge{instance_type=\"os\", __$labels__} or cpu_usage_total_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__} or cpu_usage_total_gauge{instance_type=\"os\", config_type=\"host_aix_remote\", __$labels__}"
+    },
+    {
       "id": "dashboard:v1:cf85f24a",
       "object_names": [
         "Docker"
@@ -5339,25 +5353,11 @@
       "template": "sum(rate(interface_ifInErrors{__$labels__}[__$window__])) by (instance_id)"
     },
     {
-      "id": "dashboard:v1:e4e0cd2a",
-      "object_names": [
-        "Host"
-      ],
-      "template": "max by (instance_id) (disk_used_percent{instance_type=\"os\", __$labels__} or host_disk_used_percent_gauge{instance_type=\"os\", __$labels__} or disk_used_percent_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__})"
-    },
-    {
       "id": "dashboard:v1:e54bf04a",
       "object_names": [
         "Website"
       ],
       "template": "avg(http_response_result_code{__$labels__} == bool 2) * 100"
-    },
-    {
-      "id": "dashboard:v1:e5c19424",
-      "object_names": [
-        "Host"
-      ],
-      "template": "sum by (instance_id) (rate(diskio_write_bytes{instance_type=\"os\", __$labels__}[__$window__]) or rate(diskio_write_bytes_total_gauge{instance_type=\"os\", __$labels__}[__$window__]) or rate(diskio_write_bytes_gauge_value{instance_type=\"os\", config_type=\"windows_wmi\", __$labels__}[__$window__]))"
     },
     {
       "id": "dashboard:v1:e5e98cdd",


### PR DESCRIPTION
## Summary
- 修复主机监控仪表盘健康概览 CPU/内存/磁盘使用率主值显示 `--`（CentOS 与 AIX 均受影响）。
- 根因：`d260ff35f2` 裁剪 K8s 清单时误把 Host AIX 相关 capability 回退为旧模板，前端仍发送新 `capability_id`，后端返回 `capability_not_found`。
- 重新生成并恢复 `dashboard_query_capabilities.json` 中的 Host KPI（及 diskio）capability 条目。

## Scope check
- 本次 PR 仅包含 `server/apps/monitor/support-files/dashboard_query_capabilities.json`。
- 未纳入测试文件、图标、其他工作区改动。

## Test plan
- [x] `pnpm test:monitor-query-capabilities`（838 capabilities verified）
- [x] Host 主 KPI capability id `cf22232a` / `b4e40a82` / `1d08f9aa` 已在 manifest，且含 `host_aix_remote`
- [x] 后端 `build_dashboard_query` 可渲染上述三张 KPI
- [ ] 部署后打开主机仪表盘，确认 CPU/内存/磁盘主值恢复；footer 子指标保持正常