### PR TITLE
bugfix: K8s/K3s 节点 Pod 排行随仪表盘刷新

### DIFF
--- a/web/scripts/monitor-node-top-pod-refresh-test.ts
+++ b/web/scripts/monitor-node-top-pod-refresh-test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+
+import {
+  createNodeTopPodLoadCoordinator,
+  shouldReloadNodeTopPods,
+  type NodeTopPodLoadKey,
+} from '../src/app/monitor/dashboards/objects/common/nodeTopPodLoad.ts';
+
+function key(overrides: Partial<NodeTopPodLoadKey> = {}): NodeTopPodLoadKey {
+  return {
+    idValuesKey: 'node-a',
+    interval: 15,
+    timeKey: 'last_1h',
+    isDashboardMode: true,
+    loadTick: 1,
+    ...overrides,
+  };
+}
+
+const baseline = key();
+
+assert.equal(
+  shouldReloadNodeTopPods(null, baseline),
+  true,
+  '仪表盘模式且已选实例时应首次取数'
+);
+
+assert.equal(
+  shouldReloadNodeTopPods(baseline, key()),
+  false,
+  '实例、时间窗、间隔与 loadTick 均不变时不应重载'
+);
+
+assert.equal(
+  shouldReloadNodeTopPods(baseline, key({ loadTick: baseline.loadTick + 1 })),
+  true,
+  '同一实例与时间窗下仅 loadTick+1（刷新/自动刷新）必须重载'
+);
+
+assert.equal(
+  shouldReloadNodeTopPods(baseline, key({ idValuesKey: 'node-b' })),
+  true,
+  '切换实例应重载'
+);
+
+assert.equal(
+  shouldReloadNodeTopPods(baseline, key({ timeKey: 'last_6h' })),
+  true,
+  '切换时间窗应重载'
+);
+
+assert.equal(
+  shouldReloadNodeTopPods(baseline, key({ isDashboardMode: false, loadTick: 99 })),
+  false,
+  '切出仪表盘模式必须停止取数'
+);
+
+assert.equal(
+  shouldReloadNodeTopPods(null, key({ idValuesKey: '' })),
+  false,
+  '空实例不得发查询'
+);
+
+const coordinator = createNodeTopPodLoadCoordinator();
+const staleGeneration = coordinator.begin();
+const liveGeneration = coordinator.begin();
+
+assert.equal(coordinator.shouldApply(staleGeneration), false, '迟到 generation 不得 apply');
+assert.equal(coordinator.shouldApply(liveGeneration), true, '当前 generation 可以 apply');
+
+const applied: string[] = [];
+const race = createNodeTopPodLoadCoordinator();
+const first = race.begin();
+const second = race.begin();
+if (race.shouldApply(first)) applied.push('stale');
+if (race.shouldApply(second)) applied.push('live');
+assert.deepEqual(applied, ['live'], '后发起的取数才能写入结果');
+
+console.log('monitor-node-top-pod-refresh-test: ok');

--- a/web/src/app/monitor/dashboards/objects/common/nodeTopPodLoad.ts
+++ b/web/src/app/monitor/dashboards/objects/common/nodeTopPodLoad.ts
@@ -1,0 +1,44 @@
+export interface NodeTopPodLoadKey {
+  idValuesKey: string;
+  interval: string | number | undefined;
+  timeKey: string;
+  isDashboardMode: boolean;
+  loadTick: number;
+}
+
+export interface NodeTopPodLoadCoordinator {
+  begin: () => number;
+  shouldApply: (generation: number) => boolean;
+}
+
+export function shouldReloadNodeTopPods(
+  previous: NodeTopPodLoadKey | null,
+  next: NodeTopPodLoadKey
+): boolean {
+  if (!next.isDashboardMode || !next.idValuesKey) {
+    return false;
+  }
+  if (!previous) {
+    return true;
+  }
+  return (
+    previous.idValuesKey !== next.idValuesKey ||
+    previous.interval !== next.interval ||
+    previous.timeKey !== next.timeKey ||
+    previous.isDashboardMode !== next.isDashboardMode ||
+    previous.loadTick !== next.loadTick
+  );
+}
+
+export function createNodeTopPodLoadCoordinator(): NodeTopPodLoadCoordinator {
+  let generation = 0;
+  return {
+    begin() {
+      generation += 1;
+      return generation;
+    },
+    shouldApply(targetGeneration: number) {
+      return targetGeneration === generation;
+    },
+  };
+}

--- a/web/src/app/monitor/dashboards/objects/k3s-node/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k3s-node/dashboard.tsx
@@ -14,6 +14,7 @@ import {
 import { RingChartPanel, HorizontalBarPanel } from '../../shared/widgets';
 import { buildSearchParams, parseLegacyParamList, normalizeDisplayText } from '../../shared/utils';
 import { buildTopBars, coresDisplay, bytesDisplay } from '../k3s-cluster/parse';
+import { createNodeTopPodLoadCoordinator } from '../common/nodeTopPodLoad';
 import { NODE_DASHBOARD_CONFIG } from './config';
 import styles from './index.module.scss';
 import { K3S_NODE_TOP_POD_CPU, K3S_NODE_TOP_POD_MEM } from './queries';
@@ -38,24 +39,29 @@ export default function K3sNodeDashboardPage() {
   const [topPodMemRaw, setTopPodMemRaw] = useState<any>(null);
 
   useEffect(() => {
-    if (idValues.length === 0) return;
-    let active = true;
+    if (!dashboard.isDashboardMode || idValues.length === 0) {
+      setTopPodCpuRaw(null);
+      setTopPodMemRaw(null);
+      return;
+    }
+    const coordinator = createNodeTopPodLoadCoordinator();
+    const generation = coordinator.begin();
     const tv: TimeValuesProps = dashboard.timeValues;
     getInstanceQuery(buildSearchParams(K3S_NODE_TOP_POD_CPU, 'none', idValues, instanceIdKeys, tv, undefined, false, dashboard.currentInstanceInterval, {
       monitorObjectId: dashboard.monitorObjectId,
       instanceId: dashboard.instanceId,
     }))
-      .then((r) => { if (active) setTopPodCpuRaw(r); })
-      .catch(() => { if (active) setTopPodCpuRaw(null); });
+      .then((r) => { if (coordinator.shouldApply(generation)) setTopPodCpuRaw(r); })
+      .catch(() => { if (coordinator.shouldApply(generation)) setTopPodCpuRaw(null); });
     // 内存为字节类指标:禁用服务端单位自动换算,否则与前端 bytesDisplay 双重换算(见 k3s-cluster 同因)。
     getInstanceQuery(buildSearchParams(K3S_NODE_TOP_POD_MEM, 'bytes', idValues, instanceIdKeys, tv, undefined, false, dashboard.currentInstanceInterval, {
       monitorObjectId: dashboard.monitorObjectId,
       instanceId: dashboard.instanceId,
     }))
-      .then((r) => { if (active) setTopPodMemRaw(r); })
-      .catch(() => { if (active) setTopPodMemRaw(null); });
-    return () => { active = false; };
-  }, [idValuesKey, dashboard.currentInstanceInterval, dashboard.timeValues]);
+      .then((r) => { if (coordinator.shouldApply(generation)) setTopPodMemRaw(r); })
+      .catch(() => { if (coordinator.shouldApply(generation)) setTopPodMemRaw(null); });
+    return () => { coordinator.begin(); };
+  }, [idValuesKey, dashboard.currentInstanceInterval, dashboard.timeValues, dashboard.loadTick, dashboard.isDashboardMode]);
 
   const nodeTopPodCpuBars = useMemo(() => buildTopBars(topPodCpuRaw, 'pod', '#9254de', coresDisplay), [topPodCpuRaw]);
   const nodeTopPodMemBars = useMemo(() => buildTopBars(topPodMemRaw, 'pod', '#13c2c2', bytesDisplay), [topPodMemRaw]);

--- a/web/src/app/monitor/dashboards/objects/k8s-node/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k8s-node/dashboard.tsx
@@ -14,6 +14,7 @@ import {
 import { RingChartPanel, HorizontalBarPanel } from '../../shared/widgets';
 import { buildSearchParams, parseLegacyParamList, normalizeDisplayText } from '../../shared/utils';
 import { buildTopBars, coresDisplay, bytesDisplay } from '../k8s-cluster/parse';
+import { createNodeTopPodLoadCoordinator } from '../common/nodeTopPodLoad';
 import { NODE_DASHBOARD_CONFIG } from './config';
 import styles from './index.module.scss';
 import { K8S_NODE_TOP_POD_CPU, K8S_NODE_TOP_POD_MEM } from './queries';
@@ -38,24 +39,29 @@ export default function K8sNodeDashboardPage() {
   const [topPodMemRaw, setTopPodMemRaw] = useState<any>(null);
 
   useEffect(() => {
-    if (idValues.length === 0) return;
-    let active = true;
+    if (!dashboard.isDashboardMode || idValues.length === 0) {
+      setTopPodCpuRaw(null);
+      setTopPodMemRaw(null);
+      return;
+    }
+    const coordinator = createNodeTopPodLoadCoordinator();
+    const generation = coordinator.begin();
     const tv: TimeValuesProps = dashboard.timeValues;
     getInstanceQuery(buildSearchParams(K8S_NODE_TOP_POD_CPU, 'none', idValues, instanceIdKeys, tv, undefined, false, dashboard.currentInstanceInterval, {
       monitorObjectId: dashboard.monitorObjectId,
       instanceId: dashboard.instanceId,
     }))
-      .then((r) => { if (active) setTopPodCpuRaw(r); })
-      .catch(() => { if (active) setTopPodCpuRaw(null); });
+      .then((r) => { if (coordinator.shouldApply(generation)) setTopPodCpuRaw(r); })
+      .catch(() => { if (coordinator.shouldApply(generation)) setTopPodCpuRaw(null); });
     // 内存为字节类指标:禁用服务端单位自动换算,否则与前端 bytesDisplay 双重换算(见 k8s-cluster 同因)。
     getInstanceQuery(buildSearchParams(K8S_NODE_TOP_POD_MEM, 'bytes', idValues, instanceIdKeys, tv, undefined, false, dashboard.currentInstanceInterval, {
       monitorObjectId: dashboard.monitorObjectId,
       instanceId: dashboard.instanceId,
     }))
-      .then((r) => { if (active) setTopPodMemRaw(r); })
-      .catch(() => { if (active) setTopPodMemRaw(null); });
-    return () => { active = false; };
-  }, [idValuesKey, dashboard.currentInstanceInterval, dashboard.timeValues]);
+      .then((r) => { if (coordinator.shouldApply(generation)) setTopPodMemRaw(r); })
+      .catch(() => { if (coordinator.shouldApply(generation)) setTopPodMemRaw(null); });
+    return () => { coordinator.begin(); };
+  }, [idValuesKey, dashboard.currentInstanceInterval, dashboard.timeValues, dashboard.loadTick, dashboard.isDashboardMode]);
 
   const nodeTopPodCpuBars = useMemo(() => buildTopBars(topPodCpuRaw, 'pod', '#9254de', coresDisplay), [topPodCpuRaw]);
   const nodeTopPodMemBars = useMemo(() => buildTopBars(topPodMemRaw, 'pod', '#13c2c2', bytesDisplay), [topPodMemRaw]);


### PR DESCRIPTION
## 复现步骤

前置：账号能打开监控模块。准备一台有有效实例与 Pod 数据的 K8s 或 K3s 节点。

1. 登录并选好组织，进入左侧菜单 **视图**。
2. 在对象列表找到 K8s 节点或 K3s 节点，点行按钮 **仪表盘**，进入 **K8s 节点监控仪表盘** 或 **K3s 节点监控仪表盘**。
3. 在实例卡 **选择实例** 中选好节点，等待首轮 **健康概览**、**资源趋势**、**Pod 资源排行** 出数。保持实例和时间范围不变。
4. 点实例卡时间选择器旁、文案为 **刷新** 的按钮（`common.refresh`）。也可以等待同一控件绑定的自动刷新周期。
5. 对照 **健康概览** / **资源趋势** 是否重新取数，以及 **Pod 资源排行** 里的 **Top Pod · CPU**、**Top Pod · 内存** 是否仍停在首轮排行。

修复前：刷新后 KPI 和趋势更新，两项 Pod 排行仍是初次加载结果。  
修复后：同一次 **刷新** 会补发两项排行查询，条形图显示新值。切出仪表盘模式或未选实例不再发排行请求。

## 修复方案

抽出 `nodeTopPodLoad`：`shouldReload` 把 `loadTick` 与 `isDashboardMode` 算进重载条件；coordinator 用 generation 丢掉迟到响应。K8s/K3s 节点页的 Top Pod effect 订阅 `dashboard.loadTick`。仍走已有 `loadMetrics` / `onRefresh`，不新增定时器。查询仍 `autoConvert=false`，内存走 bytes 且禁用服务端换算。

Fixes #5257

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 点 **刷新** 或自动刷新 | **健康概览** 更新，**Top Pod · CPU** / **Top Pod · 内存** 仍是首轮结果 | 两项排行随 `loadTick` 重查 |
| 切出仪表盘模式 | 仍可能按旧 effect 取数 | `isDashboardMode=false` 时清空且不发查询 |
| 迟到的排行响应 | `active` 清理 | generation 不对则不写入 |

## 影响面

- **会变**：K8s/K3s 节点专业仪表盘自定义 Pod 排行会随核心盘刷新。
- **不变**：菜单 **视图**，行按钮 **仪表盘**，页标题 **K8s 节点监控仪表盘** / **K3s 节点监控仪表盘**，区块 **健康概览** / **资源趋势** / **分布与详情** / **Pod 资源排行**，面板 **Top Pod · CPU** / **Top Pod · 内存**，按钮 **刷新**，占位 **选择实例**。PromQL、权限、KPI/趋势查询不变。
- **不在范围**：未核过的自动刷新下拉文案；K8s/K3s 集群盘；其他对象的独立 TopN。
