### PR TITLE
bugfix: 环形图空态恢复后重新绑定尺寸观察

### DIFF
--- a/web/scripts/log-docker-donut-resize-test.ts
+++ b/web/scripts/log-docker-donut-resize-test.ts
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const root = process.cwd();
+const chartSource = readFileSync(
+  join(
+    root,
+    'src/app/log/(pages)/analysis/dashBoard/widgets/docker/dockerDonutChart.tsx'
+  ),
+  'utf8'
+);
+
+const emptyEffectWithObserver = /useEffect\(\(\)\s*=>\s*\{[\s\S]*?\},\s*\[\s*\]\s*\)/g;
+const bindsObserverInEmptyEffect = [...chartSource.matchAll(emptyEffectWithObserver)].some(
+  (match) => /new ResizeObserver/.test(match[0]) || /\.observe\(/.test(match[0])
+);
+
+assert.equal(
+  bindsObserverInEmptyEffect,
+  false,
+  'DockerDonutChart must not bind ResizeObserver inside useEffect with empty deps'
+);
+assert.match(
+  chartSource,
+  /useCallback\(\s*\(node:\s*HTMLDivElement\s*\|\s*null\)/,
+  'DockerDonutChart must bind size observation with a callback ref'
+);
+assert.match(
+  chartSource,
+  /ref=\{containerCallbackRef\}/,
+  'sized container must use the callback ref so empty→data remounts rebind'
+);
+assert.match(
+  chartSource,
+  /from ['"]\.\/dockerDonutSizeObserver['"]/,
+  'chart must reuse the extracted size binder'
+);
+assert.match(
+  chartSource,
+  /if\s*\(\s*!chartOption\s*\)\s*\{\s*return\s*<ChartEmptyState/,
+  'empty state must not render the sized container'
+);
+assert.match(
+  chartSource,
+  /size\.w\s*>\s*0\s*&&/,
+  'center total must stay gated on size.w > 0'
+);
+assert.match(chartSource, /总数/, 'center copy must remain 总数');
+
+class FakeResizeObserver {
+  observeCalls: unknown[] = [];
+  disconnectCalls = 0;
+
+  constructor(public readonly callback: ResizeObserverCallback) {}
+
+  observe(target: Element) {
+    this.observeCalls.push(target);
+  }
+
+  disconnect() {
+    this.disconnectCalls += 1;
+  }
+
+  unobserve() {}
+}
+
+const created: FakeResizeObserver[] = [];
+const FakeObserver = class extends FakeResizeObserver {
+  constructor(callback: ResizeObserverCallback) {
+    super(callback);
+    created.push(this);
+  }
+} as unknown as typeof ResizeObserver;
+
+async function main() {
+  const sizes: Array<{ w: number; h: number }> = [];
+  const observerModule = await import(
+    '../src/app/log/(pages)/analysis/dashBoard/widgets/docker/dockerDonutSizeObserver.ts'
+  );
+  const binder = observerModule.createDockerDonutSizeBinder(
+    (size: { w: number; h: number }) => sizes.push(size),
+    FakeObserver
+  );
+
+  binder.bind(null);
+  assert.equal(created.length, 0, 'empty node must not construct or observe');
+
+  const firstNode = { id: 'first' } as unknown as Element;
+  binder.bind(firstNode);
+  assert.equal(created.length, 1, 'non-empty node must observe current DOM');
+  assert.equal(created[0].observeCalls[0], firstNode);
+  assert.equal(created[0].disconnectCalls, 0);
+
+  const secondNode = { id: 'second' } as unknown as Element;
+  binder.bind(secondNode);
+  assert.equal(created[0].disconnectCalls, 1, 'rebinding must disconnect the previous observer');
+  assert.equal(created.length, 2, 'rebinding must observe the new node');
+  assert.equal(created[1].observeCalls[0], secondNode);
+
+  binder.bind(null);
+  assert.equal(created[1].disconnectCalls, 1, 'returning to empty must disconnect');
+  assert.equal(created.length, 2, 'empty rebind must not observe a missing container');
+
+  binder.unbind();
+  assert.equal(created[1].disconnectCalls, 1, 'unbind after empty bind stays disconnected');
+
+  console.log('log docker donut resize behavior OK');
+}
+
+void main();

--- a/web/src/app/log/(pages)/analysis/dashBoard/widgets/docker/dockerDonutChart.tsx
+++ b/web/src/app/log/(pages)/analysis/dashBoard/widgets/docker/dockerDonutChart.tsx
@@ -1,8 +1,9 @@
-import React, { useMemo, useRef, useState, useEffect } from 'react';
+import React, { useMemo, useRef, useState, useCallback, useEffect } from 'react';
 import ReactEcharts from 'echarts-for-react';
 import ChartEmptyState from '@/components/chart-empty-state';
 import useChartColors from './useChartColors';
 import { formatNumericValue } from '@/app/log/utils/common';
+import { createDockerDonutSizeBinder } from './dockerDonutSizeObserver';
 
 const trimTrailingZeros = (value: string) =>
   value.replace(/\.0+$|(?<=\.\d*[1-9])0+$/g, '');
@@ -58,23 +59,18 @@ const DockerDonutChart: React.FC<DockerDonutChartProps> = ({
   config
 }) => {
   const colors = useChartColors();
-  const containerRef = useRef<HTMLDivElement>(null);
   // 容器尺寸，用于计算绝对像素 radius
   const [size, setSize] = useState({ w: 0, h: 0 });
+  const binderRef = useRef(createDockerDonutSizeBinder(setSize));
+
+  const containerCallbackRef = useCallback((node: HTMLDivElement | null) => {
+    binderRef.current.bind(node);
+  }, []);
 
   useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const obs = new ResizeObserver((entries) => {
-      for (const entry of entries) {
-        setSize({
-          w: entry.contentRect.width,
-          h: entry.contentRect.height
-        });
-      }
-    });
-    obs.observe(el);
-    return () => obs.disconnect();
+    return () => {
+      binderRef.current.unbind();
+    };
   }, []);
 
   const { chartOption, total } = useMemo(() => {
@@ -219,7 +215,7 @@ const DockerDonutChart: React.FC<DockerDonutChartProps> = ({
         : 0.38;
 
   return (
-    <div ref={containerRef} className="relative h-full w-full">
+    <div ref={containerCallbackRef} className="relative h-full w-full">
       <ReactEcharts
         option={chartOption}
         style={{ height: '100%', width: '100%' }}

--- a/web/src/app/log/(pages)/analysis/dashBoard/widgets/docker/dockerDonutSizeObserver.ts
+++ b/web/src/app/log/(pages)/analysis/dashBoard/widgets/docker/dockerDonutSizeObserver.ts
@@ -1,0 +1,38 @@
+export interface DonutSize {
+  w: number;
+  h: number;
+}
+
+export type DonutResizeObserverCtor = new (
+  callback: ResizeObserverCallback
+) => Pick<ResizeObserver, 'observe' | 'disconnect'>;
+
+export function createDockerDonutSizeBinder(
+  onSize: (size: DonutSize) => void,
+  Observer: DonutResizeObserverCtor = ResizeObserver
+) {
+  let observer: Pick<ResizeObserver, 'observe' | 'disconnect'> | null = null;
+
+  const unbind = () => {
+    observer?.disconnect();
+    observer = null;
+  };
+
+  const bind = (node: Element | null) => {
+    unbind();
+    if (!node) {
+      return;
+    }
+    observer = new Observer((entries) => {
+      for (const entry of entries) {
+        onSize({
+          w: entry.contentRect.width,
+          h: entry.contentRect.height
+        });
+      }
+    });
+    observer.observe(node);
+  };
+
+  return { bind, unbind };
+}


### PR DESCRIPTION
## 复现步骤

前置：账号能打开日志模块，环境里有 Docker 采集类型仪表盘；先让 **日志级别分布** 查不到扇区（空结果），再让数据回来。

1. 进入日志模块左侧菜单 **日志分析**。
2. 左侧分组 **容器**，点开 Docker 采集类型对应项。卡片名 **日志级别分布**。仪表盘配置名是 **Docker 日志仪表盘**；页标题优先用采集类型 display_name，不以「仪表盘」结尾时会补上该后缀。
3. 可按需选 **日志分组**（占位 **请选择分组**）、**实例**（占位 **请选择实例**）、**容器**（占位 **请选择容器**）。
4. 找到卡片 **日志级别分布**。
5. 时间范围默认 **最近15分钟**。点刷新按钮（aria-label **刷新**）。刷新频率可选 **关闭** / **1m** / **5m** / **10m**。先让卡片走空结果，再改时间范围或点 **刷新**，或把频率从 **关闭** 改成 **1m** 等到数据回来。

修复前：空结果时图走空态，容器 ref 不存在；`useEffect` 只在挂载时绑一次 ResizeObserver，空时提前返回。数据回来后扇区能出，但 `size.w` 仍是 0，中心 **总数** 不显示。  
修复后：空态恢复为有扇区时会在新容器上重新观察尺寸，中心 **总数** 能显示。

## 修复方案

抽出 `createDockerDonutSizeBinder`，用 callback ref 在节点挂上/卸下时 bind/unbind ResizeObserver。空→有、有→空→有都会 disconnect 旧观察器并观察当前 DOM。中心 **总数** 仍只在 `size.w > 0` 时渲染。

不改查询 API、权限、widgetWrapper，也不改 mysql/redis/nginx 等包装层。

Fixes #5239

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| **日志级别分布** 先空后有数据 | 扇区出来，中心 **总数** 不显示 | 新容器重新观察尺寸，中心 **总数** 显示 |
| 空态容器 | 不渲染带 ref 的图容器，挂载期 effect 不再跑 | 空态仍不渲染图容器；有数据挂载时 callback ref 绑定 |
| 查询与刷新入口 | **刷新**、频率 **关闭** / **1m** / **5m** / **10m** | 不变 |

## 影响面

- **会变**：`DockerDonutChart` 尺寸观察绑定时机。复用该图的 Docker / MySQL / Redis / Nginx 等环形图在空态恢复后也能重新量尺寸。
- **不变**：菜单 **日志分析**、分组 **容器**、卡片 **日志级别分布**、中心文案 **总数**、筛选 **日志分组** / **实例** / **容器**、按钮 **刷新**、频率 **关闭** / **1m** / **5m** / **10m**。
- **未改**：查询语句、权限、widgetWrapper 静默刷新、各仪表盘包装层。
- **不在范围**：其它自管 ResizeObserver 的饼图（如 `comPie`）。
