### PR TITLE
bugfix: 定时任务收起暂不支持的文件分发入口

### DIFF
--- a/web/scripts/job-cron-file-dist-entry-test.ts
+++ b/web/scripts/job-cron-file-dist-entry-test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const read = (rel: string) => fs.readFileSync(path.join(root, rel), 'utf8');
+
+const createPage = read('src/app/job/(pages)/execution/cron-task/create/page.tsx');
+const editPage = read('src/app/job/(pages)/execution/cron-task/edit/page.tsx');
+const zh = JSON.parse(read('src/app/job/locales/zh.json'));
+const en = JSON.parse(read('src/app/job/locales/en.json'));
+const menu = JSON.parse(read('src/app/job/constants/menu.json'));
+
+function radioTags(source: string): string[] {
+  return [...source.matchAll(/<Radio\b[^>]*>/g)].map((match) => match[0]);
+}
+
+function hasSavableFileRadio(source: string): boolean {
+  return radioTags(source).some(
+    (tag) => /value=["']file["']/.test(tag) && !/\bdisabled\b/.test(tag)
+  );
+}
+
+function extractHandleSubmit(source: string): string {
+  const start = source.indexOf('const handleSubmit');
+  assert.ok(start >= 0, 'handleSubmit must exist');
+  const end = source.indexOf('const handleHostConfirm', start);
+  assert.ok(end > start, 'handleSubmit must end before handleHostConfirm');
+  return source.slice(start, end);
+}
+
+function canSubmitFileJobType(submit: string): boolean {
+  if (/job_type:\s*['"]file['"]/.test(submit)) {
+    return true;
+  }
+  const buildsFilePayload = /else if\s*\(\s*jobType\s*===\s*['"]file['"]\s*\)/.test(submit);
+  const assignsJobType = /job_type:\s*jobType/.test(submit);
+  const rejectsFile =
+    /if\s*\(\s*jobType\s*===\s*['"]file['"]\s*\)\s*\{[^}]*return;/.test(submit);
+  return (assignsJobType && !rejectsFile) || buildsFilePayload;
+}
+
+const zhMenu = menu.zh.find((item: { name: string }) => item.name === 'execution');
+const cronMenu = zhMenu?.children?.find((item: { name: string }) => item.name === 'cron_task');
+assert.equal(zhMenu?.title, '作业执行');
+assert.equal(cronMenu?.title, '定时任务');
+
+assert.equal(zh.job.scriptExecution, '脚本执行');
+assert.equal(zh.job.createTask, '新建定时任务');
+assert.equal(zh.job.saveAndEnable, '保存并启用');
+assert.equal(zh.job.saveOnly, '仅保存');
+assert.equal(zh.job.cancel, '取消');
+assert.equal(zh.job.fileDistribution, '文件分发');
+assert.equal(zh.job.fileDistTitle, '文件分发');
+assert.equal(en.job.fileDistribution, 'File Distribution');
+assert.equal(en.job.fileDistTitle, 'File Distribution');
+
+assert.match(zh.job.cronFileDistNotSupported, /暂不支持/);
+assert.ok(en.job.cronFileDistNotSupported);
+
+for (const [label, source] of [
+  ['create', createPage],
+  ['edit', editPage],
+] as const) {
+  assert.equal(
+    hasSavableFileRadio(source),
+    false,
+    `${label} must not expose a savable Radio value=file`
+  );
+  assert.equal(
+    canSubmitFileJobType(extractHandleSubmit(source)),
+    false,
+    `${label} must not submit job_type=file on the save path`
+  );
+  assert.match(source, /t\('job\.cronFileDistNotSupported'\)/);
+  assert.match(source, /<Radio value="script">\{t\('job\.scriptExecution'\)\}<\/Radio>/);
+  assert.match(source, /t\('job\.saveAndEnable'\)/);
+  assert.match(source, /t\('job\.saveOnly'\)/);
+  assert.match(source, /t\('job\.cancel'\)/);
+  assert.doesNotMatch(source, /file_distribution/);
+  assert.doesNotMatch(source, /\bfiles\s*:/);
+}
+
+assert.match(createPage, /t\('job\.createTask'\)/);
+
+console.log('job-cron-file-dist-entry-test: ok');

--- a/web/src/app/job/(pages)/execution/cron-task/create/page.tsx
+++ b/web/src/app/job/(pages)/execution/cron-task/create/page.tsx
@@ -213,6 +213,11 @@ const CreateCronTaskPage = () => {
         os: h.osType?.toLowerCase() as 'linux' | 'windows',
       }));
 
+      if (jobType === 'file') {
+        message.warning(t('job.cronFileDistNotSupported'));
+        return;
+      }
+
       const formData: ScheduledTaskFormData = {
         name: values.name,
         description: values.description,
@@ -229,10 +234,6 @@ const CreateCronTaskPage = () => {
         is_enabled: enableAfterSave,
         team: selectedGroup ? [Number(selectedGroup.id)] : [],
       };
-
-      if (jobType === 'file') {
-        formData.target_path = values.target_path;
-      }
 
       await createScheduledTask(formData);
       message.success(t('job.createTaskSuccess'));
@@ -335,8 +336,10 @@ const CreateCronTaskPage = () => {
               onChange={(e) => setJobType(e.target.value)}
             >
               <Radio value="script">{t('job.scriptExecution')}</Radio>
-              <Radio value="file">{t('job.fileDistribution')}</Radio>
             </Radio.Group>
+            <p className="text-xs mt-2 m-0 text-[var(--color-text-3)]">
+              {t('job.cronFileDistNotSupported')}
+            </p>
           </Form.Item>
 
           {jobType === 'script' && (
@@ -401,16 +404,6 @@ const CreateCronTaskPage = () => {
                   </Select>
                 </Form.Item>
               )}
-            </Form.Item>
-          )}
-
-          {jobType === 'file' && (
-            <Form.Item
-              label={t('job.fileDistTargetPath')}
-              name="target_path"
-              rules={[{ required: true, message: t('job.targetPathRequired') }]}
-            >
-              <Input placeholder={t('job.fileDistTargetPathPlaceholder')} />
             </Form.Item>
           )}
 

--- a/web/src/app/job/(pages)/execution/cron-task/edit/page.tsx
+++ b/web/src/app/job/(pages)/execution/cron-task/edit/page.tsx
@@ -314,6 +314,11 @@ const EditCronTaskContent = () => {
         os: h.osType?.toLowerCase() as 'linux' | 'windows',
       }));
 
+      if (jobType === 'file') {
+        message.warning(t('job.cronFileDistNotSupported'));
+        return;
+      }
+
       const formData: ScheduledTaskFormData = {
         name: values.name,
         description: values.description,
@@ -330,10 +335,6 @@ const EditCronTaskContent = () => {
         is_enabled: enableAfterSave,
         team: selectedGroup ? [Number(selectedGroup.id)] : [],
       };
-
-      if (jobType === 'file') {
-        formData.target_path = values.target_path;
-      }
 
       await updateScheduledTask(taskId, formData);
       message.success(t('job.editTaskSuccess'));
@@ -456,8 +457,10 @@ const EditCronTaskContent = () => {
               onChange={(e) => setJobType(e.target.value)}
             >
               <Radio value="script">{t('job.scriptExecution')}</Radio>
-              <Radio value="file">{t('job.fileDistribution')}</Radio>
             </Radio.Group>
+            <p className="text-xs mt-2 m-0 text-[var(--color-text-3)]">
+              {t('job.cronFileDistNotSupported')}
+            </p>
           </Form.Item>
 
           {jobType === 'script' && (
@@ -522,16 +525,6 @@ const EditCronTaskContent = () => {
                   </Select>
                 </Form.Item>
               )}
-            </Form.Item>
-          )}
-
-          {jobType === 'file' && (
-            <Form.Item
-              label={t('job.fileDistTargetPath')}
-              name="target_path"
-              rules={[{ required: true, message: t('job.targetPathRequired') }]}
-            >
-              <Input placeholder={t('job.fileDistTargetPathPlaceholder')} />
             </Form.Item>
           )}
 

--- a/web/src/app/job/locales/en.json
+++ b/web/src/app/job/locales/en.json
@@ -480,6 +480,7 @@
     "confirmExecuteQuestion": "Do you want to proceed with execution?",
     "confirmExecute": "Confirm Execution",
     "fileDistributionNotSupported": "Re-execution is not supported for file distribution jobs",
+    "cronFileDistNotSupported": "Scheduled tasks do not support file distribution yet. Use Execution → File Distribution for immediate distribution.",
     "reExecuteSuccess": "Re-execution has been triggered",
     "reExecuteFailed": "Failed to re-execute",
     "testConnectionSuccess": "Connection test succeeded",

--- a/web/src/app/job/locales/zh.json
+++ b/web/src/app/job/locales/zh.json
@@ -480,6 +480,7 @@
     "confirmExecuteQuestion": "是否确认执行？",
     "confirmExecute": "确认执行",
     "fileDistributionNotSupported": "文件分发类型暂不支持重新执行",
+    "cronFileDistNotSupported": "定时任务暂不支持文件分发，请使用「作业执行 → 文件分发」进行即时分发。",
     "reExecuteSuccess": "重新执行已触发",
     "reExecuteFailed": "重新执行失败",
     "testConnectionSuccess": "连接测试成功",


### PR DESCRIPTION
## 复现步骤

前置：账号能打开作业平台定时任务。

1. 进入作业平台左侧菜单 **作业执行** → **定时任务**。
2. 点 **新建定时任务**。
3. 看 **作业类型**。修复前这里有 **脚本执行** 和 **文件分发**。
4. 若修复前：选 **文件分发**，填目标主机、目标路径和计划，点 **保存并启用**（或 **仅保存**）。点 **取消** 可退出。

修复前：可以选 **文件分发** 并填完整张表，保存时提交 `job_type=file`。后端枚举是 `file_distribution`，而且定时文件分发会被资源边界拒绝，页面也不说明暂不支持。  
修复后：作业类型只保留 **脚本执行**。下方说明 **定时任务暂不支持文件分发，请使用「作业执行 → 文件分发」进行即时分发。** 即时 **文件分发** 菜单不受影响。

## 修复方案

新建页和编辑页都收起可保存的文件分发 Radio 和目标路径表单。作业类型下展示 `cronFileDistNotSupported`。若状态里仍是 file，保存前 warning 并 return，不提交。

不把 `file` 改成 `file_distribution`，不补 `files` 输入，不改后端保护。

Fixes #5238

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 新建 **定时任务** 的作业类型 | 可选 **文件分发** | 只保留 **脚本执行**，并说明暂不支持 |
| 选文件分发后 **保存并启用** | 提交 `job_type=file`，必然失败 | 没有可保存入口；残留 file 状态也不提交 |
| **作业执行** → **文件分发** 即时分发 | 可用 | 不变 |

## 影响面

- **会变**：仅定时任务新建/编辑的作业类型选项。文件分发不再作为可保存入口。
- **不变**：菜单 **作业执行** → **定时任务**、按钮 **新建定时任务**、**保存并启用** / **仅保存** / **取消**、即时 **文件分发**、后端校验与资源边界。
- **未改**：存量 `file_distribution` 任务若还能打开编辑页，作业类型可能没有选中项；保存不会把它映射成后端枚举，需要改选 **脚本执行** 后才能保存。
- **不在范围**：即时文件分发页、Playbook 类型提交（见 #5237）。
