### PR TITLE
fix(ops-analysis): 关联拓扑按件动态加载，探测不再打进画布

### DIFF
--- a/web/src/app/alarm/(pages)/alarms/components/alarmDetail.tsx
+++ b/web/src/app/alarm/(pages)/alarms/components/alarmDetail.tsx
@@ -75,7 +75,12 @@ const AlertDetail = forwardRef<ModalRef, ModalConfig & { readonly?: boolean }>(
     });
     const isBaseInfo = activeTab === 'baseInfo';
     const isEventTab = activeTab === 'event';
-    const { visible: relatedTopologyVisible, centers: relatedTopologyCenters, Widget: RelatedTopologyWidget } =
+    const {
+      visible: relatedTopologyVisible,
+      centers: relatedTopologyCenters,
+      Widget: RelatedTopologyWidget,
+      loadFailed: relatedTopologyLoadFailed,
+    } =
       useRelatedTopologyTab(
         groupVisible ? formData.monitor_objects : undefined
       );
@@ -416,6 +421,7 @@ const AlertDetail = forwardRef<ModalRef, ModalConfig & { readonly?: boolean }>(
             <RelatedTopologyTabContent
               centers={relatedTopologyCenters}
               Widget={RelatedTopologyWidget}
+              loadFailed={relatedTopologyLoadFailed}
             />
           )}
           {activeTab === 'actionRecords' && (

--- a/web/src/app/alarm/components/alarm-detail-drawer/index.tsx
+++ b/web/src/app/alarm/components/alarm-detail-drawer/index.tsx
@@ -177,7 +177,12 @@ const AlarmDetailDrawer = forwardRef<
     const isBaseInfo = activeTab === 'baseInfo';
     const isEventTab = activeTab === 'event';
     const isRelatedTopologyTab = activeTab === 'relatedTopology';
-    const { visible: relatedTopologyVisible, centers: relatedTopologyCenters, Widget: RelatedTopologyWidget } =
+    const {
+      visible: relatedTopologyVisible,
+      centers: relatedTopologyCenters,
+      Widget: RelatedTopologyWidget,
+      loadFailed: relatedTopologyLoadFailed,
+    } =
       useRelatedTopologyTab(
         groupVisible ? formData.monitor_objects : undefined
       );
@@ -500,6 +505,7 @@ const AlarmDetailDrawer = forwardRef<
             <RelatedTopologyTabContent
               centers={relatedTopologyCenters}
               Widget={RelatedTopologyWidget}
+              loadFailed={relatedTopologyLoadFailed}
             />
           )}
 

--- a/web/src/app/alarm/components/related-topology-tab/__tests__/isolation.test.ts
+++ b/web/src/app/alarm/components/related-topology-tab/__tests__/isolation.test.ts
@@ -28,6 +28,8 @@ describe('alarm related topology app-capability isolation', () => {
     const tabSource = readSource('../index.tsx');
     expect(tabSource).toContain("useAppCapability('ops-analysis')");
     expect(tabSource).toContain('RelatedTopologyWidget');
+    expect(tabSource).toContain('loadWidget()');
+    expect(tabSource).toContain('.catch(');
     expect(tabSource).not.toContain('relatedTopologyAccess');
   });
 
@@ -38,10 +40,10 @@ describe('alarm related topology app-capability isolation', () => {
     expect(tabSource).toContain('centers.length > 1');
   });
 
-  it('retries from a toolbar refresh instead of an in-canvas retry button', () => {
+  it('shows a failed state instead of spinning when the chunk cannot load', () => {
     const tabSource = readSource('../index.tsx');
     expect(tabSource).toContain('ReloadOutlined');
     expect(tabSource).toContain('common.refresh');
-    expect(tabSource).toContain('setRefreshNonce');
+    expect(tabSource).toContain('common.loadFailed');
   });
 });

--- a/web/src/app/alarm/components/related-topology-tab/__tests__/loadWidget.test.tsx
+++ b/web/src/app/alarm/components/related-topology-tab/__tests__/loadWidget.test.tsx
@@ -1,0 +1,42 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useRelatedTopologyTab } from '../index';
+
+const mocks = vi.hoisted(() => ({
+  capability: {
+    status: 'ready' as const,
+    api: {
+      RelatedTopologyWidget: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/context/appCapabilities', () => ({
+  useAppCapability: () => mocks.capability,
+}));
+
+const OBJECTS = [
+  {
+    monitor_id: 'm-1',
+    cmdb_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    resource_type: 'host',
+    resource_name: 'web-1',
+  },
+];
+
+describe('useRelatedTopologyTab widget loader', () => {
+  it('surfaces a failed chunk load instead of spinning', async () => {
+    mocks.capability.api.RelatedTopologyWidget.mockRejectedValueOnce(
+      new Error('missing chunk'),
+    );
+
+    const { result } = renderHook(() => useRelatedTopologyTab(OBJECTS));
+
+    await waitFor(() => {
+      expect(result.current.loadFailed).toBe(true);
+    });
+    expect(result.current.visible).toBe(true);
+    expect(result.current.Widget).toBeNull();
+  });
+});

--- a/web/src/app/alarm/components/related-topology-tab/index.tsx
+++ b/web/src/app/alarm/components/related-topology-tab/index.tsx
@@ -13,35 +13,67 @@ import {
 } from '@/app/alarm/utils/relatedTopologyCenters';
 
 type WidgetComponent = React.ComponentType<{ instUuid: string }>;
+type WidgetLoader = () => Promise<{ default: WidgetComponent }>;
 
 export function useRelatedTopologyTab(monitorObjects?: MonitorObjectSnapshot[]) {
   const capability = useAppCapability('ops-analysis');
-  const Widget =
-    capability.status === 'ready'
+  const loadWidget: WidgetLoader | null =
+    capability.status === 'ready' &&
+    typeof capability.api.RelatedTopologyWidget === 'function'
       ? capability.api.RelatedTopologyWidget
       : null;
-  const declared = typeof Widget === 'function';
+  const declared = loadWidget !== null;
   const centers = useMemo(
     () => listRelatedTopologyCenters(monitorObjects),
     [monitorObjects],
   );
+  const visible = resolveRelatedTopologyTabVisibility({
+    declared,
+    centerCount: centers.length,
+  });
+  const [Widget, setWidget] = useState<WidgetComponent | null>(null);
+  const [loadFailed, setLoadFailed] = useState(false);
+
+  useEffect(() => {
+    if (!visible || !loadWidget) {
+      return;
+    }
+    let cancelled = false;
+    setLoadFailed(false);
+    setWidget(null);
+    loadWidget()
+      .then((mod) => {
+        if (!cancelled) {
+          setWidget(() => mod.default);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setWidget(null);
+          setLoadFailed(true);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [loadWidget, visible]);
 
   return {
-    visible: resolveRelatedTopologyTabVisibility({
-      declared,
-      centerCount: centers.length,
-    }),
+    visible,
     centers,
     Widget,
+    loadFailed,
   };
 }
 
 export function RelatedTopologyTabContent({
   centers,
   Widget,
+  loadFailed = false,
 }: {
   centers: RelatedTopologyCenter[];
   Widget: WidgetComponent | null;
+  loadFailed?: boolean;
 }) {
   const { t } = useTranslation();
   const [instUuid, setInstUuid] = useState(centers[0]?.instUuid || '');
@@ -71,16 +103,24 @@ export function RelatedTopologyTabContent({
             onChange={setInstUuid}
           />
         )}
-        <Button
-          type="text"
-          className="ml-auto"
-          aria-label={t('common.refresh')}
-          icon={<ReloadOutlined />}
-          onClick={() => setRefreshNonce((current) => current + 1)}
-        />
+        {!loadFailed && (
+          <Button
+            type="text"
+            className="ml-auto"
+            aria-label={t('common.refresh')}
+            icon={<ReloadOutlined />}
+            onClick={() => {
+              setRefreshNonce((current) => current + 1);
+            }}
+          />
+        )}
       </div>
       <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
-        {Widget ? (
+        {loadFailed ? (
+          <div className="flex h-full items-center justify-center overflow-hidden rounded-lg bg-[var(--color-fill-1)] text-[var(--color-text-3)]">
+            {t('common.loadFailed')}
+          </div>
+        ) : Widget ? (
           <Widget key={`${instUuid}:${refreshNonce}`} instUuid={instUuid} />
         ) : (
           <div className="flex h-full items-center justify-center overflow-hidden rounded-lg bg-[var(--color-fill-1)]">

--- a/web/src/app/alarm/utils/incidentAlertRelations.ts
+++ b/web/src/app/alarm/utils/incidentAlertRelations.ts
@@ -1,5 +1,7 @@
+import type { Key } from 'react';
+
 export function collectSelectedAlertIds(
-  keys: ReadonlyArray<string | number> | null | undefined
+  keys: ReadonlyArray<Key> | null | undefined
 ): number[] {
   if (!keys?.length) {
     return [];

--- a/web/src/app/ops-analysis/__tests__/capability.test.ts
+++ b/web/src/app/ops-analysis/__tests__/capability.test.ts
@@ -13,11 +13,17 @@ const capabilitySource = readFileSync(
 );
 
 describe('ops-analysis capability', () => {
-  it('registers the related topology widget for authorized hosts', () => {
+  it('registers the related topology widget as a per-widget dynamic import', () => {
     expect(APP_CAPABILITY_LOADERS['ops-analysis']).toBeTypeOf('function');
     expect(capabilitySource).toContain('export const RelatedTopologyWidget');
+    expect(capabilitySource).toMatch(
+      /RelatedTopologyWidget = \(\) =>\s*import\(/,
+    );
     expect(capabilitySource).toContain(
-      "import RelatedTopology from '@/app/ops-analysis/components/widgets/relatedTopology'",
+      "import('@/app/ops-analysis/components/widgets/relatedTopology')",
+    );
+    expect(capabilitySource).not.toMatch(
+      /import RelatedTopology from ['"]@\/app\/ops-analysis\/components\/widgets\/relatedTopology['"]/,
     );
   });
 

--- a/web/src/app/ops-analysis/capability.ts
+++ b/web/src/app/ops-analysis/capability.ts
@@ -1,6 +1,8 @@
 'use client';
 
-import RelatedTopology from '@/app/ops-analysis/components/widgets/relatedTopology';
-
-export const RelatedTopologyWidget = RelatedTopology;
 export type { RelatedTopologyProps } from '@/app/ops-analysis/components/widgets/relatedTopology';
+
+// 只登记加载器。禁止在本文件静态 import 业务组件，否则任意宿主探测本 App
+// 都会打进所有画布（X6 / WebGL）。新组件同样写成 () => import(...)。
+export const RelatedTopologyWidget = () =>
+  import('@/app/ops-analysis/components/widgets/relatedTopology');


### PR DESCRIPTION
capability 只导出 import() 加载器，避免宿主探测运营分析时带入 X6/WebGL；告警 Tab 在 chunk 失败时显示失败态，而不是一直转圈。顺带让事故详情的告警 ID 收集接受 React.Key，否则全仓 type-check 无法提交。