### PR TITLE
bugfix: 目标检测保存使用当前图片列表

### DIFF
--- a/web/scripts/mlops-object-detection-save-stale-test.ts
+++ b/web/scripts/mlops-object-detection-save-stale-test.ts
@@ -1,0 +1,196 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SOURCE_PATH = resolve(
+  process.cwd(),
+  'src/app/mlops/components/annotation/objectDetection.tsx'
+);
+
+const splitTopLevel = (text: string, separator: string): string[] => {
+  const parts: string[] = [];
+  let current = '';
+  let depth = 0;
+  let square = 0;
+  let curly = 0;
+  let quote: string | null = null;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const prev = text[index - 1];
+    if (quote) {
+      if (char === quote && prev !== '\\') {
+        quote = null;
+      }
+      current += char;
+      continue;
+    }
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      current += char;
+      continue;
+    }
+    if (char === '(') depth += 1;
+    if (char === ')') depth -= 1;
+    if (char === '[') square += 1;
+    if (char === ']') square -= 1;
+    if (char === '{') curly += 1;
+    if (char === '}') curly -= 1;
+    if (
+      char === separator &&
+      depth === 0 &&
+      square === 0 &&
+      curly === 0
+    ) {
+      parts.push(current);
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  if (current.trim()) {
+    parts.push(current);
+  }
+  return parts;
+};
+
+const extractCallArguments = (source: string, callStart: number): string[] => {
+  const openParen = source.indexOf('(', callStart);
+  assert.notEqual(openParen, -1, 'hook call is missing "("');
+
+  let depth = 0;
+  let quote: string | null = null;
+  for (let index = openParen; index < source.length; index += 1) {
+    const char = source[index];
+    const prev = source[index - 1];
+    if (quote) {
+      if (char === quote && prev !== '\\') {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      continue;
+    }
+    if (char === '(') depth += 1;
+    if (char === ')') {
+      depth -= 1;
+      if (depth === 0) {
+        return splitTopLevel(source.slice(openParen + 1, index), ',');
+      }
+    }
+  }
+  throw new Error('unclosed hook call');
+};
+
+const parseIdentList = (depsSource: string | undefined): string[] => {
+  if (!depsSource) {
+    return [];
+  }
+  const trimmed = depsSource.trim();
+  if (!trimmed.startsWith('[') || !trimmed.endsWith(']')) {
+    return [];
+  }
+  return trimmed
+    .slice(1, -1)
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+};
+
+const extractAssignment = (
+  source: string,
+  ident: string
+): {
+  hook: 'useMemo' | 'useCallback' | null;
+  body: string;
+  deps: string[];
+} => {
+  const pattern = new RegExp(`const ${ident}\\s*=\\s*`);
+  const match = pattern.exec(source);
+  assert.ok(match, `missing assignment for ${ident}`);
+  const start = match.index + match[0].length;
+  const next = source.slice(start).trimStart();
+
+  if (next.startsWith('useMemo') || next.startsWith('useCallback')) {
+    const hook = next.startsWith('useMemo') ? 'useMemo' : 'useCallback';
+    const args = extractCallArguments(source, start);
+    return {
+      hook,
+      body: args[0] || '',
+      deps: parseIdentList(args[1]),
+    };
+  }
+
+  return {
+    hook: null,
+    body: next,
+    deps: [],
+  };
+};
+
+const main = () => {
+  assert.equal(
+    existsSync(SOURCE_PATH),
+    true,
+    `source file missing: ${SOURCE_PATH}`
+  );
+
+  const source = readFileSync(SOURCE_PATH, 'utf8');
+  const toolbarRight = extractAssignment(source, 'toolbarRight');
+  const saveResult = extractAssignment(source, 'saveResult');
+  const getObjectTrainDataInfo = extractAssignment(
+    source,
+    'getObjectTrainDataInfo'
+  );
+
+  const toolbarDepsKey = toolbarRight.deps.join(',');
+  assert.notEqual(
+    toolbarRight.hook === 'useMemo' && toolbarDepsKey === 't',
+    true,
+    'toolbarRight useMemo 只依赖 [t]，保存按钮会钉在首次 trainData=[] / fileId 闭包上'
+  );
+
+  const saveReadsCurrentTrainData =
+    /num_images:\s*trainData\.length/.test(saveResult.body) ||
+    /num_images:\s*trainData\.length/.test(source);
+  assert.equal(
+    saveReadsCurrentTrainData,
+    true,
+    'saveResult 必须用当前 trainData.length 作为 num_images'
+  );
+  assert.match(
+    saveResult.body,
+    /updateObjectDetectionTrainData\(\s*fileId\s*,/,
+    'saveResult 必须把当前 fileId 传给更新接口'
+  );
+
+  const saveHasCurrentTrainDataCallback =
+    saveResult.hook === 'useCallback' &&
+    saveResult.deps.includes('trainData');
+  const toolbarMemoCancelled = toolbarRight.hook !== 'useMemo';
+  const toolbarDependsOnSaveCallback =
+    toolbarRight.hook === 'useMemo' &&
+    toolbarRight.deps.includes('saveResult') &&
+    saveHasCurrentTrainDataCallback;
+
+  assert.equal(
+    toolbarMemoCancelled || toolbarDependsOnSaveCallback,
+    true,
+    'saveResult 必须是依赖含 trainData 的 useCallback，且纳入 toolbarRight；或取消该工具栏 memo'
+  );
+
+  if (toolbarRight.hook === 'useMemo') {
+    assert.equal(
+      toolbarRight.deps.includes('getObjectTrainDataInfo') ||
+        getObjectTrainDataInfo.hook === 'useCallback',
+      true,
+      'toolbarRight 仍 memo 时，getObjectTrainDataInfo 也必须是稳定且可拿到当前 fileId 的回调'
+    );
+  }
+
+  console.log('PASS mlops-object-detection-save-stale');
+};
+
+main();

--- a/web/src/app/mlops/components/annotation/objectDetection.tsx
+++ b/web/src/app/mlops/components/annotation/objectDetection.tsx
@@ -126,6 +126,115 @@ const ObjectDetection = ({
     imageBlobsRef.current.clear();
   }, []);
 
+  const getObjectTrainDataInfo = useCallback(async () => {
+    // 清理旧的ObjectURL
+    cleanupImageUrls();
+
+    setLoading(true);
+    try {
+      // 1. 获取metadata (不获取train_data，避免大量数据传输)
+      const data = await getTrainDataInfo(fileId, DatasetType.OBJECT_DETECTION, false, true);
+
+      const metadata: ObjectDetectionMetadata = data.metadata || {
+        format: 'YOLO',
+        classes: defaultRectLabels,
+        num_classes: defaultRectLabels.length,
+        num_images: 0,
+        labels: {},
+        statistics: {
+          total_annotations: 0,
+          images_with_annotations: 0,
+          images_without_annotations: 0,
+          class_distribution: {}
+        }
+      };
+
+      // 更新标签列表（从metadata加载）
+      if (metadata.classes && metadata.classes.length > 0) {
+        const loadedLabels = metadata.classes.map((name, index) => ({
+          id: index + 1,
+          name,
+          color: rectLabels[index]?.color || generateUniqueRandomColor()
+        }));
+        setRectLabels(loadedLabels);
+      }
+
+      // 2. 下载ZIP
+      const response = await fetch(
+        `/api/proxy/mlops/object_detection_train_data/${fileId}/download/`,
+        {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${authContext?.token}`,
+          },
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error(`${t('mlops-common.downloadFailed')}: ${response.status}`);
+      }
+
+      const zipBlob = await response.blob();
+
+      // 3. 解压ZIP
+      const zip = await JSZip.loadAsync(zipBlob);
+      const imageFiles: ObjectDetectionTrainData[] = [];
+      const imageExtensions = /\.(jpg|jpeg|png|gif|bmp|webp)$/i;
+
+      let batchIndex = 0;
+      type ZipFile = (typeof zip.files)[string];
+      const entries = Object.entries(zip.files) as Array<
+        [string, ZipFile]
+      >;
+      const totalImages = entries.filter(([name, file]) => !file.dir && imageExtensions.test(name)).length;
+
+      for (const [fileName, file] of entries) {
+        if (file.dir) continue;
+        if (!imageExtensions.test(fileName)) continue;
+
+        const blob = await file.async('blob');
+        const imageUrl = URL.createObjectURL(blob);
+
+        // 保存ObjectURL和Blob
+        imageUrlsRef.current.push(imageUrl);
+        imageBlobsRef.current.set(fileName, blob);
+
+        // 获取图片尺寸
+        const dimensions = await new Promise<{ width: number; height: number }>((resolve) => {
+          const img = new Image();
+          img.onload = () => {
+            resolve({ width: img.width, height: img.height });
+          };
+          img.onerror = () => {
+            resolve({ width: 800, height: 600 }); // 默认尺寸
+          };
+          img.src = imageUrl;
+        });
+
+        imageFiles.push({
+          width: dimensions.width,
+          height: dimensions.height,
+          image_name: fileName,
+          image_url: imageUrl,
+          image_size: blob.size,
+          batch_index: batchIndex++,
+          batch_total: totalImages,
+          content_type: blob.type || 'image/jpeg',
+          type: 'train' // 默认为训练集
+        });
+      }
+
+      setTrainData(imageFiles);
+      setMetadata(metadata);
+
+    } catch (e) {
+      console.error('加载训练数据失败:', e);
+      message.error(t('datasets.loadDataError'));
+    } finally {
+      setLoading(false);
+    }
+  }, [authContext?.token, cleanupImageUrls, fileId, getTrainDataInfo, t]);
+
   // 动态生成config（基于标签状态）
   const buildConfig = useCallback(() => {
     return {
@@ -430,7 +539,7 @@ const ObjectDetection = ({
   };
 
 
-  const saveResult = async () => {
+  const saveResult = useCallback(async () => {
     setLoading(true);
     try {
       // 先保存当前图片的标注到 metaData
@@ -528,7 +637,16 @@ const ObjectDetection = ({
     } finally {
       setLoading(false);
     }
-  };
+  }, [
+    currentSample,
+    fileId,
+    getObjectTrainDataInfo,
+    rectLabels,
+    setIsChange,
+    t,
+    trainData,
+    updateObjectDetectionTrainData,
+  ]);
 
   const onError = useCallback((err: any) => {
     console.error('Error:', err);
@@ -550,116 +668,7 @@ const ObjectDetection = ({
         <ReloadOutlined onClick={() => getObjectTrainDataInfo()} />
       </div>
     )
-  }, [t]);
-
-  const getObjectTrainDataInfo = async () => {
-    // 清理旧的ObjectURL
-    cleanupImageUrls();
-
-    setLoading(true);
-    try {
-      // 1. 获取metadata (不获取train_data，避免大量数据传输)
-      const data = await getTrainDataInfo(fileId, DatasetType.OBJECT_DETECTION, false, true);
-
-      const metadata: ObjectDetectionMetadata = data.metadata || {
-        format: 'YOLO',
-        classes: defaultRectLabels,
-        num_classes: defaultRectLabels.length,
-        num_images: 0,
-        labels: {},
-        statistics: {
-          total_annotations: 0,
-          images_with_annotations: 0,
-          images_without_annotations: 0,
-          class_distribution: {}
-        }
-      };
-
-      // 更新标签列表（从metadata加载）
-      if (metadata.classes && metadata.classes.length > 0) {
-        const loadedLabels = metadata.classes.map((name, index) => ({
-          id: index + 1,
-          name,
-          color: rectLabels[index]?.color || generateUniqueRandomColor()
-        }));
-        setRectLabels(loadedLabels);
-      }
-
-      // 2. 下载ZIP
-      const response = await fetch(
-        `/api/proxy/mlops/object_detection_train_data/${fileId}/download/`,
-        {
-          method: 'GET',
-          headers: {
-            Authorization: `Bearer ${authContext?.token}`,
-          },
-        }
-      );
-
-      if (!response.ok) {
-        throw new Error(`${t('mlops-common.downloadFailed')}: ${response.status}`);
-      }
-
-      const zipBlob = await response.blob();
-
-      // 3. 解压ZIP
-      const zip = await JSZip.loadAsync(zipBlob);
-      const imageFiles: ObjectDetectionTrainData[] = [];
-      const imageExtensions = /\.(jpg|jpeg|png|gif|bmp|webp)$/i;
-
-      let batchIndex = 0;
-      type ZipFile = (typeof zip.files)[string];
-      const entries = Object.entries(zip.files) as Array<
-        [string, ZipFile]
-      >;
-      const totalImages = entries.filter(([name, file]) => !file.dir && imageExtensions.test(name)).length;
-
-      for (const [fileName, file] of entries) {
-        if (file.dir) continue;
-        if (!imageExtensions.test(fileName)) continue;
-
-        const blob = await file.async('blob');
-        const imageUrl = URL.createObjectURL(blob);
-
-        // 保存ObjectURL和Blob
-        imageUrlsRef.current.push(imageUrl);
-        imageBlobsRef.current.set(fileName, blob);
-
-        // 获取图片尺寸
-        const dimensions = await new Promise<{ width: number; height: number }>((resolve) => {
-          const img = new Image();
-          img.onload = () => {
-            resolve({ width: img.width, height: img.height });
-          };
-          img.onerror = () => {
-            resolve({ width: 800, height: 600 }); // 默认尺寸
-          };
-          img.src = imageUrl;
-        });
-
-        imageFiles.push({
-          width: dimensions.width,
-          height: dimensions.height,
-          image_name: fileName,
-          image_url: imageUrl,
-          image_size: blob.size,
-          batch_index: batchIndex++,
-          batch_total: totalImages,
-          content_type: blob.type || 'image/jpeg',
-          type: 'train' // 默认为训练集
-        });
-      }
-
-      setTrainData(imageFiles);
-      setMetadata(metadata);
-
-    } catch (e) {
-      console.error('加载训练数据失败:', e);
-      message.error(t('datasets.loadDataError'));
-    } finally {
-      setLoading(false);
-    }
-  };
+  }, [getObjectTrainDataInfo, saveResult, t]);
 
   return (
     <div className={styles.container}>


### PR DESCRIPTION
## 复现步骤

前置：账号能打开目标检测数据集，且至少一个数据文件里已有图片。

1. 进入 **目标检测** → **数据集**，打开某条进入 **数据集详情**。
2. 在文件行点 **标注**（不是 **编辑**）。
3. 等图片出现后做标注。工具栏有 **标签管理** 和 **保存变更**。
4. 点 **保存变更**。

修复前：工具栏 `useMemo` 只依赖文案函数，按钮仍绑着首次渲染的空 `trainData`。请求里 `num_images` 为 0，后端拒绝，编辑存不进去。  
修复后：保存回调依赖当前 `trainData` 和 `fileId`。图片加载后再点 **保存变更**，会提交当前文件和正数图片数。

## 修复方案

`saveResult` / `getObjectTrainDataInfo` 改为带完整依赖的 `useCallback`。`toolbarRight` 依赖纳入这两个回调，不再只依赖 `t`。不改 multipart 字段、YOLO metadata 形状、权限包装和后端正数校验。

Fixes #5247

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 图片加载后点 **保存变更** | `num_images=0`，后端拒绝 | 使用当前图片列表，正数 `num_images` |
| 切换文件后再保存 | 可能仍用首次 `fileId` | 使用当前 `fileId` |
| YOLO metadata / 权限 / 后端校验 | 原行为 | 不变 |

## 影响面

- **会变**：仅目标检测标注页工具栏 **保存变更** / 刷新所绑定的回调世代。
- **不变**：菜单 **目标检测** / **数据集**，面包屑 **数据集** / **数据集详情**，行按钮 **标注** / **编辑**，工具栏 **标签管理** / **保存变更**，成功文案 **保存成功**，multipart 字段、YOLO 结构、权限、后端 `num_images>0` 校验。
- **不在范围**：图片分类、异常检测等其它算法的标注页。
