### PR TITLE
bugfix: 定时任务切换 Playbook 时按实际类型提交

### DIFF
--- a/web/scripts/job-cron-playbook-payload-test.ts
+++ b/web/scripts/job-cron-playbook-payload-test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import {
+  buildScheduledTaskTemplatePayload,
+  restoreScheduledTaskTemplateUi,
+} from '../src/app/job/utils/scheduledTaskPayload';
+
+const root = process.cwd();
+const read = (relativePath: string) => readFileSync(path.join(root, relativePath), 'utf8');
+
+const createSource = read('src/app/job/(pages)/execution/cron-task/create/page.tsx');
+const editSource = read('src/app/job/(pages)/execution/cron-task/edit/page.tsx');
+const zh = JSON.parse(read('src/app/job/locales/zh.json'));
+const menu = JSON.parse(read('src/app/job/constants/menu.json'));
+
+const executionMenu = menu.zh.find((item: { name: string }) => item.name === 'execution');
+const cronTaskMenu = executionMenu?.children?.find((item: { name: string }) => item.name === 'cron_task');
+
+assert.equal(executionMenu?.title, '作业执行');
+assert.equal(cronTaskMenu?.title, '定时任务');
+assert.equal(zh.job.editTask, '编辑定时任务');
+assert.equal(zh.job.jobType, '作业类型');
+assert.equal(zh.job.scriptExecution, '脚本执行');
+assert.equal(zh.job.selectTemplate, '选择模版');
+assert.equal(zh.job.scriptLibrary, '脚本库');
+assert.equal(zh.job.playbook, 'Playbook');
+assert.equal(zh.job.saveAndEnable, '保存并启用');
+assert.equal(zh.job.saveOnly, '仅保存');
+assert.equal(zh.job.cancel, '取消');
+
+const switchToPlaybook = buildScheduledTaskTemplatePayload({
+  jobType: 'script',
+  templateType: 'playbook',
+  script: 11,
+  playbook: 22,
+});
+assert.deepEqual(switchToPlaybook, {
+  job_type: 'playbook',
+  script: null,
+  playbook: 22,
+});
+assert.equal(JSON.parse(JSON.stringify(switchToPlaybook)).script, null);
+
+const switchBackToScript = buildScheduledTaskTemplatePayload({
+  jobType: 'script',
+  templateType: 'script',
+  script: 11,
+  playbook: 22,
+});
+assert.deepEqual(switchBackToScript, {
+  job_type: 'script',
+  script: 11,
+  playbook: null,
+});
+assert.equal(JSON.parse(JSON.stringify(switchBackToScript)).playbook, null);
+
+const createPlaybook = buildScheduledTaskTemplatePayload({
+  jobType: 'script',
+  templateType: 'playbook',
+  playbook: 33,
+});
+assert.deepEqual(createPlaybook, {
+  job_type: 'playbook',
+  script: null,
+  playbook: 33,
+});
+
+const restoredPlaybook = restoreScheduledTaskTemplateUi({
+  job_type: 'playbook',
+  script: 11,
+  playbook: 22,
+});
+assert.deepEqual(restoredPlaybook, {
+  jobType: 'script',
+  templateType: 'playbook',
+});
+
+const dirtyScriptWithPlaybook = restoreScheduledTaskTemplateUi({
+  job_type: 'script',
+  script: 11,
+  playbook: 22,
+});
+assert.deepEqual(dirtyScriptWithPlaybook, {
+  jobType: 'script',
+  templateType: 'script',
+});
+
+assert.match(createSource, /from '@\/app\/job\/utils\/scheduledTaskPayload'/);
+assert.match(editSource, /from '@\/app\/job\/utils\/scheduledTaskPayload'/);
+assert.match(createSource, /buildScheduledTaskTemplatePayload\(/);
+assert.match(editSource, /buildScheduledTaskTemplatePayload\(/);
+assert.match(editSource, /restoreScheduledTaskTemplateUi\(/);
+assert.match(editSource, /<Radio value="script">\{t\('job\.scriptExecution'\)\}<\/Radio>/);
+assert.doesNotMatch(
+  editSource,
+  /task\.job_type === 'script'[\s\S]{0,180}task[\s\S]{0,40}\.playbook/,
+);
+
+console.log('job-cron-playbook-payload-test passed');

--- a/web/src/app/job/(pages)/execution/cron-task/create/page.tsx
+++ b/web/src/app/job/(pages)/execution/cron-task/create/page.tsx
@@ -25,6 +25,7 @@ import dayjs from 'dayjs';
 import HostSelectionModal, { HostItem, TargetSourceType } from '@/app/job/components/jobHostSelectionModalRuntime';
 import { AddTargetHostButton, TargetSourceSelector } from '@/app/job/components/target-selection-controls';
 import { createDefaultExecutionName } from '@/app/job/utils/execution-name';
+import { buildScheduledTaskTemplatePayload } from '@/app/job/utils/scheduledTaskPayload';
 import { useUserInfoContext } from '@/context/userInfo';
 
 const CreateCronTaskPage = () => {
@@ -215,7 +216,12 @@ const CreateCronTaskPage = () => {
       const formData: ScheduledTaskFormData = {
         name: values.name,
         description: values.description,
-        job_type: jobType,
+        ...buildScheduledTaskTemplatePayload({
+          jobType,
+          templateType,
+          script: values.script,
+          playbook: values.playbook,
+        }),
         ...scheduleData,
         target_source: targetSource === 'node_manager' ? 'node_mgmt' : 'manual',
         target_list: targetList,
@@ -224,13 +230,7 @@ const CreateCronTaskPage = () => {
         team: selectedGroup ? [Number(selectedGroup.id)] : [],
       };
 
-      if (jobType === 'script') {
-        if (templateType === 'script') {
-          formData.script = values.script;
-        } else {
-          formData.playbook = values.playbook;
-        }
-      } else if (jobType === 'file') {
+      if (jobType === 'file') {
         formData.target_path = values.target_path;
       }
 

--- a/web/src/app/job/(pages)/execution/cron-task/edit/page.tsx
+++ b/web/src/app/job/(pages)/execution/cron-task/edit/page.tsx
@@ -25,6 +25,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import dayjs from 'dayjs';
 import HostSelectionModal, { HostItem, TargetSourceType } from '@/app/job/components/jobHostSelectionModalRuntime';
 import { AddTargetHostButton, TargetSourceSelector } from '@/app/job/components/target-selection-controls';
+import { buildScheduledTaskTemplatePayload, restoreScheduledTaskTemplateUi } from '@/app/job/utils/scheduledTaskPayload';
 import { useUserInfoContext } from '@/context/userInfo';
 
 const EditCronTaskContent = () => {
@@ -123,7 +124,9 @@ const EditCronTaskContent = () => {
     setPageLoading(true);
     try {
       const task = await getScheduledTaskDetail(taskId);
-      setJobType(task.job_type);
+      const restoredTemplate = restoreScheduledTaskTemplateUi(task);
+      setJobType(restoredTemplate.jobType);
+      setTemplateType(restoredTemplate.templateType);
 
       form.setFieldsValue?.({}) // ensure form is ready
       form.setFieldsValue({
@@ -135,15 +138,6 @@ const EditCronTaskContent = () => {
         playbook: (task as any).playbook,
         target_path: (task as any).target_path,
       });
-
-      // Set template type based on job_type and presence of playbook
-      if (task.job_type === 'script') {
-        if ((task as any).playbook) {
-          setTemplateType('playbook');
-        } else {
-          setTemplateType('script');
-        }
-      }
 
       // Set host selection from target_list
       const taskTargetSource = (task as any).target_source;
@@ -323,7 +317,12 @@ const EditCronTaskContent = () => {
       const formData: ScheduledTaskFormData = {
         name: values.name,
         description: values.description,
-        job_type: jobType,
+        ...buildScheduledTaskTemplatePayload({
+          jobType,
+          templateType,
+          script: values.script,
+          playbook: values.playbook,
+        }),
         ...scheduleData,
         target_source: targetSource === 'node_manager' ? 'node_mgmt' : 'manual',
         target_list: targetList,
@@ -332,13 +331,7 @@ const EditCronTaskContent = () => {
         team: selectedGroup ? [Number(selectedGroup.id)] : [],
       };
 
-      if (jobType === 'script') {
-        if (templateType === 'script') {
-          formData.script = values.script;
-        } else {
-          formData.playbook = values.playbook;
-        }
-      } else if (jobType === 'file') {
+      if (jobType === 'file') {
         formData.target_path = values.target_path;
       }
 

--- a/web/src/app/job/types/index.ts
+++ b/web/src/app/job/types/index.ts
@@ -383,8 +383,8 @@ export interface ScheduledTaskFormData {
   schedule_type: ScheduleType;
   cron_expression?: string;
   scheduled_time?: string;
-  script?: number;
-  playbook?: number;
+  script?: number | null;
+  playbook?: number | null;
   target_source: ExecutionTargetSource;
   target_list: TargetListItem[];
   params?: Record<string, unknown>;

--- a/web/src/app/job/utils/scheduledTaskPayload.ts
+++ b/web/src/app/job/utils/scheduledTaskPayload.ts
@@ -1,0 +1,44 @@
+import type { JobType, ScheduledTaskFormData } from '../types';
+
+export type CronTemplateType = 'script' | 'playbook';
+
+export interface BuildScheduledTaskTemplateInput {
+  jobType: JobType;
+  templateType: CronTemplateType;
+  script?: number | null;
+  playbook?: number | null;
+}
+
+export function buildScheduledTaskTemplatePayload(
+  input: BuildScheduledTaskTemplateInput,
+): Pick<ScheduledTaskFormData, 'job_type' | 'script' | 'playbook'> {
+  if (input.jobType === 'file') {
+    return { job_type: 'file' };
+  }
+
+  if (input.templateType === 'playbook') {
+    return {
+      job_type: 'playbook',
+      script: null,
+      playbook: input.playbook ?? null,
+    };
+  }
+
+  return {
+    job_type: 'script',
+    script: input.script ?? null,
+    playbook: null,
+  };
+}
+
+export function restoreScheduledTaskTemplateUi(task: {
+  job_type?: JobType | string | null;
+}): { jobType: JobType; templateType: CronTemplateType } {
+  if (task.job_type === 'playbook') {
+    return { jobType: 'script', templateType: 'playbook' };
+  }
+  if (task.job_type === 'file') {
+    return { jobType: 'file', templateType: 'script' };
+  }
+  return { jobType: 'script', templateType: 'script' };
+}


### PR DESCRIPTION
## 复现步骤

前置：账号能打开作业平台，同一团队内已有合法脚本定时任务、可见 Playbook，以及有效目标主机。

1. 进入作业平台左侧菜单 **作业执行** → **定时任务**。列表可点 **新建定时任务**。
2. 在已有脚本任务行点 **编辑**。页头是 **编辑定时任务**。
3. **作业类型** 保持 **脚本执行**。把 **选择模版** 从 **脚本库** 切到 **Playbook**，选一个 Playbook。
4. 点 **保存并启用**（或 **仅保存**）。之后可在列表点立即执行，或等下次调度。点 **取消** 可退出。

修复前：保存成功，请求仍是 `job_type=script` 并带上 playbook，旧 script 被服务端回退保留。立即执行和下次调度仍跑旧脚本。从新建页直接选 Playbook 会保存失败。  
修复后：切到 Playbook 的请求是 `job_type=playbook`，`script` 显式为 `null`。反向切回脚本库会发 `job_type=script` 且 `playbook` 为 `null`。新建 Playbook 也可按 playbook 类型提交。

## 修复方案

抽出 `buildScheduledTaskTemplatePayload` / `restoreScheduledTaskTemplateUi`。新建页和编辑页共用。

- 选择模版为 Playbook 时提交 `job_type=playbook`，并清空 script。
- 选择模版为脚本库时提交 `job_type=script`，并清空 playbook。
- 加载已有 playbook 任务时，作业类型仍显示 **脚本执行**，选择模版为 **Playbook**。不凭 script 与 playbook 同时存在猜测意图。

不改后端校验、权限和调度器，也不靠禁用保存来修。

Fixes #5237

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 编辑页从 **脚本库** 切到 **Playbook** 后 **保存并启用** | `job_type` 仍是 script，旧脚本被保留 | `job_type=playbook`，script 显式为空 |
| 再切回 **脚本库** 保存 | playbook 可能残留 | `job_type=script`，playbook 显式为空 |
| 新建页选 **Playbook** 保存 | `job_type=script` 且无 script，校验失败 | 按 playbook 类型提交 |
| 再打开已保存的 Playbook 任务 | 可能把作业类型设成没有单选项的值 | **脚本执行** + **Playbook** |

## 影响面

- **会变**：仅 **作业执行** → **定时任务** 的新建/编辑提交载荷，以及编辑页按权威 `job_type` 还原选择模版。
- **不变**：菜单 **定时任务**、按钮 **新建定时任务** / **编辑**、**保存并启用** / **仅保存** / **取消**、权限、后端校验。
- **未改**：作业类型切到 **文件分发** 时仍不显式清空 script/playbook；节点管理来源仍不支持 Playbook。
- **不在范围**：已有 `job_type=script` 且同时带 playbook 的脏数据纠正、快速执行页。
