### PR TITLE
bugfix: 公共枚举库未加载时不清除已存默认值

### DIFF
--- a/web/scripts/cmdb-enum-default-value-load-test.ts
+++ b/web/scripts/cmdb-enum-default-value-load-test.ts
@@ -1,0 +1,209 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  canSubmitEnumDefaultValue,
+  getAttributeEnumOptionIds,
+  normalizeDefaultValue,
+  resolveEnumDefaultValue,
+  sanitizeDefaultValue,
+} from '../src/app/cmdb/utils/enumDefaultValue';
+
+const root = process.cwd();
+const read = (path: string) => readFileSync(resolve(root, path), 'utf8');
+
+const utilSource = read('src/app/cmdb/utils/enumDefaultValue.ts');
+const modalSource = read(
+  'src/app/cmdb/(pages)/assetManage/management/detail/attributes/attributesModal.tsx',
+);
+const attributesPageSource = read(
+  'src/app/cmdb/(pages)/assetManage/management/detail/attributes/page.tsx',
+);
+const zhCmdb = JSON.parse(read('src/app/cmdb/locales/zh.json'));
+const zhCommon = JSON.parse(read('src/locales/zh.json'));
+const menu = JSON.parse(read('src/app/cmdb/constants/menu.json'));
+
+const managementMenu = (menu.zh as Array<{ title: string; children?: Array<{ title: string; children?: Array<{ title: string }> }> }>).find(
+  (item) => item.title === '管理',
+);
+assert.ok(managementMenu, '菜单应包含「管理」');
+const modelMenu = managementMenu?.children?.find((item) => item.title === '模型管理');
+assert.ok(modelMenu, '菜单应包含「管理」→「模型管理」');
+assert.ok(
+  modelMenu?.children?.some((item) => item.title === '属性'),
+  '菜单应包含「管理」→「模型管理」→「属性」',
+);
+
+assert.equal(zhCmdb.Model.addAttribute, '添加属性');
+assert.equal(zhCmdb.Model.editAttribute, '编辑属性');
+assert.equal(zhCmdb.Model.defaultValue, '默认值');
+assert.equal(zhCmdb.Model.attributes, '属性');
+assert.equal(zhCmdb.PublicEnumLibrary.enumRuleType, '选项来源');
+assert.equal(zhCmdb.PublicEnumLibrary.enumRuleTypePublicLibrary, '公共选项库');
+assert.equal(zhCommon.common.edit, '编辑');
+assert.equal(zhCommon.common.confirm, '确认');
+assert.equal(zhCommon.common.cancel, '取消');
+
+assert.match(attributesPageSource, /Model\.addAttribute/);
+assert.match(attributesPageSource, /Model\.editAttribute/);
+assert.match(attributesPageSource, /common\.edit/);
+assert.match(modalSource, /Model\.defaultValue/);
+assert.match(modalSource, /PublicEnumLibrary\.enumRuleTypePublicLibrary/);
+assert.match(modalSource, /common\.confirm/);
+assert.match(modalSource, /common\.cancel/);
+
+assert.match(
+  utilSource,
+  /export type PublicEnumLibraryLoadState = 'unloaded' \| 'ready' \| 'failed'/,
+  '源码必须区分公共枚举库未加载 / ready / failed',
+);
+assert.match(utilSource, /export const resolveEnumDefaultValue/);
+assert.match(utilSource, /export const canSubmitEnumDefaultValue/);
+assert.match(
+  utilSource,
+  /publicLibraryLoadState !== 'ready'/,
+  '仅 ready 后才对公共库默认值做破坏性过滤',
+);
+
+assert.match(modalSource, /publicLibraryLoadState/);
+assert.match(modalSource, /setPublicLibraryLoadState\('unloaded'\)/);
+assert.match(modalSource, /setPublicLibraryLoadState\('ready'\)/);
+assert.match(modalSource, /setPublicLibraryLoadState\('failed'\)/);
+assert.match(modalSource, /resolveEnumDefaultValue/);
+assert.match(modalSource, /canSubmitEnumDefaultValue/);
+assert.doesNotMatch(
+  modalSource,
+  /\.catch\(\(\) => \{\s*setPublicLibraries\(\[\]\);/s,
+  'catch 不得把失败当成已加载空库',
+);
+assert.match(
+  modalSource,
+  /getPublicEnumLibraries\(\)/,
+  'getPublicEnumLibraries 调用签名不得改变',
+);
+assert.match(
+  modalSource,
+  /updateModelAttr\(params\.model_id!, requestParams\)/,
+  'updateModelAttr 调用签名不得改变',
+);
+
+const library = {
+  library_id: 'lib-status',
+  name: '状态',
+  options: [
+    { id: 'online', name: '在线' },
+    { id: 'offline', name: '离线' },
+  ],
+};
+
+const optionIdsOf = (libraries: typeof library[]) =>
+  getAttributeEnumOptionIds({
+    enumRuleType: 'public_library',
+    publicLibraryId: library.library_id,
+    publicLibraries: libraries,
+    enumList: [],
+  });
+
+const syncForm = (
+  candidate: unknown,
+  libraries: typeof library[],
+  loadState: 'unloaded' | 'ready' | 'failed',
+) =>
+  resolveEnumDefaultValue({
+    candidate,
+    validOptionIds: optionIdsOf(libraries),
+    selectMode: 'single',
+    enumRuleType: 'public_library',
+    publicLibraryLoadState: loadState,
+  });
+
+const submitForm = (
+  candidate: unknown,
+  libraries: typeof library[],
+  loadState: 'unloaded' | 'ready' | 'failed',
+) => {
+  if (
+    !canSubmitEnumDefaultValue({
+      enumRuleType: 'public_library',
+      publicLibraryLoadState: loadState,
+    })
+  ) {
+    return {
+      submitted: false as const,
+      defaultValue: normalizeDefaultValue(candidate),
+    };
+  }
+  return {
+    submitted: true as const,
+    defaultValue: syncForm(candidate, libraries, loadState),
+  };
+};
+
+assert.deepEqual(
+  sanitizeDefaultValue(['online'], optionIdsOf([]), 'single'),
+  [],
+  '未加载空选项列表会把已存默认值清掉，这是必须避开的破坏性过滤',
+);
+
+assert.deepEqual(
+  syncForm(['online'], [], 'unloaded'),
+  ['online'],
+  '公共库未加载时不得清掉已存默认值',
+);
+
+const afterDelay = syncForm(syncForm(['online'], [], 'unloaded'), [library], 'ready');
+assert.deepEqual(afterDelay, ['online'], '库延迟返回后合法 ID 仍在');
+
+const keptInvalidWhileLoading = syncForm(['deleted-id'], [], 'unloaded');
+assert.deepEqual(keptInvalidWhileLoading, ['deleted-id'], '非法 ID 在加载完成前应保留');
+assert.deepEqual(
+  syncForm(keptInvalidWhileLoading, [library], 'ready'),
+  [],
+  '非法 ID 在加载完成后才过滤',
+);
+
+assert.deepEqual(syncForm([], [], 'unloaded'), [], '用户显式清空后，未加载阶段保持空');
+assert.deepEqual(syncForm([], [library], 'ready'), [], '用户显式清空后，加载完成仍保持空');
+
+const failedKeep = syncForm(['online'], [], 'failed');
+assert.deepEqual(failedKeep, ['online'], '加载失败必须保留候选默认值');
+assert.deepEqual(submitForm(['online'], [], 'failed'), {
+  submitted: false,
+  defaultValue: ['online'],
+});
+assert.equal(
+  canSubmitEnumDefaultValue({
+    enumRuleType: 'public_library',
+    publicLibraryLoadState: 'unloaded',
+  }),
+  false,
+);
+assert.equal(
+  canSubmitEnumDefaultValue({
+    enumRuleType: 'public_library',
+    publicLibraryLoadState: 'ready',
+  }),
+  true,
+);
+assert.equal(
+  canSubmitEnumDefaultValue({
+    enumRuleType: 'custom',
+    publicLibraryLoadState: 'unloaded',
+  }),
+  true,
+);
+
+assert.deepEqual(
+  resolveEnumDefaultValue({
+    candidate: ['gone', 'keep'],
+    validOptionIds: ['keep'],
+    selectMode: 'multiple',
+    enumRuleType: 'custom',
+    publicLibraryLoadState: 'unloaded',
+  }),
+  ['keep'],
+  '自定义枚举仍应立即过滤非法选项',
+);
+
+console.log('cmdb-enum-default-value-load-test: ok');

--- a/web/src/app/cmdb/(pages)/assetManage/management/detail/attributes/attributesModal.tsx
+++ b/web/src/app/cmdb/(pages)/assetManage/management/detail/attributes/attributesModal.tsx
@@ -45,9 +45,11 @@ import {
   PublicEnumLibraryItem,
 } from '@/app/cmdb/types/assetManage';
 import {
+  canSubmitEnumDefaultValue,
   getAttributeEnumOptionIds,
   normalizeDefaultValue,
-  sanitizeDefaultValue,
+  resolveEnumDefaultValue,
+  type PublicEnumLibraryLoadState,
 } from '@/app/cmdb/utils/enumDefaultValue';
 import {
   getFileFieldConstraintMeta,
@@ -126,6 +128,8 @@ const AttributesModal = forwardRef<AttrModalRef, AttrModalProps>(
     const [enumRuleType, setEnumRuleType] = useState<EnumRuleType>('custom');
     const [publicLibraryId, setPublicLibraryId] = useState<string>('');
     const [publicLibraries, setPublicLibraries] = useState<PublicEnumLibraryItem[]>([]);
+    const [publicLibraryLoadState, setPublicLibraryLoadState] =
+      useState<PublicEnumLibraryLoadState>('unloaded');
     const [enumSelectMode, setEnumSelectMode] = useState<'single' | 'multiple'>('single');
     const formRef = useRef<FormInstance>(null);
     const searchParams = useSearchParams();
@@ -151,16 +155,17 @@ const AttributesModal = forwardRef<AttrModalRef, AttrModalProps>(
     };
 
     const syncEnumDefaultValue = (candidate?: unknown) => {
-      const sanitized = sanitizeDefaultValue(
-        candidate ?? formRef.current?.getFieldValue('default_value'),
-        getCurrentEnumOptionIds(),
-        enumSelectMode,
-      );
+      const next = resolveEnumDefaultValue({
+        candidate: candidate ?? formRef.current?.getFieldValue('default_value'),
+        validOptionIds: getCurrentEnumOptionIds(),
+        selectMode: enumSelectMode,
+        enumRuleType,
+        publicLibraryLoadState,
+      });
       formRef.current?.setFieldsValue({
-        default_value: enumSelectMode === 'multiple' ? sanitized : sanitized[0] ?? undefined,
+        default_value: enumSelectMode === 'multiple' ? next : next[0] ?? undefined,
       });
     };
-
 
     useEffect(() => {
       if (modelVisible) {
@@ -184,7 +189,7 @@ const AttributesModal = forwardRef<AttrModalRef, AttrModalProps>(
     useEffect(() => {
       if (!modelVisible || attrInfo.attr_type !== 'enum') return;
       syncEnumDefaultValue();
-    }, [modelVisible, attrInfo.attr_type, enumRuleType, publicLibraryId, publicLibraries, enumList, enumSelectMode]);
+    }, [modelVisible, attrInfo.attr_type, enumRuleType, publicLibraryId, publicLibraries, enumList, enumSelectMode, publicLibraryLoadState]);
 
     useImperativeHandle(ref, () => ({
       showModal: ({ type, attrInfo, subTitle, title }) => {
@@ -192,10 +197,12 @@ const AttributesModal = forwardRef<AttrModalRef, AttrModalProps>(
         setSubTitle(subTitle);
         setType(type);
         setTitle(title);
+        setPublicLibraryLoadState('unloaded');
         getPublicEnumLibraries().then((res: any) => {
           setPublicLibraries(res || []);
+          setPublicLibraryLoadState('ready');
         }).catch(() => {
-          setPublicLibraries([]);
+          setPublicLibraryLoadState('failed');
         });
         if (type === 'add') {
           Object.assign(attrInfo, {
@@ -276,10 +283,12 @@ const AttributesModal = forwardRef<AttrModalRef, AttrModalProps>(
         setAttrInfo(attrInfo);
       },
       refreshPublicLibraries: () => {
+        setPublicLibraryLoadState('unloaded');
         getPublicEnumLibraries().then((res: any) => {
           setPublicLibraries(res || []);
+          setPublicLibraryLoadState('ready');
         }).catch(() => {
-          setPublicLibraries([]);
+          setPublicLibraryLoadState('failed');
         });
       },
     }));
@@ -362,11 +371,16 @@ const AttributesModal = forwardRef<AttrModalRef, AttrModalProps>(
         };
 
         if (values.attr_type === 'enum') {
-          const sanitizedDefaultValue = sanitizeDefaultValue(
-            values.default_value,
-            getCurrentEnumOptionIds(),
-            enumSelectMode,
-          );
+          if (!canSubmitEnumDefaultValue({ enumRuleType, publicLibraryLoadState })) {
+            return;
+          }
+          const sanitizedDefaultValue = resolveEnumDefaultValue({
+            candidate: values.default_value,
+            validOptionIds: getCurrentEnumOptionIds(),
+            selectMode: enumSelectMode,
+            enumRuleType,
+            publicLibraryLoadState,
+          });
           submitParams.enum_rule_type = enumRuleType;
           submitParams.enum_select_mode = enumSelectMode;
           submitParams.default_value = sanitizedDefaultValue;

--- a/web/src/app/cmdb/utils/enumDefaultValue.ts
+++ b/web/src/app/cmdb/utils/enumDefaultValue.ts
@@ -2,6 +2,8 @@ import { EnumList, FullInfoAttrItem, PublicEnumLibraryItem } from '@/app/cmdb/ty
 
 export type EnumSelectMode = 'single' | 'multiple';
 
+export type PublicEnumLibraryLoadState = 'unloaded' | 'ready' | 'failed';
+
 export const normalizeDefaultValue = (value: unknown): string[] => {
   const source = Array.isArray(value)
     ? value
@@ -51,6 +53,38 @@ export const getAttributeEnumOptionIds = ({
     return getEnumOptionIds(currentLibrary?.options || []);
   }
   return getEnumOptionIds(enumList);
+};
+
+export const resolveEnumDefaultValue = ({
+  candidate,
+  validOptionIds,
+  selectMode,
+  enumRuleType,
+  publicLibraryLoadState,
+}: {
+  candidate: unknown;
+  validOptionIds: Iterable<string>;
+  selectMode: EnumSelectMode;
+  enumRuleType: 'custom' | 'public_library';
+  publicLibraryLoadState: PublicEnumLibraryLoadState;
+}): string[] => {
+  if (enumRuleType === 'public_library' && publicLibraryLoadState !== 'ready') {
+    return normalizeDefaultValue(candidate);
+  }
+  return sanitizeDefaultValue(candidate, validOptionIds, selectMode);
+};
+
+export const canSubmitEnumDefaultValue = ({
+  enumRuleType,
+  publicLibraryLoadState,
+}: {
+  enumRuleType: 'custom' | 'public_library';
+  publicLibraryLoadState: PublicEnumLibraryLoadState;
+}): boolean => {
+  if (enumRuleType !== 'public_library') {
+    return true;
+  }
+  return publicLibraryLoadState === 'ready';
 };
 
 export const getEnumDefaultValueForForm = (field: FullInfoAttrItem): string | string[] | undefined => {


### PR DESCRIPTION
## 复现步骤

前置：账号能打开 CMDB 模型管理。准备一个枚举属性，选项来源是 **公共选项库**，并且已经保存过合法 **默认值**。可用开发者工具把公共选项库接口延迟返回。

1. 进入 CMDB 左侧菜单 **管理** → **模型管理**，打开该模型，点子菜单 **属性**。
2. 等属性列表加载完成。右侧可点 **添加属性**。
3. 在该枚举属性行点 **编辑**。弹框标题是 **编辑属性**。
4. 不要改 **默认值**。只改名称之类无关字段，立刻点 **确认**（也可等库请求很慢时先看表单里的默认值是否还在）。点 **取消** 可退出。

修复前：弹框先填入已存默认值，公共库还是空数组时就把该值清掉。库返回后只校验已经清空的表单，不会恢复。点 **确认** 会把空默认值写回模型。  
修复后：库未加载或失败时保留已存默认值，也不得把空值提交上去。库 ready 后才过滤已删除选项。用户主动清空后仍可保存空值。

## 修复方案

增加 `unloaded | ready | failed` 加载态。抽出 `resolveEnumDefaultValue` / `canSubmitEnumDefaultValue`。

- 公共库未 ready 时只规范化候选，不做破坏性过滤。
- 仅 `ready` 后才按选项 ID 过滤默认值。
- 未加载或失败时拒绝提交，避免把空默认值写回。
- 请求失败不再 `setPublicLibraries([])`，避免和空库混成同一种状态。
- 不改 `getPublicEnumLibraries` / `updateModelAttr` 参数、权限和存储格式。

Fixes #5235

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 打开 **编辑属性**，公共库还在请求 | 已存 **默认值** 被空选项列表清掉 | 保留已存默认值 |
| 库延迟返回后 | 表单已空，无法恢复 | 合法 ID 仍在 |
| 选项已从库中删除 | 加载完成后被清掉 | 仍只在 ready 后过滤 |
| 用户主动清空 **默认值** | 可保存空值 | 仍可保存空值 |
| 库请求失败后点 **确认** | 可能把空默认值写回 | 拒绝提交，保留候选 |

## 影响面

- **会变**：仅 **管理** → **模型管理** → **属性** 里，选项来源为 **公共选项库** 的枚举属性编辑默认值生命周期。
- **不变**：按钮 **添加属性** / **编辑**、弹框 **编辑属性**、字段 **默认值**、**确认** / **取消**、自定义枚举、接口参数、权限。
- **未改**：库未加载或失败时点确认会直接 return，没有新增提示文案。
- **不在范围**：公共选项库管理页、实例新增页的默认值回填、连续打开弹框时在途库请求晚到覆盖。
