### PR TITLE
bugfix: 日志检索只接受最新查询批次

### DIFF
--- a/web/scripts/log-search-query-generation-test.ts
+++ b/web/scripts/log-search-query-generation-test.ts
@@ -108,6 +108,14 @@ function assertPageUsesGeneration(source: string) {
   );
   assert.match(source, /AbortController/, '新查询必须 abort 旧请求');
   assert.match(source, /\.abort\(\)/, '新查询必须 abort 旧请求');
+  const canceledGuards = source.match(
+    /if \(signal\.aborted \|\| isCanceledRequest\(error\)\)/g,
+  );
+  assert.equal(
+    canceledGuards?.length,
+    2,
+    'getChartData 与 getTableData 必须在 catch 中用 signal.aborted 识别取消，避免拦截器把 CanceledError 包成 HandledRequestError 后误抛',
+  );
   assert.match(
     source,
     /getHits\([\s\S]*?\{\s*signal/,

--- a/web/scripts/log-search-query-generation-test.ts
+++ b/web/scripts/log-search-query-generation-test.ts
@@ -1,0 +1,225 @@
+import * as assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createLatestRequestGuard } from '../src/context/latestRequestGuard.ts';
+
+interface SearchViewState {
+  tableData: Array<{ id: string }>;
+  chartData: Array<{ id: string }>;
+  tableLoading: boolean;
+  chartLoading: boolean;
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pagePath = resolve(here, '../src/app/log/(pages)/search/page.tsx');
+const apiPath = resolve(here, '../src/app/log/api/search.ts');
+const guardPath = resolve(here, '../src/context/latestRequestGuard.ts');
+
+function createSearchSession() {
+  const guard = createLatestRequestGuard();
+  let aborted: number[] = [];
+  let activeRequestId = 0;
+  let state: SearchViewState = {
+    tableData: [],
+    chartData: [],
+    tableLoading: false,
+    chartLoading: false,
+  };
+
+  const start = () => {
+    if (activeRequestId) {
+      aborted.push(activeRequestId);
+    }
+    const requestId = guard.begin();
+    activeRequestId = requestId;
+    state = {
+      ...state,
+      tableData: [],
+      chartData: [],
+      tableLoading: true,
+      chartLoading: true,
+    };
+    return requestId;
+  };
+
+  const commitTable = (requestId: number, rows: Array<{ id: string }>) => {
+    guard.commitIfCurrent(requestId, () => {
+      state = { ...state, tableData: rows };
+    });
+  };
+
+  const commitChart = (requestId: number, rows: Array<{ id: string }>) => {
+    guard.commitIfCurrent(requestId, () => {
+      state = { ...state, chartData: rows };
+    });
+  };
+
+  const settleTable = (requestId: number) => {
+    guard.commitIfCurrent(requestId, () => {
+      state = { ...state, tableLoading: false };
+    });
+  };
+
+  const settleChart = (requestId: number) => {
+    guard.commitIfCurrent(requestId, () => {
+      state = { ...state, chartLoading: false };
+    });
+  };
+
+  return {
+    getState: () => state,
+    wasAborted: (requestId: number) => aborted.includes(requestId),
+    start,
+    commitTable,
+    commitChart,
+    settleTable,
+    settleChart,
+  };
+}
+
+function assertPageUsesGeneration(source: string) {
+  assert.match(
+    source,
+    /from ['"]@\/context\/latestRequestGuard['"]/,
+    'page 必须复用 @/context/latestRequestGuard，不得复制新 guard',
+  );
+  assert.match(source, /createLatestRequestGuard/, 'page 必须创建 latest request guard');
+  assert.match(source, /requestGuard\.begin\(\)/, 'getLogData 必须为每次查询分配代次');
+  assert.match(
+    source,
+    /requestGuard\.commitIfCurrent\([\s\S]*?setTableData\(/,
+    '列表只能由当前代次提交',
+  );
+  assert.match(
+    source,
+    /requestGuard\.commitIfCurrent\([\s\S]*?setChartData\(/,
+    '图表只能由当前代次提交',
+  );
+  assert.match(
+    source,
+    /requestGuard\.commitIfCurrent\([\s\S]*?setTableLoading\(false\)/,
+    '旧批次 finally 不得无条件清掉新批次 table loading',
+  );
+  assert.match(
+    source,
+    /requestGuard\.commitIfCurrent\([\s\S]*?setChartLoading\(false\)/,
+    '旧批次 finally 不得无条件清掉新批次 chart loading',
+  );
+  assert.match(source, /AbortController/, '新查询必须 abort 旧请求');
+  assert.match(source, /\.abort\(\)/, '新查询必须 abort 旧请求');
+  assert.match(
+    source,
+    /getHits\([\s\S]*?\{\s*signal/,
+    'getHits 必须传入 AbortSignal',
+  );
+  assert.match(
+    source,
+    /getLogs\([\s\S]*?\{\s*signal/,
+    'getLogs 必须传入 AbortSignal',
+  );
+  assert.match(source, /min=\{1\}/, '条数下限必须仍为 1');
+  assert.match(source, /max=\{1000\}/, '条数上限必须仍为 1000');
+  assert.match(
+    source,
+    /!extra\?\.logGroups\?\.length && !groups\.length/,
+    '分组为空时的检索拦截必须保留',
+  );
+  assert.doesNotMatch(
+    source,
+    /function createLatestRequestGuard|const createLatestRequestGuard\s*=/,
+    '不得在 page 内复制一套序号 guard',
+  );
+  assert.doesNotMatch(
+    source,
+    /setTableData\(listData\);\s*\}\s*finally \{\s*setTableLoading\(false\)/,
+    'getTableData 不得在 await 后无条件 setTableData 并由 finally 清 loading',
+  );
+  assert.doesNotMatch(
+    source,
+    /setChartData\(chartData\);\s*\}\s*finally \{\s*setChartLoading\(false\)/,
+    'getChartData 不得在 await 后无条件 setChartData 并由 finally 清 loading',
+  );
+  assert.doesNotMatch(
+    source,
+    /finally \{\s*setTableLoading\(false\);/,
+    'getTableData 不得在 finally 无条件清 loading',
+  );
+  assert.doesNotMatch(
+    source,
+    /finally \{\s*setChartLoading\(false\);/,
+    'getChartData 不得在 finally 无条件清 loading',
+  );
+}
+
+function assertApiAcceptsHitsConfig(source: string) {
+  assert.match(
+    source,
+    /const getHits = async \(data: SearchParams, config\?: AxiosRequestConfig\)/,
+    'getHits 必须接受 AxiosRequestConfig',
+  );
+  assert.match(
+    source,
+    /post\(`\/log\/search\/hits\/`, data, config\)/,
+    'getHits 必须把 config 传给 hits 请求',
+  );
+  assert.match(source, /post\(`\/log\/search\/search\/`, data, config\)/, '不得改 search 路径');
+  assert.match(source, /post\(`\/log\/search\/hits\/`, data/, '不得改 hits 路径');
+}
+
+function main() {
+  const guardSource = readFileSync(guardPath, 'utf8');
+  assert.match(guardSource, /export const createLatestRequestGuard/, '必须复用已有 latestRequestGuard');
+
+  const race = createSearchSession();
+  const requestA = race.start();
+  const requestB = race.start();
+  assert.ok(race.wasAborted(requestA), '新查询必须 abort 旧请求');
+  race.commitTable(requestB, [{ id: 'table-B' }]);
+  race.commitChart(requestB, [{ id: 'chart-B' }]);
+  race.settleTable(requestB);
+  race.settleChart(requestB);
+  race.commitTable(requestA, [{ id: 'table-A' }]);
+  race.commitChart(requestA, [{ id: 'chart-A' }]);
+  race.settleTable(requestA);
+  race.settleChart(requestA);
+  assert.deepEqual(race.getState().tableData, [{ id: 'table-B' }], 'A 后到不得覆盖 B 的列表');
+  assert.deepEqual(race.getState().chartData, [{ id: 'chart-B' }], 'A 后到不得覆盖 B 的图表');
+  assert.equal(race.getState().tableLoading, false);
+  assert.equal(race.getState().chartLoading, false);
+
+  const staleFinally = createSearchSession();
+  const oldInflight = staleFinally.start();
+  staleFinally.start();
+  staleFinally.commitTable(oldInflight, [{ id: 'table-old' }]);
+  staleFinally.commitChart(oldInflight, [{ id: 'chart-old' }]);
+  staleFinally.settleTable(oldInflight);
+  staleFinally.settleChart(oldInflight);
+  assert.deepEqual(staleFinally.getState().tableData, [], '旧成功不得在最新请求仍在途时写回列表');
+  assert.deepEqual(staleFinally.getState().chartData, [], '旧成功不得在最新请求仍在途时写回图表');
+  assert.equal(staleFinally.getState().tableLoading, true, '旧 finally 不得清掉新批次 table loading');
+  assert.equal(staleFinally.getState().chartLoading, true, '旧 finally 不得清掉新批次 chart loading');
+
+  const mixed = createSearchSession();
+  const mixedA = mixed.start();
+  const mixedB = mixed.start();
+  mixed.commitChart(mixedA, [{ id: 'chart-A' }]);
+  mixed.commitTable(mixedB, [{ id: 'table-B' }]);
+  mixed.settleChart(mixedA);
+  mixed.commitChart(mixedB, [{ id: 'chart-B' }]);
+  mixed.settleTable(mixedB);
+  mixed.settleChart(mixedB);
+  assert.deepEqual(mixed.getState().tableData, [{ id: 'table-B' }], '图表与列表必须同属最新世代');
+  assert.deepEqual(mixed.getState().chartData, [{ id: 'chart-B' }], '旧图表不得与新列表混批');
+  assert.equal(mixed.getState().tableLoading, false);
+  assert.equal(mixed.getState().chartLoading, false);
+
+  const pageSource = readFileSync(pagePath, 'utf8');
+  const apiSource = readFileSync(apiPath, 'utf8');
+  assertPageUsesGeneration(pageSource);
+  assertApiAcceptsHitsConfig(apiSource);
+
+  console.log('log search query generation test passed');
+}
+
+main();

--- a/web/src/app/log/(pages)/search/page.tsx
+++ b/web/src/app/log/(pages)/search/page.tsx
@@ -336,9 +336,10 @@ const SearchView: React.FC = () => {
         setChartData(chartData);
       });
     } catch (error) {
-      if (!isCanceledRequest(error)) {
-        throw error;
+      if (signal.aborted || isCanceledRequest(error)) {
+        return;
       }
+      throw error;
     } finally {
       requestGuard.commitIfCurrent(requestId, () => {
         setChartLoading(false);
@@ -368,9 +369,10 @@ const SearchView: React.FC = () => {
         setTableData(listData);
       });
     } catch (error) {
-      if (!isCanceledRequest(error)) {
-        throw error;
+      if (signal.aborted || isCanceledRequest(error)) {
+        return;
       }
+      throw error;
     } finally {
       requestGuard.commitIfCurrent(requestId, () => {
         setTableLoading(false);

--- a/web/src/app/log/(pages)/search/page.tsx
+++ b/web/src/app/log/(pages)/search/page.tsx
@@ -43,6 +43,7 @@ import useLogUserHabitApi, {
   LOG_SEARCH_HISTOGRAM_HABIT_KEY
 } from '@/app/log/api/userHabit';
 import { useHabitExpanded } from '@/hooks/useHabitExpanded';
+import { createLatestRequestGuard } from '@/context/latestRequestGuard';
 import {
   SearchParams,
   LogTerminalRef,
@@ -137,6 +138,8 @@ const SearchView: React.FC = () => {
   const conditionRef = useRef<ModalRef>(null);
   const conditionListRef = useRef<ModalRef>(null);
   const searchTextRef = useRef<string>(queryText);
+  const searchAbortRef = useRef<AbortController | null>(null);
+  const [requestGuard] = useState(createLatestRequestGuard);
   const [hasSearchText, setHasSearchText] = useState<boolean>(!!queryText);
   const [frequence, setFrequence] = useState<number>(0);
   const [defaultSearchText, setDefaultSearchText] = useState<string>(queryText);
@@ -305,38 +308,73 @@ const SearchView: React.FC = () => {
     }
   };
 
-  const getChartData = async (type: string, extra?: SearchConfig) => {
-    setChartLoading(type !== 'timer');
+  const isCanceledRequest = (error: unknown) => {
+    const canceled = error as { name?: string; code?: string };
+    return canceled?.name === 'CanceledError' || canceled?.code === 'ERR_CANCELED';
+  };
+
+  const getChartData = async (
+    type: string,
+    extra: SearchConfig | undefined,
+    requestId: number,
+    signal: AbortSignal
+  ) => {
+    requestGuard.commitIfCurrent(requestId, () => {
+      setChartLoading(type !== 'timer');
+    });
     try {
       const params = getParams(extra);
-      const res = await getHits(params);
+      const res = await getHits(params, { signal });
       const chartData = aggregateLogs(res?.hits);
       const total = chartData.reduce((pre, cur) => (pre += cur.value), 0);
-      setPagination((pre) => ({
-        ...pre,
-        total: total,
-        current: 1
-      }));
-      setChartData(chartData);
+      requestGuard.commitIfCurrent(requestId, () => {
+        setPagination((pre) => ({
+          ...pre,
+          total: total,
+          current: 1
+        }));
+        setChartData(chartData);
+      });
+    } catch (error) {
+      if (!isCanceledRequest(error)) {
+        throw error;
+      }
     } finally {
-      setChartLoading(false);
+      requestGuard.commitIfCurrent(requestId, () => {
+        setChartLoading(false);
+      });
     }
   };
 
-  const getTableData = async (type: string, extra?: SearchConfig) => {
-    setTableLoading(type !== 'timer');
+  const getTableData = async (
+    type: string,
+    extra: SearchConfig | undefined,
+    requestId: number,
+    signal: AbortSignal
+  ) => {
+    requestGuard.commitIfCurrent(requestId, () => {
+      setTableLoading(type !== 'timer');
+    });
     try {
       const params = getParams(extra);
-      const res = await getLogs(params);
+      const res = await getLogs(params, { signal });
       const listData: TableDataItem[] = (res || []).map(
         (item: TableDataItem) => ({
           ...item,
           id: uuidv4()
         })
       );
-      setTableData(listData);
+      requestGuard.commitIfCurrent(requestId, () => {
+        setTableData(listData);
+      });
+    } catch (error) {
+      if (!isCanceledRequest(error)) {
+        throw error;
+      }
     } finally {
-      setTableLoading(false);
+      requestGuard.commitIfCurrent(requestId, () => {
+        setTableLoading(false);
+      });
     }
   };
 
@@ -344,16 +382,23 @@ const SearchView: React.FC = () => {
     if (!extra?.logGroups?.length && !groups.length) {
       return message.error(t('log.search.searchError'));
     }
+    searchAbortRef.current?.abort();
+    const abortController = new AbortController();
+    searchAbortRef.current = abortController;
+    const requestId = requestGuard.begin();
     setHighlightQuery(extra?.text || searchTextRef.current || '*');
     setTableData([]);
     setChartData([]);
     setQueryTime(new Date());
     setQueryEndTime(new Date());
-    Promise.all([getChartData(type, extra), getTableData(type, extra)]).finally(
-      () => {
+    Promise.all([
+      getChartData(type, extra, requestId, abortController.signal),
+      getTableData(type, extra, requestId, abortController.signal)
+    ]).finally(() => {
+      requestGuard.commitIfCurrent(requestId, () => {
         setQueryEndTime(new Date());
-      }
-    );
+      });
+    });
   };
 
   const getParams = (extra?: SearchConfig) => {

--- a/web/src/app/log/api/search.ts
+++ b/web/src/app/log/api/search.ts
@@ -15,8 +15,8 @@ const useSearchApi = () => {
     return await post(`/log/search/search/`, data, config);
   };
 
-  const getHits = async (data: SearchParams) => {
-    return await post(`/log/search/hits/`, data);
+  const getHits = async (data: SearchParams, config?: AxiosRequestConfig) => {
+    return await post(`/log/search/hits/`, data, config);
   };
 
   const getLogTail = async (params = {}) => {


### PR DESCRIPTION
## 复现步骤

前置：账号能打开日志检索，且至少有一个可访问日志分组。

1. 进入日志模块左侧菜单 **日志搜索**。
2. 在 **搜索条件** 里用占位为 **请选择分组** 的多选框选分组。未选时点 **搜索** 会提示 **日志分组不能为空**。
3. 分段保持 **列表**（另一个是 **终端**）。
4. 点 **搜索**。再立刻改搜索词或时间范围，再点 **搜索**，或把刷新频率从 **关闭** 改成 **1m** / **5m** / **10m** 后等下一轮，或点刷新按钮（aria-label **刷新**）。**列表展示上限** 仍是 1–1000。

修复前：先按条件 A 检索、再改成 B；A 较慢时，B 已经显示仍会被 A 的日志和 **查询直方图** 盖回去。图表和列表也可能来自不同批次。  
修复后：只接受最新查询批次。慢的 A 晚到不会覆盖 B；旧批次的 loading/finally 不会清掉新查询。

## 修复方案

`getLogData` 复用 `createLatestRequestGuard`，新查询 abort 旧请求。`getTableData` / `getChartData` 只在 `commitIfCurrent` 时写列表、图表和 loading。`getHits` 补上 `AxiosRequestConfig` 并传 `signal`。不改 search/hits 路径、分组权限和 1–1000 条限制。

Fixes #5244

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 连续点 **搜索**，慢请求后到 | 旧条件覆盖最新列表和 **查询直方图** | 只保留最新批次 |
| 旧请求 finally | 可能提前清掉新查询 loading | 只在当前代次清 loading |
| 条数 1–1000、**日志分组不能为空** | 原行为 | 不变 |

## 影响面

- **会变**：仅 **列表** 模式的 search/hits 提交时序。界面以最新查询为准。
- **不变**：菜单 **日志搜索**、**搜索条件**、占位 **请选择分组**、按钮 **搜索**、分段 **列表** / **终端**、提示 **日志分组不能为空**、**查询直方图**、**列表展示上限**、刷新按钮 **刷新**、频率 **关闭** / **1m** / **5m** / **10m**、接口路径、分组权限、1–1000 条限制。
- **未改**：非取消错误时 `Promise.all` 仍可能出现未捕获拒绝（修复前已有）。
- **不在范围**：**终端** 实时流、条件保存/加载。
