### PR TITLE
bugfix: 邮件通知人搜索改为按 id 索引

### DIFF
--- a/web/scripts/log-notifier-search-index-test.ts
+++ b/web/scripts/log-notifier-search-index-test.ts
@@ -1,0 +1,169 @@
+/**
+ * 日志告警策略「通知者」邮件搜索：按 id 索引，避免对每个 option 线性扫 userList。
+ *
+ * 运行：
+ * cd web && <tsx> scripts/log-notifier-search-index-test.ts
+ */
+
+import * as assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+interface UserItem {
+  id: string;
+  username: string;
+  display_name: string;
+}
+
+interface NotifierSearchFns {
+  buildNotifierUserIndex: (users: UserItem[]) => Map<string, UserItem>;
+  matchNotifierUser: (user: UserItem | undefined, input: string) => boolean;
+  filterNotifierOption: (
+    input: string,
+    option: { value?: string } | undefined,
+    userIndex: Map<string, UserItem>,
+  ) => boolean;
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const formPath = resolve(
+  here,
+  '../src/app/log/(pages)/event/strategy/detail/notificationForm.tsx',
+);
+
+function makeUsers(n: number): UserItem[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `u-${i}`,
+    username: `user${i}`,
+    display_name: `显示${i}`,
+  }));
+}
+
+function countFindComparisons(n: number): number {
+  const users = makeUsers(n);
+  let comparisons = 0;
+  for (const option of users) {
+    users.find((u) => {
+      comparisons += 1;
+      return u.id === option.id;
+    });
+  }
+  return comparisons;
+}
+
+async function loadNotifierSearch(): Promise<NotifierSearchFns> {
+  let loaded: Partial<NotifierSearchFns> = {};
+  try {
+    loaded = await import(
+      '../src/app/log/(pages)/event/strategy/detail/notifierSearch.ts'
+    );
+  } catch {
+    // RED：搜索辅助尚未抽出。
+  }
+
+  assert.equal(typeof loaded.buildNotifierUserIndex, 'function', '应抽出 buildNotifierUserIndex');
+  assert.equal(typeof loaded.matchNotifierUser, 'function', '应抽出 matchNotifierUser');
+  assert.equal(typeof loaded.filterNotifierOption, 'function', '应抽出 filterNotifierOption');
+
+  return loaded as NotifierSearchFns;
+}
+
+function wrapIndex(
+  index: Map<string, UserItem>,
+  stats: { lookups: number },
+): Map<string, UserItem> {
+  return {
+    get(id: string) {
+      stats.lookups += 1;
+      return index.get(id);
+    },
+  } as Map<string, UserItem>;
+}
+
+async function main(): Promise<void> {
+  const find20 = countFindComparisons(20);
+  const find40 = countFindComparisons(40);
+  assert.equal(find20, (20 * 21) / 2, 'find 路径 n=20 比较次数应为 n(n+1)/2');
+  assert.equal(find40, (40 * 41) / 2, 'find 路径 n=40 比较次数应为 n(n+1)/2');
+  assert.ok(find40 > find20 * 3, 'find 路径比较次数随 n 二次增长');
+
+  const fns = await loadNotifierSearch();
+  const users = makeUsers(40);
+  const index = fns.buildNotifierUserIndex(users);
+  const stats = { lookups: 0 };
+  const counted = wrapIndex(index, stats);
+
+  for (const user of users) {
+    assert.equal(
+      fns.filterNotifierOption('', { value: user.id }, counted),
+      true,
+      `空搜索应保留用户 ${user.id}`,
+    );
+  }
+  assert.equal(stats.lookups, 40, '索引路径对 n 个 option 只做 n 次按 id 取值');
+
+  const alice: UserItem = {
+    id: 'alice-id',
+    username: 'alice.wang',
+    display_name: 'Alice Display',
+  };
+  const bob: UserItem = {
+    id: 'bob-id',
+    username: 'bob.li',
+    display_name: '李四',
+  };
+  const namedIndex = fns.buildNotifierUserIndex([alice, bob]);
+
+  assert.equal(
+    fns.filterNotifierOption('alice dis', { value: 'alice-id' }, namedIndex),
+    true,
+    '应按 display_name 大小写不敏感包含匹配',
+  );
+  assert.equal(
+    fns.filterNotifierOption('WANG', { value: 'alice-id' }, namedIndex),
+    true,
+    '应按 username 大小写不敏感包含匹配',
+  );
+  assert.equal(
+    fns.filterNotifierOption('bob', { value: 'alice-id' }, namedIndex),
+    false,
+    '不应误匹配其他用户',
+  );
+  assert.equal(
+    fns.filterNotifierOption('李', { value: 'bob-id' }, namedIndex),
+    true,
+    'display_name 中文包含应命中',
+  );
+  assert.equal(
+    fns.matchNotifierUser(undefined, 'alice'),
+    false,
+    '索引未命中时应返回 false',
+  );
+  assert.equal(
+    fns.filterNotifierOption('alice', { value: 'missing' }, namedIndex),
+    false,
+    '未知 id 不应命中',
+  );
+
+  const source = readFileSync(formPath, 'utf8');
+  assert.doesNotMatch(
+    source,
+    /userList\.find/,
+    'filterOption 不应再对 userList 做线性 find',
+  );
+  assert.match(
+    source,
+    /buildNotifierUserIndex/,
+    'NotificationForm 应按 id 建立用户索引',
+  );
+  assert.match(
+    source,
+    /filterNotifierOption/,
+    'NotificationForm 的 filterOption 应走索引查找',
+  );
+
+  console.log('log notifier search index tests passed');
+}
+
+void main();

--- a/web/src/app/log/(pages)/event/strategy/detail/notificationForm.tsx
+++ b/web/src/app/log/(pages)/event/strategy/detail/notificationForm.tsx
@@ -9,6 +9,10 @@ import {
   seedNoticeUsersFromHandlers,
   shouldRequireNoticeUsers
 } from './policyFormUtils';
+import {
+  buildNotifierUserIndex,
+  filterNotifierOption
+} from './notifierSearch';
 
 const { Option } = Select;
 
@@ -82,6 +86,8 @@ const NotificationForm: React.FC<NotificationFormProps> = ({
     form.setFieldValue('notice_users', []);
   };
 
+  const userIndex = useMemo(() => buildNotifierUserIndex(userList), [userList]);
+
   // 将 channelList 转换为 SelectCard 需要的数据格式
   const channelCardData: CardItem[] = useMemo(() => {
     return channelList.map((item) => {
@@ -110,15 +116,9 @@ const NotificationForm: React.FC<NotificationFormProps> = ({
           maxTagCount="responsive"
           placeholder={t('log.event.handler')}
           virtual
-          filterOption={(input, option) => {
-            const user = userList.find((u) => u.id === option?.value);
-            if (!user) return false;
-            const searchText = input.toLowerCase();
-            return (
-              user.display_name?.toLowerCase().includes(searchText) ||
-              user.username.toLowerCase().includes(searchText)
-            );
-          }}
+          filterOption={(input, option) =>
+            filterNotifierOption(input, option, userIndex)
+          }
           optionLabelProp="label"
         >
           {userList.map((item) => (
@@ -229,19 +229,9 @@ const NotificationForm: React.FC<NotificationFormProps> = ({
                           maxTagCount="responsive"
                           placeholder={t('log.event.notifier')}
                           virtual
-                          filterOption={(input, option) => {
-                            const user = userList.find(
-                              (u) => u.id === option?.value
-                            );
-                            if (!user) return false;
-                            const searchText = input.toLowerCase();
-                            return (
-                              user.display_name
-                                ?.toLowerCase()
-                                .includes(searchText) ||
-                              user.username.toLowerCase().includes(searchText)
-                            );
-                          }}
+                          filterOption={(input, option) =>
+                            filterNotifierOption(input, option, userIndex)
+                          }
                           optionLabelProp="label"
                         >
                           {userList.map((item) => (

--- a/web/src/app/log/(pages)/event/strategy/detail/notifierSearch.ts
+++ b/web/src/app/log/(pages)/event/strategy/detail/notifierSearch.ts
@@ -1,0 +1,27 @@
+import { UserItem } from '@/app/log/types';
+
+interface NotifierOption {
+  value?: string | number;
+}
+
+export function buildNotifierUserIndex(users: UserItem[]): Map<string, UserItem> {
+  return new Map(users.map((user) => [user.id, user]));
+}
+
+export function matchNotifierUser(user: UserItem | undefined, input: string): boolean {
+  if (!user) return false;
+  const searchText = input.toLowerCase();
+  return (
+    user.display_name?.toLowerCase().includes(searchText) ||
+    user.username.toLowerCase().includes(searchText)
+  );
+}
+
+export function filterNotifierOption(
+  input: string,
+  option: NotifierOption | undefined,
+  userIndex: Map<string, UserItem>,
+): boolean {
+  if (option?.value == null) return false;
+  return matchNotifierUser(userIndex.get(String(option.value)), input);
+}


### PR DESCRIPTION
## 复现步骤

前置：账号能打开日志告警策略，所选组织内有可分配用户。

1. 进入日志模块左侧菜单 **事件** → **策略**。
2. 点 **创建关键字告警策略** 或 **创建聚合规则告警策略**，或打开已有策略进入 **编辑策略**。
3. 步骤 **基本信息** 里选 **组织**。
4. 到步骤 **配置通知**，打开 **通知配置** 开关。说明文案是 **选择告警触发时的通知方式和接收人。**
5. 选渠道标签为 **电子邮件** 的通知方式。
6. 在 **通知者** 多选框（占位也是 **通知者**）输入搜索词。点 **确认** 保存，**取消** 退出。

修复前：每输入一次，都会对每个候选再 `userList.find`，比较次数随用户数二次增长。  
修复后：按用户 id 建 Map，每次 option 常数时间取值；仍按 **通知者** 的 display_name / username 大小写不敏感包含匹配。

## 修复方案

抽出 `buildNotifierUserIndex` / `filterNotifierOption`。`NotificationForm` 用 `useMemo` 建索引，邮件渠道 `filterOption` 走 Map。不改组织权限求交、用户 id、候选列表接口和 `formatUserName` 展示。

Fixes #5242

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| **通知者** 输入搜索词 | 每个 option 线性扫 `userList`，约 n(n+1)/2 次比较 | 按 id 取值，n 个 option 只查 n 次 |
| display_name / username 匹配 | 大小写不敏感包含 | 不变 |
| 候选范围 | 所选 **组织** 内可分配用户 | 不变 |

## 影响面

- **会变**：仅邮件渠道 **通知者** 搜索的查找方式。
- **不变**：菜单 **事件** → **策略**、标题 **创建关键字告警策略** / **创建聚合规则告警策略** / **编辑策略**、步骤 **基本信息** / **设置告警条件** / **配置通知**、字段 **组织** / **通知配置** / **通知者**、渠道标签 **电子邮件**、按钮 **确认** / **取消**、组织权限、用户 id、响应结构。
- **未改**：非邮件渠道的通知者输入（自由文本/标签）。
- **不在范围**：用户目录接口、其它模块通知人选择。
