### PR TITLE
bugfix: 订阅表单关联字段缓存不再自触发渲染

### DIFF
--- a/web/scripts/cmdb-subscribe-relation-fields-loop-test.ts
+++ b/web/scripts/cmdb-subscribe-relation-fields-loop-test.ts
@@ -1,0 +1,132 @@
+import * as assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+interface RelationField {
+  attr_id: string;
+}
+
+type RelationFieldsCache = Record<string, RelationField[]>;
+
+type PruneRelationFieldsCache = (
+  prev: RelationFieldsCache,
+  selectedModelIds: string[],
+) => RelationFieldsCache;
+
+const here = dirname(fileURLToPath(import.meta.url));
+const utilPath = resolve(here, '../src/app/cmdb/utils/relationFieldsCache.ts');
+const subscriptionFormPath = resolve(
+  here,
+  '../src/app/cmdb/components/subscription/subscriptionRuleForm.tsx',
+);
+const drawerFormPath = resolve(
+  here,
+  '../src/app/cmdb/components/cmdb-subscription-drawer/subscriptionRuleForm.tsx',
+);
+
+const REPRO_COPY = {
+  menu: ['资产', '基础信息'],
+  button: '订阅',
+  modal: '新建规则',
+  footer: ['保存并启用', '仅保存', '取消'],
+  triggerType: '关联变化',
+} as const;
+
+async function loadPrune(): Promise<PruneRelationFieldsCache> {
+  let loaded: { pruneRelationFieldsCache?: unknown } = {};
+  try {
+    loaded = await import('../src/app/cmdb/utils/relationFieldsCache.ts');
+  } catch {
+    // RED：关联字段缓存尚未抽出。
+  }
+
+  assert.equal(
+    typeof loaded.pruneRelationFieldsCache,
+    'function',
+    '应抽出 pruneRelationFieldsCache',
+  );
+  return loaded.pruneRelationFieldsCache as PruneRelationFieldsCache;
+}
+
+function assertFormUsesSharedPrune(source: string, label: string) {
+  assert.match(
+    source,
+    /from ['"]@\/app\/cmdb\/utils\/relationFieldsCache['"]/,
+    `${label} 必须复用抽出的 relationFieldsCache`,
+  );
+  assert.match(
+    source,
+    /pruneRelationFieldsCache\(/,
+    `${label} 必须调用 pruneRelationFieldsCache`,
+  );
+  assert.doesNotMatch(
+    source,
+    /setRelationFieldsByModel\(\{\}\)/,
+    `${label} 空选择不得无条件 setRelationFieldsByModel({})`,
+  );
+  assert.doesNotMatch(
+    source,
+    /return next;/,
+    `${label} prune 不得无条件 return next`,
+  );
+}
+
+async function main() {
+  assert.deepEqual(REPRO_COPY.menu, ['资产', '基础信息']);
+  assert.equal(REPRO_COPY.button, '订阅');
+  assert.equal(REPRO_COPY.modal, '新建规则');
+  assert.deepEqual(REPRO_COPY.footer, ['保存并启用', '仅保存', '取消']);
+  assert.equal(REPRO_COPY.triggerType, '关联变化');
+
+  const pruneRelationFieldsCache = await loadPrune();
+
+  const emptyPrev: RelationFieldsCache = {};
+  const emptyFirst = pruneRelationFieldsCache(emptyPrev, []);
+  const emptySecond = pruneRelationFieldsCache(emptyFirst, []);
+  assert.equal(emptyFirst, emptyPrev, '挂载空配置不得写新对象');
+  assert.equal(emptySecond, emptyFirst, '空配置连续 prune 必须返回同一引用');
+
+  const fieldsA: RelationField[] = [{ attr_id: 'name' }];
+  const fieldsB: RelationField[] = [{ attr_id: 'status' }];
+  const cached: RelationFieldsCache = { modelA: fieldsA, modelB: fieldsB };
+  const unchanged = pruneRelationFieldsCache(cached, ['modelA', 'modelB']);
+  assert.equal(unchanged, cached, '已缓存配置键未变必须返回 prev');
+
+  const stillCachedWhilePending = pruneRelationFieldsCache(cached, ['modelA', 'modelB', 'modelC']);
+  assert.equal(stillCachedWhilePending, cached, '未缓存的新增模型不得在 prune 时换引用');
+
+  const removed = pruneRelationFieldsCache(cached, ['modelA']);
+  assert.notEqual(removed, cached, '删除已缓存模型必须写新对象');
+  assert.deepEqual(Object.keys(removed), ['modelA']);
+  assert.equal(removed.modelA, fieldsA, '保留模型字段引用不得被复制');
+
+  const addedAfterFetch: RelationFieldsCache = { ...cached, modelC: [{ attr_id: 'id' }] };
+  const afterAdd = pruneRelationFieldsCache(addedAfterFetch, ['modelA', 'modelB', 'modelC']);
+  assert.equal(afterAdd, addedAfterFetch, '增模型后键未变的再次 prune 必须返回 prev');
+  assert.notEqual(addedAfterFetch, cached, '增模型写入新对象后不得回写旧缓存');
+
+  const cleared = pruneRelationFieldsCache(cached, []);
+  assert.notEqual(cleared, cached, '从已缓存清空必须写新对象');
+  assert.deepEqual(cleared, {});
+  assert.equal(
+    pruneRelationFieldsCache(cleared, []),
+    cleared,
+    '清空后的空缓存连续调用不得再换引用',
+  );
+
+  const subscriptionSource = readFileSync(subscriptionFormPath, 'utf8');
+  const drawerSource = readFileSync(drawerFormPath, 'utf8');
+  assertFormUsesSharedPrune(subscriptionSource, 'subscription/subscriptionRuleForm');
+  assertFormUsesSharedPrune(drawerSource, 'cmdb-subscription-drawer/subscriptionRuleForm');
+
+  const utilSource = readFileSync(utilPath, 'utf8');
+  assert.match(utilSource, /export function pruneRelationFieldsCache/, '必须导出 pruneRelationFieldsCache');
+
+  console.log('cmdb-subscribe-relation-fields-loop-test: ok');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/web/src/app/cmdb/components/cmdb-subscription-drawer/subscriptionRuleForm.tsx
+++ b/web/src/app/cmdb/components/cmdb-subscription-drawer/subscriptionRuleForm.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { Form, Input, Radio, Select } from 'antd';
 import type { CmdbAttrField } from '@/app/cmdb/components/cmdb-shared';
+import { pruneRelationFieldsCache } from '@/app/cmdb/utils/relationFieldsCache';
 import { useTranslation } from '@/utils/i18n';
 import { useUserInfoContext } from '@/context/userInfo';
 import TriggerTypeConfig from './triggerTypeConfig';
@@ -159,8 +160,8 @@ const SubscriptionRuleForm = forwardRef<SubscriptionRuleFormRef, SubscriptionRul
 
   useEffect(() => {
     const selectedModelIds = relationChangeModels.map((item) => item.related_model);
+    setRelationFieldsByModel((prev) => pruneRelationFieldsCache(prev, selectedModelIds));
     if (selectedModelIds.length === 0) {
-      setRelationFieldsByModel({});
       return;
     }
 
@@ -209,17 +210,6 @@ const SubscriptionRuleForm = forwardRef<SubscriptionRuleFormRef, SubscriptionRul
           }));
         });
     });
-
-    setRelationFieldsByModel((prev) => {
-      const next: Record<string, CmdbAttrField[]> = {};
-      selectedModelIds.forEach((id) => {
-        if (prev[id]) {
-          next[id] = prev[id];
-        }
-      });
-      return next;
-    });
-     
   }, [
     relationChangeModels,
     runtime,

--- a/web/src/app/cmdb/components/subscription/subscriptionRuleForm.tsx
+++ b/web/src/app/cmdb/components/subscription/subscriptionRuleForm.tsx
@@ -16,6 +16,7 @@ import type {
 } from '@/app/cmdb/types/subscription';
 import { useChannelApi } from '@/app/system-manager/api/channel';
 import type { AttrFieldType } from '@/app/cmdb/types/assetManage';
+import { pruneRelationFieldsCache } from '@/app/cmdb/utils/relationFieldsCache';
 
 interface SubscriptionRuleFormProps {
   initialValues?: SubscriptionRule;
@@ -162,8 +163,8 @@ const SubscriptionRuleForm = forwardRef<SubscriptionRuleFormRef, SubscriptionRul
 
   useEffect(() => {
     const selectedModelIds = relationChangeModels.map((item) => item.related_model);
+    setRelationFieldsByModel((prev) => pruneRelationFieldsCache(prev, selectedModelIds));
     if (selectedModelIds.length === 0) {
-      setRelationFieldsByModel({});
       return;
     }
 
@@ -212,17 +213,6 @@ const SubscriptionRuleForm = forwardRef<SubscriptionRuleFormRef, SubscriptionRul
           }));
         });
     });
-
-    setRelationFieldsByModel((prev) => {
-      const next: Record<string, AttrFieldType[]> = {};
-      selectedModelIds.forEach((id) => {
-        if (prev[id]) {
-          next[id] = prev[id];
-        }
-      });
-      return next;
-    });
-     
   }, [
     relationChangeModels,
     getModelAttrGroupsFullInfo,

--- a/web/src/app/cmdb/utils/relationFieldsCache.ts
+++ b/web/src/app/cmdb/utils/relationFieldsCache.ts
@@ -1,0 +1,19 @@
+export function pruneRelationFieldsCache<T>(
+  prev: Record<string, T>,
+  selectedModelIds: string[],
+): Record<string, T> {
+  const selected = new Set(selectedModelIds);
+  const prevKeys = Object.keys(prev);
+  const hasDroppedKey = prevKeys.some((key) => !selected.has(key));
+  if (!hasDroppedKey) {
+    return prev;
+  }
+
+  const next: Record<string, T> = {};
+  for (const key of prevKeys) {
+    if (selected.has(key)) {
+      next[key] = prev[key];
+    }
+  }
+  return next;
+}


### PR DESCRIPTION
## 复现步骤

前置：账号能打开 CMDB，准备一个可访问的资产实例，模型里至少有一个可编辑属性，且不在批量编辑状态。

1. 进入 CMDB 左侧菜单 **资产**，打开该实例，点子菜单 **基础信息**。
2. 等基本信息加载完成。页头附近有铃铛按钮 **订阅**（旁边是批量编辑，不要点它）。
3. 点 **订阅**。弹出 **新建规则**。页脚是 **保存并启用**、**仅保存**、**取消**。
4. 不要选触发类型 **关联变化**，也不要等字段请求。打开后看页面是否持续重绘、控制台是否出现最大更新深度警告。

修复前：表单一挂载，关联字段 effect 在空选择时每次写入新的 `{}`，又把这段缓存放进依赖，自己触发下一轮。  
修复后：空选择且缓存已空时复用原对象；模型集合未变也复用原对象。增删已缓存模型仍更新缓存。默认字段选择规则不变。

## 修复方案

抽出 `pruneRelationFieldsCache`。无丢键时返回 `prev`；只有删掉已缓存模型时才写新对象。快捷订阅表单和订阅抽屉里的两套 `SubscriptionRuleForm` 都改用它。

不改规则 JSON、收件人、组织权限、`getModelAttrGroupsFullInfo` 参数，也不靠禁用 **订阅** 来修。

Fixes #5236

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 点 **订阅** 打开 **新建规则**，未选 **关联变化** | 每轮写新 `{}`，持续渲染 | 空缓存复用同一引用，渲染收敛 |
| 已选关联模型且字段已缓存 | prune 总是 `return next` | 键未变返回 `prev` |
| 删掉某个已缓存关联模型 | 更新缓存 | 仍写新对象，去掉该模型 |
| 新增尚未拉完字段的模型 | 可能换引用 | prune 不换引用，等请求写入 |

## 影响面

- **会变**：仅资产详情 **基础信息** → **订阅** 的快捷 **新建规则**，以及订阅抽屉里同一套关联字段缓存更新方式。
- **不变**：按钮 **订阅**、页脚 **保存并启用** / **仅保存** / **取消**、触发类型 **关联变化** 的默认字段选择、规则 JSON、权限。
- **未改**：字段请求成功/失败仍会写入该模型的新缓存项；空数组失败占位也视为已缓存。
- **不在范围**：批量编辑、数据订阅规则列表页本身的筛选。
