### PR TITLE
bugfix: 实时日志按 SSE 分帧解析避免丢事件

### DIFF
--- a/web/scripts/log-terminal-sse-parse-test.ts
+++ b/web/scripts/log-terminal-sse-parse-test.ts
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+type SseLogStreamModule = typeof import('../src/app/log/(pages)/search/logTerminal/sseLogStream');
+
+function parseChunks(
+  parseSseLogChunk: SseLogStreamModule['parseSseLogChunk'],
+  createSseLogStreamState: SseLogStreamModule['createSseLogStreamState'],
+  chunks: string[],
+): string[] {
+  const state = createSseLogStreamState();
+  return chunks.flatMap((chunk) => parseSseLogChunk(chunk, state));
+}
+
+async function main() {
+  const terminalSource = readFileSync(
+    path.resolve(process.cwd(), 'src/app/log/(pages)/search/logTerminal/index.tsx'),
+    'utf8',
+  );
+  assert.doesNotMatch(
+    terminalSource,
+    /chunk\.split\(['"]data:['"]\)/,
+    '终端源码不得再用 chunk.split("data:") 当事件边界',
+  );
+  assert.match(
+    terminalSource,
+    /parseSseLogChunk/,
+    '终端源码必须调用 SSE 分帧解析器',
+  );
+  assert.match(
+    terminalSource,
+    /const MAX_LOGS_COUNT = 1000/,
+    '1000 条保留上限不得改动',
+  );
+  assert.match(
+    terminalSource,
+    /\/api\/proxy\/log\/search\/tail/,
+    'tail 代理路径不得改动',
+  );
+
+  const moduleUrl = pathToFileURL(
+    path.resolve(process.cwd(), 'src/app/log/(pages)/search/logTerminal/sseLogStream.ts'),
+  );
+  const {
+    parseSseLogChunk,
+    createSseLogStreamState,
+    MAX_SSE_LEFTOVER_BYTES,
+  } = (await import(moduleUrl.href)) as SseLogStreamModule;
+
+  assert.equal(
+    parseChunks(parseSseLogChunk, createSseLogStreamState, [
+      'data: {"message":"hello"}\n\n',
+    ]).join('\n'),
+    'hello',
+    '完整普通事件必须输出 1 条',
+  );
+
+  assert.deepEqual(
+    parseChunks(parseSseLogChunk, createSseLogStreamState, [
+      'data: {"message":"metadata: configuration loaded"}\n\n',
+    ]),
+    ['metadata: configuration loaded'],
+    'message 含 metadata: 的完整 JSON 必须输出 1 条，不能按 data: 切开',
+  );
+
+  assert.deepEqual(
+    parseChunks(parseSseLogChunk, createSseLogStreamState, [
+      'data: {"message":"hello',
+      ' world"}\n\n',
+    ]),
+    ['hello world'],
+    '同一 JSON 被拆成两块必须拼出 1 条',
+  );
+
+  assert.deepEqual(
+    parseChunks(parseSseLogChunk, createSseLogStreamState, [
+      'data: {"message":"foo data: bar"}\n\n',
+    ]),
+    ['foo data: bar'],
+    '只认行首 data:，正文中的 data: 不得当分帧符',
+  );
+
+  assert.deepEqual(
+    parseChunks(parseSseLogChunk, createSseLogStreamState, [
+      'data: {"message":"a"}\n\ndata: {"_msg":"b"}\n\n',
+    ]),
+    ['a', 'b'],
+    '同一块内多个事件必须全部输出',
+  );
+
+  assert.deepEqual(
+    parseChunks(parseSseLogChunk, createSseLogStreamState, [
+      ':heartbeat\n\ndata: {"message":"ok"}\n\n',
+    ]),
+    ['ok'],
+    '心跳注释必须跳过，后续事件仍要输出',
+  );
+
+  const overflowState = createSseLogStreamState();
+  parseSseLogChunk(`data: ${'x'.repeat(MAX_SSE_LEFTOVER_BYTES + 8)}`, overflowState);
+  assert.ok(
+    overflowState.leftover.length <= MAX_SSE_LEFTOVER_BYTES,
+    '残片缓存必须有界，禁止无限缓冲',
+  );
+
+  console.log('log-terminal-sse-parse-test: GREEN');
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.stack || error.message : error);
+  process.exit(1);
+});

--- a/web/src/app/log/(pages)/search/logTerminal/index.tsx
+++ b/web/src/app/log/(pages)/search/logTerminal/index.tsx
@@ -21,9 +21,12 @@ import terminalstyles from './index.module.scss';
 import { useAuth } from '@/context/auth';
 import useApiClient from '@/utils/request';
 import { useTranslation } from '@/utils/i18n';
-import { isJSON } from '@/app/log/utils/common';
 import SearchHighlight from '@/app/log/components/search-highlight';
 import { extractHighlightTerms } from '@/app/log/utils/searchHighlight';
+import {
+  createSseLogStreamState,
+  parseSseLogChunk,
+} from './sseLogStream';
 
 const MAX_LOGS_COUNT = 1000;
 
@@ -43,6 +46,7 @@ const LogTerminal = forwardRef<LogTerminalRef, LogTerminalProps>(
     );
     const containerRef = useRef<HTMLDivElement>(null);
     const abortControllerRef = useRef<AbortController | null>(null);
+    const sseParseStateRef = useRef(createSseLogStreamState());
     const highlightTerms = useMemo(
       () => extractHighlightTerms(highlightQuery ?? query.query),
       [highlightQuery, query.query]
@@ -108,13 +112,6 @@ const LogTerminal = forwardRef<LogTerminalRef, LogTerminalProps>(
       });
     }, []);
 
-    const updateLogs = useCallback(
-      (log: string) => {
-        appendLogs([log]);
-      },
-      [appendLogs]
-    );
-
     // 开始日志流
     const startLogStream = useCallback(async (preserveLogs = false) => {
       // 先停止当前流；普通重启清空日志，暂停后继续则保留冻结画面。
@@ -169,35 +166,16 @@ const LogTerminal = forwardRef<LogTerminalRef, LogTerminalProps>(
         streamReader = reader;
         readerRef.current = reader;
         const decoder = new TextDecoder();
+        sseParseStateRef.current = createSseLogStreamState();
         // 持续读取流数据
         while (!abortController.signal.aborted) {
           try {
             const { done, value } = await reader.read();
             if (done) break;
             const chunk = decoder.decode(value, { stream: true });
-            const lines = chunk.split('data:');
-            for (const line of lines) {
-              const trimmed = line.trim();
-              // 跳过空行和心跳检测
-              if (!trimmed || trimmed.startsWith(':')) {
-                continue;
-              }
-              // 处理SSE格式数据
-              try {
-                if (isJSON(trimmed)) {
-                  // 尝试解析JSON
-                  const logData = JSON.parse(trimmed);
-                  const msg = logData.message || logData._msg || trimmed;
-                  updateLogs(msg);
-                } else {
-                  const msgMatch = trimmed.match(/"(?:message|_msg)"\s*:\s*"(.*?)",/);
-                  if (msgMatch?.[1]) {
-                    updateLogs(msgMatch[1]);
-                  }
-                }
-              } catch {
-                console.log('error', trimmed);
-              }
+            const messages = parseSseLogChunk(chunk, sseParseStateRef.current);
+            if (messages.length) {
+              appendLogs(messages);
             }
           } catch (error: any) {
             if (error?.name === 'AbortError') {
@@ -226,7 +204,7 @@ const LogTerminal = forwardRef<LogTerminalRef, LogTerminalProps>(
           isStreaming.current = false;
         }
       }
-    }, [query, stopLogStream, t, fetchData, token, updateLogs]);
+    }, [query, stopLogStream, t, fetchData, token, appendLogs]);
 
     // 暂停会真正关闭实时查询；继续时从当前时刻建立新的 tail 连接。
     const togglePause = useCallback(async () => {

--- a/web/src/app/log/(pages)/search/logTerminal/sseLogStream.ts
+++ b/web/src/app/log/(pages)/search/logTerminal/sseLogStream.ts
@@ -1,0 +1,64 @@
+export const MAX_SSE_LEFTOVER_BYTES = 64 * 1024;
+
+export interface SseLogStreamState {
+  leftover: string;
+}
+
+export function createSseLogStreamState(): SseLogStreamState {
+  return { leftover: '' };
+}
+
+export function parseSseLogChunk(
+  chunk: string,
+  state: SseLogStreamState
+): string[] {
+  const messages: string[] = [];
+  let buffer = `${state.leftover}${chunk}`;
+
+  while (true) {
+    const separator = buffer.match(/\r?\n\r?\n/);
+    if (!separator || separator.index === undefined) {
+      break;
+    }
+    const frame = buffer.slice(0, separator.index);
+    buffer = buffer.slice(separator.index + separator[0].length);
+    const message = extractMessageFromFrame(frame);
+    if (message !== null) {
+      messages.push(message);
+    }
+  }
+
+  state.leftover =
+    buffer.length > MAX_SSE_LEFTOVER_BYTES ? '' : buffer;
+  return messages;
+}
+
+function extractMessageFromFrame(frame: string): string | null {
+  const dataParts: string[] = [];
+  for (const line of frame.split(/\r?\n/)) {
+    if (line.startsWith(':') || !line.startsWith('data:')) {
+      continue;
+    }
+    const rawValue = line.slice(5);
+    dataParts.push(rawValue.startsWith(' ') ? rawValue.slice(1) : rawValue);
+  }
+  if (!dataParts.length) {
+    return null;
+  }
+  const payload = dataParts.join('\n');
+  try {
+    const parsed: unknown = JSON.parse(payload);
+    if (parsed && typeof parsed === 'object') {
+      const record = parsed as Record<string, unknown>;
+      if (typeof record.message === 'string') {
+        return record.message;
+      }
+      if (typeof record._msg === 'string') {
+        return record._msg;
+      }
+    }
+  } catch {
+    return null;
+  }
+  return payload;
+}


### PR DESCRIPTION
## 复现步骤

前置：账号能打开日志检索，且至少有一个可访问日志分组，该分组会持续产生日志。

1. 进入日志模块左侧菜单 **日志搜索**。
2. 在 **搜索条件** 里用占位为 **请选择分组** 的多选框选分组。未选时点 **搜索** 会提示 **日志分组不能为空**。
3. 点 **搜索**。把分段从 **列表** 切到 **终端**。
4. 观察终端输出。可用 **暂停日志** / **继续日志**、**清空日志**、**全屏展示** / **退出全屏**。

修复前：传输块用 `data:` 字符串切开。正文含 `metadata:` 的完整事件、以及被拆成两块的同一 JSON，都会解析失败后静默丢掉。  
修复后：按 SSE 空行分帧，只认行首 `data:`，跨 `read` 的残片会拼起来。上述两类事件都能显示。仍最多保留 1000 条。

## 修复方案

抽出 `parseSseLogChunk`：按 `\n\n` 分帧，缓存未完成残片（上限 64KiB），只解析行首 `data:` 后的 JSON，优先取 `message` / `_msg`。`LogTerminal` 不再 `chunk.split('data:')`。不改 tail 接口、代理、暂停/继续和 1000 条上限。

Fixes #5243

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 正文含 `metadata:` 的完整事件 | 终端不显示 | 显示 1 条 |
| 同一 JSON 跨两次网络块 | 终端不显示 | 拼成 1 条 |
| **暂停日志** / **继续日志**、最多 1000 条 | 原行为 | 不变 |

## 影响面

- **会变**：仅 **终端** 的 SSE 读法。迟到残片和正文里的 `data:` 不再当事件边界。
- **不变**：菜单 **日志搜索**、**搜索条件**、分段 **列表** / **终端**、按钮 **搜索**、占位 **请选择分组**、控件 **暂停日志** / **继续日志** / **清空日志** / **全屏展示** / **退出全屏**、提示 **日志分组不能为空**、tail 路径、Bearer、1000 条保留。
- **未改**：单帧残片超过 64KiB 且还没有空行时丢掉该残片，避免无限缓冲。
- **不在范围**：列表检索、后端 tail 输出格式。
