### PR TITLE
bugfix: 对象配置加载失败后允许重试

### DIFF
--- a/web/scripts/monitor-object-config-load-test.ts
+++ b/web/scripts/monitor-object-config-load-test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  applyObjectConfigLoadReject,
+  applyObjectConfigLoadSuccess,
+  canOpenObjectConfigForm,
+  createObjectConfigLoadState,
+  retryObjectConfigLoad,
+  switchObjectConfigLoad,
+} from '../src/app/monitor/hooks/integration/objectConfigLoad.ts';
+
+const webRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const hookSource = readFileSync(
+  join(webRoot, 'src/app/monitor/hooks/integration/index.tsx'),
+  'utf8'
+);
+const getObjectConfigSource = readFileSync(
+  join(webRoot, 'src/app/monitor/hooks/integration/common/getObjectConfig.ts'),
+  'utf8'
+);
+const configureSource = readFileSync(
+  join(
+    webRoot,
+    'src/app/monitor/(pages)/integration/list/detail/configure/page.tsx'
+  ),
+  'utf8'
+);
+
+const cached = createObjectConfigLoadState({
+  objectName: 'Mysql',
+  cached: true,
+});
+assert.equal(cached.status, 'ready', '缓存命中必须直接 ready');
+assert.equal(canOpenObjectConfigForm(cached), true);
+
+const waiting = createObjectConfigLoadState({ objectName: 'Mysql' });
+assert.equal(waiting.status, 'waiting');
+assert.equal(canOpenObjectConfigForm(waiting), false);
+
+const rejected = applyObjectConfigLoadReject(waiting, waiting.generation);
+assert.equal(rejected.status, 'error', '拒绝后必须进入 error，不能一直 waiting');
+assert.equal(
+  canOpenObjectConfigForm(rejected),
+  false,
+  '失败不得变成空配置 ready 而开放表单'
+);
+
+const retried = retryObjectConfigLoad(rejected);
+assert.equal(retried.status, 'waiting');
+assert.equal(retried.generation, rejected.generation + 1);
+
+const recovered = applyObjectConfigLoadSuccess(retried, retried.generation);
+assert.equal(recovered.status, 'ready', 'retry 后成功必须进入 ready');
+assert.equal(canOpenObjectConfigForm(recovered), true);
+
+const switched = switchObjectConfigLoad(waiting, { objectName: 'Redis' });
+const staleSuccess = applyObjectConfigLoadSuccess(switched, waiting.generation);
+const staleReject = applyObjectConfigLoadReject(switched, waiting.generation);
+assert.equal(staleSuccess.status, 'waiting', '迟到成功必须丢弃');
+assert.equal(staleSuccess.generation, switched.generation);
+assert.equal(staleReject.status, 'waiting', '迟到拒绝必须丢弃');
+assert.equal(staleReject.generation, switched.generation);
+
+assert.match(hookSource, /from '\.\/objectConfigLoad'/);
+assert.match(hookSource, /applyObjectConfigLoadReject/);
+assert.match(hookSource, /retryObjectConfigLoad|retryNonce|retry\s*=/);
+assert.match(getObjectConfigSource, /\berror\b/);
+assert.match(getObjectConfigSource, /\bretry\b/);
+assert.match(configureSource, /t\('common\.loadFailed'\)/);
+assert.match(configureSource, /t\('common\.retry'\)/);
+assert.match(configureSource, /objectConfigError/);
+assert.match(
+  configureSource,
+  /if \(templateType !== 'api' && objectConfigError\) \{[\s\S]*?<Alert[\s\S]*?t\('common\.loadFailed'\)[\s\S]*?t\('common\.retry'\)[\s\S]*?if \(templateType !== 'api' && !objectConfigReady\)/,
+  '失败时先 Alert 重试，不得在 error 时开放采集表单'
+);
+
+console.log('monitor object config load passed');

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/page.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React, { useMemo } from 'react';
-import { Alert, Spin } from 'antd';
+import { Alert, Button, Spin } from 'antd';
 import AutomaticConfiguration from './automatic';
 import { useSearchParams } from 'next/navigation';
 import configureStyle from './index.module.scss';
@@ -21,7 +21,12 @@ const Configure: React.FC = () => {
   const objectId = parseIntegrationObjectId(searchParams.get('id'));
   const pluginId = parseIntegrationObjectId(searchParams.get('plugin_id'));
   const templateType = searchParams.get('template_type') || '';
-  const { getCollectType, ready: objectConfigReady } = useObjectConfigInfo(objectName);
+  const {
+    getCollectType,
+    ready: objectConfigReady,
+    error: objectConfigError,
+    retry: retryObjectConfig
+  } = useObjectConfigInfo(objectName);
 
   const collectType = useMemo(
     () => (objectConfigReady ? getCollectType(objectName, pluginName) : undefined),
@@ -40,6 +45,23 @@ const Configure: React.FC = () => {
           showIcon
           message={t('monitor.integrations.missingEntryContext')}
           description={t('monitor.integrations.missingEntryContextDescription')}
+        />
+      </div>
+    );
+  }
+
+  if (templateType !== 'api' && objectConfigError) {
+    return (
+      <div className={configureStyle.configure}>
+        <Alert
+          type="error"
+          showIcon
+          message={t('common.loadFailed')}
+          action={
+            <Button size="small" onClick={retryObjectConfig}>
+              {t('common.retry')}
+            </Button>
+          }
         />
       </div>
     );

--- a/web/src/app/monitor/hooks/integration/common/getObjectConfig.ts
+++ b/web/src/app/monitor/hooks/integration/common/getObjectConfig.ts
@@ -3,7 +3,7 @@ import { useMonitorConfig } from '../index';
 import { normalizeDashboardDisplay } from '../configContracts';
 
 export const useObjectConfigInfo = (objectName?: string | null) => {
-  const { resolveConfig, ready } = useMonitorConfig(objectName);
+  const { resolveConfig, ready, error, retry } = useMonitorConfig(objectName);
 
   const getCollectType = useCallback(
     (name: string, pluginName: string) => {
@@ -39,6 +39,8 @@ export const useObjectConfigInfo = (objectName?: string | null) => {
 
   return {
     ready,
+    error,
+    retry,
     getCollectType,
     getInstanceType,
     getGroupIds,

--- a/web/src/app/monitor/hooks/integration/index.tsx
+++ b/web/src/app/monitor/hooks/integration/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   getCachedObjectConfig,
   loadObjectConfig
@@ -7,31 +7,61 @@ import {
   PluginConfigRequest,
   resolvePluginConfig
 } from './configContracts';
+import {
+  applyObjectConfigLoadReject,
+  applyObjectConfigLoadSuccess,
+  createObjectConfigLoadState,
+  retryObjectConfigLoad,
+  switchObjectConfigLoad
+} from './objectConfigLoad';
 
 /**
  * 按当前对象按需加载配置，避免一次挂载全部对象 hook/模块。
  */
 export const useMonitorConfig = (objectName?: string | null) => {
   const [configVersion, setConfigVersion] = useState(0);
-  const [ready, setReady] = useState(() => !objectName || !!getCachedObjectConfig(objectName));
+  const [loadState, setLoadState] = useState(() =>
+    createObjectConfigLoadState({
+      objectName,
+      cached: !objectName || !!getCachedObjectConfig(objectName)
+    })
+  );
+  const trackedObjectRef = useRef(objectName);
 
   useEffect(() => {
-    if (!objectName) {
-      setReady(true);
+    if (trackedObjectRef.current === objectName) {
       return;
     }
+    trackedObjectRef.current = objectName;
+    const cached = !objectName || !!getCachedObjectConfig(objectName);
+    setLoadState((prev) => switchObjectConfigLoad(prev, { objectName, cached }));
+  }, [objectName]);
+
+  const retry = useCallback(() => {
+    setLoadState((prev) => retryObjectConfigLoad(prev));
+  }, []);
+
+  useEffect(() => {
+    if (!objectName || loadState.status !== 'waiting') {
+      return;
+    }
+    const generation = loadState.generation;
     let active = true;
-    const cached = getCachedObjectConfig(objectName);
-    setReady(!!cached);
-    loadObjectConfig(objectName).then(() => {
-      if (!active) return;
-      setConfigVersion((v) => v + 1);
-      setReady(true);
-    });
+    loadObjectConfig(objectName).then(
+      () => {
+        if (!active) return;
+        setLoadState((prev) => applyObjectConfigLoadSuccess(prev, generation));
+        setConfigVersion((v) => v + 1);
+      },
+      () => {
+        if (!active) return;
+        setLoadState((prev) => applyObjectConfigLoadReject(prev, generation));
+      }
+    );
     return () => {
       active = false;
     };
-  }, [objectName]);
+  }, [objectName, loadState.status, loadState.generation]);
 
   const resolveConfig = useCallback(
     (name?: string | null) => {
@@ -59,7 +89,9 @@ export const useMonitorConfig = (objectName?: string | null) => {
   return {
     config,
     getPlugin,
-    ready,
+    ready: loadState.status === 'ready',
+    error: loadState.status === 'error',
+    retry,
     resolveConfig
   };
 };

--- a/web/src/app/monitor/hooks/integration/objectConfigLoad.ts
+++ b/web/src/app/monitor/hooks/integration/objectConfigLoad.ts
@@ -1,0 +1,57 @@
+export type ObjectConfigLoadStatus = 'waiting' | 'ready' | 'error';
+
+export interface ObjectConfigLoadState {
+  status: ObjectConfigLoadStatus;
+  generation: number;
+}
+
+export const createObjectConfigLoadState = (input: {
+  objectName?: string | null;
+  cached?: boolean;
+}): ObjectConfigLoadState => {
+  if (!input.objectName || input.cached) {
+    return { status: 'ready', generation: 0 };
+  }
+  return { status: 'waiting', generation: 0 };
+};
+
+export const applyObjectConfigLoadSuccess = (
+  state: ObjectConfigLoadState,
+  generation: number
+): ObjectConfigLoadState => {
+  if (generation !== state.generation) {
+    return state;
+  }
+  return { ...state, status: 'ready' };
+};
+
+export const applyObjectConfigLoadReject = (
+  state: ObjectConfigLoadState,
+  generation: number
+): ObjectConfigLoadState => {
+  if (generation !== state.generation) {
+    return state;
+  }
+  return { ...state, status: 'error' };
+};
+
+export const retryObjectConfigLoad = (
+  state: ObjectConfigLoadState
+): ObjectConfigLoadState => ({
+  status: 'waiting',
+  generation: state.generation + 1,
+});
+
+export const switchObjectConfigLoad = (
+  state: ObjectConfigLoadState,
+  input: { objectName?: string | null; cached?: boolean }
+): ObjectConfigLoadState => {
+  const generation = state.generation + 1;
+  if (!input.objectName || input.cached) {
+    return { status: 'ready', generation };
+  }
+  return { status: 'waiting', generation };
+};
+
+export const canOpenObjectConfigForm = (state: ObjectConfigLoadState): boolean =>
+  state.status === 'ready';


### PR DESCRIPTION
## 复现步骤

前置：账号有监控集成 **Setting** 权限。用社区对象（例如 Mysql）的非 api 插件，第一次进入时不要命中对象配置缓存。

1. 登录并选好组织，进入左侧菜单 **集成**。
2. 在对象卡片上点 **接入**，进入该对象的配置页。
3. 让首次动态配置代码块请求失败（断网或对应 chunk 404）。
4. 观察页面是否一直转圈，没有失败原因。
5. 恢复网络后不要整页刷新，看页面是否仍停在转圈。

修复前：`objectConfigReady` 一直为 false，页面只显示 Spin；同一对象不会重试。  
修复后：显示 **加载失败**，可点 **重试**；成功后进入采集配置表单。失败不会当成空配置直接打开表单。

## 修复方案

抽出对象配置加载状态机：拒绝进入 `error` 并停止等待；`retry` 递增 generation 再拉。Configure 在非 api 入口用已有文案 **加载失败** / **重试**。命中缓存仍直接 ready；切对象丢掉在途响应。

Fixes #5262

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 动态 import 拒绝 | 一直 Spin | **加载失败** + **重试** |
| 恢复网络后点 **重试** | 同一对象 effect 不重跑 | 重新加载，成功后进表单 |
| 加载失败是否开放表单 | 不开放（卡在 Spin） | 仍不开放，直到成功 ready |

## 影响面

- **会变**：集成配置页在对象配置 chunk 失败时给出失败态和重试。
- **不变**：菜单 **集成**，按钮 **接入**，Setting 权限，成功缓存，api 模板入口，采集类型映射。
- **不在范围**：视图概览、策略详情等其它只读 `ready` 的调用方仍可能在失败时继续等待；未新增 locale 键。
