### PR TITLE
bugfix: 监控视图指标失败后释放并发槽

### DIFF
--- a/web/scripts/monitor-view-metric-slot-test.ts
+++ b/web/scripts/monitor-view-metric-slot-test.ts
@@ -1,0 +1,203 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  MAX_CONCURRENT_REQUESTS,
+  occupyMetricRequestSlot,
+  releaseMetricRequestSlot,
+  runMetricRangeQuery,
+  waitForAvailableMetricSlot,
+} from '../src/app/monitor/(pages)/view/metricRequestSlot.ts';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const monitorViewPath = resolve(
+  here,
+  '../src/app/monitor/(pages)/view/monitorView.tsx'
+);
+const metricViewsPath = resolve(
+  here,
+  '../src/app/monitor/components/metric-views/index.tsx'
+);
+
+function rejectAs(name: string, message: string): Promise<never> {
+  const error = new Error(message);
+  error.name = name;
+  return Promise.reject(error);
+}
+
+async function assertPostRejectReleasesSlot() {
+  const slots = new Map<number, AbortController>();
+  const outcome = await runMetricRangeQuery({
+    slots,
+    metricId: 11,
+    controller: new AbortController(),
+    postQuery: () => rejectAs('Error', 'query failed'),
+  });
+
+  assert.equal(outcome, 'failed');
+  assert.equal(
+    slots.size,
+    0,
+    'post 拒绝后必须释放该指标槽，不能让 activeRequestsRef 继续占用'
+  );
+}
+
+async function assertFourFailuresAllowFifth() {
+  const slots = new Map<number, AbortController>();
+  await Promise.all(
+    [1, 2, 3, 4].map((metricId) =>
+      runMetricRangeQuery({
+        slots,
+        metricId,
+        controller: new AbortController(),
+        postQuery: () => rejectAs('Error', `metric ${metricId} failed`),
+      })
+    )
+  );
+
+  assert.equal(
+    slots.size,
+    0,
+    '四次 post 拒绝后槽位数必须回到 0，否则第五个指标会卡在 while 等待'
+  );
+
+  const fifthController = new AbortController();
+  let fifthOccupied = false;
+  const waitFifth = (async () => {
+    const ready = await waitForAvailableMetricSlot(slots, () => true, {
+      intervalMs: 5,
+    });
+    if (ready) {
+      occupyMetricRequestSlot(slots, 5, fifthController);
+      fifthOccupied = true;
+    }
+  })();
+
+  let timedOut = false;
+  await Promise.race([
+    waitFifth,
+    new Promise<void>((resolve) => {
+      setTimeout(() => {
+        timedOut = true;
+        resolve();
+      }, 80);
+    }),
+  ]);
+
+  assert.equal(timedOut, false, '四个失败后第五个必须能立刻占槽，不能继续排队');
+  assert.equal(fifthOccupied, true, '四个失败后第五个指标仍可请求');
+  assert.equal(slots.get(5), fifthController);
+}
+
+async function assertAbortReleasesSlot() {
+  const slots = new Map<number, AbortController>();
+  const controller = new AbortController();
+  const outcome = await runMetricRangeQuery({
+    slots,
+    metricId: 21,
+    controller,
+    postQuery: () => {
+      controller.abort();
+      return rejectAs('AbortError', 'aborted');
+    },
+  });
+
+  assert.equal(outcome, 'aborted');
+  assert.equal(slots.size, 0, 'Abort 后必须释放槽');
+}
+
+async function assertOldRequestDoesNotDropReplacement() {
+  const slots = new Map<number, AbortController>();
+  const oldController = new AbortController();
+  const newController = new AbortController();
+  let rejectOld: ((error: unknown) => void) | undefined;
+
+  const oldDone = runMetricRangeQuery({
+    slots,
+    metricId: 31,
+    controller: oldController,
+    postQuery: () =>
+      new Promise<never>((_, reject) => {
+        rejectOld = reject;
+      }),
+  });
+
+  assert.equal(slots.get(31), oldController);
+  occupyMetricRequestSlot(slots, 31, newController);
+  assert.equal(slots.get(31), newController);
+
+  const abortError = new Error('replaced');
+  abortError.name = 'AbortError';
+  rejectOld?.(abortError);
+  const outcome = await oldDone;
+
+  assert.equal(outcome, 'aborted');
+  assert.equal(slots.get(31), newController, '旧请求结束不得删替代的新槽');
+  assert.equal(slots.size, 1);
+  assert.equal(releaseMetricRequestSlot(slots, 31, oldController), false);
+  assert.equal(slots.get(31), newController);
+}
+
+function assertMonitorViewWiresSlotHelpers() {
+  const source = readFileSync(monitorViewPath, 'utf8');
+  const metricViews = readFileSync(metricViewsPath, 'utf8');
+
+  assert.match(
+    source,
+    /from ['"]\.\/metricRequestSlot['"]/,
+    'monitorView 必须使用抽出的 metricRequestSlot'
+  );
+  assert.match(
+    source,
+    /MAX_CONCURRENT_REQUESTS/,
+    '并发上限必须继续来自 MAX_CONCURRENT_REQUESTS'
+  );
+  assert.match(
+    source,
+    /query_by_metric_range/,
+    '查询 URL 不得改动'
+  );
+  assert.match(
+    source,
+    /suppressErrorNotification:\s*true/,
+    '失败仍须 suppressErrorNotification'
+  );
+  assert.match(
+    source,
+    /runMetricRangeQuery|releaseMetricRequestSlot/,
+    'post 与释放必须走抽出的槽位契约'
+  );
+  assert.match(
+    source,
+    /waitForAvailableMetricSlot|generation !== requestGenerationRef/,
+    '代际变化在占槽前退出时必须能结束 loading'
+  );
+
+  assert.match(
+    metricViews,
+    /activeRequestsRef\.current\.set\(metric\.id, abortController\)/,
+    '#5254 metric-views 本轮不得改动'
+  );
+  assert.match(
+    metricViews,
+    /if \(error\.name === 'AbortError'\) \{\s*return;/,
+    'metric-views 仍保持原 post catch 早退，留给 #5254'
+  );
+}
+
+async function main() {
+  assert.equal(MAX_CONCURRENT_REQUESTS, 4, '不得改并发上限');
+  await assertPostRejectReleasesSlot();
+  await assertFourFailuresAllowFifth();
+  await assertAbortReleasesSlot();
+  await assertOldRequestDoesNotDropReplacement();
+  assertMonitorViewWiresSlotHelpers();
+  console.log('monitor view metric slot ok');
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/web/src/app/monitor/(pages)/view/metricRequestSlot.ts
+++ b/web/src/app/monitor/(pages)/view/metricRequestSlot.ts
@@ -1,0 +1,99 @@
+export const MAX_CONCURRENT_REQUESTS = 4;
+
+export interface WaitForAvailableMetricSlotOptions {
+  maxConcurrent?: number;
+  intervalMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export type MetricRequestOutcome = 'ok' | 'failed' | 'aborted' | 'superseded';
+
+export interface RunMetricRangeQueryOptions<T> {
+  slots: Map<number, AbortController>;
+  metricId: number;
+  controller: AbortController;
+  postQuery: () => Promise<T>;
+  handleResponse?: (response: T) => void | Promise<void>;
+  onSettled?: (released: boolean) => void;
+}
+
+function errorName(error: unknown): string {
+  if (error && typeof error === 'object' && 'name' in error) {
+    const name = (error as { name: unknown }).name;
+    return typeof name === 'string' ? name : '';
+  }
+  return '';
+}
+
+export function occupyMetricRequestSlot(
+  slots: Map<number, AbortController>,
+  metricId: number,
+  controller: AbortController
+): void {
+  slots.set(metricId, controller);
+}
+
+export function releaseMetricRequestSlot(
+  slots: Map<number, AbortController>,
+  metricId: number,
+  controller: AbortController
+): boolean {
+  if (slots.get(metricId) !== controller) {
+    return false;
+  }
+  slots.delete(metricId);
+  return true;
+}
+
+export async function waitForAvailableMetricSlot(
+  slots: Map<number, AbortController>,
+  isCurrentGeneration: () => boolean,
+  options?: WaitForAvailableMetricSlotOptions
+): Promise<boolean> {
+  const maxConcurrent = options?.maxConcurrent ?? MAX_CONCURRENT_REQUESTS;
+  const intervalMs = options?.intervalMs ?? 30;
+  const sleep =
+    options?.sleep ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  while (slots.size >= maxConcurrent) {
+    await sleep(intervalMs);
+    if (!isCurrentGeneration()) {
+      return false;
+    }
+  }
+  return isCurrentGeneration();
+}
+
+export async function runMetricRangeQuery<T>({
+  slots,
+  metricId,
+  controller,
+  postQuery,
+  handleResponse,
+  onSettled,
+}: RunMetricRangeQueryOptions<T>): Promise<MetricRequestOutcome> {
+  occupyMetricRequestSlot(slots, metricId, controller);
+  let outcome: MetricRequestOutcome = 'failed';
+  try {
+    const response = await postQuery();
+    if (slots.get(metricId) !== controller) {
+      outcome = 'superseded';
+      return outcome;
+    }
+    await handleResponse?.(response);
+    outcome = 'ok';
+    return outcome;
+  } catch (error: unknown) {
+    const name = errorName(error);
+    if (name === 'AbortError' || name === 'CancelledError') {
+      outcome = 'aborted';
+      return outcome;
+    }
+    outcome = 'failed';
+    return outcome;
+  } finally {
+    const released = releaseMetricRequestSlot(slots, metricId, controller);
+    onSettled?.(released);
+  }
+}

--- a/web/src/app/monitor/(pages)/view/monitorView.tsx
+++ b/web/src/app/monitor/(pages)/view/monitorView.tsx
@@ -35,6 +35,12 @@ import {
   resolveProcessNameFromInstance,
   withHostProcessMetricsTab
 } from '@/app/monitor/dashboards/objects/host/host-process-metrics-tab';
+import {
+  MAX_CONCURRENT_REQUESTS,
+  releaseMetricRequestSlot,
+  runMetricRangeQuery,
+  waitForAvailableMetricSlot,
+} from './metricRequestSlot';
 
 const MonitorView: React.FC<ViewModalProps> = ({
   monitorObject,
@@ -100,7 +106,6 @@ const MonitorView: React.FC<ViewModalProps> = ({
   );
 
   // 请求并发控制：与指标详情页一致，排队而非取消最早请求。
-  const MAX_CONCURRENT_REQUESTS = 4;
   const activeRequestsRef = useRef<Map<number, AbortController>>(new Map());
   const metricCatalogAbortRef = useRef<AbortController | null>(null);
   const requestGenerationRef = useRef(0);
@@ -426,136 +431,146 @@ const MonitorView: React.FC<ViewModalProps> = ({
     }
     const generation = requestGenerationRef.current;
     setLoadingMetricIds((prev) => new Set(prev).add(metric.id));
-    while (activeRequestsRef.current.size >= MAX_CONCURRENT_REQUESTS) {
-      await new Promise((resolve) => window.setTimeout(resolve, 30));
-      if (generation !== requestGenerationRef.current) return;
-    }
-    if (generation !== requestGenerationRef.current) return;
-    const previousController = activeRequestsRef.current.get(metric.id);
-    if (previousController) {
-      previousController.abort();
-      activeRequestsRef.current.delete(metric.id);
-    }
-    const abortController = new AbortController();
-    activeRequestsRef.current.set(metric.id, abortController);
-    let response;
-    try {
-      const params = getParams(metric);
-      response = await post(
-        `/monitor/api/metrics_instance/query_by_metric_range/`,
-        params,
-        {
-          signal: abortController.signal,
-          // 全量指标并行展开时由卡片空态承接失败，避免同类 400 刷 toast。
-          suppressErrorNotification: true,
-        },
-      );
-    } catch (error: any) {
-      if (error.name === 'AbortError') {
-        return;
-      }
-      return;
-    }
-    // 响应返回后若已被新请求替换，丢弃结果，避免 force 刷新被旧数据覆盖。
-    if (activeRequestsRef.current.get(metric.id) !== abortController) {
-      return;
-    }
-    try {
-      const instanceRow = [
-        {
-          instance_id_values: form.instance_id_values,
-          instance_name: form.instance_name,
-          instance_id_keys: isHostProcessMetricsTab(activeTab)
-            ? ['instance_id']
-            : metric?.instance_id_keys || [],
-          dimensions: metric?.dimensions || [],
-          title: metric?.display_name || '--',
-        },
-      ];
-      const chartData = response?.data?.result || [];
-      const displayUnit = response?.data?.unit || '';
-      const seriesBudget = response?.data?.series_budget;
-      const viewData = attachGapIntervals(
-        renderChart(chartData, instanceRow),
-        response?.data?.gaps || []
-      );
-      setMetricData((prevData) => {
-        const updatedData = prevData.map((group) => ({
-          ...group,
-          child: (group.child || []).map((item) =>
-            item.id === metric.id
-              ? {
-                ...item,
-                displayUnit,
-                viewData,
-                seriesBudget,
-              }
-              : item
-          ),
-        }));
-        return updatedData;
-      });
-      // 同时更新originMetricData，保持数据同步
-      setOriginMetricData((prevData) => {
-        const updatedData = prevData.map((group) => ({
-          ...group,
-          child: (group.child || []).map((item) =>
-            item.id === metric.id
-              ? {
-                ...item,
-                displayUnit,
-                viewData,
-                seriesBudget,
-              }
-              : item
-          ),
-        }));
-        return updatedData;
-      });
-      setLoadedMetricIds((prev) => {
-        const newSet = new Set(prev).add(metric.id);
-        return newSet;
-      });
-      setCancelledMetricIds((prev) => {
-        if (prev.has(metric.id)) {
-          const newSet = new Set(prev);
-          newSet.delete(metric.id);
-          return newSet;
-        }
-        return prev;
-      });
-      if (needsRefreshOnExpand) {
-        setNeedsRefreshOnExpand(false);
-      }
-    } catch (error: any) {
-      if (error.name === 'CancelledError') {
-        setCancelledMetricIds((prev) => {
-          const newSet = new Set(prev);
-          newSet.add(metric.id);
-          return newSet;
-        });
-        return;
-      }
-      return;
-    } finally {
-      // 仅当前请求仍占用该指标槽时清理 loading/loaded，避免 force 刷新时被中止的旧请求清掉新请求状态。
-      if (activeRequestsRef.current.get(metric.id) !== abortController) {
-        return;
-      }
-      activeRequestsRef.current.delete(metric.id);
+    const canOccupy = await waitForAvailableMetricSlot(
+      activeRequestsRef.current,
+      () => generation === requestGenerationRef.current,
+      { maxConcurrent: MAX_CONCURRENT_REQUESTS }
+    );
+    if (!canOccupy) {
       setLoadingMetricIds((prev) => {
         const newSet = new Set(prev);
         newSet.delete(metric.id);
         return newSet;
       });
-      if (abortController.signal.aborted) {
-        setLoadedMetricIds((prev) => {
+      return;
+    }
+    const previousController = activeRequestsRef.current.get(metric.id);
+    if (previousController) {
+      previousController.abort();
+      releaseMetricRequestSlot(
+        activeRequestsRef.current,
+        metric.id,
+        previousController
+      );
+    }
+    const abortController = new AbortController();
+    await runMetricRangeQuery({
+      slots: activeRequestsRef.current,
+      metricId: metric.id,
+      controller: abortController,
+      postQuery: async () => {
+        const params = getParams(metric);
+        return post(
+          `/monitor/api/metrics_instance/query_by_metric_range/`,
+          params,
+          {
+            signal: abortController.signal,
+            // 全量指标并行展开时由卡片空态承接失败，避免同类 400 刷 toast。
+            suppressErrorNotification: true,
+          },
+        );
+      },
+      handleResponse: (response) => {
+        try {
+          const instanceRow = [
+            {
+              instance_id_values: form.instance_id_values,
+              instance_name: form.instance_name,
+              instance_id_keys: isHostProcessMetricsTab(activeTab)
+                ? ['instance_id']
+                : metric?.instance_id_keys || [],
+              dimensions: metric?.dimensions || [],
+              title: metric?.display_name || '--',
+            },
+          ];
+          const chartData = response?.data?.result || [];
+          const displayUnit = response?.data?.unit || '';
+          const seriesBudget = response?.data?.series_budget;
+          const viewData = attachGapIntervals(
+            renderChart(chartData, instanceRow),
+            response?.data?.gaps || []
+          );
+          setMetricData((prevData) => {
+            const updatedData = prevData.map((group) => ({
+              ...group,
+              child: (group.child || []).map((item) =>
+                item.id === metric.id
+                  ? {
+                    ...item,
+                    displayUnit,
+                    viewData,
+                    seriesBudget,
+                  }
+                  : item
+              ),
+            }));
+            return updatedData;
+          });
+          // 同时更新originMetricData，保持数据同步
+          setOriginMetricData((prevData) => {
+            const updatedData = prevData.map((group) => ({
+              ...group,
+              child: (group.child || []).map((item) =>
+                item.id === metric.id
+                  ? {
+                    ...item,
+                    displayUnit,
+                    viewData,
+                    seriesBudget,
+                  }
+                  : item
+              ),
+            }));
+            return updatedData;
+          });
+          setLoadedMetricIds((prev) => {
+            const newSet = new Set(prev).add(metric.id);
+            return newSet;
+          });
+          setCancelledMetricIds((prev) => {
+            if (prev.has(metric.id)) {
+              const newSet = new Set(prev);
+              newSet.delete(metric.id);
+              return newSet;
+            }
+            return prev;
+          });
+          if (needsRefreshOnExpand) {
+            setNeedsRefreshOnExpand(false);
+          }
+        } catch (error: unknown) {
+          const name =
+            error && typeof error === 'object' && 'name' in error
+              ? (error as { name: unknown }).name
+              : '';
+          if (name === 'CancelledError') {
+            setCancelledMetricIds((prev) => {
+              const newSet = new Set(prev);
+              newSet.add(metric.id);
+              return newSet;
+            });
+          }
+        }
+      },
+      onSettled: (released) => {
+        // 仅当前请求仍占用该指标槽时清理 loading/loaded，避免 force 刷新时被中止的旧请求清掉新请求状态。
+        if (!released) {
+          return;
+        }
+        setLoadingMetricIds((prev) => {
           const newSet = new Set(prev);
           newSet.delete(metric.id);
           return newSet;
         });
-      }
-    }
+        if (abortController.signal.aborted) {
+          setLoadedMetricIds((prev) => {
+            const newSet = new Set(prev);
+            newSet.delete(metric.id);
+            return newSet;
+          });
+        }
+      },
+    });
   };
 
   const onTimeChange = (val: number[], originValue: number | null) => {


### PR DESCRIPTION
## 复现步骤

前置：账号能打开监控模块「视图」，并能进入某实例的监控视图。打开开发者工具，把 `POST /monitor/api/metrics_instance/query_by_metric_range/` 拦成失败（断网、500 均可）。

1. 进入监控模块左侧菜单 **视图**。
2. 在实例行点 **详情**（旁边是 **仪表盘**）。抽屉标题 **视图**，默认页签 **监控视图**（另一个页签是 **告警列表**，右上有 **查看仪表盘**）。
3. 滚动让至少 4 张指标卡片进入可视范围，观察卡片是否一直转圈。
4. 再滚入第 5 张卡片，或点 **刷新**。

修复前：失败卡片一直 loading；四次失败占满并发槽后，第 5 张和刷新会一直等。  
修复后：失败卡片结束 loading 并释放槽；四个失败后第 5 张仍可发请求。被替换的旧请求不会清掉新请求的槽。

## 修复方案

把 `query_by_metric_range` 的请求和响应处理放进同一 try/finally。finally 只在当前 AbortController 仍占槽时释放并发槽并清 loading。等待队列因代际取消退出时也清 loading。不改并发上限 4、查询参数，也不改指标详情页（#5254）。

Fixes #5253

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 单张卡片查询失败 | loading 不结束，槽不释放 | 释放槽，loading 结束 |
| 累计 4 次失败后再出第 5 张 | while 等待，发不出请求 | 第 5 张可占槽请求 |
| 同指标被新请求替换 | 旧请求不得清新槽（成功路径已有） | 失败/取消路径同样保留 |

## 影响面

- **会变**：实例 **监控视图** 里指标查询失败/取消后的并发槽和 loading。
- **不变**：菜单 **视图**，行按钮 **详情** / **仪表盘**，抽屉标题 **视图**，页签 **监控视图** / **告警列表**，链接 **查看仪表盘**，按钮 **刷新**，并发上限 4、查询 URL 与参数。
- **不在范围**：指标详情页 `metric-views`（#5254）、告警列表页签。
