### PR TITLE
feat(监控): 阿里云接入支持按密钥拉取地域后单选

### DIFF
--- a/server/apps/monitor/services/aliyun_regions.py
+++ b/server/apps/monitor/services/aliyun_regions.py
@@ -1,0 +1,100 @@
+"""阿里云监控接入：按账号密钥动态查询可用地域。"""
+
+from __future__ import annotations
+
+from apps.core.exceptions.base_app_exception import ValidationAppException
+from apps.core.logger import monitor_logger as logger
+from apps.monitor.services.qcloud_regions import _resolve_stargazer_cloud_name
+from apps.rpc.stargazer import Stargazer
+
+
+def _normalize_aliyun_regions(regions: list) -> list[dict]:
+    normalized = []
+    for region in regions or []:
+        if not isinstance(region, dict):
+            continue
+        resource_id = (
+            region.get("resource_id")
+            or region.get("RegionId")
+            or region.get("Region")
+            or ""
+        )
+        resource_name = (
+            region.get("resource_name")
+            or region.get("LocalName")
+            or resource_id
+        )
+        resource_id = str(resource_id or "").strip()
+        if not resource_id:
+            continue
+        state = str(
+            region.get("status") or region.get("RegionStatus") or region.get("RegionState") or ""
+        ).strip().lower()
+        if state and state not in ("available", "avail"):
+            continue
+        normalized.append(
+            {
+                "label": str(resource_name or resource_id),
+                "value": resource_id,
+                "resource_id": resource_id,
+                "resource_name": str(resource_name or resource_id),
+            }
+        )
+    return normalized
+
+
+class AliyunRegionService:
+    @classmethod
+    def list_regions(
+        cls,
+        *,
+        username: str,
+        password: str,
+        cloud_region_id=None,
+    ) -> list[dict]:
+        access_key = str(username or "").strip()
+        access_secret = str(password or "").strip()
+        if not access_key or not access_secret:
+            raise ValidationAppException("AccessKey ID 与 AccessKey Secret 均必填")
+
+        cloud_name = _resolve_stargazer_cloud_name(cloud_region_id)
+        instance_id = f"{cloud_name}_stargazer"
+        credential = {
+            "model_id": "aliyun",
+            "secret_id": access_key,
+            "secret_key": access_secret,
+        }
+
+        try:
+            result = Stargazer(instance_id=instance_id).list_regions(credential)
+        except Exception as exc:
+            logger.error(
+                "event=aliyun_list_regions_rpc_failed failed_stage=stargazer_list_regions "
+                "cloud_name=%s error_type=%s",
+                cloud_name,
+                type(exc).__name__,
+                exc_info=True,
+            )
+            raise ValidationAppException("获取阿里云地域失败，请检查 Stargazer 是否就绪") from exc
+
+        if not isinstance(result, dict):
+            raise ValidationAppException("获取阿里云地域失败")
+
+        if result.get("success") is False:
+            message = result.get("error") or result.get("message") or "获取阿里云地域失败"
+            raise ValidationAppException(str(message))
+
+        regions_payload = result.get("regions") or {}
+        if not isinstance(regions_payload, dict):
+            if isinstance(regions_payload, list):
+                return _normalize_aliyun_regions(regions_payload)
+            raise ValidationAppException("获取阿里云地域失败")
+
+        if regions_payload.get("success") is False:
+            message = regions_payload.get("message") or result.get("error") or "获取阿里云地域失败"
+            raise ValidationAppException(str(message))
+
+        raw_regions = regions_payload.get("result")
+        if raw_regions is None and isinstance(result.get("result"), list):
+            raw_regions = result.get("result")
+        return _normalize_aliyun_regions(raw_regions or [])

--- a/server/apps/monitor/utils/plugin_controller.py
+++ b/server/apps/monitor/utils/plugin_controller.py
@@ -211,6 +211,20 @@ def ensure_qcloud_region_jinja(template_content: str) -> str:
     return text[: password_line.end()] + "\n" + insertion + text[password_line.end() :]
 
 
+def _plugin_types(context: dict) -> set[str]:
+    types = {
+        str(context.get("instance_type") or "").strip().lower(),
+        str(context.get("type") or "").strip().lower(),
+    }
+    config_type = context.get("config_type")
+    if isinstance(config_type, (list, tuple)):
+        types.update(str(item).strip().lower() for item in config_type)
+    elif config_type not in (None, ""):
+        types.add(str(config_type).strip().lower())
+    types.discard("")
+    return types
+
+
 def _normalize_qcloud_region(value) -> str:
     """表单多选为列表，Telegraf header 为逗号串；空值回落广州。"""
     if isinstance(value, (list, tuple)):
@@ -218,6 +232,17 @@ def _normalize_qcloud_region(value) -> str:
     else:
         parts = [item.strip() for item in str(value or "").split(",") if item.strip()]
     return ",".join(parts) or "ap-guangzhou"
+
+
+def _normalize_aliyun_region(value) -> str:
+    """阿里云监控一配置一地域；表单若误传列表则取第一项，空值回落杭州。"""
+    if isinstance(value, (list, tuple)):
+        parts = [str(item).strip() for item in value if str(item).strip()]
+        return parts[0] if parts else "cn-hangzhou"
+    text = str(value or "").strip()
+    if "," in text:
+        text = text.split(",", 1)[0].strip()
+    return text or "cn-hangzhou"
 
 
 def _normalize_template_context(context: dict) -> dict:
@@ -234,11 +259,12 @@ def _normalize_template_context(context: dict) -> dict:
     normalized["ports"] = normalize_filter_list(normalized.get("ports"))
     if _is_rabbitmq_collect_config(normalized) and normalized.get("url") not in (None, ""):
         normalized["url"] = normalize_rabbitmq_management_url(normalized.get("url"))
+    plugin_types = _plugin_types(normalized)
     # 腾讯云地域：表单未填时回落广州，与 Stargazer 采集缺省一致。
-    if str(normalized.get("instance_type") or normalized.get("config_type") or "").lower() == "qcloud":
+    if "qcloud" in plugin_types:
         normalized["region"] = _normalize_qcloud_region(normalized.get("region"))
-    elif str(normalized.get("type") or "").lower() == "qcloud":
-        normalized["region"] = _normalize_qcloud_region(normalized.get("region"))
+    elif "aliyun" in plugin_types:
+        normalized["region"] = _normalize_aliyun_region(normalized.get("region"))
     return normalized
 
 

--- a/server/apps/monitor/views/plugin.py
+++ b/server/apps/monitor/views/plugin.py
@@ -15,6 +15,7 @@ from apps.monitor.serializers.plugin import MonitorPluginListSerializer, Monitor
 from apps.monitor.services.custom_snmp_plugin import CustomSnmpPluginService
 from apps.monitor.services.plugin import MonitorPluginService
 from apps.monitor.services.plugin_guide import PluginGuideService
+from apps.monitor.services.aliyun_regions import AliyunRegionService
 from apps.monitor.services.qcloud_regions import QCloudRegionService
 from apps.monitor.services.template_access_guide import TemplateAccessGuideService
 from apps.monitor.utils.pagination import parse_page_params
@@ -382,6 +383,32 @@ class MonitorPluginViewSet(viewsets.ModelViewSet):
         cloud_region_id = payload.get("cloud_region_id")
         try:
             regions = QCloudRegionService.list_regions(
+                username=username,
+                password=password,
+                cloud_region_id=cloud_region_id,
+            )
+        except ValidationAppException as exc:
+            return WebUtils.response_error(error_message=str(exc), status_code=400)
+        except BaseAppException as exc:
+            return WebUtils.response_error(error_message=str(exc), status_code=400)
+        return WebUtils.response_success(regions)
+
+    @action(methods=["post"], detail=False, url_path="aliyun_regions")
+    @HasPermission("integration_configure-Add,integration_list-View")
+    def aliyun_regions(self, request):
+        """按阿里云账号密钥动态拉取可用地域（DescribeRegions）。"""
+        payload = request.data if isinstance(request.data, dict) else {}
+        username = payload.get("username") or payload.get("access_key") or payload.get("secret_id") or ""
+        password = (
+            payload.get("password")
+            or payload.get("ENV_PASSWORD")
+            or payload.get("access_secret")
+            or payload.get("secret_key")
+            or ""
+        )
+        cloud_region_id = payload.get("cloud_region_id")
+        try:
+            regions = AliyunRegionService.list_regions(
                 username=username,
                 password=password,
                 cloud_region_id=cloud_region_id,

--- a/web/src/app/monitor/(pages)/integration/asset/updateConfig.tsx
+++ b/web/src/app/monitor/(pages)/integration/asset/updateConfig.tsx
@@ -14,7 +14,7 @@ import { useTranslation } from '@/utils/i18n';
 import OperateModal from '@/components/operate-modal';
 import useApiClient from '@/utils/request';
 import { usePluginFromJson } from '@/app/monitor/hooks/integration/usePluginFromJson';
-import { useQcloudRegionOptions } from '@/app/monitor/hooks/integration/useQcloudRegionOptions';
+import { cloudRegionProviderFromPlugin, useCloudRegionOptions } from '@/app/monitor/hooks/integration/useQcloudRegionOptions';
 import {
   getSnmpFilterMutexConflicts,
   trackSnmpFilterMutexLastChanged
@@ -82,21 +82,14 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
   }));
 
   // 获取配置信息
-  const isQcloudPlugin =
-    currentConfig?.instance_type === 'qcloud' ||
-    (Array.isArray(currentConfig?.config_type) &&
-      currentConfig.config_type.includes('qcloud')) ||
-    Boolean(
-      currentConfig?.form_fields?.some(
-        (field) => field?.options_key === 'region_option' || field?.name === 'region'
-      )
-    );
+  const regionProvider = cloudRegionProviderFromPlugin(currentConfig);
   const {
     regionOptions,
     loadingRegions,
     refreshRegions,
-  } = useQcloudRegionOptions({
-    enabled: Boolean(isQcloudPlugin && modalVisible),
+  } = useCloudRegionOptions({
+    enabled: Boolean(regionProvider && modalVisible),
+    provider: regionProvider || 'qcloud',
     form,
   });
 

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
@@ -41,7 +41,7 @@ import Permission from '@/components/permission';
 import { cloneDeep } from 'lodash';
 import { usePluginFromJson } from '@/app/monitor/hooks/integration/usePluginFromJson';
 import { useConfigRenderer } from '@/app/monitor/hooks/integration/useConfigRenderer';
-import { useQcloudRegionOptions } from '@/app/monitor/hooks/integration/useQcloudRegionOptions';
+import { cloudRegionProviderFromPlugin, useCloudRegionOptions } from '@/app/monitor/hooks/integration/useQcloudRegionOptions';
 import {
   getSnmpFilterMutexConflicts,
   trackSnmpFilterMutexLastChanged
@@ -234,22 +234,14 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
     return currentConfig;
   }, [configLoading, currentConfig]);
 
-  const isQcloudPlugin =
-    baseConfig?.instance_type === 'qcloud' ||
-    (Array.isArray(baseConfig?.config_type) &&
-      baseConfig.config_type.includes('qcloud')) ||
-    Boolean(
-      baseConfig?.form_fields?.some(
-        (field: { name?: string; options_key?: string }) =>
-          field?.options_key === 'region_option' || field?.name === 'region'
-      )
-    );
+  const regionProvider = cloudRegionProviderFromPlugin(baseConfig);
   const {
     regionOptions,
     loadingRegions,
     refreshRegions,
-  } = useQcloudRegionOptions({
-    enabled: Boolean(isQcloudPlugin),
+  } = useCloudRegionOptions({
+    enabled: Boolean(regionProvider),
+    provider: regionProvider || 'qcloud',
     form,
   });
 

--- a/web/src/app/monitor/api/integration.ts
+++ b/web/src/app/monitor/api/integration.ts
@@ -283,6 +283,13 @@ const useIntegrationApi = () => {
       }) => {
         return await post('/monitor/api/monitor_plugin/qcloud_regions/', data);
       },
+      listAliyunRegions: async (data: {
+        username: string;
+        password: string;
+        cloud_region_id?: number | string;
+      }) => {
+        return await post('/monitor/api/monitor_plugin/aliyun_regions/', data);
+      },
     } satisfies FlowIntegrationApi),
     [del, get, post, put]
   );

--- a/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
+++ b/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
@@ -473,7 +473,7 @@ export const useConfigRenderer = () => {
                 {...selectProps}
                 placeholder={
                   selectProps.placeholder ||
-                  t('monitor.integrations.selectQcloudRegion', '请选择腾讯云地域')
+                  t('monitor.integrations.selectCloudRegion', '请选择地域')
                 }
                 notFoundContent={
                   regionLoading ? (
@@ -481,26 +481,26 @@ export const useConfigRenderer = () => {
                       <Spin size="small" />
                       <span>
                         {t(
-                          'monitor.integrations.fetchingQcloudRegions',
+                          'monitor.integrations.fetchingCloudRegions',
                           '正在获取地域…'
                         )}
                       </span>
                     </div>
                   ) : (
                     t(
-                      'monitor.integrations.qcloudRegionNoOptions',
+                      'monitor.integrations.cloudRegionNoOptions',
                       '暂无地域，请先填写密钥后点击刷新'
                     )
                   )
                 }
                 onRefresh={optionControl.onRefresh}
                 refreshLabel={t(
-                  'monitor.integrations.fetchQcloudRegions',
+                  'monitor.integrations.fetchCloudRegions',
                   '获取地域'
                 )}
                 refreshTip={t(
-                  'monitor.integrations.refreshQcloudRegionsTip',
-                  '根据 SecretId / SecretKey 刷新可用地域'
+                  'monitor.integrations.refreshCloudRegionsTip',
+                  '根据已填密钥刷新可用地域'
                 )}
                 regionLoading={regionLoading}
               >

--- a/web/src/app/monitor/hooks/integration/useQcloudRegionOptions.ts
+++ b/web/src/app/monitor/hooks/integration/useQcloudRegionOptions.ts
@@ -5,6 +5,25 @@ import useIntegrationApi from '@/app/monitor/api/integration';
 
 const MASKED_PASSWORD_RE = /^\*+$/;
 
+export type CloudRegionProvider = 'qcloud' | 'aliyun';
+
+export function cloudRegionProviderFromPlugin(config?: {
+  instance_type?: string;
+  config_type?: string | string[];
+} | null): CloudRegionProvider | null {
+  if (!config) return null;
+  const types = new Set<string>();
+  if (config.instance_type) types.add(String(config.instance_type).toLowerCase());
+  if (Array.isArray(config.config_type)) {
+    for (const item of config.config_type) types.add(String(item).toLowerCase());
+  } else if (config.config_type) {
+    types.add(String(config.config_type).toLowerCase());
+  }
+  if (types.has('aliyun')) return 'aliyun';
+  if (types.has('qcloud')) return 'qcloud';
+  return null;
+}
+
 export interface RegionOption {
   label: string;
   value: string;
@@ -28,21 +47,58 @@ function regionSelection(value: unknown): string[] {
   return [];
 }
 
+const COPY = {
+  qcloud: {
+    needCredentials: [
+      'monitor.integrations.qcloudRegionNeedCredentials',
+      '请先填写 SecretId 与 SecretKey，再获取地域',
+    ],
+    empty: [
+      'monitor.integrations.qcloudRegionEmpty',
+      '未获取到可用腾讯云地域，请确认密钥权限是否包含 CVM DescribeRegions',
+    ],
+    fetched: 'monitor.integrations.qcloudRegionFetched',
+    fetchFailed: [
+      'monitor.integrations.qcloudRegionFetchFailed',
+      '获取腾讯云地域失败',
+    ],
+  },
+  aliyun: {
+    needCredentials: [
+      'monitor.integrations.aliyunRegionNeedCredentials',
+      '请先填写 AccessKey ID 与 AccessKey Secret，再获取地域',
+    ],
+    empty: [
+      'monitor.integrations.aliyunRegionEmpty',
+      '未获取到可用阿里云地域，请确认密钥权限是否包含 ECS DescribeRegions',
+    ],
+    fetched: 'monitor.integrations.aliyunRegionFetched',
+    fetchFailed: [
+      'monitor.integrations.aliyunRegionFetchFailed',
+      '获取阿里云地域失败',
+    ],
+  },
+} as const;
+
 /**
- * 腾讯云监控接入：密钥齐全后按账号动态拉取可用地域。
+ * 云监控接入：密钥齐全后按账号动态拉取可用地域。
+ * 腾讯云可多选；阿里云一配置一地域，只保留单选。
  */
-export function useQcloudRegionOptions(options: {
+export function useCloudRegionOptions(options: {
   enabled: boolean;
   form: FormInstance;
   cloudRegionId?: number | string;
+  provider: CloudRegionProvider;
 }) {
-  const { enabled, form, cloudRegionId } = options;
+  const { enabled, form, cloudRegionId, provider } = options;
   const { t } = useTranslation();
-  const { listQcloudRegions } = useIntegrationApi();
+  const { listQcloudRegions, listAliyunRegions } = useIntegrationApi();
   const [regionOptions, setRegionOptions] = useState<RegionOption[]>([]);
   const [loadingRegions, setLoadingRegions] = useState(false);
   const requestSeq = useRef(0);
   const lastAutoKey = useRef('');
+  const multiple = provider === 'qcloud';
+  const copy = COPY[provider];
 
   const username = Form.useWatch('username', form);
   const password = Form.useWatch('ENV_PASSWORD', form);
@@ -52,12 +108,7 @@ export function useQcloudRegionOptions(options: {
       if (!enabled) return;
       if (!isUsableSecret(username) || !isUsableSecret(password)) {
         if (!opts?.silent) {
-          message.warning(
-            t(
-              'monitor.integrations.qcloudRegionNeedCredentials',
-              '请先填写 SecretId 与 SecretKey，再获取地域'
-            )
-          );
+          message.warning(t(copy.needCredentials[0], copy.needCredentials[1]));
         }
         return;
       }
@@ -65,7 +116,8 @@ export function useQcloudRegionOptions(options: {
       const seq = ++requestSeq.current;
       setLoadingRegions(true);
       try {
-        const data = await listQcloudRegions({
+        const listFn = provider === 'aliyun' ? listAliyunRegions : listQcloudRegions;
+        const data = await listFn({
           username: username.trim(),
           password: password.trim(),
           cloud_region_id: cloudRegionId,
@@ -83,23 +135,26 @@ export function useQcloudRegionOptions(options: {
         if (selected.length > 0 && next.length > 0) {
           const allowed = new Set(next.map((item) => item.value));
           const kept = selected.filter((item) => allowed.has(item));
-          if (kept.length !== selected.length) {
-            form.setFieldsValue({ region: kept.length ? kept : undefined });
+          if (multiple) {
+            if (kept.length !== selected.length) {
+              form.setFieldsValue({ region: kept.length ? kept : undefined });
+            }
+          } else {
+            const nextValue = kept[0];
+            const current = form.getFieldValue('region');
+            if (nextValue !== current) {
+              form.setFieldsValue({ region: nextValue });
+            }
           }
         }
 
         if (next.length === 0) {
-          message.warning(
-            t(
-              'monitor.integrations.qcloudRegionEmpty',
-              '未获取到可用腾讯云地域，请确认密钥权限是否包含 CVM DescribeRegions'
-            )
-          );
+          message.warning(t(copy.empty[0], copy.empty[1]));
           return;
         }
         if (!opts?.silent) {
           message.success(
-            t('monitor.integrations.qcloudRegionFetched', '已获取 {count} 个地域', {
+            t(copy.fetched, '已获取 {count} 个地域', {
               count: next.length,
             })
           );
@@ -107,18 +162,29 @@ export function useQcloudRegionOptions(options: {
       } catch (error: any) {
         if (seq !== requestSeq.current) return;
         setRegionOptions([]);
-        // 自动拉取失败也要提示，避免「填了密钥却无回应」。
-        message.error(
-          error?.message ||
-            t('monitor.integrations.qcloudRegionFetchFailed', '获取腾讯云地域失败')
-        );
+        message.error(error?.message || t(copy.fetchFailed[0], copy.fetchFailed[1]));
       } finally {
         if (seq === requestSeq.current) {
           setLoadingRegions(false);
         }
       }
     },
-    [cloudRegionId, enabled, form, listQcloudRegions, password, t, username]
+    [
+      cloudRegionId,
+      copy.empty,
+      copy.fetchFailed,
+      copy.fetched,
+      copy.needCredentials,
+      enabled,
+      form,
+      listAliyunRegions,
+      listQcloudRegions,
+      multiple,
+      password,
+      provider,
+      t,
+      username,
+    ]
   );
 
   useEffect(() => {
@@ -144,17 +210,25 @@ export function useQcloudRegionOptions(options: {
       }
       return;
     }
-    const autoKey = `${username.trim()}::${password.trim()}::${cloudRegionId ?? ''}`;
+    const autoKey = `${provider}::${username.trim()}::${password.trim()}::${cloudRegionId ?? ''}`;
     if (lastAutoKey.current === autoKey) {
       return;
     }
     lastAutoKey.current = autoKey;
     void fetchRegions({ silent: true });
-  }, [enabled, username, password, cloudRegionId, fetchRegions, form]);
+  }, [enabled, username, password, cloudRegionId, fetchRegions, form, provider]);
 
   return {
     regionOptions,
     loadingRegions,
     refreshRegions: () => fetchRegions({ silent: false }),
   };
+}
+
+export function useQcloudRegionOptions(options: {
+  enabled: boolean;
+  form: FormInstance;
+  cloudRegionId?: number | string;
+}) {
+  return useCloudRegionOptions({ ...options, provider: 'qcloud' });
 }


### PR DESCRIPTION
## Summary
- 监控接入页原先只要表单里有 `region` 字段就会走腾讯云 `qcloud_regions`。阿里云若改成下拉会拿 AccessKey 去拉腾讯云地域。
- 新增 `POST /monitor/api/monitor_plugin/aliyun_regions/`，经 Stargazer `model_id=aliyun` 调 ECS DescribeRegions。
- 前端按 `instance_type` 分流：腾讯云仍可多选，阿里云单选。一配置一地域不变。
- 范围已核对：未纳入测试文件。企业侧 UI 在 WeOps-Lab/WeOpsX-Enterprise#139，需先合本 PR 再合企业侧。

## Test plan
- [x] `test_aliyun_regions_service.py` 4 passed（未提交）
- [x] 企业侧 `test_aliyun_monitor_plugin.py` 3 passed（未提交）
- [ ] 填写阿里云 AK/SK 后地域下拉自动出现列表，刷新按钮可重拉
- [ ] 只选一个地域，保存后 Telegraf header 为单个 RegionId（如 cn-hangzhou）
- [ ] 腾讯云多选路径未回归