### PR TITLE
bugfix: K8s 接入切换集群忽略迟到配置回读

### DIFF
--- a/web/scripts/log-k8s-access-setting-race-test.ts
+++ b/web/scripts/log-k8s-access-setting-race-test.ts
@@ -1,0 +1,251 @@
+import * as assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createLatestRequestGuard } from '../src/context/latestRequestGuard.ts';
+
+interface ClusterSetting {
+  instanceId: string;
+  host_log_path: string;
+  namespace_patterns: string;
+  pod_patterns: string;
+  unknown?: boolean;
+}
+
+interface FormState {
+  accessType: 'new' | 'existing';
+  k8sCluster: string | undefined;
+  host_log_path: string | undefined;
+  namespace_patterns: string | undefined;
+  pod_patterns: string | undefined;
+  settingUnknown: boolean;
+}
+
+interface InFlightRead {
+  requestId: number;
+  instanceId: string;
+  apply: (setting: ClusterSetting) => boolean;
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const accessConfigPath = resolve(
+  here,
+  '../src/app/log/(pages)/integration/list/detail/configure/k8s/accessConfig.tsx',
+);
+
+const settingA: ClusterSetting = {
+  instanceId: 'cluster-a',
+  host_log_path: '/var/log/a',
+  namespace_patterns: 'ns-a',
+  pod_patterns: 'pod-a',
+};
+
+const settingB: ClusterSetting = {
+  instanceId: 'cluster-b',
+  host_log_path: '/var/log/b',
+  namespace_patterns: 'ns-b',
+  pod_patterns: 'pod-b',
+};
+
+function createAccessSession() {
+  const guard = createLatestRequestGuard();
+  let form: FormState = {
+    accessType: 'existing',
+    k8sCluster: undefined,
+    host_log_path: undefined,
+    namespace_patterns: undefined,
+    pod_patterns: undefined,
+    settingUnknown: false,
+  };
+
+  const applyIfCurrent = (requestId: number, instanceId: string, setting: ClusterSetting) => {
+    return guard.commitIfCurrent(requestId, () => {
+      if (form.accessType !== 'existing' || form.k8sCluster !== instanceId) {
+        return;
+      }
+      if (setting.unknown) {
+        form = {
+          ...form,
+          settingUnknown: true,
+          host_log_path: undefined,
+          namespace_patterns: undefined,
+          pod_patterns: undefined,
+        };
+        return;
+      }
+      form = {
+        ...form,
+        settingUnknown: false,
+        host_log_path: setting.host_log_path,
+        namespace_patterns: setting.namespace_patterns,
+        pod_patterns: setting.pod_patterns,
+      };
+    });
+  };
+
+  const loadSetting = (instanceId: string): InFlightRead => {
+    const requestId = guard.begin();
+    return {
+      requestId,
+      instanceId,
+      apply: (setting) => applyIfCurrent(requestId, instanceId, setting),
+    };
+  };
+
+  const selectCluster = (instanceId: string): InFlightRead => {
+    guard.invalidate();
+    form = { ...form, accessType: 'existing', k8sCluster: instanceId };
+    return loadSetting(instanceId);
+  };
+
+  const switchToNew = () => {
+    guard.invalidate();
+    form = { ...form, accessType: 'new', settingUnknown: false };
+  };
+
+  const unmount = () => {
+    guard.invalidate();
+  };
+
+  return {
+    getForm: () => form,
+    selectCluster,
+    pointCluster: (instanceId: string) => {
+      form = { ...form, accessType: 'existing', k8sCluster: instanceId };
+    },
+    switchToNew,
+    unmount,
+    submitInstanceId: () => form.k8sCluster,
+  };
+}
+
+function assertAccessConfigUsesGuard(source: string) {
+  assert.match(
+    source,
+    /from ['"]@\/context\/latestRequestGuard['"]/,
+    'loadSetting 必须复用 @/context/latestRequestGuard，不得复制新 guard',
+  );
+  assert.match(source, /createLatestRequestGuard/, 'AccessConfig 必须创建 latest request guard');
+  assert.match(
+    source,
+    /requestGuard\.begin\(\)/,
+    'loadSetting 必须按单调序号 begin',
+  );
+  assert.match(
+    source,
+    /requestGuard\.commitIfCurrent\(/,
+    'loadSetting 只能经 commitIfCurrent 回填表单',
+  );
+  assert.match(
+    source,
+    /requestGuard\.commitIfCurrent\([\s\S]*setFieldsValue/,
+    '只有当前请求才允许 setFieldsValue',
+  );
+  assert.match(
+    source,
+    /requestGuard\.invalidate\(\)/,
+    '切换集群、新建资产或卸载必须 invalidate 在途回读',
+  );
+  assert.match(
+    source,
+    /event\.target\.value === 'new'[\s\S]*requestGuard\.invalidate\(\)/,
+    '切到新建资产必须作废在途回读',
+  );
+  assert.match(
+    source,
+    /return\s*\(\)\s*=>\s*requestGuard\.invalidate\(\)/,
+    '卸载必须作废在途回读',
+  );
+  assert.match(
+    source,
+    /onChange=\{\(value\)\s*=>[\s\S]*requestGuard\.invalidate\(\)/,
+    '切换集群必须 invalidate',
+  );
+  assert.match(
+    source,
+    /getFieldValue\(['"]k8sCluster['"]\)/,
+    '当前集群只接受匹配 instance 的最新响应',
+  );
+  assert.match(
+    source,
+    /let instanceId = values\.k8sCluster as string/,
+    'handleSubmit 仍须用当前 k8sCluster 作为保存目标',
+  );
+  assert.match(
+    source,
+    /saveK8sCollectSetting\(\{[\s\S]*instance_id: instanceId/,
+    '保存 payload 的 instance_id 必须来自当前选中集群',
+  );
+  assert.match(source, /setting\?\.unknown/, '不得改 unknown 配置引导');
+  assert.match(source, /getK8sCollectSetting\(instanceId\)/, '不得改 GET 入参');
+  assert.doesNotMatch(
+    source,
+    /await getK8sCollectSetting\([^)]*\);\s*(?:if \(setting\?\.unknown\)|setSettingUnknown|form\.setFieldsValue)/,
+    'loadSetting 不得在 await 后无条件回填',
+  );
+  assert.doesNotMatch(
+    source,
+    /function createLatestRequestGuard|const createLatestRequestGuard\s*=/,
+    '不得在 AccessConfig 内复制一套序号 guard',
+  );
+}
+
+async function main() {
+  const race = createAccessSession();
+  const staleA = race.selectCluster(settingA.instanceId);
+  const latestB = race.selectCluster(settingB.instanceId);
+  assert.equal(race.submitInstanceId(), 'cluster-b', '切换后保存目标必须是当前 k8sCluster');
+  assert.equal(latestB.apply(settingB), true, '当前集群的最新响应必须回填');
+  assert.equal(staleA.apply(settingA), false, '先 B 后 A 的完成顺序不得回填 A');
+  assert.equal(race.getForm().host_log_path, '/var/log/b', '迟到的 A 路径不得覆盖 B');
+  assert.equal(race.getForm().namespace_patterns, 'ns-b');
+  assert.equal(race.getForm().pod_patterns, 'pod-b');
+  assert.equal(race.getForm().k8sCluster, 'cluster-b');
+  assert.equal(race.submitInstanceId(), 'cluster-b', 'handleSubmit 仍用当前 k8sCluster');
+
+  const mismatched = createAccessSession();
+  const readA = mismatched.selectCluster(settingA.instanceId);
+  mismatched.pointCluster(settingB.instanceId);
+  assert.equal(readA.apply(settingA), true, '序号仍当前时回调会执行');
+  assert.equal(
+    mismatched.getForm().host_log_path,
+    undefined,
+    '当前集群不得接受不匹配 instance 的响应字段',
+  );
+  assert.equal(mismatched.submitInstanceId(), 'cluster-b');
+
+  const switchedToNew = createAccessSession();
+  const inflightNew = switchedToNew.selectCluster(settingA.instanceId);
+  switchedToNew.switchToNew();
+  assert.equal(inflightNew.apply(settingA), false, '切到新建资产必须作废在途回读');
+  assert.equal(switchedToNew.getForm().host_log_path, undefined);
+  assert.equal(switchedToNew.getForm().accessType, 'new');
+
+  const unmounted = createAccessSession();
+  const inflightUnmount = unmounted.selectCluster(settingA.instanceId);
+  unmounted.unmount();
+  assert.equal(inflightUnmount.apply(settingA), false, '卸载必须作废在途回读');
+  assert.equal(unmounted.getForm().host_log_path, undefined);
+
+  const unknownLatest = createAccessSession();
+  const staleKnown = unknownLatest.selectCluster(settingA.instanceId);
+  const latestUnknown = unknownLatest.selectCluster(settingB.instanceId);
+  assert.equal(
+    latestUnknown.apply({ ...settingB, unknown: true }),
+    true,
+    '当前集群的 unknown 引导仍可回填',
+  );
+  assert.equal(staleKnown.apply(settingA), false, '迟到的已知配置不得覆盖 unknown 引导');
+  assert.equal(unknownLatest.getForm().settingUnknown, true);
+  assert.equal(unknownLatest.getForm().host_log_path, undefined);
+
+  const source = readFileSync(accessConfigPath, 'utf8');
+  assertAccessConfigUsesGuard(source);
+
+  console.log('log k8s access setting race test passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/web/src/app/log/(pages)/integration/list/detail/configure/k8s/accessConfig.tsx
+++ b/web/src/app/log/(pages)/integration/list/detail/configure/k8s/accessConfig.tsx
@@ -17,6 +17,7 @@ import CollectSettingFields, {
 import IntegrationStepCallout, {
   createLogK8sStepCalloutPreset,
 } from '@/components/integration-step-callout';
+import { createLatestRequestGuard } from '@/context/latestRequestGuard';
 import {
   DEFAULT_K8S_IMAGE_REGISTRY_PREFIX,
   isValidK8sImageRegistryPrefix
@@ -67,6 +68,7 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
   const [k8sClusterLoading, setK8sClusterLoading] = useState(false);
   const [k8sClusterList, setK8sClusterList] = useState<InstanceItem[]>([]);
   const [settingUnknown, setSettingUnknown] = useState(false);
+  const [requestGuard] = useState(createLatestRequestGuard);
   const [dockerPathForFields, setDockerPathForFields] = useState(
     commandData?.docker_container_log_path
   );
@@ -77,6 +79,10 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
       void getK8sClusters();
     }
   }, [isLoading]);
+
+  useEffect(() => {
+    return () => requestGuard.invalidate();
+  }, [requestGuard]);
 
   useEffect(() => {
     if (commandData) {
@@ -129,30 +135,36 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
   };
 
   const loadSetting = async (instanceId: string) => {
+    const requestId = requestGuard.begin();
     const setting = await getK8sCollectSetting(instanceId);
-    if (setting?.unknown) {
-      setSettingUnknown(true);
-      setDockerPathForFields(undefined);
+    requestGuard.commitIfCurrent(requestId, () => {
+      if (form.getFieldValue('k8sCluster') !== instanceId) {
+        return;
+      }
+      if (setting?.unknown) {
+        setSettingUnknown(true);
+        setDockerPathForFields(undefined);
+        form.setFieldsValue({
+          runtime_profile: undefined,
+          host_log_path: undefined,
+          docker_container_log_path: undefined,
+          namespace_patterns: undefined,
+          pod_patterns: undefined,
+          tolerations: null
+        });
+        return;
+      }
+      setSettingUnknown(false);
+      const dockerPath = setting?.docker_container_log_path;
+      setDockerPathForFields(dockerPath);
       form.setFieldsValue({
-        runtime_profile: undefined,
-        host_log_path: undefined,
-        docker_container_log_path: undefined,
-        namespace_patterns: undefined,
-        pod_patterns: undefined,
-        tolerations: null
+        runtime_profile: setting?.runtime_profile,
+        host_log_path: setting?.host_log_path,
+        docker_container_log_path: dockerPath,
+        namespace_patterns: (setting?.namespace_patterns || []).join('\n'),
+        pod_patterns: (setting?.pod_patterns || []).join('\n'),
+        tolerations: setting?.tolerations ?? null
       });
-      return;
-    }
-    setSettingUnknown(false);
-    const dockerPath = setting?.docker_container_log_path;
-    setDockerPathForFields(dockerPath);
-    form.setFieldsValue({
-      runtime_profile: setting?.runtime_profile,
-      host_log_path: setting?.host_log_path,
-      docker_container_log_path: dockerPath,
-      namespace_patterns: (setting?.namespace_patterns || []).join('\n'),
-      pod_patterns: (setting?.pod_patterns || []).join('\n'),
-      tolerations: setting?.tolerations ?? null
     });
   };
 
@@ -246,6 +258,7 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
                   className="w-[300px]"
                   onChange={(event) => {
                     if (event.target.value === 'new') {
+                      requestGuard.invalidate();
                       setSettingUnknown(false);
                       form.setFieldsValue({ runtime_profile: 'standard' });
                     }
@@ -356,6 +369,7 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
                           value: item.id
                         }))}
                         onChange={(value) => {
+                          requestGuard.invalidate();
                           if (value) {
                             void loadSetting(String(value));
                           }


### PR DESCRIPTION
## 复现步骤

前置：账号能打开日志集成，且至少有两个已保存过配置的 K8s 接入实例，当前用户对两者都有权限。

1. 进入日志模块左侧菜单 **集成** → **日志集成**。
2. 打开会进入 K8s **接入配置** 的采集类型，进入子菜单 **配置**。
3. 页内标题 **接入配置**。**接入资产** 选 **选择已有资产**（另一个选项是 **新建资产**）。
4. **K8s 集群** 下拉（占位 **请选择 K8s 集群**）先选一个已有实例，再立刻改选另一个。
5. 等配置回读结束后点 **下一步**。

修复前：后发出的旧实例 GET 仍会 `setFieldsValue`。表单字段变成旧实例的路径、Namespace/Pod 范围或 tolerations，但 **K8s 集群** 仍是新选中的实例。点 **下一步** 会把旧配置写到新实例。  
修复后：只有当前选中实例的最新回读会进表单。迟到的旧实例响应被丢掉。**下一步** 仍把当前 **K8s 集群** 作为保存目标。

## 修复方案

`loadSetting` 复用 `createLatestRequestGuard`。请求 `begin`，返回后只在 `commitIfCurrent` 且 `k8sCluster` 仍等于该 instance 时 `setFieldsValue`。切换 **K8s 集群**、改选 **新建资产**、组件卸载时 `invalidate`。

不改 GET/POST 字段、权限和 unknown 配置引导。

Fixes #5241

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 连续改选 **K8s 集群** 且旧 GET 后到 | 旧实例字段覆盖当前表单 | 旧响应不回填 |
| 点 **下一步** | 当前集群 ID + 被覆盖的旧字段 | 当前集群 ID + 该集群最新成功回读 |
| **新建资产** / 离开页面 | 在途回读仍可能回填 | `invalidate`，不再回填 |

## 影响面

- **会变**：仅 K8s **接入配置** 里已有集群的配置回读时序。迟到响应不再写表单。
- **不变**：菜单 **集成** → **日志集成** → **配置**、标题 **接入配置**、**接入资产**（**新建资产** / **选择已有资产**）、字段 **K8s 集群**、占位 **请选择 K8s 集群**、按钮 **下一步**、接口字段、权限、unknown 引导。
- **未改**：若最新 GET 尚未返回就立刻点 **下一步**，仍可能把尚未回读完的当前表单存到当前集群。本修复只挡住旧集群迟到回填。
- **不在范围**：其它采集类型接入页、后端 `save_setting`。
