### PR TITLE
bugfix: 资产关系拓扑按层级索引查找节点

### DIFF
--- a/web/scripts/cmdb-topo-level-index-test.ts
+++ b/web/scripts/cmdb-topo-level-index-test.ts
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  buildFirstLevelIndex,
+  lookupFirstLevel,
+  resolveTopoEdgeEndpoints,
+  type LevelNodes,
+} from '../src/app/cmdb/(pages)/assetData/detail/relationships/topoLevelIndex.ts';
+
+const webRoot = process.cwd();
+const topoDataPath = path.join(
+  webRoot,
+  'src/app/cmdb/(pages)/assetData/detail/relationships/topoData.tsx'
+);
+const pagePath = path.join(
+  webRoot,
+  'src/app/cmdb/(pages)/assetData/detail/relationships/page.tsx'
+);
+const menuPath = path.join(webRoot, 'src/app/cmdb/constants/menu.json');
+const localePath = path.join(webRoot, 'src/app/cmdb/locales/zh.json');
+
+const topoDataSource = fs.readFileSync(topoDataPath, 'utf8');
+const pageSource = fs.readFileSync(pagePath, 'utf8');
+const menuSource = fs.readFileSync(menuPath, 'utf8');
+const localeSource = fs.readFileSync(localePath, 'utf8');
+
+assert.match(menuSource, /"title": "资产"/);
+assert.match(menuSource, /"title": "关联关系"/);
+assert.match(localeSource, /"topo": "拓扑"/);
+assert.match(pageSource, /t\('topo'\)/);
+assert.match(pageSource, /activeTab === 'topo'/);
+
+const createNodesAndEdgesMatch = topoDataSource.match(
+  /const createNodesAndEdges = \([\s\S]*?\n  \};/
+);
+assert.ok(createNodesAndEdgesMatch, 'createNodesAndEdges must exist');
+const createNodesAndEdgesSource = createNodesAndEdgesMatch[0];
+
+assert.doesNotMatch(
+  createNodesAndEdgesSource,
+  /Object\.keys\(levelNodes\)\.find/,
+  'createNodesAndEdges must not scan levelNodes with Object.keys().find for each id'
+);
+assert.doesNotMatch(
+  createNodesAndEdgesSource,
+  /levelNodes\[.*\]\?\.some\(\(n\) => n\.id === id\)/,
+  'createNodesAndEdges must not scan a level array with some() for each id'
+);
+assert.match(
+  topoDataSource,
+  /from ['"]\.\/topoLevelIndex['"]/,
+  'topoData must import the extracted level index'
+);
+assert.match(
+  createNodesAndEdgesSource,
+  /lookupFirstLevel\(|levelIndex\.get\(/,
+  'createNodesAndEdges must query the Map instead of scanning levelNodes'
+);
+
+const emptyIndex = buildFirstLevelIndex({});
+assert.equal(emptyIndex.size, 0);
+assert.equal(lookupFirstLevel(emptyIndex, 'missing'), undefined);
+
+const emptyStats = { comparisons: 0 };
+assert.equal(lookupFirstLevel(emptyIndex, 'root', emptyStats), undefined);
+assert.equal(emptyStats.comparisons, 1);
+
+const duplicateLevelNodes: LevelNodes = {
+  1: [{ id: 'root', parentId: null }],
+  3: [{ id: 'dup', parentId: 'other' }],
+  2: [
+    { id: 'dup', parentId: 'root' },
+    { id: 'leaf', parentId: 'dup' },
+  ],
+};
+const duplicateIndex = buildFirstLevelIndex(duplicateLevelNodes);
+assert.equal(duplicateIndex.get('root'), 1);
+assert.equal(duplicateIndex.get('dup'), 2);
+assert.equal(duplicateIndex.get('leaf'), 2);
+assert.equal(lookupFirstLevel(duplicateIndex, 'dup'), 2);
+
+assert.deepEqual(resolveTopoEdgeEndpoints('src', 'child', 'parent'), {
+  source: 'parent',
+  target: 'child',
+});
+assert.deepEqual(resolveTopoEdgeEndpoints('dst', 'child', 'parent'), {
+  source: 'child',
+  target: 'parent',
+});
+assert.match(
+  createNodesAndEdgesSource,
+  /resolveTopoEdgeEndpoints\(|type === ["']src["'] \? parentId : id/,
+  'src/dst edge direction must stay parent→child for src and child→parent for dst'
+);
+
+const assertLinearLookups = (size: number) => {
+  const levelNodes: LevelNodes = {
+    1: [{ id: 'root', parentId: null }],
+    2: Array.from({ length: size }, (_, index) => ({
+      id: `n${index}`,
+      parentId: 'root',
+    })),
+  };
+  const index = buildFirstLevelIndex(levelNodes);
+  const stats = { comparisons: 0 };
+  assert.equal(lookupFirstLevel(index, 'root', stats), 1);
+  for (let i = 0; i < size; i += 1) {
+    assert.equal(lookupFirstLevel(index, `n${i}`, stats), 2);
+  }
+  const lookupCount = size + 1;
+  assert.equal(
+    stats.comparisons,
+    lookupCount,
+    `${size} same-layer lookups must stay linear (1 Map get per id), got ${stats.comparisons}`
+  );
+  assert.ok(
+    stats.comparisons <= lookupCount,
+    `${size} same-layer lookups must not rescan the layer array`
+  );
+};
+
+assertLinearLookups(100);
+assertLinearLookups(1000);
+
+console.log('cmdb topo level index behavior OK');
+console.log('页面入口：菜单「资产」→「关联关系」；页签「拓扑」');

--- a/web/src/app/cmdb/(pages)/assetData/detail/relationships/topoData.tsx
+++ b/web/src/app/cmdb/(pages)/assetData/detail/relationships/topoData.tsx
@@ -5,6 +5,11 @@ import { useGraphStore, useGraphInstance } from '@antv/xflow';
 import { TopoDataProps, NodeData } from '@/app/cmdb/types/assetData';
 import { registerReverseCurveConnector } from '@/app/cmdb/utils/reverse_curve';
 import { useInstanceApi } from '@/app/cmdb/api';
+import {
+  buildFirstLevelIndex,
+  lookupFirstLevel,
+  resolveTopoEdgeEndpoints,
+} from './topoLevelIndex';
 
 const CONFIG = {
   verticalGap: 100,
@@ -602,13 +607,7 @@ export const InitNode: React.FC<TopoDataProps> = ({
     type: string,
     node: NodeData,
     parentId: string | null,
-    levelNodes: {
-      [key: number]: Array<{
-        id: string;
-        parentId: string | null;
-        node: NodeData;
-      }>;
-    },
+    levelIndex: Map<string, number>,
     nodePositions: { [key: string]: { x: number; y: number } },
     isSrc: boolean,
     nodes: any[],
@@ -625,10 +624,7 @@ export const InitNode: React.FC<TopoDataProps> = ({
 
     if (!position) return;
 
-    const level = Object.keys(levelNodes).find((lvl) =>
-      levelNodes[Number(lvl)]?.some((n) => n.id === id)
-    );
-    const currentLevel = Number(level);
+    const currentLevel = Number(lookupFirstLevel(levelIndex, id));
     const isExpanded = currentLevel < CONFIG.maxExpandedLevel;
     const hasLeftBtn = (currentLevel === 1 && hasSrc) || (currentLevel !== 1 && isSrc && has_more)
     const hasRightBtn = (currentLevel === 1 && hasDst) || (currentLevel !== 1 && !isSrc && has_more) || node.has_more;
@@ -696,10 +692,11 @@ export const InitNode: React.FC<TopoDataProps> = ({
     // 如果父节点存在且父节点不是回退节点，则创建边
     if (parentId) {
       // type为当前节点类型（src或dst）
+      const { source, target } = resolveTopoEdgeEndpoints(type, id, parentId);
       edges.push({
         // 设置源节点和目标节点
-        source: type === "src" ? parentId : id,
-        target: type === "dst" ? parentId : id,
+        source,
+        target,
         attrs: {
           line: { stroke: 'var(--color-border-3)', strokeWidth: 1 },
         },
@@ -724,7 +721,7 @@ export const InitNode: React.FC<TopoDataProps> = ({
           type,
           child,
           id,
-          levelNodes,
+          levelIndex,
           nodePositions,
           isSrc,
           nodes,
@@ -751,12 +748,13 @@ export const InitNode: React.FC<TopoDataProps> = ({
     } = {};
 
     collectLevelInfo(data, null, 1, levelNodes);
+    const levelIndex = buildFirstLevelIndex(levelNodes);
     calculateNodePosition(levelNodes, nodePositions, isSrc);
     createNodesAndEdges(
       type,
       data,
       null,
-      levelNodes,
+      levelIndex,
       nodePositions,
       isSrc,
       nodes,

--- a/web/src/app/cmdb/(pages)/assetData/detail/relationships/topoLevelIndex.ts
+++ b/web/src/app/cmdb/(pages)/assetData/detail/relationships/topoLevelIndex.ts
@@ -1,0 +1,54 @@
+export interface LevelNodeItem {
+  id: string;
+  parentId: string | null;
+}
+
+export interface LevelNodes {
+  [level: number]: LevelNodeItem[];
+}
+
+export interface LookupStats {
+  comparisons: number;
+}
+
+export function buildFirstLevelIndex(levelNodes: LevelNodes): Map<string, number> {
+  const index = new Map<string, number>();
+  const levels = Object.keys(levelNodes)
+    .map(Number)
+    .filter((level) => Number.isFinite(level))
+    .sort((a, b) => a - b);
+
+  for (const level of levels) {
+    const nodes = levelNodes[level];
+    if (!nodes) continue;
+    for (const item of nodes) {
+      if (!index.has(item.id)) {
+        index.set(item.id, level);
+      }
+    }
+  }
+
+  return index;
+}
+
+export function lookupFirstLevel(
+  index: Map<string, number>,
+  id: string,
+  stats?: LookupStats
+): number | undefined {
+  if (stats) {
+    stats.comparisons += 1;
+  }
+  return index.get(id);
+}
+
+export function resolveTopoEdgeEndpoints(
+  type: string,
+  id: string,
+  parentId: string
+): { source: string; target: string } {
+  return {
+    source: type === 'src' ? parentId : id,
+    target: type === 'dst' ? parentId : id,
+  };
+}


### PR DESCRIPTION
## 复现步骤

前置：账号能打开 CMDB，准备一个同层关联较多的资产实例。

1. 进入 CMDB 左侧菜单 **资产**，打开该资产详情。
2. 点子菜单 **关联关系**。顶部 Segmented 默认可能是 **列表**。
3. 切到 **拓扑**。
4. 等图完成初次节点转换。关联越多，修复前主线程卡顿越明显。

修复前：`collectLevelInfo` 已经按层收好节点，`createNodesAndEdges` 仍对每个节点 `Object.keys(levelNodes).find` 再 `some` 扫一层。同层 m 个关联时，仅找层级就接近平方次 ID 比较。  
修复后：按层序建一次 `Map<uuid, 首次出现的最低层>`，每个节点 O(1) 查询。重复 UUID 仍取最低层；左右方向和边标签不变。

## 修复方案

抽出 `buildFirstLevelIndex` / `lookupFirstLevel`。只在第一次遇见 UUID 时写入，层号按数值从小到大，与原来 `Object.keys().find` 的最低层优先一致。`createNodesAndEdges` 不再扫描 `levelNodes`。

不改拓扑接口、`depth=3`、权限和图引擎。

Fixes #5233

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 打开 **拓扑**，同层关联很多 | 每个节点重扫全部层级数组 | 先建索引，每个 UUID 查一次 Map |
| 同一 UUID 出现在不同层 | `find` 取最低层 | 仍取最低层 |
| src / dst 边方向 | 源端 parent→child，目标端 child→parent | 不变 |

## 影响面

- **会变**：仅资产详情 **关联关系** → **拓扑** 的初始化查找成本。图的位置、展开按钮、边方向不因这次索引改动而变。
- **不变**：列表页签、网络拓扑、应用资源总览、后端 `topo_search`、权限剪枝。
- **未改**：展开后再补节点的路径不走这套初始化索引。
- **不在范围**：机柜视图、机房布局。
