### PR TITLE
bugfix: 图片分类拒绝追加同名图片以免覆盖原图

### DIFF
--- a/web/scripts/mlops-image-name-conflict-test.ts
+++ b/web/scripts/mlops-image-name-conflict-test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { tryAppendImage } from '../src/app/mlops/components/annotation/imageNameConflict';
+
+interface ImageRecord {
+  image_name: string;
+  image_url: string;
+  label?: string;
+}
+
+const packZipLike = (trainData: ImageRecord[], blobs: Map<string, Blob>) => {
+  const zip = new Map<string, Blob>();
+  trainData.forEach((item) => {
+    const blob = blobs.get(item.image_name);
+    if (blob) {
+      zip.set(item.image_name, blob);
+    }
+  });
+  return zip;
+};
+
+const oldBlob = new Blob(['old-pixels'], { type: 'image/jpeg' });
+const newBlob = new Blob(['new-pixels'], { type: 'image/jpeg' });
+const blobs = new Map<string, Blob>([['a.jpg', oldBlob]]);
+const trainData: ImageRecord[] = [
+  { image_name: 'a.jpg', image_url: 'blob:old', label: 'cat' },
+];
+
+const conflictResult = tryAppendImage(blobs, trainData, {
+  fileName: 'a.jpg',
+  blob: newBlob,
+  imageUrl: 'blob:new',
+});
+
+assert.equal(
+  blobs.get('a.jpg'),
+  oldBlob,
+  'same-name append must keep the original Blob; overwriting would make save pack the new content',
+);
+assert.equal(conflictResult.accepted, false, 'same-name append must be rejected');
+assert.equal(trainData.length, 1, 'must not append a second record for the same image_name');
+assert.equal(trainData[0].label, 'cat', 'original label must stay on the original image');
+assert.notEqual(blobs.get('a.jpg'), newBlob, 'two records must not share the new Blob');
+
+const packedAfterConflict = packZipLike(trainData, blobs);
+assert.equal(packedAfterConflict.size, 1);
+assert.equal(
+  packedAfterConflict.get('a.jpg'),
+  oldBlob,
+  'handleSave-style ZIP packing must still emit the original a.jpg bytes',
+);
+
+const uniqueBlob = new Blob(['unique-pixels'], { type: 'image/jpeg' });
+const uniqueResult = tryAppendImage(blobs, trainData, {
+  fileName: 'b.jpg',
+  blob: uniqueBlob,
+  imageUrl: 'blob:unique',
+});
+
+assert.equal(uniqueResult.accepted, true, 'a unique filename must still be appended');
+assert.equal(blobs.get('a.jpg'), oldBlob, 'adding a unique name must not touch the original Blob');
+assert.equal(blobs.get('b.jpg'), uniqueBlob);
+assert.equal(trainData.length, 2);
+assert.equal(trainData[1].image_name, 'b.jpg');
+
+const packedAfterUnique = packZipLike(trainData, blobs);
+assert.equal(packedAfterUnique.get('a.jpg'), oldBlob);
+assert.equal(packedAfterUnique.get('b.jpg'), uniqueBlob);
+
+const root = process.cwd();
+const imageContent = fs.readFileSync(
+  path.join(root, 'src/app/mlops/components/annotation/imageContent.tsx'),
+  'utf8',
+);
+const addNewImageStart = imageContent.indexOf('const addNewImage');
+assert.ok(addNewImageStart >= 0, 'imageContent.tsx must define addNewImage');
+const addNewImage = imageContent.slice(addNewImageStart);
+const conflictIdx = addNewImage.indexOf('hasImageNameConflict');
+const setIdx = addNewImage.indexOf('imageBlobsRef.current.set(fileName, blob)');
+assert.ok(conflictIdx >= 0, 'addNewImage must consult hasImageNameConflict');
+assert.ok(
+  setIdx > conflictIdx,
+  'Blob Map write must happen after the name-conflict check',
+);
+assert.match(addNewImage, /datasets\.imageNameConflict/);
+
+const zh = JSON.parse(fs.readFileSync(path.join(root, 'src/app/mlops/locales/zh.json'), 'utf8'));
+const en = JSON.parse(fs.readFileSync(path.join(root, 'src/app/mlops/locales/en.json'), 'utf8'));
+assert.ok(zh.datasets.imageNameConflict, 'missing zh datasets.imageNameConflict');
+assert.ok(en.datasets.imageNameConflict, 'missing en datasets.imageNameConflict');
+
+console.log('mlops image name conflict test passed');

--- a/web/src/app/mlops/components/annotation/imageContent.tsx
+++ b/web/src/app/mlops/components/annotation/imageContent.tsx
@@ -10,6 +10,7 @@ import PermissionWrapper from '@/components/permission';
 import styles from './index.module.scss';
 import { hashColor } from "@/app/mlops/utils/common";
 import { DatasetType } from '@/app/mlops/types';
+import { hasImageNameConflict } from './imageNameConflict';
 
 interface TrainDataItem {
   image_name: string;
@@ -276,6 +277,11 @@ const ImageContent = () => {
     try {
       const blob = file.originFileObj as Blob;
       const fileName = file.name;
+
+      if (hasImageNameConflict(imageBlobsRef.current, trainData, fileName)) {
+        message.warning(t('datasets.imageNameConflict'));
+        return;
+      }
       
       // 创建ObjectURL
       const imageUrl = URL.createObjectURL(blob);

--- a/web/src/app/mlops/components/annotation/imageNameConflict.ts
+++ b/web/src/app/mlops/components/annotation/imageNameConflict.ts
@@ -1,0 +1,43 @@
+export interface ImageRecord {
+  image_name: string;
+  image_url: string;
+  label?: string;
+  predicted_label?: string;
+}
+
+export interface AppendImageInput {
+  fileName: string;
+  blob: Blob;
+  imageUrl: string;
+}
+
+export type AppendImageResult =
+  | { accepted: true }
+  | { accepted: false; reason: 'duplicate_name' };
+
+export const hasImageNameConflict = (
+  blobs: Map<string, Blob>,
+  trainData: readonly Pick<ImageRecord, 'image_name'>[],
+  fileName: string,
+): boolean => {
+  if (blobs.has(fileName)) {
+    return true;
+  }
+  return trainData.some((item) => item.image_name === fileName);
+};
+
+export const tryAppendImage = (
+  blobs: Map<string, Blob>,
+  trainData: ImageRecord[],
+  input: AppendImageInput,
+): AppendImageResult => {
+  if (hasImageNameConflict(blobs, trainData, input.fileName)) {
+    return { accepted: false, reason: 'duplicate_name' };
+  }
+  blobs.set(input.fileName, input.blob);
+  trainData.push({
+    image_name: input.fileName,
+    image_url: input.imageUrl,
+  });
+  return { accepted: true };
+};

--- a/web/src/app/mlops/locales/en.json
+++ b/web/src/app/mlops/locales/en.json
@@ -125,6 +125,7 @@
     "labelExists": "Label already exists",
     "labelInUse": "This label is already in use",
     "addImageFailed": "Failed to add image",
+    "imageNameConflict": "An image with this name already exists. The new file was not added, so the original image is unchanged.",
     "pressEnterToAdd": "Press Enter to add",
     "fileNameVaild": "The filename does not comply with specifications (it may only contain English letters, numbers, and underscores, and must not exceed 64 characters in length)",
     "fileNameEmpty": "Filename cannot be empty",

--- a/web/src/app/mlops/locales/zh.json
+++ b/web/src/app/mlops/locales/zh.json
@@ -125,6 +125,7 @@
     "labelExists": "标签已存在",
     "labelInUse": "该标签已被使用",
     "addImageFailed": "添加图片失败",
+    "imageNameConflict": "已存在同名图片，未添加以免覆盖原图",
     "pressEnterToAdd": "按下回车添加",
     "fileNameVaild": "文件名不符合规范(只能包含英文字母、数字、下划线, 长度不超过64个字符)",
     "fileNameEmpty": "文件名不能为空",


### PR DESCRIPTION
## 复现步骤

前置：账号能打开图片分类数据集，且某个数据文件里已有 `a.jpg`。

1. 进入 **图片分类** → **数据集**，打开该条进入 **数据集详情**。
2. 在文件行点 **标注**。
3. 点 **添加图片**，选另一目录里内容不同、但文件名同为 `a.jpg`、且小于 2MB 的图片。
4. 再点 **保存**。

修复前：界面可能出现两张缩略图，保存成功后重新打开只剩新图，原图内容丢失，旧标签可能落到新内容上。  
修复后：同名时提示 **已存在同名图片，未添加以免覆盖原图**，不写入 Blob Map，原图和标签不变。文件名不同的图片仍可添加。

## 修复方案

抽出 `hasImageNameConflict`。`addNewImage` 在 `imageBlobsRef.set` 之前检查已有 `image_name`；冲突则 `message.warning` 并返回。不静默重命名历史图片。不改 ZIP 接口、serializer 和权限。

Fixes #5248

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| **添加图片** 同名 `a.jpg` | 覆盖旧 Blob，却仍追加缩略图 | 提示 **已存在同名图片，未添加以免覆盖原图** |
| 再点 **保存** | ZIP 只剩新内容，原图丢失 | 原图与标签不变 |
| 文件名不同的图片 | 可添加 | 仍可添加 |

## 影响面

- **会变**：仅图片分类标注页 **添加图片** 对同名文件的处理。从覆盖改为拒绝。
- **不变**：菜单 **图片分类** / **数据集**，面包屑 **数据集** / **数据集详情**，行按钮 **标注**，按钮 **保存**，成功文案 **上传成功**，2MB / MIME 校验，ZIP 接口、权限、后端替换训练文件的契约。
- **不在范围**：目标检测标注页里同类按文件名写 Blob Map 的路径。
