### PR TITLE
bugfix: 监控公共数据失败后允许重试单位列表

### DIFF
--- a/web/scripts/monitor-common-context-loader-test.ts
+++ b/web/scripts/monitor-common-context-loader-test.ts
@@ -32,6 +32,19 @@ assert.equal(
   false
 );
 
+const sampleUnit = {
+  category: 'time',
+  unit_id: 'min',
+  unit_name: '分钟',
+  display_unit: 'min',
+  description: '',
+  is_standalone: false,
+  system: 'time',
+  label: '分钟',
+  value: 'min',
+  unit: 'min',
+};
+
 async function main() {
   clearMonitorCommonDataCache();
   const data = await loadMonitorCommonData({
@@ -46,56 +59,100 @@ async function main() {
   assert.deepEqual(data.units, []);
   assert.deepEqual(data.groupedUnits, []);
 
-  // 同 key 命中会话缓存,不再打 API
+  // 单位失败不得当成成功空结果缓存；再次加载必须重试单位，并保留已成功用户
   let secondUsersCalls = 0;
-  const cached = await loadMonitorCommonData({
+  let secondUnitCalls = 0;
+  const retried = await loadMonitorCommonData({
     cacheKey: 'case-users-ok',
     getAllUsers: async () => {
       secondUsersCalls += 1;
       return [];
     },
-    getUnitList: async () => [],
+    getUnitList: async () => {
+      secondUnitCalls += 1;
+      return [sampleUnit];
+    },
   });
-  assert.equal(secondUsersCalls, 0);
-  assert.deepEqual(cached.users, data.users);
+  assert.equal(secondUsersCalls, 0, '成功用户不得因单位失败而重拉');
+  assert.equal(secondUnitCalls, 1, '单位失败后再次加载必须重试 getUnitList');
+  assert.deepEqual(retried.users, data.users);
+  assert.deepEqual(retried.units, [sampleUnit]);
+
+  clearMonitorCommonDataCache();
+  let emptyUserCalls = 0;
+  let emptyUnitCalls = 0;
+  const emptyFirst = await loadMonitorCommonData({
+    cacheKey: 'case-empty-success',
+    getAllUsers: async () => {
+      emptyUserCalls += 1;
+      return [];
+    },
+    getUnitList: async () => {
+      emptyUnitCalls += 1;
+      return [];
+    },
+  });
+  assert.deepEqual(emptyFirst.users, []);
+  assert.deepEqual(emptyFirst.units, []);
+  assert.equal(emptyUserCalls, 1);
+  assert.equal(emptyUnitCalls, 1);
+
+  const emptyCached = await loadMonitorCommonData({
+    cacheKey: 'case-empty-success',
+    getAllUsers: async () => {
+      emptyUserCalls += 1;
+      return [{ id: '2', username: 'bob', display_name: 'Bob' }];
+    },
+    getUnitList: async () => {
+      emptyUnitCalls += 1;
+      return [sampleUnit];
+    },
+  });
+  assert.equal(emptyUserCalls, 1, '成功空用户列表必须缓存');
+  assert.equal(emptyUnitCalls, 1, '成功空单位列表必须缓存，不再请求');
+  assert.deepEqual(emptyCached.users, []);
+  assert.deepEqual(emptyCached.units, []);
+
+  clearMonitorCommonDataCache();
+  let concurrentUserCalls = 0;
+  let concurrentUnitCalls = 0;
+  const getAllUsers = async () => {
+    concurrentUserCalls += 1;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    return [{ id: '1', username: 'alice', display_name: 'Alice' }];
+  };
+  const getUnitList = async () => {
+    concurrentUnitCalls += 1;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    return [] as typeof sampleUnit[];
+  };
+  const [firstInflight, secondInflight] = await Promise.all([
+    loadMonitorCommonData({
+      cacheKey: 'case-inflight',
+      getAllUsers,
+      getUnitList,
+    }),
+    loadMonitorCommonData({
+      cacheKey: 'case-inflight',
+      getAllUsers,
+      getUnitList,
+    }),
+  ]);
+  assert.equal(concurrentUserCalls, 1, '同 key 并发必须去重用户请求');
+  assert.equal(concurrentUnitCalls, 1, '同 key 并发必须去重单位请求');
+  assert.deepEqual(firstInflight.users, secondInflight.users);
 
   clearMonitorCommonDataCache();
   const grouped = await loadMonitorCommonData({
     cacheKey: 'case-grouped',
     getAllUsers: async () => [],
-    getUnitList: async () => [
-      {
-        category: 'time',
-        unit_id: 'min',
-        unit_name: '分钟',
-        display_unit: 'min',
-        description: '',
-        is_standalone: false,
-        system: 'time',
-        label: '分钟',
-        value: 'min',
-        unit: 'min',
-      },
-    ],
+    getUnitList: async () => [sampleUnit],
   });
 
   assert.deepEqual(grouped.groupedUnits, [
     {
       label: 'time',
-      children: [
-        {
-          category: 'time',
-          unit_id: 'min',
-          unit_name: '分钟',
-          display_unit: 'min',
-          description: '',
-          is_standalone: false,
-          system: 'time',
-          label: '分钟',
-          value: 'min',
-          unit: 'min',
-        },
-      ],
+      children: [sampleUnit],
     },
   ]);
 

--- a/web/src/app/monitor/context/commonDataLoader.ts
+++ b/web/src/app/monitor/context/commonDataLoader.ts
@@ -23,9 +23,26 @@ export interface MonitorCommonData {
   groupedUnits: GroupedUnitList[];
 }
 
-// 会话级缓存:同组织下只拉一次 user_all / unit/list
-const commonDataCache = new Map<string, MonitorCommonData>();
+interface CachedCommonPartial {
+  users?: UserItem[];
+  units?: UnitListItem[];
+  usersReady: boolean;
+  unitsReady: boolean;
+}
+
+// 会话级缓存:同组织下成功的 user_all / unit/list 只拉一次；失败部分可重试
+const commonDataCache = new Map<string, CachedCommonPartial>();
 const commonDataInflight = new Map<string, Promise<MonitorCommonData>>();
+
+const toMonitorCommonData = (partial: CachedCommonPartial): MonitorCommonData => {
+  const users = partial.usersReady && Array.isArray(partial.users) ? partial.users : [];
+  const units = partial.unitsReady && Array.isArray(partial.units) ? partial.units : [];
+  return {
+    users,
+    units,
+    groupedUnits: buildGroupedUnitList(units),
+  };
+};
 
 export const shouldLoadMonitorCommonData = ({
   requestLoading,
@@ -65,8 +82,8 @@ export const loadMonitorCommonData = async ({
 }: LoadMonitorCommonDataParams & { cacheKey?: string }): Promise<MonitorCommonData> => {
   const key = cacheKey || '__default__';
   const cached = commonDataCache.get(key);
-  if (cached) {
-    return cached;
+  if (cached?.usersReady && cached.unitsReady) {
+    return toMonitorCommonData(cached);
   }
 
   const inflight = commonDataInflight.get(key);
@@ -75,26 +92,34 @@ export const loadMonitorCommonData = async ({
   }
 
   const request = (async () => {
+    const previous = commonDataCache.get(key) ?? { usersReady: false, unitsReady: false };
+    const needUsers = !previous.usersReady;
+    const needUnits = !previous.unitsReady;
     const [usersResult, unitsResult] = await Promise.allSettled([
-      getAllUsers(),
-      getUnitList(),
+      needUsers ? getAllUsers() : Promise.resolve(previous.users ?? []),
+      needUnits ? getUnitList() : Promise.resolve(previous.units ?? []),
     ]);
-    const users =
-      usersResult.status === 'fulfilled' && Array.isArray(usersResult.value)
-        ? usersResult.value
-        : [];
-    const units =
-      unitsResult.status === 'fulfilled' && Array.isArray(unitsResult.value)
-        ? unitsResult.value
-        : [];
 
-    const data: MonitorCommonData = {
-      users,
-      units,
-      groupedUnits: buildGroupedUnitList(units),
-    };
-    commonDataCache.set(key, data);
-    return data;
+    const next: CachedCommonPartial = { ...previous };
+    if (
+      needUsers &&
+      usersResult.status === 'fulfilled' &&
+      Array.isArray(usersResult.value)
+    ) {
+      next.users = usersResult.value;
+      next.usersReady = true;
+    }
+    if (
+      needUnits &&
+      unitsResult.status === 'fulfilled' &&
+      Array.isArray(unitsResult.value)
+    ) {
+      next.units = unitsResult.value;
+      next.unitsReady = true;
+    }
+
+    commonDataCache.set(key, next);
+    return toMonitorCommonData(next);
   })();
 
   commonDataInflight.set(key, request);


### PR DESCRIPTION
## 复现步骤

前置：账号能打开监控模块。准备在首次进入时让 `GET /monitor/api/unit/list` 失败一次（断网或 500），随后恢复。

1. 登录并选好组织，进入监控。首次公共数据加载时让单位接口失败。
2. 恢复网络。不要整页刷新。
3. 进入左侧菜单 **事件** → **策略**，点 **添加**，或打开已有策略进入标题含 **编辑策略** 的页面。
4. 打开公式编辑，看硬编码标签 **结果单位** 的 Cascader 是否仍没有选项。
5. 对照：整页刷新后再进同一页，选项会回来。

修复前：同组织、同一 JS 会话里再进监控或切回该组织，单位列表仍是空缓存。  
修复后：再次进入会重试失败的单位接口，成功后 **结果单位** 有选项。用户列表若已成功不会重拉。接口成功返回空列表仍会缓存。

## 修复方案

会话缓存改为按资源记录是否成功。`getUnitList` / `getAllUsers` 只有 fulfilled 才标记就绪；rejected 下次只补失败部分。`Promise.allSettled` 和同 key 并发去重保留。不改 REST 字段。

Fixes #5256

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 单位接口失败后再进同一组织 | 命中空缓存，**结果单位** 无选项 | 重试单位接口，恢复后有选项 |
| 单位接口成功返回空列表 | 缓存空列表 | 仍缓存，不再请求 |
| 用户接口已成功、单位失败 | 用户也会被整包空缓存绑死 | 用户保留，只补单位 |

## 影响面

- **会变**：监控公共数据里失败的 `unit/list` / `user_all` 可在同会话再次进入时重试。
- **不变**：菜单 **事件** / **策略**，按钮 **添加**，页标题 **编辑策略**，标签 **结果单位**，字段 **公式**，REST 字段、组织参数、权限。
- **不在范围**：整页刷新以外的后台自动轮询；策略保存按钮文案未改。
