### PR TITLE
bugfix: K3s 接入列表请求按对象加载

### DIFF
--- a/web/scripts/monitor-k3s-access-list-loop-test.ts
+++ b/web/scripts/monitor-k3s-access-list-loop-test.ts
@@ -1,0 +1,196 @@
+import * as assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  createK3sAccessListLoad,
+  shouldReloadK3sAccessList,
+  type K3sAccessListLoad,
+  type K3sAccessListLoadDeps,
+} from '../src/app/monitor/(pages)/integration/list/detail/configure/k3s/k3sAccessListLoad.ts';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const accessConfigPath = resolve(
+  here,
+  '../src/app/monitor/(pages)/integration/list/detail/configure/k3s/accessConfig.tsx',
+);
+const localePath = resolve(here, '../src/app/monitor/locales/zh.json');
+const commonLocalePath = resolve(here, '../src/locales/zh.json');
+
+const REPRO_COPY = {
+  menu: '集成',
+  buttons: ['接入', '下一步'],
+  step: 'K3S 接入配置',
+  radios: ['新建 K3S 集群', '选择已有 K3S 集群'],
+  fields: ['K3S 集群名称', '所属组织', 'K3S 集群', '云区域'],
+} as const;
+
+interface ListRequestCounts {
+  cloudRegion: number;
+  instance: number;
+}
+
+function makeFn(label: string): () => typeof label {
+  return () => label;
+}
+
+function simulateStayOnFirstStep(
+  loader: K3sAccessListLoad,
+  renders: K3sAccessListLoadDeps[]
+): ListRequestCounts {
+  const counts: ListRequestCounts = { cloudRegion: 0, instance: 0 };
+  let previous: K3sAccessListLoadDeps | null = null;
+  let clusters: unknown[] = [];
+
+  for (const next of renders) {
+    if (!shouldReloadK3sAccessList(previous, next)) {
+      previous = next;
+      continue;
+    }
+
+    const ticket = loader.begin(next.objectId);
+    counts.cloudRegion += 1;
+    counts.instance += 1;
+    const nextClusters: unknown[] = [];
+    if (loader.shouldApply(ticket)) {
+      clusters = nextClusters;
+    }
+    previous = {
+      ...next,
+      getInstanceList: makeFn(`clusters-setter-${clusters.length}`),
+    };
+  }
+
+  return counts;
+}
+
+function assertReproCopy() {
+  const monitorLocale = JSON.parse(readFileSync(localePath, 'utf8')) as {
+    monitor: {
+      integrations: {
+        integration: string;
+        access: string;
+        k3s: {
+          accessConfig: string;
+          newAsset: string;
+          existingAsset: string;
+          clusterName: string;
+          organization: string;
+          k3sCluster: string;
+          cloudRegion: string;
+        };
+      };
+    };
+  };
+  const commonLocale = JSON.parse(readFileSync(commonLocalePath, 'utf8')) as {
+    common: { next: string };
+  };
+  const k3s = monitorLocale.monitor.integrations.k3s;
+
+  assert.equal(monitorLocale.monitor.integrations.integration, REPRO_COPY.menu);
+  assert.equal(monitorLocale.monitor.integrations.access, REPRO_COPY.buttons[0]);
+  assert.equal(commonLocale.common.next, REPRO_COPY.buttons[1]);
+  assert.equal(k3s.accessConfig, REPRO_COPY.step);
+  assert.equal(k3s.newAsset, REPRO_COPY.radios[0]);
+  assert.equal(k3s.existingAsset, REPRO_COPY.radios[1]);
+  assert.equal(k3s.clusterName, REPRO_COPY.fields[0]);
+  assert.equal(k3s.organization, REPRO_COPY.fields[1]);
+  assert.equal(k3s.k3sCluster, REPRO_COPY.fields[2]);
+  assert.equal(k3s.cloudRegion, REPRO_COPY.fields[3]);
+}
+
+function assertAccessConfigUsesObjectIdLoad(source: string) {
+  assert.match(
+    source,
+    /from ['"]\.\/k3sAccessListLoad['"]/,
+    'AccessConfig 必须复用抽出的 k3sAccessListLoad'
+  );
+  assert.match(source, /createK3sAccessListLoad/, 'AccessConfig 必须创建列表加载世代');
+  assert.match(source, /\.begin\(/, 'AccessConfig 必须 begin 当前 objectId 加载');
+  assert.match(source, /\.shouldApply\(/, 'AccessConfig 必须用 shouldApply 忽略过期响应');
+  assert.match(source, /\.invalidate\(/, 'AccessConfig 必须在卸载或 objectId 变化时作废在途响应');
+  assert.match(
+    source,
+    /getInstanceListRef/,
+    'AccessConfig 必须把 getInstanceList 放进 ref，避免函数身份进入 effect'
+  );
+  assert.match(
+    source,
+    /getCloudRegionListRef/,
+    'AccessConfig 必须把 getCloudRegionList 放进 ref'
+  );
+  assert.doesNotMatch(
+    source,
+    /\[getCloudRegionList, getInstanceList, objectId\]/,
+    'effect 不得继续依赖不稳定的 API 函数身份'
+  );
+  assert.match(
+    source,
+    /page_size:\s*-1/,
+    '不得改实例/云区域列表的 page_size=-1'
+  );
+}
+
+function main() {
+  assertReproCopy();
+
+  const getCloudRegionList = makeFn('cloud-region');
+  const firstGetInstanceList = makeFn('instance-a');
+  const secondGetInstanceList = makeFn('instance-b');
+  assert.notEqual(
+    firstGetInstanceList,
+    secondGetInstanceList,
+    '两次 render 的 getInstanceList 必须是不同函数身份'
+  );
+
+  const stayLoader = createK3sAccessListLoad();
+  const stayCounts = simulateStayOnFirstStep(stayLoader, [
+    { objectId: 42, getCloudRegionList, getInstanceList: firstGetInstanceList },
+    { objectId: 42, getCloudRegionList, getInstanceList: secondGetInstanceList },
+    { objectId: 42, getCloudRegionList, getInstanceList: makeFn('instance-c') },
+  ]);
+
+  assert.equal(
+    stayCounts.cloudRegion,
+    1,
+    'objectId 不变时，getInstanceList 身份变化 + setClusters 新数组不得继续请求云区域'
+  );
+  assert.equal(
+    stayCounts.instance,
+    1,
+    'objectId 不变时，getInstanceList 身份变化 + setClusters 新数组不得继续请求实例列表'
+  );
+  assert.equal(
+    shouldReloadK3sAccessList(
+      { objectId: 42, getCloudRegionList, getInstanceList: firstGetInstanceList },
+      { objectId: 42, getCloudRegionList, getInstanceList: secondGetInstanceList }
+    ),
+    false,
+    '同一 objectId 不得因函数身份重载'
+  );
+
+  const switchLoader = createK3sAccessListLoad();
+  const switchCounts = simulateStayOnFirstStep(switchLoader, [
+    { objectId: 42, getCloudRegionList, getInstanceList: firstGetInstanceList },
+    { objectId: 99, getCloudRegionList, getInstanceList: firstGetInstanceList },
+  ]);
+  assert.deepEqual(
+    switchCounts,
+    { cloudRegion: 2, instance: 2 },
+    'objectId 变化必须重新加载云区域和实例列表'
+  );
+
+  const staleLoader = createK3sAccessListLoad();
+  const firstTicket = staleLoader.begin(42);
+  staleLoader.invalidate();
+  const secondTicket = staleLoader.begin(99);
+  assert.equal(staleLoader.shouldApply(firstTicket), false, '过期世代必须忽略');
+  assert.equal(staleLoader.shouldApply(secondTicket), true, '最新世代可以写回');
+
+  const accessConfigSource = readFileSync(accessConfigPath, 'utf8');
+  assertAccessConfigUsesObjectIdLoad(accessConfigSource);
+
+  console.log('monitor-k3s-access-list-loop-test: ok');
+}
+
+main();

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/k3s/accessConfig.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/k3s/accessConfig.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Button, Form, Input, Radio, Select } from 'antd';
 import { v4 as uuidv4 } from 'uuid';
 import { useSearchParams } from 'next/navigation';
@@ -9,6 +9,7 @@ import useIntegrationApi from '@/app/monitor/api/integration';
 import useMonitorApi from '@/app/monitor/api';
 import { useTranslation } from '@/utils/i18n';
 import type { K3sCommandData } from '@/app/monitor/types/integration';
+import { createK3sAccessListLoad } from './k3sAccessListLoad';
 
 interface AccessConfigProps {
   commandData: K3sCommandData | null;
@@ -29,15 +30,35 @@ const AccessConfig: React.FC<AccessConfigProps> = ({
   const { getCloudRegionList, createK3sInstance, getK3sCommands } =
     useIntegrationApi();
   const { getInstanceList } = useMonitorApi();
+  const getCloudRegionListRef = useRef(getCloudRegionList);
+  const getInstanceListRef = useRef(getInstanceList);
+  const listLoadRef = useRef(createK3sAccessListLoad());
 
   useEffect(() => {
-    void getCloudRegionList({ page_size: -1 }).then((items) =>
-      setCloudRegions(items || [])
-    );
-    void getInstanceList(objectId, { page_size: -1 }).then((result) =>
-      setClusters(result?.results || [])
-    );
-  }, [getCloudRegionList, getInstanceList, objectId]);
+    getCloudRegionListRef.current = getCloudRegionList;
+  }, [getCloudRegionList]);
+
+  useEffect(() => {
+    getInstanceListRef.current = getInstanceList;
+  }, [getInstanceList]);
+
+  useEffect(() => {
+    const listLoad = listLoadRef.current;
+    const ticket = listLoad.begin(objectId);
+    void getCloudRegionListRef.current({ page_size: -1 }).then((items) => {
+      if (listLoad.shouldApply(ticket)) {
+        setCloudRegions(items || []);
+      }
+    });
+    void getInstanceListRef.current(objectId, { page_size: -1 }).then((result) => {
+      if (listLoad.shouldApply(ticket)) {
+        setClusters(result?.results || []);
+      }
+    });
+    return () => {
+      listLoad.invalidate();
+    };
+  }, [objectId]);
 
   useEffect(() => {
     if (commandData) {

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/k3s/k3sAccessListLoad.ts
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/k3s/k3sAccessListLoad.ts
@@ -1,0 +1,44 @@
+export interface K3sAccessListLoadTicket {
+  generation: number;
+  objectId: number;
+}
+
+export interface K3sAccessListLoadDeps {
+  objectId: number;
+  getCloudRegionList: unknown;
+  getInstanceList: unknown;
+}
+
+export interface K3sAccessListLoad {
+  begin: (objectId: number) => K3sAccessListLoadTicket;
+  shouldApply: (ticket: K3sAccessListLoadTicket) => boolean;
+  invalidate: () => void;
+}
+
+/** 只按监控对象重载；API 函数身份变化不得触发新请求。 */
+export function shouldReloadK3sAccessList(
+  previous: K3sAccessListLoadDeps | null,
+  next: K3sAccessListLoadDeps
+): boolean {
+  if (previous == null) {
+    return true;
+  }
+  return previous.objectId !== next.objectId;
+}
+
+export function createK3sAccessListLoad(): K3sAccessListLoad {
+  let generation = 0;
+
+  return {
+    begin(objectId: number): K3sAccessListLoadTicket {
+      generation += 1;
+      return { generation, objectId };
+    },
+    shouldApply(ticket: K3sAccessListLoadTicket): boolean {
+      return ticket.generation === generation;
+    },
+    invalidate(): void {
+      generation += 1;
+    },
+  };
+}


### PR DESCRIPTION
## 复现步骤

前置：账号能打开监控模块「集成」，并能进入 K3S 插件接入向导。打开浏览器开发者工具 Network，过滤云区域列表和实例列表（`page_size=-1`）。

1. 进入监控模块左侧菜单 **集成**。
2. 打开 K3S 插件，点 **接入**。
3. 停在向导第一步 **K3S 接入配置**，不要点 **下一步**。页面上有单选 **新建 K3S 集群** / **选择已有 K3S 集群**，以及字段 **K3S 集群名称**、**所属组织**、**K3S 集群**、**云区域**。
4. 停留数秒，观察 Network 里云区域列表和实例列表是否在成功返回后继续发出。

修复前：列表成功写入新数组后会再次请求，停留越久请求越多。  
修复后：同一监控对象下这两类列表只在进入该步时各发一轮。切到别的对象会重载。离开页面后，迟到响应不再写回。

## 修复方案

本页不再把每次 render 新建的 `getInstanceList` 放进 effect 依赖。API 放进 ref，只按 `objectId` 加载；卸载或对象变化时作废在途响应。不改共享 `useMonitorApi`、REST URL、`page_size=-1`、权限和向导字段。

Fixes #5251

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 停留在 **K3S 接入配置** | 成功响应后继续请求云区域和实例列表 | 同一对象只发一轮 |
| 切换监控对象 | 会重载，但旧响应也可能写回 | 重载，且过期响应忽略 |
| 离开向导 | 在途响应仍可能 setState | 作废后不再写回 |

## 影响面

- **会变**：K3S 接入向导第一步的列表请求时机；离开页面后迟到响应不再写回。
- **不变**：菜单 **集成**，按钮 **接入** / **下一步**，步骤 **K3S 接入配置**，单选 **新建 K3S 集群** / **选择已有 K3S 集群**，字段 **K3S 集群名称** / **所属组织** / **K3S 集群** / **云区域**，REST URL、`page_size=-1`、权限。
- **不在范围**：K8s / Flow 接入页，共享 `useMonitorApi`。
