### PR TITLE
bugfix: 训练任务切换数据集后清空旧版本

### DIFF
--- a/web/scripts/mlops-train-task-dataset-version-test.ts
+++ b/web/scripts/mlops-train-task-dataset-version-test.ts
@@ -1,0 +1,182 @@
+import * as assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+interface DatasetVersionOption {
+  label: string;
+  value: string;
+}
+
+interface DatasetVersionRestoreParams {
+  restoreVersion?: string | number | null;
+  options: DatasetVersionOption[];
+  allowRestore: boolean;
+}
+
+interface DatasetVersionRequestMatchParams {
+  requestGeneration: number;
+  currentGeneration: number;
+  requestedDataset: number;
+  currentDataset: number;
+}
+
+interface DatasetVersionSelectionFns {
+  resolveDatasetVersionRestore: (params: DatasetVersionRestoreParams) => string | undefined;
+  shouldApplyDatasetVersionResponse: (params: DatasetVersionRequestMatchParams) => boolean;
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const formPath = resolve(here, '../src/app/mlops/hooks/task/forms/useGenericDatasetForm.tsx');
+const modalPath = resolve(here, '../src/app/mlops/components/TrainTaskModal.tsx');
+
+const datasetAVersion = '101';
+const datasetBOptions: DatasetVersionOption[] = [{ label: 'B-v1', value: '201' }];
+const datasetAOptions: DatasetVersionOption[] = [{ label: 'A-v1', value: datasetAVersion }];
+
+function legacyUnconditionalRestore(params: DatasetVersionRestoreParams): string | undefined {
+  // 当前 renderOptions：if (formData?.dataset_version) 无条件 setFieldsValue
+  if (params.restoreVersion) {
+    return String(params.restoreVersion);
+  }
+  return undefined;
+}
+
+function legacyAlwaysApplyResponse(): boolean {
+  return true;
+}
+
+async function loadSelectionFns(): Promise<DatasetVersionSelectionFns> {
+  try {
+    const loaded = await import('../src/app/mlops/hooks/task/forms/datasetVersionSelection.ts');
+    if (
+      typeof loaded.resolveDatasetVersionRestore === 'function' &&
+      typeof loaded.shouldApplyDatasetVersionResponse === 'function'
+    ) {
+      return {
+        resolveDatasetVersionRestore: loaded.resolveDatasetVersionRestore,
+        shouldApplyDatasetVersionResponse: loaded.shouldApplyDatasetVersionResponse,
+      };
+    }
+  } catch {
+    // RED：选择逻辑尚未抽出，回退到当前无条件回填行为。
+  }
+
+  return {
+    resolveDatasetVersionRestore: legacyUnconditionalRestore,
+    shouldApplyDatasetVersionResponse: legacyAlwaysApplyResponse,
+  };
+}
+
+function testSwitchDatasetDoesNotRestoreOldVersion(fns: DatasetVersionSelectionFns) {
+  const restored = fns.resolveDatasetVersionRestore({
+    restoreVersion: datasetAVersion,
+    options: datasetBOptions,
+    allowRestore: false,
+  });
+
+  assert.equal(
+    restored,
+    undefined,
+    `切换数据集后不得回填旧 dataset_version，实际回填了 ${String(restored)}`,
+  );
+}
+
+function testEditRestoresVersionInCurrentOptions(fns: DatasetVersionSelectionFns) {
+  const restored = fns.resolveDatasetVersionRestore({
+    restoreVersion: datasetAVersion,
+    options: datasetAOptions,
+    allowRestore: true,
+  });
+
+  assert.equal(restored, datasetAVersion, '首次编辑应回填属于当前 options 的原版本');
+}
+
+function testEditDoesNotRestoreVersionOutsideOptions(fns: DatasetVersionSelectionFns) {
+  const restored = fns.resolveDatasetVersionRestore({
+    restoreVersion: datasetAVersion,
+    options: datasetBOptions,
+    allowRestore: true,
+  });
+
+  assert.equal(
+    restored,
+    undefined,
+    `原版本不属于当前 options 时不得回填，实际回填了 ${String(restored)}`,
+  );
+}
+
+function testStaleGenerationIsIgnored(fns: DatasetVersionSelectionFns) {
+  const applyStale = fns.shouldApplyDatasetVersionResponse({
+    requestGeneration: 1,
+    currentGeneration: 2,
+    requestedDataset: 1,
+    currentDataset: 2,
+  });
+  assert.equal(applyStale, false, '过期世代或数据集不匹配的版本响应必须忽略');
+
+  const applyCurrent = fns.shouldApplyDatasetVersionResponse({
+    requestGeneration: 2,
+    currentGeneration: 2,
+    requestedDataset: 2,
+    currentDataset: 2,
+  });
+  assert.equal(applyCurrent, true, '当前世代且数据集匹配时才更新选项');
+}
+
+function testFormClearsVersionOnDatasetSwitch() {
+  const formSource = readFileSync(formPath, 'utf8');
+
+  assert.match(
+    formSource,
+    /from\s+['"]\.\/datasetVersionSelection['"]/,
+    'useGenericDatasetForm 必须使用抽出的 datasetVersionSelection',
+  );
+  assert.doesNotMatch(
+    formSource,
+    /if\s*\(\s*formData\?\.dataset_version\s*\)[\s\S]{0,120}setFieldsValue\(\s*\{\s*dataset_version:\s*String\(\s*formData\.dataset_version\s*\)/,
+    'renderOptions 不得再无条件回填 formData.dataset_version',
+  );
+  assert.match(
+    formSource,
+    /setFieldsValue\(\s*\{\s*dataset_version:\s*(?:undefined|null|['"]{2})\s*\}\s*\)/,
+    '用户切换数据集时必须立即清空版本值',
+  );
+  assert.match(
+    formSource,
+    /setDatasetVersions\(\s*\[\s*\]\s*\)/,
+    '用户切换数据集时必须立即清空旧 options',
+  );
+  assert.match(
+    formSource,
+    /shouldApplyDatasetVersionResponse|requestGeneration|currentGeneration/,
+    '加载版本必须有请求世代保护',
+  );
+  assert.match(
+    formSource,
+    /datasetVersions\.some\(|options\.some\(/,
+    '提交前必须校验版本属于已加载 options',
+  );
+}
+
+function testModalDisablesConfirmWhileSelectLoading() {
+  const modalSource = readFileSync(modalPath, 'utf8');
+  assert.match(
+    modalSource,
+    /disabled=\{[^}]*loadingState\.select/,
+    'TrainTaskModal 必须在 select loading 时禁用确认',
+  );
+}
+
+async function main() {
+  const fns = await loadSelectionFns();
+  testSwitchDatasetDoesNotRestoreOldVersion(fns);
+  testEditRestoresVersionInCurrentOptions(fns);
+  testEditDoesNotRestoreVersionOutsideOptions(fns);
+  testStaleGenerationIsIgnored(fns);
+  testFormClearsVersionOnDatasetSwitch();
+  testModalDisablesConfirmWhileSelectLoading();
+  console.log('mlops-train-task-dataset-version-test: ok');
+}
+
+void main();

--- a/web/src/app/mlops/components/TrainTaskModal.tsx
+++ b/web/src/app/mlops/components/TrainTaskModal.tsx
@@ -43,7 +43,7 @@ const TrainTaskModal = forwardRef<ModalRef, TrainTaskModalProps>(({ datasetOptio
         open={modalState.isOpen}
         onCancel={handleCancel}
         footer={[
-          <Button key="submit" loading={loadingState.confirm} type="primary" onClick={handleSubmit}>
+          <Button key="submit" loading={loadingState.confirm} disabled={loadingState.select} type="primary" onClick={handleSubmit}>
             {t('common.confirm')}
           </Button>,
           <Button key="cancel" onClick={handleCancel}>

--- a/web/src/app/mlops/hooks/task/forms/datasetVersionSelection.ts
+++ b/web/src/app/mlops/hooks/task/forms/datasetVersionSelection.ts
@@ -1,0 +1,70 @@
+interface DatasetVersionOption {
+  label: string;
+  value: string;
+}
+
+interface DatasetVersionRestoreParams {
+  restoreVersion?: string | number | null;
+  options: DatasetVersionOption[];
+  allowRestore: boolean;
+}
+
+interface DatasetVersionRequestMatchParams {
+  requestGeneration: number;
+  currentGeneration: number;
+  requestedDataset: number;
+  currentDataset: number;
+}
+
+interface DatasetVersionRequestState {
+  generation: number;
+  dataset: number | null;
+}
+
+const isVersionInOptions = (
+  restoreVersion: string | number | null | undefined,
+  options: DatasetVersionOption[],
+): string | undefined => {
+  if (restoreVersion == null || restoreVersion === '') {
+    return undefined;
+  }
+  const value = String(restoreVersion);
+  return options.some((item) => String(item.value) === value) ? value : undefined;
+};
+
+export const resolveDatasetVersionRestore = ({
+  restoreVersion,
+  options,
+  allowRestore,
+}: DatasetVersionRestoreParams): string | undefined => {
+  if (!allowRestore) {
+    return undefined;
+  }
+  return isVersionInOptions(restoreVersion, options);
+};
+
+export const shouldApplyDatasetVersionResponse = ({
+  requestGeneration,
+  currentGeneration,
+  requestedDataset,
+  currentDataset,
+}: DatasetVersionRequestMatchParams): boolean => {
+  return requestGeneration === currentGeneration && requestedDataset === currentDataset;
+};
+
+export const createDatasetVersionRequestState = (): DatasetVersionRequestState => ({
+  generation: 0,
+  dataset: null,
+});
+
+export const beginDatasetVersionRequest = (
+  state: DatasetVersionRequestState,
+  dataset: number,
+): { generation: number; dataset: number } => {
+  state.generation += 1;
+  state.dataset = dataset;
+  return {
+    generation: state.generation,
+    dataset,
+  };
+};

--- a/web/src/app/mlops/hooks/task/forms/useGenericDatasetForm.tsx
+++ b/web/src/app/mlops/hooks/task/forms/useGenericDatasetForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, RefObject } from 'react';
+import { useState, useCallback, useEffect, useRef, RefObject } from 'react';
 import { FormInstance, message, Form, Select, Input, InputNumber, Spin } from 'antd';
 import { useTranslation } from '@/utils/i18n';
 import type { Option } from '@/types';
@@ -23,6 +23,12 @@ import {
 } from '@/app/mlops/utils/algorithmConfigUtils';
 import { useAlgorithmConfigs } from '@/app/mlops/hooks/useAlgorithmConfigs';
 import type { AlgorithmType } from '@/app/mlops/types/algorithmConfig';
+import {
+  beginDatasetVersionRequest,
+  createDatasetVersionRequestState,
+  resolveDatasetVersionRestore,
+  shouldApplyDatasetVersionResponse,
+} from './datasetVersionSelection';
 
 interface ModalState {
   isOpen: boolean;
@@ -90,6 +96,7 @@ export const useGenericDatasetForm = ({
     select: false,
   });
   const [datasetVersions, setDatasetVersions] = useState<Option[]>([]);
+  const datasetVersionRequestRef = useRef(createDatasetVersionRequestState());
   const [isShow, setIsShow] = useState<boolean>(false);
   const [formValues, setFormValues] = useState<TrainJobFormValues>({
     name: '',
@@ -208,6 +215,7 @@ export const useGenericDatasetForm = ({
 
   // 显示模态框
   const showModal = useCallback(({ type, title, form }: ShowModalParams) => {
+    datasetVersionRequestRef.current = createDatasetVersionRequestState();
     setLoadingState((prev) => ({ ...prev, select: false }));
     setFormData(form);
     setModalState({
@@ -236,48 +244,78 @@ export const useGenericDatasetForm = ({
     }
   };
 
+  const loadDatasetVersions = useCallback(async (dataset: number, allowRestore: boolean) => {
+    const request = beginDatasetVersionRequest(datasetVersionRequestRef.current, dataset);
+    setLoadingState((prev) => ({ ...prev, select: true }));
+    try {
+      if (!formRef.current || !dataset) return;
+      const releases = await apiMethods.getDatasetReleases(datasetType, { dataset });
+      const currentDataset = datasetVersionRequestRef.current.dataset;
+      if (
+        currentDataset == null ||
+        !shouldApplyDatasetVersionResponse({
+          requestGeneration: request.generation,
+          currentGeneration: datasetVersionRequestRef.current.generation,
+          requestedDataset: request.dataset,
+          currentDataset,
+        })
+      ) {
+        return;
+      }
+      const nextOptions: Option[] = releases.map((item: DatasetRelease) => ({
+        label: item?.name || '',
+        value: String(item?.id)
+      }));
+      setDatasetVersions(nextOptions);
+      const restored = resolveDatasetVersionRestore({
+        restoreVersion: formData?.dataset_version,
+        options: nextOptions,
+        allowRestore,
+      });
+      if (restored) {
+        formRef.current.setFieldsValue({
+          dataset_version: restored,
+        });
+      }
+    } catch (e) {
+      console.error(e);
+    } finally {
+      if (request.generation === datasetVersionRequestRef.current.generation) {
+        setLoadingState((prev) => ({ ...prev, select: false }));
+      }
+    }
+  }, [formData, datasetType, apiMethods.getDatasetReleases]);
+
+  const handleDatasetChange = useCallback((dataset: number) => {
+    formRef.current?.setFieldsValue({ dataset_version: undefined });
+    setDatasetVersions([]);
+    void loadDatasetVersions(dataset, false);
+  }, [loadDatasetVersions]);
+
   // 以数据集版本文件ID获取数据集ID
   const handleAsyncDataLoading = useCallback(async (dataset_version_id: number) => {
     if (!dataset_version_id) return;
+    const generationAtStart = datasetVersionRequestRef.current.generation;
     setLoadingState((prev) => ({ ...prev, select: true }));
     try {
       const { dataset } = await apiMethods.getDatasetReleaseByID(datasetType, dataset_version_id);
+      if (datasetVersionRequestRef.current.generation !== generationAtStart) {
+        return;
+      }
       if (dataset && formRef.current) {
         formRef.current.setFieldsValue({
           dataset
         });
-        await renderOptions(dataset);
+        await loadDatasetVersions(dataset, true);
       }
     } catch (e) {
       console.error(e);
     } finally {
-      setLoadingState(prev => ({ ...prev, select: false }));
-    }
-  }, [datasetType, apiMethods.getDatasetReleaseByID]);
-
-  // 渲染数据集版本选项
-  const renderOptions = useCallback(async (dataset: number) => {
-    setLoadingState(prev => ({ ...prev, select: true }));
-    try {
-      if (!formRef.current || !dataset) return;
-      // 加载数据集版本
-      const datasetVersions = await apiMethods.getDatasetReleases(datasetType, { dataset });
-      const _versionOptions: Option[] = datasetVersions.map((item: DatasetRelease) => ({
-        label: item?.name || '',
-        value: String(item?.id)
-      }));
-      setDatasetVersions(_versionOptions);
-      if (formData?.dataset_version) {
-        formRef.current.setFieldsValue({
-          dataset_version: String(formData.dataset_version)
-        });
+      if (datasetVersionRequestRef.current.generation === generationAtStart) {
+        setLoadingState((prev) => ({ ...prev, select: false }));
       }
-    } catch (e) {
-      console.error(e);
-    } finally {
-      setLoadingState(prev => ({ ...prev, select: false }));
     }
-  }, [formData, datasetType, apiMethods.getDatasetReleases]);
+  }, [datasetType, apiMethods.getDatasetReleaseByID, loadDatasetVersions]);
 
   // 算法变化处理
   const onAlgorithmChange = useCallback((algorithm: string) => {
@@ -307,11 +345,16 @@ export const useGenericDatasetForm = ({
 
   // 提交处理
   const handleSubmit = useCallback(async () => {
-    if (loadingState.confirm) return;
+    if (loadingState.confirm || loadingState.select) return;
     setLoadingState((prev) => ({ ...prev, confirm: true }));
 
     try {
       const formValues = await formRef.current?.validateFields();
+      const selectedVersion = String(formValues.dataset_version ?? '');
+      if (!datasetVersions.some((item) => String(item.value) === selectedVersion)) {
+        message.error(t('traintask.selectDatasetVersion'));
+        return;
+      }
       const params = formToApi(formValues);
 
       if (modalState.type === 'add') {
@@ -330,7 +373,7 @@ export const useGenericDatasetForm = ({
     } finally {
       setLoadingState((prev) => ({ ...prev, confirm: false }));
     }
-  }, [modalState.type, formData, onSuccess, apiMethods, formToApi, t, loadingState.confirm]);
+  }, [modalState.type, formData, onSuccess, apiMethods, formToApi, t, loadingState.confirm, loadingState.select, datasetVersions]);
 
   // 取消处理
   const handleCancel = useCallback(() => {
@@ -340,6 +383,7 @@ export const useGenericDatasetForm = ({
       title: 'addtask',
     });
     formRef.current?.resetFields();
+    datasetVersionRequestRef.current = createDatasetVersionRequestState();
     setDatasetVersions([]);
     setFormData(null);
     setFormValues({
@@ -393,11 +437,25 @@ export const useGenericDatasetForm = ({
             placeholder={t('traintask.selectDatasets')}
             loading={loadingState.select}
             options={datasetOptions}
-            onChange={renderOptions}
+            onChange={handleDatasetChange}
           />
         </Form.Item>
 
-        <Form.Item name='dataset_version' label={t('traintask.datasetVersion')} rules={[{ required: true, message: t('traintask.selectDatasetVersion') }]}>
+        <Form.Item
+          name='dataset_version'
+          label={t('traintask.datasetVersion')}
+          rules={[
+            { required: true, message: t('traintask.selectDatasetVersion') },
+            {
+              validator: async (_, value) => {
+                if (!value) return;
+                if (!datasetVersions.some((item) => String(item.value) === String(value))) {
+                  return Promise.reject(new Error(t('traintask.selectDatasetVersion')));
+                }
+              },
+            },
+          ]}
+        >
           <Select
             placeholder={t('traintask.selectDatasetVersion')}
             showSearch
@@ -433,7 +491,7 @@ export const useGenericDatasetForm = ({
         )}
       </>
     );
-  }, [t, configLoading, datasetOptions, datasetVersions, loadingState.select, isShow, formValues, algorithmConfigs, algorithmScenarios, algorithmOptions, onAlgorithmChange, renderOptions]);
+  }, [t, configLoading, datasetOptions, datasetVersions, loadingState.select, isShow, formValues, algorithmConfigs, algorithmScenarios, algorithmOptions, onAlgorithmChange, handleDatasetChange]);
 
   return {
     modalState,


### PR DESCRIPTION
## 复现步骤

前置：同一组织内至少有两个可访问数据集 A、B，且各有已发布版本。

1. 进入任一算法（异常检测 / 时序预测 / 日志聚类 / 文本分类 / 图片分类 / 目标检测）的 **训练任务**。
2. 点 **添加**，弹窗标题 **新增训练任务**。或在已有任务行点 **编辑**，标题 **编辑训练任务**。
3. 在 **数据集**（占位 **请选择数据训练集**）先选 A 的 **数据集版本**（占位 **请选择数据集版本**），再把 **数据集** 改成 B，不重选版本。
4. 点 **确认**（旁边是 **取消**）。

修复前：提交参数仍可带上 A 的版本；编辑时 B 的版本列表加载完还会把原来的 A 版本写回去。  
修复后：切换 **数据集** 会立刻清空 **数据集版本** 和旧选项。首次编辑只回填属于当前数据集的原版本。版本加载期间 **确认** 不可点。过期请求不会盖住新选项。

## 修复方案

抽出 `resolveDatasetVersionRestore` / 请求世代保护。用户切换数据集时 `allowRestore=false` 并清空字段；首次编辑仅当原版本在当前 options 里才回填。`TrainTaskModal` 在 `loadingState.select` 时禁用 **确认**。提交前校验版本属于已加载 options。不改 REST 字段和后端。

Fixes #5250

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| **数据集** A→B 后不重选版本 | 仍提交 A 的 `dataset_version` | 版本清空，需重选 B 的版本 |
| 编辑任务加载 B 的版本列表 | 无条件写回原 A 版本 | 只回填属于当前 options 的版本 |
| 版本列表 loading 时点 **确认** | 可点 | 禁用 |

## 影响面

- **会变**：六类训练任务弹窗里 **数据集** / **数据集版本** 的切换与回填、**确认** 在版本加载时的可点状态。
- **不变**：菜单 **训练任务**，按钮 **添加** / **编辑** / **确认** / **取消**，弹窗 **新增训练任务** / **编辑训练任务**，占位 **请选择数据训练集** / **请选择数据集版本**，REST 字段、组织权限、后端校验。
- **不在范围**：数据集发布、标注页。
