### PR TITLE
bugfix: 保存查询加载时合并同插件指标

### DIFF
--- a/web/scripts/monitor-saved-query-metric-merge-test.ts
+++ b/web/scripts/monitor-saved-query-metric-merge-test.ts
@@ -1,0 +1,273 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import type React from 'react';
+
+import type { MetricItem } from '../src/app/monitor/types';
+import {
+  collectMetricIdsByResource,
+  getMetricsAbortKey,
+  mergeMetricsById,
+  writeMetricsMap
+} from '../src/app/monitor/(pages)/search/savedQueryMetricMerge.ts';
+import { loadSavedQueryResources } from '../src/app/monitor/(pages)/search/savedQueryLoading.ts';
+
+const makeMetric = (id: number, name = `metric_${id}`): MetricItem => ({
+  id,
+  metric_group: 1,
+  metric_object: 8,
+  name,
+  type: 'gauge',
+  dimensions: []
+});
+
+const makeGroup = (
+  id: string,
+  metric: React.Key | null,
+  plugin: React.Key | null = 6,
+  object: React.Key = 8
+) => ({
+  id,
+  name: `查询条件 ${id}`,
+  object,
+  plugin,
+  instanceIds: ['host-1'],
+  metric,
+  legacyMetricName: null as string | null,
+  aggregation: 'AVG',
+  conditions: [],
+  collapsed: false
+});
+
+const getResourceKey = (objectId: React.Key, pluginId: React.Key | null) =>
+  pluginId !== null && pluginId !== undefined && pluginId !== ''
+    ? `${objectId}_${pluginId}`
+    : String(objectId);
+
+const FIRST_PAGE = Array.from({ length: 100 }, (_, index) =>
+  makeMetric(index + 1)
+);
+
+const simulateLastWrite = (
+  writes: Array<{ key: string; metrics: MetricItem[]; aborted?: boolean }>
+) => {
+  const map: Record<string, MetricItem[]> = {};
+  for (const write of writes) {
+    map[write.key] = write.aborted ? [] : write.metrics;
+  }
+  return map;
+};
+
+const lastWriteLost = simulateLastWrite([
+  { key: '8_6', metrics: [...FIRST_PAGE, makeMetric(101)] },
+  { key: '8_6', metrics: [...FIRST_PAGE, makeMetric(102)] }
+]);
+assert.equal(
+  lastWriteLost['8_6'].some((metric) => metric.id === 101),
+  false,
+  '对照：last-write 会丢掉较早的 101'
+);
+assert.ok(
+  lastWriteLost['8_6'].some((metric) => metric.id === 102),
+  '对照：last-write 只保留最后写入的 102'
+);
+
+const abortedLost = simulateLastWrite([
+  { key: '8_6', metrics: [...FIRST_PAGE, makeMetric(101)], aborted: true },
+  { key: '8_6', metrics: [...FIRST_PAGE, makeMetric(102)] }
+]);
+assert.equal(
+  abortedLost['8_6'].some((metric) => metric.id === 101),
+  false,
+  '对照：同 abort key 取消后 101 缺失'
+);
+
+const collected = collectMetricIdsByResource(
+  [
+    makeGroup('g1', 101),
+    makeGroup('g2', 102),
+    makeGroup('g3', 101),
+    makeGroup('remote', 201, 30)
+  ],
+  getResourceKey
+);
+assert.deepEqual(collected.get('8_6')?.metricIds, [101, 102]);
+assert.deepEqual(collected.get('8_30')?.metricIds, [201]);
+
+const mergedCatalog = mergeMetricsById(
+  [...FIRST_PAGE, makeMetric(101)],
+  [...FIRST_PAGE, makeMetric(102)]
+);
+assert.ok(mergedCatalog.some((metric) => metric.id === 101));
+assert.ok(mergedCatalog.some((metric) => metric.id === 102));
+
+let protectedMap = writeMetricsMap({}, '8_6', [
+  ...FIRST_PAGE,
+  makeMetric(101),
+  makeMetric(102)
+]);
+protectedMap = writeMetricsMap(protectedMap, '8_6', []);
+assert.ok(
+  protectedMap['8_6'].some((metric) => metric.id === 101),
+  '空的取消结果不得覆盖已有 101'
+);
+assert.ok(protectedMap['8_6'].some((metric) => metric.id === 102));
+
+assert.equal(getMetricsAbortKey('8_6', '', undefined, 101), '8_6|metric:101');
+assert.equal(getMetricsAbortKey('8_6', '', undefined, 102), '8_6|metric:102');
+assert.notEqual(
+  getMetricsAbortKey('8_6', '', undefined, 101),
+  getMetricsAbortKey('8_6', '', undefined, 102),
+  '空 keyword 下不同 selectedMetricId 不得共用 abort key'
+);
+assert.equal(
+  getMetricsAbortKey('8_6', 'cpu', 'g1', 101),
+  getMetricsAbortKey('8_6', 'mem', 'g1', 102),
+  'keyword+groupId 搜索仍按组取消'
+);
+assert.notEqual(
+  getMetricsAbortKey('8_6', 'cpu', 'g1'),
+  getMetricsAbortKey('8_6', 'cpu', 'g2')
+);
+
+const run = async () => {
+  const metricCalls: Array<React.Key | null | undefined> = [];
+  const result = await loadSavedQueryResources({
+    queryGroups: [makeGroup('g1', 101), makeGroup('g2', 102)],
+    pluginsMap: { '8': [{ id: 6, name: 'Host' }] },
+    metricsMap: {},
+    instancesMap: {},
+    loadPlugins: async () => [{ id: 6, name: 'Host' }],
+    loadMetrics: async (_objectId, _pluginId, selectedMetricId) => {
+      metricCalls.push(selectedMetricId);
+      if (selectedMetricId === null || selectedMetricId === undefined) {
+        return FIRST_PAGE;
+      }
+      return [makeMetric(Number(selectedMetricId))];
+    },
+    loadInstances: async () => [
+      {
+        instance_id: 'host-1',
+        instance_name: 'Host 1',
+        instance_id_values: ['host-1']
+      }
+    ],
+    getResourceKey,
+    resolvePlugin: (_plugins, group) => group.plugin,
+    resolveLegacyMetric: () => null
+  });
+
+  const merged = result.metricsMap['8_6'] || [];
+  assert.ok(
+    merged.some((metric) => metric.id === 101),
+    '101 被 102 覆盖或取消后缺失'
+  );
+  assert.ok(
+    merged.some((metric) => metric.id === 102),
+    '同插件首屏外指标 102 应保留'
+  );
+
+  const queryPanelSource = readFileSync(
+    new URL(
+      '../src/app/monitor/(pages)/search/queryPanel.tsx',
+      import.meta.url
+    ),
+    'utf8'
+  );
+  assert.match(queryPanelSource, /getMetricsAbortKey/);
+  assert.match(queryPanelSource, /mergeMetricsById/);
+
+  const resolveMetricId = (
+    metrics: MetricItem[],
+    selected: React.Key | null
+  ) => metrics.find((metric) => String(metric.id) === String(selected))?.id;
+  assert.equal(resolveMetricId(merged, 101), 101, 'buildSearchQueryParams 应对 101 得到 metric_id');
+  assert.equal(resolveMetricId(merged, 102), 102, 'buildSearchQueryParams 应对 102 得到 metric_id');
+  const searchQueryLogicSource = readFileSync(
+    new URL(
+      '../src/app/monitor/(pages)/search/searchQueryLogic.ts',
+      import.meta.url
+    ),
+    'utf8'
+  );
+  assert.match(
+    searchQueryLogicSource,
+    /metric_id: metricItem\?\.id/,
+    'buildSearchQueryParams 仍从合并后的 metrics 解析 metric_id'
+  );
+
+  let duplicateCalls = 0;
+  await loadSavedQueryResources({
+    queryGroups: [makeGroup('d1', 101), makeGroup('d2', 101)],
+    pluginsMap: { '8': [{ id: 6, name: 'Host' }] },
+    metricsMap: {},
+    instancesMap: {},
+    loadPlugins: async () => [{ id: 6, name: 'Host' }],
+    loadMetrics: async (_objectId, _pluginId, selectedMetricId) => {
+      if (selectedMetricId === 101 || String(selectedMetricId) === '101') {
+        duplicateCalls += 1;
+      }
+      if (selectedMetricId === null || selectedMetricId === undefined) {
+        return FIRST_PAGE;
+      }
+      return [makeMetric(Number(selectedMetricId))];
+    },
+    loadInstances: async () => [],
+    getResourceKey,
+    resolvePlugin: (_plugins, group) => group.plugin,
+    resolveLegacyMetric: () => null
+  });
+  assert.equal(duplicateCalls, 1, '同键重复指标请求仍应去重');
+
+  const distinct = await loadSavedQueryResources({
+    queryGroups: [makeGroup('host', 101, 6), makeGroup('remote', 201, 30)],
+    pluginsMap: { '8': [{ id: 6 }, { id: 30 }] },
+    metricsMap: {},
+    instancesMap: {},
+    loadPlugins: async () => {
+      throw new Error('已有 plugin 缓存时不应再次加载');
+    },
+    loadMetrics: async (_objectId, pluginId, selectedMetricId) => {
+      if (selectedMetricId === null || selectedMetricId === undefined) {
+        return FIRST_PAGE;
+      }
+      return [makeMetric(Number(selectedMetricId))];
+    },
+    loadInstances: async () => [],
+    getResourceKey,
+    resolvePlugin: (_plugins, group) => group.plugin,
+    resolveLegacyMetric: () => null
+  });
+  assert.ok(distinct.metricsMap['8_6']?.some((metric) => metric.id === 101));
+  assert.ok(distinct.metricsMap['8_30']?.some((metric) => metric.id === 201));
+  assert.equal(
+    distinct.metricsMap['8_6']?.some((metric) => metric.id === 201),
+    false
+  );
+
+  const legacyGroup = makeGroup('legacy', null);
+  legacyGroup.legacyMetricName = 'metric_7';
+  const legacyResult = await loadSavedQueryResources({
+    queryGroups: [legacyGroup],
+    pluginsMap: { '8': [{ id: 6, name: 'Host' }] },
+    metricsMap: {},
+    instancesMap: {},
+    loadPlugins: async () => [{ id: 6, name: 'Host' }],
+    loadMetrics: async () => FIRST_PAGE,
+    loadInstances: async () => [],
+    getResourceKey,
+    resolvePlugin: (_plugins, group) => group.plugin,
+    resolveLegacyMetric: (metrics, legacyName) =>
+      metrics.find((metric) => metric.name === legacyName) || null
+  });
+  assert.equal(legacyResult.queryGroups[0].metric, 7);
+  assert.equal(legacyResult.queryGroups[0].legacyMetricName, null);
+
+  console.log(
+    `monitor saved query metric merge: calls=${JSON.stringify(metricCalls)} merged=${merged.map((metric) => metric.id).filter((id) => id >= 101).join(',')}`
+  );
+};
+
+void run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/web/src/app/monitor/(pages)/search/queryPanel.tsx
+++ b/web/src/app/monitor/(pages)/search/queryPanel.tsx
@@ -56,6 +56,10 @@ import SavedQueryDrawer from './savedQueryDrawer';
 import SaveQueryModal from './saveQueryModal';
 import { loadSavedQueryResources } from './savedQueryLoading';
 import {
+  getMetricsAbortKey,
+  mergeMetricsById
+} from './savedQueryMetricMerge';
+import {
   generateSearchId,
   getMetricsMapKey,
   extractDimensionLabelValues,
@@ -380,7 +384,12 @@ const QueryPanel = forwardRef<QueryPanelRef, QueryPanelProps>(
       keyword = ''
     ): Promise<MetricItem[]> => {
       const key = getMetricsMapKey(objectId, pluginId);
-      const requestKey = keyword.trim() && groupId ? `${key}|${groupId}` : key;
+      const requestKey = getMetricsAbortKey(
+        key,
+        keyword,
+        groupId,
+        selectedMetricId
+      );
       metricsAbortControllerRef.current[requestKey]?.abort();
       const abortController = new AbortController();
       metricsAbortControllerRef.current[requestKey] = abortController;
@@ -427,7 +436,10 @@ const QueryPanel = forwardRef<QueryPanelRef, QueryPanelProps>(
         }
         const metricData = cloneDeep(metricsList.items);
         if (!keyword.trim()) {
-          setMetricsMap((prev) => ({ ...prev, [key]: metricsList.items }));
+          setMetricsMap((prev) => ({
+            ...prev,
+            [key]: mergeMetricsById(prev[key], metricsList.items)
+          }));
         }
         const groupData: IndexViewItem[] = (
           metricsList.metric_groups || groupList.items

--- a/web/src/app/monitor/(pages)/search/savedQueryLoading.ts
+++ b/web/src/app/monitor/(pages)/search/savedQueryLoading.ts
@@ -6,6 +6,10 @@ import type {
   PluginItem,
   QueryGroup
 } from '@/app/monitor/types/search';
+import {
+  collectMetricIdsByResource,
+  mergeMetricsById
+} from './savedQueryMetricMerge';
 
 interface LoadSavedQueryResourcesArgs {
   queryGroups: QueryGroup[];
@@ -86,41 +90,75 @@ export const loadSavedQueryResources = async ({
         (group) => group.object === objectId
       );
 
+      for (const group of groupsForObject) {
+        const pluginId = resolvePlugin(plugins, group);
+        if (pluginId && !group.plugin) group.plugin = pluginId;
+      }
+
+      const resourceIds = collectMetricIdsByResource(
+        groupsForObject,
+        getResourceKey
+      );
+
       await Promise.all(
-        groupsForObject.map(async (group) => {
-          const pluginId = resolvePlugin(plugins, group);
-          if (pluginId && !group.plugin) group.plugin = pluginId;
-          const resourceKey = getResourceKey(objectId, pluginId);
-          const metricRequestKey = `${resourceKey}|${String(group.metric || '')}`;
-          const metricsPromise = loadedMetricsMap[resourceKey]?.some(
-            (metric) => String(metric.id) === String(group.metric)
-          )
-            ? Promise.resolve(loadedMetricsMap[resourceKey])
-            : getOrCreateRequest(metricRequests, metricRequestKey, () =>
-              loadMetrics(objectId, pluginId, group.metric)
-            );
+        [...resourceIds.entries()].map(async ([resourceKey, resource]) => {
+          const { pluginId, metricIds } = resource;
+          const groupsForResource = groupsForObject.filter(
+            (group) => getResourceKey(objectId, group.plugin) === resourceKey
+          );
           const instancesPromise = loadedInstancesMap[resourceKey]
             ? Promise.resolve(loadedInstancesMap[resourceKey])
             : getOrCreateRequest(instanceRequests, resourceKey, () =>
               loadInstances(objectId, pluginId)
             );
-          const [metrics, instances] = await Promise.all([
-            metricsPromise,
-            instancesPromise
-          ]);
 
-          if (group.legacyMetricName && !group.metric) {
-            const legacyMetric = resolveLegacyMetric(
-              metrics,
-              group.legacyMetricName
+          const cached = loadedMetricsMap[resourceKey] || [];
+          const missingFromCache = metricIds.filter(
+            (id) => !cached.some((metric) => String(metric.id) === String(id))
+          );
+          let metrics = cached;
+          if (!cached.length || missingFromCache.length) {
+            const catalog = cached.length
+              ? cached
+              : await getOrCreateRequest(
+                metricRequests,
+                `${resourceKey}|catalog`,
+                () => loadMetrics(objectId, pluginId)
+              );
+            metrics = mergeMetricsById(metrics, catalog);
+            const stillMissing = metricIds.filter(
+              (id) =>
+                !metrics.some((metric) => String(metric.id) === String(id))
             );
-            if (legacyMetric) {
-              group.metric = legacyMetric.id;
-              group.legacyMetricName = null;
+            const extras = await Promise.all(
+              stillMissing.map((id) =>
+                getOrCreateRequest(
+                  metricRequests,
+                  `${resourceKey}|${String(id)}`,
+                  () => loadMetrics(objectId, pluginId, id)
+                )
+              )
+            );
+            for (const extra of extras) {
+              metrics = mergeMetricsById(metrics, extra);
             }
           }
+
           loadedMetricsMap[resourceKey] = metrics;
-          loadedInstancesMap[resourceKey] = instances;
+          loadedInstancesMap[resourceKey] = await instancesPromise;
+
+          for (const group of groupsForResource) {
+            if (group.legacyMetricName && !group.metric) {
+              const legacyMetric = resolveLegacyMetric(
+                metrics,
+                group.legacyMetricName
+              );
+              if (legacyMetric) {
+                group.metric = legacyMetric.id;
+                group.legacyMetricName = null;
+              }
+            }
+          }
         })
       );
     })

--- a/web/src/app/monitor/(pages)/search/savedQueryMetricMerge.ts
+++ b/web/src/app/monitor/(pages)/search/savedQueryMetricMerge.ts
@@ -1,0 +1,88 @@
+import type React from 'react';
+
+import type { MetricItem } from '@/app/monitor/types';
+
+export interface ResourceMetricIds {
+  objectId: React.Key;
+  pluginId: React.Key | null;
+  metricIds: React.Key[];
+}
+
+export const collectMetricIdsByResource = (
+  groups: Array<{
+    object: React.Key;
+    plugin?: React.Key | null;
+    metric?: React.Key | null;
+  }>,
+  getResourceKey: (objectId: React.Key, pluginId: React.Key | null) => string
+): Map<string, ResourceMetricIds> => {
+  const collected = new Map<string, ResourceMetricIds>();
+  for (const group of groups) {
+    const pluginId = group.plugin ?? null;
+    const resourceKey = getResourceKey(group.object, pluginId);
+    const current = collected.get(resourceKey) || {
+      objectId: group.object,
+      pluginId,
+      metricIds: []
+    };
+    if (
+      group.metric !== null &&
+      group.metric !== undefined &&
+      group.metric !== '' &&
+      !current.metricIds.some((id) => String(id) === String(group.metric))
+    ) {
+      current.metricIds.push(group.metric);
+    }
+    collected.set(resourceKey, current);
+  }
+  return collected;
+};
+
+export const mergeMetricsById = (
+  existing: MetricItem[] = [],
+  incoming: MetricItem[] = []
+): MetricItem[] => {
+  const byId = new Map<string, MetricItem>();
+  for (const metric of existing) {
+    if (metric?.id === undefined || metric.id === null) continue;
+    byId.set(String(metric.id), metric);
+  }
+  for (const metric of incoming) {
+    if (metric?.id === undefined || metric.id === null) continue;
+    byId.set(String(metric.id), metric);
+  }
+  return Array.from(byId.values());
+};
+
+export const writeMetricsMap = (
+  map: Record<string, MetricItem[]>,
+  resourceKey: string,
+  incoming: MetricItem[]
+): Record<string, MetricItem[]> => {
+  if (!incoming.length) {
+    return map;
+  }
+  return {
+    ...map,
+    [resourceKey]: mergeMetricsById(map[resourceKey], incoming)
+  };
+};
+
+export const getMetricsAbortKey = (
+  resourceKey: string,
+  keyword = '',
+  groupId?: string,
+  selectedMetricId?: React.Key | null
+): string => {
+  if (keyword.trim() && groupId) {
+    return `${resourceKey}|${groupId}`;
+  }
+  if (
+    selectedMetricId !== null &&
+    selectedMetricId !== undefined &&
+    selectedMetricId !== ''
+  ) {
+    return `${resourceKey}|metric:${String(selectedMetricId)}`;
+  }
+  return resourceKey;
+};


### PR DESCRIPTION
## 复现步骤

前置：同一监控对象、同一插件下至少有两个可搜索指标，且其中两个都不在指标目录默认前 100 条。缓存为空。

1. 进入监控模块左侧菜单 **搜索**，面板标题 **数据查询**。
2. 点 **添加查询** 得到两组。每组选择同一 **对象**、同一 **插件**（文案也可能是硬编码「插件」/「请选择插件」），再选 **资产**，并在 **指标** 里搜索后分别选两个不同指标。可用工具提示 **复制** 复制查询组后再改指标。
3. 点 **保存查询**，填名称后点 **确认**（旁边是 **取消**）。
4. 刷新页面或清空缓存后，点工具提示 **加载已保存的查询**。抽屉标题 **加载已保存的查询**，点 **载入**。
5. 再点 **搜索**。

修复前：较早那组的指标元数据会丢，自动搜索参数里该组 `metric_id` 变成空。  
修复后：两组指标都会进同一插件的目录合并结果，搜索参数各自带上原来的 `metric_id`。

## 修复方案

加载保存查询时按对象/插件共享一次目录，再补取缺失指标 ID，按 ID 合并写入，不再 last-write 覆盖。空 keyword 下不同 `selectedMetricId` 使用独立取消键；带 keyword 的按组搜索取消语义不变。不改保存 JSON、REST 和后端过滤。

Fixes #5252

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 同插件两个首屏外指标载入 | 较早组元数据丢失，`metric_id` 为空 | 两组指标都在合并后的目录里 |
| 同指标重复组 | 已去重 | 仍去重 |
| 指标搜索（带关键词） | 按查询组取消在途请求 | 不变 |

## 影响面

- **会变**：加载已保存查询时同插件多指标的目录合并与取消键；空 keyword 的 `metricsMap` 按 ID 合并。
- **不变**：菜单 **搜索**，面板 **数据查询**，按钮 **添加查询** / **搜索** / **载入** / **确认** / **取消**，工具提示 **保存查询** / **加载已保存的查询** / **复制**，字段 **对象** / **插件** / **资产** / **指标**，保存查询 JSON、REST、权限、后端 keyword 过滤。
- **不在范围**：策略、仪表盘跳转查询。
