### PR TITLE
bugfix: 数据集详情查询随当前分页更新

### DIFF
--- a/web/scripts/mlops-dataset-detail-pagination-test.ts
+++ b/web/scripts/mlops-dataset-detail-pagination-test.ts
@@ -1,0 +1,218 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SOURCE_PATH = resolve(
+  process.cwd(),
+  'src/app/mlops/components/algorithm-detail/AlgorithmDetail.tsx'
+);
+
+const splitTopLevel = (text: string, separator: string): string[] => {
+  const parts: string[] = [];
+  let current = '';
+  let depth = 0;
+  let square = 0;
+  let curly = 0;
+  let quote: string | null = null;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const prev = text[index - 1];
+    if (quote) {
+      if (char === quote && prev !== '\\') {
+        quote = null;
+      }
+      current += char;
+      continue;
+    }
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      current += char;
+      continue;
+    }
+    if (char === '(') depth += 1;
+    if (char === ')') depth -= 1;
+    if (char === '[') square += 1;
+    if (char === ']') square -= 1;
+    if (char === '{') curly += 1;
+    if (char === '}') curly -= 1;
+    if (
+      char === separator &&
+      depth === 0 &&
+      square === 0 &&
+      curly === 0
+    ) {
+      parts.push(current);
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  if (current.trim()) {
+    parts.push(current);
+  }
+  return parts;
+};
+
+const extractCallArguments = (source: string, callStart: number): string[] => {
+  const openParen = source.indexOf('(', callStart);
+  assert.notEqual(openParen, -1, 'hook call is missing "("');
+
+  let depth = 0;
+  let quote: string | null = null;
+  for (let index = openParen; index < source.length; index += 1) {
+    const char = source[index];
+    const prev = source[index - 1];
+    if (quote) {
+      if (char === quote && prev !== '\\') {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      continue;
+    }
+    if (char === '(') depth += 1;
+    if (char === ')') {
+      depth -= 1;
+      if (depth === 0) {
+        return splitTopLevel(source.slice(openParen + 1, index), ',');
+      }
+    }
+  }
+  throw new Error('unclosed hook call');
+};
+
+const parseIdentList = (depsSource: string | undefined): string[] => {
+  if (!depsSource) {
+    return [];
+  }
+  const trimmed = depsSource.trim();
+  if (!trimmed.startsWith('[') || !trimmed.endsWith(']')) {
+    return [];
+  }
+  return trimmed
+    .slice(1, -1)
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+};
+
+const extractAssignment = (
+  source: string,
+  ident: string
+): {
+  hook: 'useMemo' | 'useCallback' | null;
+  body: string;
+  deps: string[];
+} => {
+  const pattern = new RegExp(`const ${ident}\\s*=\\s*`);
+  const match = pattern.exec(source);
+  assert.ok(match, `missing assignment for ${ident}`);
+  const start = match.index + match[0].length;
+  const next = source.slice(start).trimStart();
+
+  if (next.startsWith('useMemo') || next.startsWith('useCallback')) {
+    const hook = next.startsWith('useMemo') ? 'useMemo' : 'useCallback';
+    const args = extractCallArguments(source, start);
+    return {
+      hook,
+      body: args[0] || '',
+      deps: parseIdentList(args[1]),
+    };
+  }
+
+  return {
+    hook: null,
+    body: next,
+    deps: [],
+  };
+};
+
+const extractGetDatasetEffectDeps = (source: string): string[] => {
+  const effectPattern = /useEffect\(\(\)\s*=>\s*\{\s*getDataset\(\);\s*\},\s*\[([^\]]*)\]\)/;
+  const match = effectPattern.exec(source);
+  if (!match) {
+    return [];
+  }
+  return match[1]
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+};
+
+const hasRequiredPaginationDeps = (deps: string[]): boolean =>
+  deps.includes('pagination.current') && deps.includes('pagination.pageSize');
+
+const main = () => {
+  assert.equal(
+    existsSync(SOURCE_PATH),
+    true,
+    `source file missing: ${SOURCE_PATH}`
+  );
+
+  const source = readFileSync(SOURCE_PATH, 'utf8');
+  const getDataset = extractAssignment(source, 'getDataset');
+  const queryBody = getDataset.body || source;
+
+  assert.match(
+    queryBody,
+    /page:\s*pagination\.current/,
+    '查询必须用 page: pagination.current'
+  );
+  assert.match(
+    queryBody,
+    /page_size:\s*pagination\.pageSize/,
+    '查询必须用 page_size: pagination.pageSize'
+  );
+
+  const staleOnlySearchDeps =
+    getDataset.hook === 'useCallback' &&
+    getDataset.deps.length === 2 &&
+    getDataset.deps[0] === 't' &&
+    getDataset.deps[1] === 'searchParams';
+
+  assert.equal(
+    staleOnlySearchDeps,
+    false,
+    `getDataset 的 useCallback 依赖只有 [${getDataset.deps.join(', ')}]，翻页后 effect 重跑仍调用初始闭包`
+  );
+
+  const callbackHasPageDeps =
+    getDataset.hook === 'useCallback' &&
+    hasRequiredPaginationDeps(getDataset.deps) &&
+    !getDataset.deps.includes('pagination');
+
+  const queryMovedIntoEffect =
+    getDataset.hook !== 'useCallback' &&
+    hasRequiredPaginationDeps(extractGetDatasetEffectDeps(source));
+
+  assert.equal(
+    callbackHasPageDeps || queryMovedIntoEffect,
+    true,
+    'getDataset 必须显式依赖 pagination.current 与 pagination.pageSize，或把查询放进依赖完整的 effect；禁止依赖整个 pagination 对象'
+  );
+
+  if (getDataset.hook === 'useCallback') {
+    assert.equal(
+      getDataset.deps.includes('datasetType'),
+      true,
+      'getDataset 必须显式依赖 datasetType'
+    );
+    assert.equal(
+      getDataset.deps.includes('datasetId'),
+      true,
+      'getDataset 必须显式依赖 datasetId'
+    );
+    assert.equal(
+      getDataset.deps.includes('getTrainDataByDataset'),
+      true,
+      'getDataset 必须显式依赖 API getTrainDataByDataset'
+    );
+  }
+
+  console.log('PASS mlops-dataset-detail-pagination');
+};
+
+main();

--- a/web/src/app/mlops/components/algorithm-detail/AlgorithmDetail.tsx
+++ b/web/src/app/mlops/components/algorithm-detail/AlgorithmDetail.tsx
@@ -183,7 +183,7 @@ const AlgorithmDetail = ({ datasetType }: AlgorithmDetailProps) => {
     }
     catch (e) { console.error(e) }
     finally { setLoading(false) }
-  }, [t, searchParams]);
+  }, [datasetType, datasetId, pagination.current, pagination.pageSize, getTrainDataByDataset]);
 
   const onUpload = () => {
     const data = {


### PR DESCRIPTION
## 复现步骤

前置：账号能打开机器学习数据集，且某详情里样本数超过一页（异常检测 / 时序预测 / 日志聚类默认 10 条，文本分类 / 图片分类 / 目标检测默认 20 条）。

1. 进入上述任一算法菜单 → **数据集**，打开一条进入 **数据集详情**（面包屑 **数据集** > **数据集详情**）。
2. 表格底部分页合计是 **共 N 项**。点分页器翻到第 2 页。
3. 再改每页条数。

修复前：分页器数字变了，请求仍是 `page=1` 和初始 `page_size`，表格内容停在首页。  
修复后：翻到第 2 页请求 `page=2`；改每页条数后请求使用新的 `page_size`，表格与页码一致。

## 修复方案

`getDataset` 的 `useCallback` 改为显式依赖 `datasetType`、`datasetId`、`pagination.current`、`pagination.pageSize` 和 `getTrainDataByDataset`。不依赖整个 `pagination` 对象，避免 `total` 更新造成循环请求。不改 `page` / `page_size` 字段、权限和 CustomTable。

Fixes #5249

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 点分页器第 2 页 | 请求仍 `page=1` | 请求 `page=2` |
| 改每页条数 | 仍用初始 `page_size` | 用新的 `page_size` |
| 查询字段 / 权限 / **共 N 项** | 原行为 | 不变 |

## 影响面

- **会变**：共用 `AlgorithmDetail` 的六类数据集详情翻页、改 pageSize 时发出的 `page` / `page_size`。
- **不变**：菜单 **异常检测** / **时序预测** / **日志聚类** / **文本分类** / **图片分类** / **目标检测**，面包屑 **数据集** / **数据集详情**，搜索占位 **搜索**，按钮 **上传**，合计 **共 N 项**，接口字段、组织过滤、权限。
- **不在范围**：标注页、训练任务列表分页。
