### PR TITLE
bugfix: Docker 日志编辑从解析后的 source 节点回填

### DIFF
--- a/web/scripts/log-vector-docker-hydrate-test.ts
+++ b/web/scripts/log-vector-docker-hydrate-test.ts
@@ -1,0 +1,202 @@
+/**
+ * Vector Docker 采集：编辑回填必须读解析后的 sources.docker_*。
+ *
+ * get_config_content 返回的是 docker.child.toml.j2 渲染并解析后的嵌套 TOML，
+ * 自定义 docker_host / 容器数组 / multiline 在 sources.docker_<id> 上。
+ * 只读扁平 endpoint/enable_* 会把端点打回 unix:///var/run/docker.sock，
+ * 并把容器过滤、多行合并打成 false。
+ *
+ * 运行：
+ * cd web && <tsx> scripts/log-vector-docker-hydrate-test.ts
+ */
+
+import assert from 'node:assert/strict';
+import {
+  getVectorDockerDefaultForm,
+  getVectorDockerParams
+} from '../src/app/log/hooks/integration/collectors/vector/dockerDefaults';
+
+const DEFAULT_SOCKET = 'unix:///var/run/docker.sock';
+const CUSTOM_HOST = 'tcp://192.168.1.10:2375';
+const SOURCE_ID = 'docker_0198f0d7_1d4e_7db1_b7c2_132807fa330e';
+
+const nestedFullContent = {
+  sources: {
+    [SOURCE_ID]: {
+      type: 'docker_logs',
+      docker_host: CUSTOM_HOST,
+      auto_partial_merge: true,
+      include_containers: ['nginx', 'app'],
+      exclude_containers: ['logspout'],
+      multiline: {
+        condition_pattern: '^\\s',
+        mode: 'continue_past',
+        start_pattern: '^[A-Z]',
+        timeout_ms: 1500
+      }
+    }
+  }
+};
+
+// Case 1: nested sources.docker_* 必须回填自定义 docker_host / 过滤开 / 多行开
+{
+  const loaded = getVectorDockerDefaultForm({
+    child: { content: nestedFullContent }
+  });
+
+  assert.equal(
+    loaded.endpoint,
+    CUSTOM_HOST,
+    'nested docker_host 应回填到 endpoint，不能落到 unix:///var/run/docker.sock'
+  );
+  assert.notEqual(
+    loaded.endpoint,
+    DEFAULT_SOCKET,
+    'nested 自定义 docker_host 不得被默认 socket 覆盖'
+  );
+  assert.equal(
+    loaded.containerFilter.enabled,
+    true,
+    'nested 有 include/exclude 容器数组时容器过滤应开启'
+  );
+  assert.deepEqual(loaded.container_name_contains, ['nginx', 'app']);
+  assert.deepEqual(loaded.container_name_exclude, ['logspout']);
+  assert.equal(
+    loaded.multiline.enabled,
+    true,
+    'nested 有 multiline 对象时多行合并应开启'
+  );
+  assert.equal(loaded.multiline.mode, 'continue_past');
+  assert.equal(loaded.multiline.condition_pattern, '^\\s');
+  assert.equal(loaded.multiline.start_pattern, '^[A-Z]');
+  assert.equal(loaded.multiline.timeout_ms, 1500);
+}
+
+// Case 2: hydrate 后再 getVectorDockerParams，不得写回默认 socket 或把开关打成 false
+{
+  const loaded = getVectorDockerDefaultForm({
+    child: { content: nestedFullContent }
+  });
+  const params = getVectorDockerParams(loaded, {});
+  const saved = (params.child as { content: Record<string, unknown> }).content;
+
+  assert.equal(
+    saved.endpoint,
+    CUSTOM_HOST,
+    'roundtrip 保存的 endpoint 必须是自定义 docker_host，不能是默认 socket'
+  );
+  assert.notEqual(saved.endpoint, DEFAULT_SOCKET);
+  assert.equal(
+    saved.enable_container_filter,
+    true,
+    'roundtrip 不得把容器过滤写成 false'
+  );
+  assert.equal(
+    saved.enable_multiline,
+    true,
+    'roundtrip 不得把多行合并写成 false'
+  );
+  assert.equal(saved.container_name_contains, 'nginx,app');
+  assert.equal(saved.container_name_exclude, 'logspout');
+  assert.equal(saved.multiline_mode, 'continue_past');
+}
+
+// Case 3: 无过滤字段 → 容器过滤关闭；缺字段不得当成默认排除列表
+{
+  const loaded = getVectorDockerDefaultForm({
+    child: {
+      content: {
+        sources: {
+          [SOURCE_ID]: {
+            type: 'docker_logs',
+            docker_host: CUSTOM_HOST,
+            auto_partial_merge: true
+          }
+        }
+      }
+    }
+  });
+
+  assert.equal(loaded.endpoint, CUSTOM_HOST);
+  assert.equal(
+    loaded.containerFilter.enabled,
+    false,
+    '无 include_containers/exclude_containers 时容器过滤应关闭'
+  );
+  assert.deepEqual(
+    loaded.container_name_contains,
+    [],
+    '无过滤字段时包含列表应为空'
+  );
+  assert.deepEqual(
+    loaded.container_name_exclude,
+    [],
+    '无过滤字段时不得填入 vector,logspout 默认排除列表'
+  );
+  assert.equal(
+    loaded.multiline.enabled,
+    false,
+    '无 multiline 时多行合并应关闭'
+  );
+}
+
+// Case 4: 仅 include_containers，过滤开，排除列表为空
+{
+  const loaded = getVectorDockerDefaultForm({
+    child: {
+      content: {
+        sources: {
+          [SOURCE_ID]: {
+            type: 'docker_logs',
+            docker_host: CUSTOM_HOST,
+            include_containers: ['web']
+          }
+        }
+      }
+    }
+  });
+  assert.equal(loaded.containerFilter.enabled, true);
+  assert.deepEqual(loaded.container_name_contains, ['web']);
+  assert.deepEqual(loaded.container_name_exclude, []);
+}
+
+// Case 5: 扁平 enable_* 结构保持兼容
+{
+  const loaded = getVectorDockerDefaultForm({
+    child: {
+      content: {
+        endpoint: 'tcp://10.0.0.1:2376',
+        enable_container_filter: true,
+        container_name_contains: 'web, db',
+        container_name_exclude: 'logspout',
+        enable_multiline: true,
+        multiline_mode: 'continue_through',
+        multiline_pattern: '\\s+',
+        multiline_start_pattern: '^\\d{4}',
+        multiline_timeout_ms: 2000
+      }
+    }
+  });
+
+  assert.equal(loaded.endpoint, 'tcp://10.0.0.1:2376');
+  assert.equal(loaded.containerFilter.enabled, true);
+  assert.deepEqual(loaded.container_name_contains, ['web', 'db']);
+  assert.deepEqual(loaded.container_name_exclude, ['logspout']);
+  assert.equal(loaded.multiline.enabled, true);
+  assert.equal(loaded.multiline.mode, 'continue_through');
+  assert.equal(loaded.multiline.condition_pattern, '\\s+');
+  assert.equal(loaded.multiline.start_pattern, '^\\d{4}');
+  assert.equal(loaded.multiline.timeout_ms, 2000);
+}
+
+// Case 6: 扁平无开关字段时过滤/多行关闭
+{
+  const loaded = getVectorDockerDefaultForm({
+    child: { content: { endpoint: CUSTOM_HOST } }
+  });
+  assert.equal(loaded.endpoint, CUSTOM_HOST);
+  assert.equal(loaded.containerFilter.enabled, false);
+  assert.equal(loaded.multiline.enabled, false);
+}
+
+console.log('log-vector-docker-hydrate tests passed');

--- a/web/src/app/log/hooks/integration/collectors/vector/dockerDefaults.ts
+++ b/web/src/app/log/hooks/integration/collectors/vector/dockerDefaults.ts
@@ -59,14 +59,25 @@ export const getVectorDockerParams = (
 /**
  * 把后端拉回的 child.content 反解为编辑表单默认值。
  *
- * 必须与 `getVectorDockerParams` 写入结构完全一致，否则会出现
- * "编辑时多行合并开关、容器过滤开关显示为关闭"等 bug。
+ * `get_config_content` 会先解析已经渲染的 TOML，因此正常响应中的采集参数
+ * 位于 `content.sources.docker_<config_id>`（docker_host / include_containers /
+ * exclude_containers / multiline）。同时兼容尚未经过模板渲染的扁平 enable_* 结构。
+ *
+ * 无过滤字段时容器过滤关闭；无 multiline 时多行关闭。缺字段不得当成
+ * 模板默认排除列表（vector,logspout）。
  */
 export const getVectorDockerDefaultForm = (formData: TableDataItem) => {
   const content = formData?.child?.content || {};
+  const sources = content.sources || {};
+  const sourceKey =
+    Object.keys(sources).find((key) => key.startsWith('docker_')) || '';
+  const sourceData = sources[sourceKey] || content;
 
-  // CSV 字符串 → 数组（与 getParams 中的 join(',') 互逆）
+  // CSV 字符串或 TOML 数组 → 表单数组（与 getParams 中的 join(',') 互逆）
   const splitCsv = (s: unknown): string[] => {
+    if (Array.isArray(s)) {
+      return s.map((v) => String(v).trim()).filter(Boolean);
+    }
     if (typeof s !== 'string' || !s) return [];
     return s
       .split(',')
@@ -74,19 +85,43 @@ export const getVectorDockerDefaultForm = (formData: TableDataItem) => {
       .filter(Boolean);
   };
 
+  const hasInclude = Array.isArray(sourceData.include_containers);
+  const hasExclude = Array.isArray(sourceData.exclude_containers);
+  const enableContainerFilter =
+    hasInclude || hasExclude || !!sourceData.enable_container_filter;
+
+  const multilineNode = sourceData.multiline;
+  const enableMultiline =
+    !!multilineNode?.mode || !!sourceData.enable_multiline;
+
   return {
-    endpoint: content.endpoint || 'unix:///var/run/docker.sock',
+    endpoint:
+      sourceData.docker_host ||
+      sourceData.endpoint ||
+      'unix:///var/run/docker.sock',
     containerFilter: {
-      enabled: !!content.enable_container_filter
+      enabled: enableContainerFilter
     },
-    container_name_contains: splitCsv(content.container_name_contains),
-    container_name_exclude: splitCsv(content.container_name_exclude),
+    container_name_contains: hasInclude
+      ? splitCsv(sourceData.include_containers)
+      : splitCsv(sourceData.container_name_contains),
+    container_name_exclude: hasExclude
+      ? splitCsv(sourceData.exclude_containers)
+      : splitCsv(sourceData.container_name_exclude),
     multiline: {
-      enabled: !!content.enable_multiline,
-      mode: content.multiline_mode || 'continue_through',
-      condition_pattern: content.multiline_pattern || '^[\\s]+',
-      start_pattern: content.multiline_start_pattern || '^[^\\s]',
-      timeout_ms: content.multiline_timeout_ms || 1000
+      enabled: enableMultiline,
+      mode:
+        multilineNode?.mode || sourceData.multiline_mode || 'continue_through',
+      condition_pattern:
+        multilineNode?.condition_pattern ||
+        sourceData.multiline_pattern ||
+        '^[\\s]+',
+      start_pattern:
+        multilineNode?.start_pattern ||
+        sourceData.multiline_start_pattern ||
+        '^[^\\s]',
+      timeout_ms:
+        multilineNode?.timeout_ms || sourceData.multiline_timeout_ms || 1000
     }
   };
 };


### PR DESCRIPTION
## 复现步骤

前置：账号能打开日志接收，且已有 Docker/Vector 采集实例。该实例接入时改过 **端点**，或打开过 **容器过滤条件** / **多行合并**。

1. 进入日志模块左侧菜单 **集成** → **日志接收**。
2. 找到该 Docker 实例，点行内 **更新配置**（不是 **编辑**）。
3. 弹窗标题是 **更新配置**。看 **端点**、**容器过滤条件** 开关、**多行合并** 开关。
4. 不改任何项，直接点 **确认**（旁边是 **取消**）。

修复前：后端返回的是解析后的 `sources.docker_*`（`docker_host`、容器数组、`multiline`），表单却只读扁平字段。自定义 **端点** 会变成 `unix:///var/run/docker.sock`，两个开关都是关。再点 **确认** 会把这些默认值写回。  
修复后：从 `sources.docker_*` 回填。自定义 **端点**、已开的 **容器过滤条件** / **多行合并** 会保留。无过滤字段、无 `multiline` 时开关保持关，也不会填入默认排除列表。

## 修复方案

`getVectorDockerDefaultForm` 参照文件采集，从 `content.sources.docker_*` 读 `docker_host`、`include_containers` / `exclude_containers`、`multiline`，再转成现有表单字段。尚未渲染的扁平 `enable_*` 仍可用。`getVectorDockerParams` 仍提交扁平模板变量。不改权限、`child.id`、`instance_id`、`collect_type_id`、Jinja 模板和后端解析。

Fixes #5246

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 打开 **更新配置** | 自定义 **端点** 变回默认 socket，**容器过滤条件** / **多行合并** 为关 | 按解析后的 source 节点回填 |
| 再点 **确认** | 覆盖已部署采集设置 | 扁平保存仍对应刚才回填的值 |
| 无过滤 / 无 multiline 的实例 | 开关为关 | 仍为关，不填默认排除列表 |

## 影响面

- **会变**：仅 Docker 采集 **更新配置** 的编辑回填。读 nested TOML 时不再落到默认端点和两个关闭开关。
- **不变**：菜单 **集成** / **日志接收**，按钮 **更新配置** / **编辑** / **确认** / **取消**，字段 **端点** / **容器过滤条件** / **多行合并**，保存接口字段、权限、模板、自动接入 `getParams`。
- **不在范围**：文件采集、K8s 配置弹窗、实例 **编辑** 名称组织。
