### PR TITLE
bugfix: 告警定时刷新改用当前筛选条件

### DIFF
--- a/web/scripts/log-alert-refresh-query-test.ts
+++ b/web/scripts/log-alert-refresh-query-test.ts
@@ -1,0 +1,167 @@
+import * as assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+interface AlertRefreshFilters {
+  level: string[];
+  state: string[];
+}
+
+interface AlertRefreshQueryState {
+  activeTab: string;
+  filters: AlertRefreshFilters;
+}
+
+interface AlertRefreshExtra {
+  tab?: string;
+  filtersConfig?: AlertRefreshFilters;
+}
+
+interface AlertRefreshQuerySnapshot {
+  current: AlertRefreshQueryState;
+}
+
+interface LoadedModule {
+  createAlertRefreshQuerySnapshot?: (
+    initial: AlertRefreshQueryState
+  ) => AlertRefreshQuerySnapshot;
+  updateAlertRefreshQuerySnapshot?: (
+    snapshot: AlertRefreshQuerySnapshot,
+    next: AlertRefreshQueryState
+  ) => void;
+  resolveAlertRefreshQuery?: (
+    snapshot: AlertRefreshQuerySnapshot,
+    extra?: AlertRefreshExtra
+  ) => AlertRefreshQueryState;
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pagePath = resolve(
+  here,
+  '../src/app/log/(pages)/event/alert/page.tsx'
+);
+
+function toQueryFields(state: AlertRefreshQueryState) {
+  return {
+    status: state.activeTab === 'activeAlarms' ? 'new' : 'closed',
+    levels: state.filters.level.join(',')
+  };
+}
+
+async function loadModule(): Promise<LoadedModule> {
+  try {
+    return (await import(
+      '../src/app/log/(pages)/event/alert/alertRefreshQuery.ts'
+    )) as LoadedModule;
+  } catch {
+    return {};
+  }
+}
+
+async function main() {
+  const loaded = await loadModule();
+  assert.equal(
+    typeof loaded.createAlertRefreshQuerySnapshot,
+    'function',
+    '应抽出 createAlertRefreshQuerySnapshot'
+  );
+  assert.equal(
+    typeof loaded.updateAlertRefreshQuerySnapshot,
+    'function',
+    '应抽出 updateAlertRefreshQuerySnapshot'
+  );
+  assert.equal(
+    typeof loaded.resolveAlertRefreshQuery,
+    'function',
+    '应抽出 resolveAlertRefreshQuery'
+  );
+
+  const snapshot = loaded.createAlertRefreshQuerySnapshot!({
+    activeTab: 'activeAlarms',
+    filters: { level: [], state: [] }
+  });
+
+  // 模拟 setInterval：创建定时器时不带 extra，后续 tick 必须读最新快照
+  const timerTick = () => loaded.resolveAlertRefreshQuery!(snapshot);
+
+  const initial = toQueryFields(timerTick());
+  assert.equal(initial.status, 'new');
+  assert.equal(initial.levels, '');
+
+  loaded.updateAlertRefreshQuerySnapshot!(snapshot, {
+    activeTab: 'activeAlarms',
+    filters: { level: ['critical'], state: [] }
+  });
+  const afterLevel = toQueryFields(timerTick());
+  assert.equal(
+    afterLevel.levels,
+    'critical',
+    '级别改成 critical 后下一 tick levels=critical'
+  );
+  assert.equal(afterLevel.status, 'new');
+
+  loaded.updateAlertRefreshQuerySnapshot!(snapshot, {
+    activeTab: 'historicalAlarms',
+    filters: { level: ['critical'], state: [] }
+  });
+  const afterTab = toQueryFields(timerTick());
+  assert.equal(
+    afterTab.status,
+    'closed',
+    '切到 historicalAlarms 后下一 tick status=closed'
+  );
+  assert.equal(afterTab.levels, 'critical');
+
+  const withExtra = toQueryFields(
+    loaded.resolveAlertRefreshQuery!(snapshot, {
+      tab: 'activeAlarms',
+      filtersConfig: { level: ['error'], state: [] }
+    })
+  );
+  assert.equal(withExtra.status, 'new');
+  assert.equal(withExtra.levels, 'error');
+
+  const page = readFileSync(pagePath, 'utf8');
+  assert.match(
+    page,
+    /from '\.\/alertRefreshQuery'/,
+    '告警页必须使用抽出的查询快照'
+  );
+  assert.match(
+    page,
+    /resolveAlertRefreshQuery/,
+    '定时与手工刷新必须经 resolveAlertRefreshQuery 读取页签和级别'
+  );
+  assert.match(
+    page,
+    /getAssetInsts\('timer'\)/,
+    '定时路径仍应无 extra 调用表格刷新'
+  );
+  assert.match(
+    page,
+    /getChartData\('timer'\)/,
+    '定时路径仍应无 extra 调用分布图刷新'
+  );
+  assert.doesNotMatch(
+    page,
+    /extra\?\.tab \|\| activeTab/,
+    '源码定时路径不得直接闭包旧 activeTab'
+  );
+  assert.doesNotMatch(
+    page,
+    /extra\?\.filtersConfig \|\| filters/,
+    '源码定时路径不得直接闭包旧 filters'
+  );
+  assert.match(page, /alertAbortControllerRef/, '须保留告警列表 abort');
+  assert.match(page, /alertRequestIdRef/, '须保留告警列表序号');
+  assert.match(page, /chartAbortControllerRef/, '须保留分布图 abort');
+  assert.match(page, /chartRequestIdRef/, '须保留分布图序号');
+
+  console.log('log-alert-refresh-query validation passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/web/src/app/log/(pages)/event/alert/alertRefreshQuery.ts
+++ b/web/src/app/log/(pages)/event/alert/alertRefreshQuery.ts
@@ -1,0 +1,53 @@
+export interface AlertRefreshFilters {
+  level: string[];
+  state: string[];
+}
+
+export interface AlertRefreshQueryState {
+  activeTab: string;
+  filters: AlertRefreshFilters;
+}
+
+export interface AlertRefreshExtra {
+  tab?: string;
+  filtersConfig?: AlertRefreshFilters;
+}
+
+export interface AlertRefreshQuerySnapshot {
+  current: AlertRefreshQueryState;
+}
+
+const cloneFilters = (filters: AlertRefreshFilters): AlertRefreshFilters => ({
+  level: [...filters.level],
+  state: [...filters.state]
+});
+
+const cloneQueryState = (
+  state: AlertRefreshQueryState
+): AlertRefreshQueryState => ({
+  activeTab: state.activeTab,
+  filters: cloneFilters(state.filters)
+});
+
+export const createAlertRefreshQuerySnapshot = (
+  initial: AlertRefreshQueryState
+): AlertRefreshQuerySnapshot => ({
+  current: cloneQueryState(initial)
+});
+
+export const updateAlertRefreshQuerySnapshot = (
+  snapshot: AlertRefreshQuerySnapshot,
+  next: AlertRefreshQueryState
+): void => {
+  snapshot.current = cloneQueryState(next);
+};
+
+export const resolveAlertRefreshQuery = (
+  snapshot: AlertRefreshQuerySnapshot,
+  extra?: AlertRefreshExtra
+): AlertRefreshQueryState => ({
+  activeTab: extra?.tab ?? snapshot.current.activeTab,
+  filters: extra?.filtersConfig
+    ? cloneFilters(extra.filtersConfig)
+    : snapshot.current.filters
+});

--- a/web/src/app/log/(pages)/event/alert/page.tsx
+++ b/web/src/app/log/(pages)/event/alert/page.tsx
@@ -35,6 +35,11 @@ import Permission from '@/components/permission';
 import Collapse from '@/components/collapse';
 import StackedBarChart from '@/app/log/components/charts/stackedBarChart';
 import AlertDetail from './alertDetail';
+import {
+  createAlertRefreshQuerySnapshot,
+  resolveAlertRefreshQuery,
+  updateAlertRefreshQuerySnapshot
+} from './alertRefreshQuery';
 import { useLocalizedTime } from '@/hooks/useLocalizedTime';
 import { useAlarmTabs } from '@/app/log/hooks/event';
 import dayjs from 'dayjs';
@@ -95,6 +100,16 @@ const Alert: React.FC = () => {
     state: []
   });
   const [activeTab, setActiveTab] = useState<string>('activeAlarms');
+  const querySnapshotRef = useRef(
+    createAlertRefreshQuerySnapshot({
+      activeTab: 'activeAlarms',
+      filters: { level: [], state: [] }
+    }).current
+  );
+  updateAlertRefreshQuerySnapshot(querySnapshotRef, {
+    activeTab,
+    filters
+  });
   const [chartData, setChartData] = useState<Record<string, any>[]>([]);
   const loadChartHabit = useCallback(
     () => getUserHabit(LOG_ALERT_CHART_HABIT_KEY),
@@ -280,6 +295,10 @@ const Alert: React.FC = () => {
     };
     setFilters(filtersConfig);
     setSearchText('');
+    updateAlertRefreshQuerySnapshot(querySnapshotRef, {
+      activeTab: val,
+      filters: filtersConfig
+    });
     getAssetInsts('refresh', { tab: val, filtersConfig, text: 'clear' });
     getChartData('refresh', { tab: val, filtersConfig });
   };
@@ -343,10 +362,11 @@ const Alert: React.FC = () => {
     const abortController = new AbortController();
     alertAbortControllerRef.current = abortController;
     const currentRequestId = ++alertRequestIdRef.current;
-    const params: any = getParams(
-      extra?.tab || activeTab,
-      extra?.filtersConfig || filters
+    const { activeTab: tab, filters: filtersMap } = resolveAlertRefreshQuery(
+      querySnapshotRef,
+      extra
     );
+    const params: any = getParams(tab, filtersMap);
     if (extra?.text === 'clear') {
       params.content = '';
     }
@@ -379,10 +399,11 @@ const Alert: React.FC = () => {
     const abortController = new AbortController();
     chartAbortControllerRef.current = abortController;
     const currentRequestId = ++chartRequestIdRef.current;
-    const params = getParams(
-      extra?.tab || activeTab,
-      extra?.filtersConfig || filters
+    const { activeTab: tab, filters: filtersMap } = resolveAlertRefreshQuery(
+      querySnapshotRef,
+      extra
     );
+    const params = getParams(tab, filtersMap);
     const chartParams: any = cloneDeep(params);
     delete chartParams.page;
     delete chartParams.page_size;
@@ -443,6 +464,10 @@ const Alert: React.FC = () => {
     const filtersConfig = cloneDeep(filters);
     filtersConfig[field] = checkedValues;
     setFilters(filtersConfig);
+    updateAlertRefreshQuerySnapshot(querySnapshotRef, {
+      activeTab,
+      filters: filtersConfig
+    });
     getAssetInsts('refresh', { filtersConfig });
     getChartData('refresh', { filtersConfig });
   };


### PR DESCRIPTION
## 复现步骤

前置：账号能打开日志告警页。

1. 进入日志模块左侧菜单 **事件** → **告警**。
2. 页签默认 **活跃告警**。也可切到 **历史告警**。
3. 把时间选择器频率从 **关闭** 改成 **1m**（还有 **5m** / **10m**）。点刷新按钮（aria-label **刷新**）可立即拉一次。
4. **级别** 多选 **严重** / **错误** / **警告**。先只选 **严重**。表格和 **分布图** 会立刻按新级别请求。
5. 不要改搜索（占位 **搜索...**）、页码和时间范围，等下一次按频率触发的刷新。

修复前：手工改级别后当次结果是对的，下一次定时刷新仍用创建定时器时的旧 `levels`/`status`，表格和分布图被旧范围覆盖；切到 **历史告警** 后也可能被活跃告警数据盖回去。  
修复后：定时刷新读当前页签和级别。选 **严重** 后下一 tick 仍是 `levels=critical`；在 **历史告警** 下下一 tick `status=closed`。

## 修复方案

抽出 `createAlertRefreshQuerySnapshot` / `resolveAlertRefreshQuery`。渲染以及改级别、切页签时更新快照。`getAssetInsts` / `getChartData` 无 extra 时（含 `'timer'`）从快照读当前 `activeTab` 和 `filters`。带 extra 的立即刷新仍覆盖快照。保留 AbortController 与 requestId。

不改接口字段、权限、默认空级别和频率选项。

Fixes #5240

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| **级别** 只选 **严重** 后等下一次频率刷新 | 表格/**分布图** 回到旧级别范围 | 仍按 `levels=critical` |
| **历史告警** 下的下一次频率刷新 | 可能被活跃告警 `status=new` 覆盖 | `status=closed` |
| 点 **刷新** | 用当前筛选 | 不变 |

## 影响面

- **会变**：仅告警页定时刷新读取的页签和级别，改为当前快照。
- **不变**：菜单 **事件** → **告警**、页签 **活跃告警** / **历史告警**、筛选 **级别**（**严重** / **错误** / **警告**）、**分布图**、搜索占位 **搜索...**、按钮 **刷新**、频率 **关闭** / **1m** / **5m** / **10m**、接口字段、权限、默认空级别、abort/序号。
- **未改**：策略页、告警详情关闭后的手工刷新语义（仍走当前快照）。
- **不在范围**：其它模块的 TimeSelector 定时刷新。
