### PR TITLE
bugfix: Tomcat 错误占比不再用整数分母下界

### DIFF
--- a/server/apps/monitor/support-files/dashboard_query_capabilities.json
+++ b/server/apps/monitor/support-files/dashboard_query_capabilities.json
@@ -212,13 +212,6 @@
       "template": "count(prometheus_remote_write_kube_deployment_status_replicas_unavailable{instance_type=\"k3s\",__$labels__} > 0)"
     },
     {
-      "id": "dashboard:v1:07aee933",
-      "object_names": [
-        "Tomcat"
-      ],
-      "template": "100 * (rate(tomcat_connector_error_count{__$labels__}[__$window__]) / clamp_min(rate(tomcat_connector_request_count{__$labels__}[__$window__]), 1))"
-    },
-    {
       "id": "dashboard:v1:08002511",
       "object_names": [
         "Postgres"
@@ -4735,6 +4728,13 @@
         "SGLang"
       ],
       "template": "count({instance_type='sglang', collect_type='bkpull', __$labels__}) by (instance_id)"
+    },
+    {
+      "id": "dashboard:v1:ca3c51c1",
+      "object_names": [
+        "Tomcat"
+      ],
+      "template": "100 * (rate(tomcat_connector_error_count{__$labels__}[__$window__]) / clamp_min(rate(tomcat_connector_request_count{__$labels__}[__$window__]), 1e-6))"
     },
     {
       "id": "dashboard:v1:ca5b5e26",

--- a/web/scripts/monitor-tomcat-error-rate-test.ts
+++ b/web/scripts/monitor-tomcat-error-rate-test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+
+import { TOMCAT_DASHBOARD_CONFIG } from '../src/app/monitor/dashboards/objects/tomcat/config';
+import {
+  TOMCAT_ERROR_RATE_MIN_REQUEST_RATE,
+  tomcatErrorRatePct,
+} from '../src/app/monitor/dashboards/objects/tomcat/errorRate';
+
+assert.equal(tomcatErrorRatePct(0.1, 0.1), 100);
+assert.equal(tomcatErrorRatePct(0.5, 1), 50);
+assert.equal(tomcatErrorRatePct(2, 4), 50);
+assert.equal(tomcatErrorRatePct(0, 0), 0);
+assert.ok(Number.isFinite(tomcatErrorRatePct(0, 0)));
+
+const errorRateMetric = TOMCAT_DASHBOARD_CONFIG.metrics.find(
+  (metric) => metric.name === 'tomcat_connector_error_rate_pct'
+);
+assert.ok(errorRateMetric);
+assert.match(errorRateMetric.query, /1e-6/);
+assert.doesNotMatch(
+  errorRateMetric.query,
+  /clamp_min\(rate\(tomcat_connector_request_count\{__\$labels__\}\[__\$window__\]\),\s*1\)/
+);
+assert.equal(TOMCAT_ERROR_RATE_MIN_REQUEST_RATE, 1e-6);
+
+console.log('monitor-tomcat-error-rate-test: ok');

--- a/web/src/app/monitor/dashboards/objects/tomcat/config.ts
+++ b/web/src/app/monitor/dashboards/objects/tomcat/config.ts
@@ -183,7 +183,7 @@ export const TOMCAT_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       display_name: '错误请求占比',
       description: '由错误请求速率与总请求速率推导出的错误占比（error_rate / request_rate × 100）。',
       unit: 'percent',
-      query: '100 * (rate(tomcat_connector_error_count{__$labels__}[__$window__]) / clamp_min(rate(tomcat_connector_request_count{__$labels__}[__$window__]), 1))',
+      query: '100 * (rate(tomcat_connector_error_count{__$labels__}[__$window__]) / clamp_min(rate(tomcat_connector_request_count{__$labels__}[__$window__]), 1e-6))',
       color: '#8a5cff'
     }
   ],

--- a/web/src/app/monitor/dashboards/objects/tomcat/errorRate.ts
+++ b/web/src/app/monitor/dashboards/objects/tomcat/errorRate.ts
@@ -1,0 +1,5 @@
+export const TOMCAT_ERROR_RATE_MIN_REQUEST_RATE = 1e-6;
+
+export function tomcatErrorRatePct(errorRate: number, requestRate: number): number {
+  return (100 * errorRate) / Math.max(requestRate, TOMCAT_ERROR_RATE_MIN_REQUEST_RATE);
+}


### PR DESCRIPTION
## 复现步骤

前置：账号能打开监控模块。准备一台采集到 Connector 请求/错误计数的 Tomcat 实例；查询窗口内总请求速率 r 满足 0 < r < 1 次/秒，且错误速率接近 r（例如几乎全部失败）。

1. 登录并选好组织，进入左侧菜单 **视图**。
2. 在对象列表找到 Tomcat，点行按钮 **仪表盘**，进入 **Tomcat 监控仪表盘**。
3. 在实例卡 **选择实例** 中选好实例，等待 **健康概览** 出数。
4. 看 KPI **错误占比**，对照旁边的 **请求处理速率**。当两者都约为 0.1 次/秒时，占比按声明应为 100%，而不是 10%。
5. 可再点 **刷新** 确认同一公式每次都会算。

修复前：r=e=0.1 时 **错误占比** 显示约 10.0%。  
修复后：同样速率下显示约 100.0%。r ≥ 1 时比例与原来一致。

## 修复方案

错误占比分母下界从整数 `1` 改为与 Nginx 同类速率比一致的 `1e-6`。抽出 `tomcatErrorRatePct` 固定代数，并重新生成 `dashboard_query_capabilities.json`（旧 ID `dashboard:v1:07aee933` → `dashboard:v1:ca3c51c1`）。指标名、percent 单位和面板结构不变。

Fixes #5258

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| r=e=0.1（全失败） | **错误占比** ≈ 10.0% | ≈ 100.0% |
| r ≥ 1 | 比例正确 | 不变 |
| 查询能力 ID | `dashboard:v1:07aee933` | `dashboard:v1:ca3c51c1`，前后端同发 |

## 影响面

- **会变**：Tomcat 专业仪表盘 **错误占比** 在低于每秒 1 次请求时按真实比率计算；后端允许列表同步换新模板。
- **不变**：菜单 **视图**，行按钮 **仪表盘**，页标题 **Tomcat 监控仪表盘**，区块 **健康概览**，KPI **错误占比** / **请求处理速率** / **线程池利用率**，占位 **选择实例**，按钮 **刷新**。JVM 堆公式、权限、其它对象看板不变。
- **不在范围**：未核过的自动刷新下拉文案；服务端告警策略；零请求且错误速率非零时的极大值（与 Nginx `1e-6` 同类）。
