### PR TITLE
bugfix: 指标详情失败后释放并发槽

### DIFF
--- a/web/scripts/monitor-metric-views-slot-test.ts
+++ b/web/scripts/monitor-metric-views-slot-test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+
+import {
+  MAX_CONCURRENT_METRIC_REQUESTS,
+  canEnterMetricRequestSlot,
+  executeMetricViewRequest,
+  occupyMetricRequestSlot,
+  releaseMetricRequestSlotIfCurrent,
+} from '../src/app/monitor/components/metric-views/metricRequestSlot.ts';
+
+const rejectPost = async (): Promise<never> => {
+  throw new Error('query_by_metric_range rejected');
+};
+
+const abortPost = async (): Promise<never> => {
+  const error = new Error('The user aborted a request.');
+  error.name = 'AbortError';
+  throw error;
+};
+
+const main = async () => {
+  assert.equal(MAX_CONCURRENT_METRIC_REQUESTS, 4, '并发上限必须保持 4');
+
+  const failedSlots = new Map<number, AbortController>();
+  const failedIds = [11, 12, 13, 14];
+  await Promise.all(
+    failedIds.map((metricId) =>
+      executeMetricViewRequest({
+        slots: failedSlots,
+        metricId,
+        controller: new AbortController(),
+        post: rejectPost,
+      }),
+    ),
+  );
+
+  assert.equal(
+    failedSlots.size,
+    0,
+    'post 拒绝后必须释放槽位，activeRequestsRef.size 应回到 0',
+  );
+  assert.equal(
+    canEnterMetricRequestSlot(failedSlots),
+    true,
+    '四个 post 失败后第五个指标仍应能占槽',
+  );
+
+  const fifthController = new AbortController();
+  occupyMetricRequestSlot(failedSlots, 15, fifthController);
+  assert.equal(failedSlots.size, 1, '第五个指标应成功占槽');
+  assert.equal(
+    releaseMetricRequestSlotIfCurrent(failedSlots, 15, fifthController),
+    true,
+  );
+  assert.equal(failedSlots.size, 0);
+
+  const replacedSlots = new Map<number, AbortController>();
+  const oldController = new AbortController();
+  const newController = new AbortController();
+  occupyMetricRequestSlot(replacedSlots, 21, oldController);
+  occupyMetricRequestSlot(replacedSlots, 21, newController);
+  assert.equal(
+    releaseMetricRequestSlotIfCurrent(replacedSlots, 21, oldController),
+    false,
+    '被替换的旧请求不得删除新槽',
+  );
+  assert.equal(replacedSlots.get(21), newController);
+  assert.equal(
+    releaseMetricRequestSlotIfCurrent(replacedSlots, 21, newController),
+    true,
+  );
+
+  const abortSlots = new Map<number, AbortController>();
+  const abortController = new AbortController();
+  await executeMetricViewRequest({
+    slots: abortSlots,
+    metricId: 31,
+    controller: abortController,
+    post: abortPost,
+  });
+  assert.equal(abortSlots.size, 0, 'AbortError 也必须释放槽位');
+
+  console.log('monitor metric-views slot helpers ok');
+};
+
+void main();

--- a/web/src/app/monitor/components/metric-views/index.tsx
+++ b/web/src/app/monitor/components/metric-views/index.tsx
@@ -32,6 +32,10 @@ import {
   useMetricSelectOptions,
 } from '@/app/monitor/components/metricSelectOptions';
 import { buildSearchTimeQueryParams } from '@/app/monitor/utils/searchTimeQuery';
+import {
+  MAX_CONCURRENT_METRIC_REQUESTS,
+  executeMetricViewRequest,
+} from '@/app/monitor/components/metric-views/metricRequestSlot';
 import { isHostMonitorObject,
   isHostProcessMetricsTab,
   resolveHostProcessMetricsTarget,
@@ -196,7 +200,7 @@ const MetricViews: React.FC<ViewDetailProps> = ({
 
   // 大量指标卡片同时请求会挤占浏览器、VictoriaMetrics 和 Telegraf 的资源。
   // 只允许可视区域及下一行卡片以最多四路请求排队加载。
-  const MAX_CONCURRENT_REQUESTS = 4;
+  const MAX_CONCURRENT_REQUESTS = MAX_CONCURRENT_METRIC_REQUESTS;
   const activeRequestsRef = useRef<Map<number, AbortController>>(new Map());
   const metricCatalogAbortRef = useRef<AbortController | null>(null);
   const requestGenerationRef = useRef(0);
@@ -596,12 +600,25 @@ const MetricViews: React.FC<ViewDetailProps> = ({
     }
     const generation = requestGenerationRef.current;
     setLoadingMetricIds((prev) => new Set(prev).add(metric.id));
+    const clearLoadingBeforeOccupy = () => {
+      setLoadingMetricIds((prev) => {
+        const newSet = new Set(prev);
+        newSet.delete(metric.id);
+        return newSet;
+      });
+    };
     // 不再取消最早请求。超出并发上限的可视卡片在这里排队，直到有空槽。
     while (activeRequestsRef.current.size >= MAX_CONCURRENT_REQUESTS) {
       await new Promise((resolve) => window.setTimeout(resolve, 30));
-      if (generation !== requestGenerationRef.current) return;
+      if (generation !== requestGenerationRef.current) {
+        clearLoadingBeforeOccupy();
+        return;
+      }
     }
-    if (generation !== requestGenerationRef.current) return;
+    if (generation !== requestGenerationRef.current) {
+      clearLoadingBeforeOccupy();
+      return;
+    }
     // force 刷新时中止同指标旧请求，避免竞态覆盖。
     const previousController = activeRequestsRef.current.get(metric.id);
     if (previousController) {
@@ -609,126 +626,114 @@ const MetricViews: React.FC<ViewDetailProps> = ({
       activeRequestsRef.current.delete(metric.id);
     }
     const abortController = new AbortController();
-    activeRequestsRef.current.set(metric.id, abortController);
-    let response;
-    try {
-      const params = getParams(metric);
-      response = await post(
-        `/monitor/api/metrics_instance/query_by_metric_range/`,
-        params,
-        {
-          signal: abortController.signal,
-          // 全量指标并行展开时由卡片空态承接失败，避免同类 400 刷 toast。
-          suppressErrorNotification: true,
-        },
-      );
-    } catch (error: any) {
-      if (error.name === 'AbortError') {
-        return;
-      }
-      return;
-    }
-    // 响应返回后若已被新请求替换，丢弃结果，避免 force 刷新被旧数据覆盖。
-    if (activeRequestsRef.current.get(metric.id) !== abortController) {
-      return;
-    }
-    try {
-      const instanceRow = [
-        {
-          instance_id_values: idValues,
-          instance_name: instanceName,
-          instance_id_keys: resolveQueryInstanceIdKeys(
-            metric?.instance_id_keys || []
-          ),
-          dimensions: metric?.dimensions || [],
-          title: metric?.display_name || '--'
-        }
-      ];
-      const chartData = response?.data?.result || [];
-      const displayUnit = response?.data?.unit || '';
-      const seriesBudget = response?.data?.series_budget;
-      const viewData = attachGapIntervals(
-        renderChart(chartData, instanceRow),
-        response?.data?.gaps || []
-      );
+    await executeMetricViewRequest({
+      slots: activeRequestsRef.current,
+      metricId: metric.id,
+      controller: abortController,
+      post: () => {
+        const params = getParams(metric);
+        return post(
+          `/monitor/api/metrics_instance/query_by_metric_range/`,
+          params,
+          {
+            signal: abortController.signal,
+            // 全量指标并行展开时由卡片空态承接失败，避免同类 400 刷 toast。
+            suppressErrorNotification: true,
+          },
+        );
+      },
+      handleResponse: (response) => {
+        const instanceRow = [
+          {
+            instance_id_values: idValues,
+            instance_name: instanceName,
+            instance_id_keys: resolveQueryInstanceIdKeys(
+              metric?.instance_id_keys || []
+            ),
+            dimensions: metric?.dimensions || [],
+            title: metric?.display_name || '--'
+          }
+        ];
+        const chartData = response?.data?.result || [];
+        const displayUnit = response?.data?.unit || '';
+        const seriesBudget = response?.data?.series_budget;
+        const viewData = attachGapIntervals(
+          renderChart(chartData, instanceRow),
+          response?.data?.gaps || []
+        );
 
-      setMetricData((prevData) => {
-        const updatedData = prevData.map((group) => ({
-          ...group,
-          child: (group.child || []).map((item) =>
-            item.id === metric.id
-              ? {
-                ...item,
-                displayUnit,
-                viewData,
-                seriesBudget
-              }
-              : item
-          )
-        }));
-        return updatedData;
-      });
-      // 同时更新originMetricData，保持数据同步
-      setOriginMetricData((prevData) => {
-        const updatedData = prevData.map((group) => ({
-          ...group,
-          child: (group.child || []).map((item) =>
-            item.id === metric.id
-              ? {
-                ...item,
-                displayUnit,
-                viewData,
-                seriesBudget
-              }
-              : item
-          )
-        }));
-        return updatedData;
-      });
-      setLoadedMetricIds((prev) => {
-        const newSet = new Set(prev).add(metric.id);
-        return newSet;
-      });
-      setCancelledMetricIds((prev) => {
-        if (prev.has(metric.id)) {
-          const newSet = new Set(prev);
-          newSet.delete(metric.id);
+        setMetricData((prevData) => {
+          const updatedData = prevData.map((group) => ({
+            ...group,
+            child: (group.child || []).map((item) =>
+              item.id === metric.id
+                ? {
+                  ...item,
+                  displayUnit,
+                  viewData,
+                  seriesBudget
+                }
+                : item
+            )
+          }));
+          return updatedData;
+        });
+        // 同时更新originMetricData，保持数据同步
+        setOriginMetricData((prevData) => {
+          const updatedData = prevData.map((group) => ({
+            ...group,
+            child: (group.child || []).map((item) =>
+              item.id === metric.id
+                ? {
+                  ...item,
+                  displayUnit,
+                  viewData,
+                  seriesBudget
+                }
+                : item
+            )
+          }));
+          return updatedData;
+        });
+        setLoadedMetricIds((prev) => {
+          const newSet = new Set(prev).add(metric.id);
           return newSet;
+        });
+        setCancelledMetricIds((prev) => {
+          if (prev.has(metric.id)) {
+            const newSet = new Set(prev);
+            newSet.delete(metric.id);
+            return newSet;
+          }
+          return prev;
+        });
+        if (needsRefreshOnExpand) {
+          setNeedsRefreshOnExpand(false);
         }
-        return prev;
-      });
-      if (needsRefreshOnExpand) {
-        setNeedsRefreshOnExpand(false);
-      }
-    } catch (error: any) {
-      if (error.name === 'CancelledError') {
+      },
+      onCancelled: () => {
         setCancelledMetricIds((prev) => {
           const newSet = new Set(prev);
           newSet.add(metric.id);
           return newSet;
         });
-        return;
-      }
-      return;
-    } finally {
-      // 仅当前请求仍占用该指标槽时清理 loading/loaded，避免 force 刷新时被中止的旧请求清掉新请求状态。
-      if (activeRequestsRef.current.get(metric.id) !== abortController) {
-        return;
-      }
-      activeRequestsRef.current.delete(metric.id);
-      setLoadingMetricIds((prev) => {
-        const newSet = new Set(prev);
-        newSet.delete(metric.id);
-        return newSet;
-      });
-      if (abortController.signal.aborted) {
-        setLoadedMetricIds((prev) => {
+      },
+      onCurrentSettled: () => {
+        // 仅当前请求仍占用该指标槽时清理 loading/loaded，避免 force 刷新时被中止的旧请求清掉新请求状态。
+        setLoadingMetricIds((prev) => {
           const newSet = new Set(prev);
           newSet.delete(metric.id);
           return newSet;
         });
-      }
-    }
+        if (abortController.signal.aborted) {
+          setLoadedMetricIds((prev) => {
+            const newSet = new Set(prev);
+            newSet.delete(metric.id);
+            return newSet;
+          });
+        }
+      },
+    });
   };
 
   const onTimeChange = (val: number[], originValue: number | null) => {

--- a/web/src/app/monitor/components/metric-views/metricRequestSlot.ts
+++ b/web/src/app/monitor/components/metric-views/metricRequestSlot.ts
@@ -1,0 +1,74 @@
+export const MAX_CONCURRENT_METRIC_REQUESTS = 4;
+
+export function occupyMetricRequestSlot(
+  slots: Map<number, AbortController>,
+  metricId: number,
+  controller: AbortController,
+): void {
+  slots.set(metricId, controller);
+}
+
+export function isCurrentMetricRequestSlot(
+  slots: Map<number, AbortController>,
+  metricId: number,
+  controller: AbortController,
+): boolean {
+  return slots.get(metricId) === controller;
+}
+
+export function releaseMetricRequestSlotIfCurrent(
+  slots: Map<number, AbortController>,
+  metricId: number,
+  controller: AbortController,
+): boolean {
+  if (!isCurrentMetricRequestSlot(slots, metricId, controller)) {
+    return false;
+  }
+  slots.delete(metricId);
+  return true;
+}
+
+export function canEnterMetricRequestSlot(
+  slots: Map<number, AbortController>,
+  limit = MAX_CONCURRENT_METRIC_REQUESTS,
+): boolean {
+  return slots.size < limit;
+}
+
+interface ExecuteMetricViewRequestInput<T> {
+  slots: Map<number, AbortController>;
+  metricId: number;
+  controller: AbortController;
+  post: () => Promise<T>;
+  handleResponse?: (response: T) => void | Promise<void>;
+  onCancelled?: () => void;
+  onCurrentSettled?: () => void;
+}
+
+function errorName(error: unknown): string {
+  if (error && typeof error === 'object' && 'name' in error) {
+    return String((error as { name: unknown }).name);
+  }
+  return '';
+}
+
+export async function executeMetricViewRequest<T>(
+  input: ExecuteMetricViewRequestInput<T>,
+): Promise<void> {
+  occupyMetricRequestSlot(input.slots, input.metricId, input.controller);
+  try {
+    const response = await input.post();
+    if (!isCurrentMetricRequestSlot(input.slots, input.metricId, input.controller)) {
+      return;
+    }
+    await input.handleResponse?.(response);
+  } catch (error: unknown) {
+    if (errorName(error) === 'CancelledError') {
+      input.onCancelled?.();
+    }
+  } finally {
+    if (releaseMetricRequestSlotIfCurrent(input.slots, input.metricId, input.controller)) {
+      input.onCurrentSettled?.();
+    }
+  }
+}


### PR DESCRIPTION
## 复现步骤

前置：选一个没有专业仪表盘、会进入实例详情的对象。账号能打开监控模块「视图」。打开开发者工具，把 `POST /monitor/api/metrics_instance/query_by_metric_range/` 拦成失败。

1. 进入监控模块左侧菜单 **视图**。
2. 在实例行点 **仪表盘**（会进入 `/monitor/view/detail`）。
3. 左侧分段保持 **全量指标**。滚动让至少 4 张指标卡片进入可视范围。
4. 再滚入第 5 张，或点时间选择器上的 **刷新**。

修复前：失败卡片一直 loading；四次失败占满并发槽后，第 5 张和刷新会一直等。  
修复后：失败卡片结束 loading 并释放槽；四个失败后第 5 张仍可发请求。被替换的旧请求不会清掉新请求的槽。

## 修复方案

把指标详情页 `query_by_metric_range` 的请求和响应处理放进同一 try/finally。finally 只在当前 AbortController 仍占槽时释放并发槽并清 loading。等待队列因代际取消退出时也清 loading。不改并发上限 4、查询参数，也不改实例监控视图（#5253）。

Fixes #5254

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 单张卡片查询失败 | loading 不结束，槽不释放 | 释放槽，loading 结束 |
| 累计 4 次失败后再出第 5 张 | while 等待，发不出请求 | 第 5 张可占槽请求 |
| 同指标被新请求替换 | 旧请求不得清新槽（成功路径已有） | 失败/取消路径同样保留 |

## 影响面

- **会变**：实例详情 **全量指标** 里查询失败/取消后的并发槽和 loading。
- **不变**：菜单 **视图**，行按钮 **仪表盘**，分段 **全量指标**，按钮 **刷新**，并发上限 4、查询 URL 与参数。
- **不在范围**：抽屉里的 **监控视图**（#5253）、专业对象仪表盘。
