### PR TITLE
bugfix: 标签视图只接受当前视图的查询结果

### DIFF
--- a/web/scripts/scene-view-execute-race-test.ts
+++ b/web/scripts/scene-view-execute-race-test.ts
@@ -1,0 +1,357 @@
+import * as assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createLatestRequestGuard } from '../src/context/latestRequestGuard.ts';
+import type { LatestRequestGuard } from '../src/context/latestRequestGuard.ts';
+import type { SceneExecuteResult } from '../src/app/cmdb/api/sceneView.ts';
+
+interface ModelPager {
+  page: number;
+  pageSize: number;
+}
+
+interface CommitFns {
+  beginSceneViewExecute: (guard: LatestRequestGuard) => number;
+  commitSceneViewExecuteSuccess: (
+    guard: LatestRequestGuard,
+    requestId: number,
+    apply: () => void,
+  ) => boolean;
+  commitSceneViewExecuteSettled: (
+    guard: LatestRequestGuard,
+    requestId: number,
+    settle: () => void,
+  ) => boolean;
+}
+
+interface ViewState {
+  result: SceneExecuteResult | null;
+  modelPagers: Record<string, ModelPager>;
+  loadingScope: 'all' | string | null;
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pagePath = resolve(here, '../src/app/cmdb/(pages)/views/scene/page.tsx');
+const utilPath = resolve(
+  here,
+  '../src/app/cmdb/(pages)/views/scene/sceneViewExecuteRequest.ts',
+);
+const localePath = resolve(here, '../src/app/cmdb/locales/zh.json');
+const menuPath = resolve(here, '../src/app/cmdb/constants/menu.json');
+
+const PAGE_COPY = {
+  menuViews: '视图',
+  menuTagView: '标签视图',
+  pageTitle: '标签视图',
+  createButton: '新建视图',
+  emptyPick: '从左侧打开视图，或新建一个',
+};
+
+async function loadCommitFns(): Promise<CommitFns> {
+  let loaded: Partial<CommitFns> = {};
+  try {
+    loaded = await import(
+      '../src/app/cmdb/(pages)/views/scene/sceneViewExecuteRequest.ts'
+    );
+  } catch {
+    // RED：提交函数尚未抽出。
+  }
+
+  assert.equal(typeof loaded.beginSceneViewExecute, 'function', '应抽出 beginSceneViewExecute');
+  assert.equal(
+    typeof loaded.commitSceneViewExecuteSuccess,
+    'function',
+    '应抽出 commitSceneViewExecuteSuccess',
+  );
+  assert.equal(
+    typeof loaded.commitSceneViewExecuteSettled,
+    'function',
+    '应抽出 commitSceneViewExecuteSettled',
+  );
+
+  return loaded as CommitFns;
+}
+
+function resultFor(view: string, modelId = 'host'): SceneExecuteResult {
+  return {
+    total: 1,
+    models: [
+      {
+        model_id: modelId,
+        count: 1,
+        insts: [{ inst_name: view, inst_uuid: view }],
+      },
+    ],
+  };
+}
+
+function mergePagers(
+  pagers: Record<string, ModelPager>,
+  data: SceneExecuteResult,
+): Record<string, ModelPager> {
+  const next = { ...pagers };
+  for (const item of data.models || []) {
+    if (!next[item.model_id]) {
+      next[item.model_id] = { page: 1, pageSize: 20 };
+    }
+  }
+  return next;
+}
+
+function createExecuteSession(fns: CommitFns) {
+  const guard = createLatestRequestGuard();
+  const state: ViewState = {
+    result: null,
+    modelPagers: {},
+    loadingScope: null,
+  };
+
+  const start = (scope: 'all' | string) => {
+    const requestId = fns.beginSceneViewExecute(guard);
+    state.loadingScope = scope;
+    return requestId;
+  };
+
+  const succeed = (
+    requestId: number,
+    data: SceneExecuteResult,
+    pagers: Record<string, ModelPager> = {},
+  ) => {
+    const applied = fns.commitSceneViewExecuteSuccess(guard, requestId, () => {
+      state.result = data;
+      state.modelPagers = mergePagers(pagers, data);
+    });
+    fns.commitSceneViewExecuteSettled(guard, requestId, () => {
+      state.loadingScope = null;
+    });
+    return applied;
+  };
+
+  const fail = (requestId: number) => {
+    return fns.commitSceneViewExecuteSettled(guard, requestId, () => {
+      state.loadingScope = null;
+    });
+  };
+
+  const switchView = () => {
+    guard.invalidate();
+    state.result = null;
+    state.modelPagers = {};
+  };
+
+  return {
+    getState: () => state,
+    start,
+    succeed,
+    fail,
+    switchView,
+    unmount: () => guard.invalidate(),
+  };
+}
+
+function assertPageUsesGeneration(source: string) {
+  assert.match(
+    source,
+    /from ['"]@\/context\/latestRequestGuard['"]/,
+    'page 必须复用 @/context/latestRequestGuard，不得复制新 guard',
+  );
+  assert.match(source, /createLatestRequestGuard/, 'page 必须创建 latest request guard');
+  assert.match(
+    source,
+    /from ['"]\.\/sceneViewExecuteRequest['"]/,
+    'page 必须调用抽出的 sceneViewExecuteRequest',
+  );
+  assert.match(source, /beginSceneViewExecute\(/, 'runExecute 必须按单调序号 begin');
+  assert.match(
+    source,
+    /commitSceneViewExecuteSuccess\(/,
+    '成功响应必须经 commitSceneViewExecuteSuccess 提交',
+  );
+  assert.match(
+    source,
+    /commitSceneViewExecuteSettled\(/,
+    '结束 loading 必须经 commitSceneViewExecuteSettled 提交',
+  );
+  assert.match(source, /requestGuard\.invalidate\(\)/, '切换 selectedId 与卸载必须 invalidate');
+
+  const runExecuteFn =
+    source.match(/const runExecute = useCallback\([\s\S]*?(?=\n  useEffect)/)?.[0] || '';
+  assert.ok(runExecuteFn.includes('const runExecute'), '必须能定位 runExecute');
+  assert.match(runExecuteFn, /beginSceneViewExecute\(/, 'runExecute 必须 begin 新代次');
+  assert.match(
+    runExecuteFn,
+    /commitSceneViewExecuteSuccess\(/,
+    'runExecute await 后必须按序号提交 result/pagers',
+  );
+  assert.match(
+    runExecuteFn,
+    /commitSceneViewExecuteSettled\(/,
+    'runExecute finally 必须按序号提交 loading',
+  );
+  assert.match(
+    runExecuteFn,
+    /executeSceneView\(\s*id\s*,/,
+    '不得改 executeSceneView 调用签名',
+  );
+  assert.match(
+    runExecuteFn,
+    /pagination:\s*toPaginationPayload\(pagers\)/,
+    'executeSceneView 仍须传 pagination',
+  );
+  assert.match(
+    runExecuteFn,
+    /searches:\s*toSearchPayload\(searches\)/,
+    'executeSceneView 仍须传 searches',
+  );
+
+  const invalidates = source.match(/requestGuard\.invalidate\(\)/g);
+  assert.ok(
+    invalidates && invalidates.length >= 1,
+    '切换 selectedId 或卸载必须 invalidate',
+  );
+
+  assert.match(source, /setResult\(null\)/, '切换视图时必须清理旧结果');
+  assert.match(source, /t\('SceneView\.title'\)/, '页头必须仍用 SceneView.title');
+  assert.match(source, /t\('SceneView\.create'\)/, '按钮必须仍用 SceneView.create');
+  assert.match(source, /t\('SceneView\.emptyPick'\)/, '空态必须仍用 SceneView.emptyPick');
+
+  assert.doesNotMatch(
+    source,
+    /function createLatestRequestGuard|const createLatestRequestGuard\s*=/,
+    '不得在 page 内复制一套序号 guard',
+  );
+
+  const aside = source.match(/<aside[\s\S]*?<\/aside>/)?.[0] || '';
+  assert.ok(aside.includes('<aside'), '必须能定位侧栏');
+  assert.doesNotMatch(aside, /\bdisabled\b/, '不得把禁用侧栏当唯一修复');
+}
+
+function assertCopy() {
+  const menu = JSON.parse(readFileSync(menuPath, 'utf8')) as {
+    zh: Array<{ title: string; url?: string; children?: Array<{ title: string; name: string }> }>;
+  };
+  const views = menu.zh.find((item) => item.title === PAGE_COPY.menuViews);
+  assert.ok(views, '菜单必须有「视图」');
+  const tagView = (views?.children || []).find((item) => item.name === 'asset_views_scene');
+  assert.equal(tagView?.title, PAGE_COPY.menuTagView, '菜单「视图」下必须是「标签视图」');
+
+  const locale = JSON.parse(readFileSync(localePath, 'utf8')) as {
+    SceneView: { title: string; create: string; emptyPick: string };
+  };
+  assert.equal(locale.SceneView.title, PAGE_COPY.pageTitle);
+  assert.equal(locale.SceneView.create, PAGE_COPY.createButton);
+  assert.equal(locale.SceneView.emptyPick, PAGE_COPY.emptyPick);
+}
+
+async function main() {
+  assertCopy();
+
+  const fns = await loadCommitFns();
+
+  const viewRace = createExecuteSession(fns);
+  const staleView = viewRace.start('all');
+  viewRace.switchView();
+  const latestView = viewRace.start('all');
+  assert.equal(viewRace.getState().result, null, '切到视图 B 必须先清掉 A 的结果');
+  const bApplied = viewRace.succeed(latestView, resultFor('view-B'), {});
+  const aApplied = viewRace.succeed(staleView, resultFor('view-A'), {});
+  assert.equal(bApplied, true, '当前视图 B 的成功必须可写');
+  assert.equal(aApplied, false, 'A 后发先至不得覆盖 B');
+  assert.equal(
+    viewRace.getState().result?.models[0]?.insts[0]?.inst_name,
+    'view-B',
+    '侧栏切到 B 后旧 A 响应不得覆盖 B 的 result',
+  );
+  assert.equal(viewRace.getState().loadingScope, null, '当前代次结束后才清 loading');
+
+  const pageRace = createExecuteSession(fns);
+  const stalePage = pageRace.start('host');
+  const latestPage = pageRace.start('host');
+  pageRace.succeed(latestPage, resultFor('page-2'), {
+    host: { page: 2, pageSize: 20 },
+  });
+  pageRace.succeed(stalePage, resultFor('page-1'), {
+    host: { page: 1, pageSize: 20 },
+  });
+  assert.equal(
+    pageRace.getState().result?.models[0]?.insts[0]?.inst_name,
+    'page-2',
+    '同视图翻页乱序：旧页结果不得覆盖新页',
+  );
+  assert.deepEqual(
+    pageRace.getState().modelPagers.host,
+    { page: 2, pageSize: 20 },
+    '同视图翻页乱序：pagers 必须属于最新请求',
+  );
+
+  const filterRace = createExecuteSession(fns);
+  const staleFilter = filterRace.start('host');
+  const latestFilter = filterRace.start('host');
+  filterRace.succeed(latestFilter, resultFor('filter-prod'), {
+    host: { page: 1, pageSize: 20 },
+  });
+  filterRace.succeed(staleFilter, resultFor('filter-all'), {
+    host: { page: 1, pageSize: 20 },
+  });
+  assert.equal(
+    filterRace.getState().result?.models[0]?.insts[0]?.inst_name,
+    'filter-prod',
+    '同视图筛选乱序：旧筛选结果不得覆盖新筛选',
+  );
+
+  const lateFail = createExecuteSession(fns);
+  const staleFail = lateFail.start('all');
+  const latestOk = lateFail.start('all');
+  assert.equal(lateFail.getState().loadingScope, 'all', '新请求必须持有 loading');
+  const staleSettled = lateFail.fail(staleFail);
+  assert.equal(staleSettled, false, '旧失败晚到不得提交 settle');
+  assert.equal(lateFail.getState().loadingScope, 'all', '旧失败晚到不得清掉新 loading');
+  lateFail.succeed(latestOk, resultFor('current-ok'));
+  assert.equal(
+    lateFail.getState().result?.models[0]?.insts[0]?.inst_name,
+    'current-ok',
+    '旧失败晚到不得覆盖当前成功',
+  );
+  assert.equal(lateFail.getState().loadingScope, null);
+
+  const unmounted = createExecuteSession(fns);
+  const lateSuccess = unmounted.start('all');
+  unmounted.unmount();
+  assert.equal(
+    unmounted.succeed(lateSuccess, resultFor('after-unmount')),
+    false,
+    '卸载后旧成功不得提交',
+  );
+  assert.equal(unmounted.getState().result, null, '卸载后旧成功不得写回 result');
+  assert.equal(unmounted.getState().loadingScope, 'all', '卸载后旧成功不得改 loading');
+  assert.equal(unmounted.fail(lateSuccess), false, '卸载后旧失败不得清 loading');
+
+  const currentOk = createExecuteSession(fns);
+  const currentGen = currentOk.start('all');
+  assert.equal(currentOk.succeed(currentGen, resultFor('current')), true);
+  assert.equal(currentOk.getState().result?.models[0]?.insts[0]?.inst_name, 'current');
+  assert.equal(currentOk.getState().loadingScope, null);
+
+  const pageSource = readFileSync(pagePath, 'utf8');
+  const utilSource = readFileSync(utilPath, 'utf8');
+  assertPageUsesGeneration(pageSource);
+  assert.match(
+    utilSource,
+    /from ['"]@\/context\/latestRequestGuard['"]/,
+    'sceneViewExecuteRequest 必须复用 LatestRequestGuard 类型',
+  );
+  assert.doesNotMatch(
+    utilSource,
+    /createLatestRequestGuard\s*=|function createLatestRequestGuard/,
+    'sceneViewExecuteRequest 不得复制一套序号 guard',
+  );
+  assert.match(utilSource, /commitIfCurrent/, '抽出模块必须经 commitIfCurrent 提交');
+
+  console.log('scene view execute race test passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/web/src/app/cmdb/(pages)/views/scene/page.tsx
+++ b/web/src/app/cmdb/(pages)/views/scene/page.tsx
@@ -12,6 +12,7 @@ import {
 import { PlusOutlined } from '@ant-design/icons';
 import CompactEmptyState from '@/components/compact-empty-state';
 import { useTranslation } from '@/utils/i18n';
+import { createLatestRequestGuard } from '@/context/latestRequestGuard';
 import { useCommon } from '@/app/cmdb/context/common';
 import { useModelApi, useSceneViewApi, useInstanceApi } from '@/app/cmdb/api';
 import type { AttrFieldType, ColumnItem, ModelItem, UserItem } from '@/app/cmdb/types/assetManage';
@@ -36,6 +37,11 @@ import type {
   SceneExecuteResult,
   SceneViewPayload,
 } from '@/app/cmdb/api/sceneView';
+import {
+  beginSceneViewExecute,
+  commitSceneViewExecuteSettled,
+  commitSceneViewExecuteSuccess,
+} from './sceneViewExecuteRequest';
 
 const DEFAULT_PAGE_SIZE = 20;
 const GROUP_LABEL: Record<SceneViewRecord['visibility'], string> = {
@@ -73,6 +79,7 @@ const SceneViewPage = () => {
     saveAsSceneView,
     exportSceneView,
   } = useSceneViewApi();
+  const [requestGuard] = useState(createLatestRequestGuard);
 
   const [scenes, setScenes] = useState<SceneViewRecord[]>([]);
   const [capabilities, setCapabilities] = useState({
@@ -127,27 +134,32 @@ const SceneViewPage = () => {
       searches: Record<string, ModelSearchPreference>,
       scope: 'all' | string
     ) => {
+      const requestId = beginSceneViewExecute(requestGuard);
       setLoadingScope(scope);
       try {
         const data = await executeSceneView(id, {
           pagination: toPaginationPayload(pagers),
           searches: toSearchPayload(searches),
         });
-        setResult(data);
-        setModelPagers(() => {
-          const next = { ...pagers };
-          for (const item of data?.models || []) {
-            if (!next[item.model_id]) {
-              next[item.model_id] = { page: 1, pageSize: DEFAULT_PAGE_SIZE };
+        commitSceneViewExecuteSuccess(requestGuard, requestId, () => {
+          setResult(data);
+          setModelPagers(() => {
+            const next = { ...pagers };
+            for (const item of data?.models || []) {
+              if (!next[item.model_id]) {
+                next[item.model_id] = { page: 1, pageSize: DEFAULT_PAGE_SIZE };
+              }
             }
-          }
-          return next;
+            return next;
+          });
         });
       } finally {
-        setLoadingScope(null);
+        commitSceneViewExecuteSettled(requestGuard, requestId, () => {
+          setLoadingScope(null);
+        });
       }
     },
-    [executeSceneView]
+    [executeSceneView, requestGuard]
   );
 
   useEffect(() => {
@@ -160,14 +172,21 @@ const SceneViewPage = () => {
       setModelPagers({});
       setModelSearches({});
       setCollapsed({});
-      return;
+      setLoadingScope(null);
+      return () => {
+        requestGuard.invalidate();
+      };
     }
     const searches = readModelSearches(browserStorage(), selectedId);
+    setResult(null);
     setModelPagers({});
     setModelSearches(searches);
     setCollapsed({});
     runExecute(selectedId, {}, searches, 'all');
-  }, [runExecute, selectedId]);
+    return () => {
+      requestGuard.invalidate();
+    };
+  }, [requestGuard, runExecute, selectedId]);
 
   const selectedModelKey = (selected?.model_ids || []).join(',');
 

--- a/web/src/app/cmdb/(pages)/views/scene/sceneViewExecuteRequest.ts
+++ b/web/src/app/cmdb/(pages)/views/scene/sceneViewExecuteRequest.ts
@@ -1,0 +1,21 @@
+import type { LatestRequestGuard } from '@/context/latestRequestGuard';
+
+export function beginSceneViewExecute(guard: LatestRequestGuard): number {
+  return guard.begin();
+}
+
+export function commitSceneViewExecuteSuccess(
+  guard: LatestRequestGuard,
+  requestId: number,
+  apply: () => void,
+): boolean {
+  return guard.commitIfCurrent(requestId, apply);
+}
+
+export function commitSceneViewExecuteSettled(
+  guard: LatestRequestGuard,
+  requestId: number,
+  settle: () => void,
+): boolean {
+  return guard.commitIfCurrent(requestId, settle);
+}


### PR DESCRIPTION
## 复现步骤

前置：账号能打开 CMDB，左侧至少有两个已保存的标签视图。可用开发者工具把查询接口延迟返回。

1. 进入 CMDB 左侧菜单 **视图** → **标签视图**。页头是 **标签视图**，右侧有 **新建视图**。
2. 若空态出现 **从左侧打开视图，或新建一个**，先在左侧 **我的 / 组织 / 全局** 里点开一个视图。
3. 点左侧视图 A，等资产列表开始请求。不要等请求结束。
4. 立刻点左侧另一个视图 B。
5. 让 B 先返回、A 后返回，看标题/标签已是 B 时，资产列表、数量和分页是否被 A 盖回去。

修复前：`runExecute` 在 `await executeSceneView` 后无条件写入结果和分页，`finally` 无条件清 loading。切到 B 后，晚到的 A 仍会覆盖 B 的资产列表。  
修复后：只有当前请求代次能写结果、分页和 loading。切换视图会作废旧代次并清掉旧结果。同视图翻页、筛选乱序也只接受最新快照。

## 修复方案

抽出 `beginSceneViewExecute` / `commitSceneViewExecuteSuccess` / `commitSceneViewExecuteSettled`，复用已有的 `createLatestRequestGuard`。

- `runExecute` 开始时领取序号；成功后按序号提交 result 和 modelPagers；结束 loading 也按序号提交。
- 切换 `selectedId` 与卸载时 `invalidate`，并清掉旧结果。
- 不改 `executeSceneView` 参数、权限、新建/编辑/导出，也不靠禁用侧栏来修。

Fixes #5234

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 侧栏从视图 A 切到 B，A 后到 | 标题是 B，资产列表/分页可能是 A | 只保留 B 的结果和分页 |
| 同视图翻页或筛选乱序 | 旧页/旧筛选可盖住新结果 | 只接受最新请求 |
| 旧失败晚到 | `finally` 可能清掉新请求的 loading | 旧失败不得清新 loading |
| 离开页面后旧成功返回 | 可能写回已卸载页 | 不再写回 |

## 影响面

- **会变**：仅 **视图** → **标签视图** 的查询提交时序。切视图、翻页、筛选只接受当前代次。
- **不变**：页头 **标签视图**、按钮 **新建视图**、空态 **从左侧打开视图，或新建一个**、侧栏分组、权限、导出、`executeSceneView` 参数。
- **未改**：编辑保存后仍可能与 `selectedId` 的 effect 各打一次查询；两次都受代次保护。
- **不在范围**：资产列表、拓扑、其他专题视图。
