### PR TITLE
bugfix: 采集状态时间线不再把长缺数涂成正常

### DIFF
--- a/web/scripts/monitor-collection-status-timeline-test.ts
+++ b/web/scripts/monitor-collection-status-timeline-test.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { buildCollectionStatusTimeline } from '../src/app/monitor/dashboards/shared/utils/collection-status';
+
+const SEGMENT_COUNT = 18;
+const WINDOW_MS = 15 * 60 * 1000;
+const START_MS = 1_700_000_000_000;
+const END_MS = START_MS + WINDOW_MS;
+const BUCKET_MS = WINDOW_MS / SEGMENT_COUNT;
+
+const tones = (
+  loadState: string | undefined,
+  viewData: Array<{ time: number; value1?: number }>,
+  sampleIntervalMs?: number
+) =>
+  buildCollectionStatusTimeline(
+    loadState,
+    viewData,
+    START_MS,
+    END_MS,
+    SEGMENT_COUNT,
+    sampleIntervalMs
+  ).map((segment) => segment.tone);
+
+const longGapTones = tones('success', [
+  { time: START_MS, value1: 1 },
+  { time: END_MS, value1: 1 }
+]);
+
+assert.equal(longGapTones.length, SEGMENT_COUNT);
+assert.equal(longGapTones[0], 'success', 'window start success point may mark nearby buckets normal');
+assert.equal(longGapTones[SEGMENT_COUNT - 1], 'success', 'window end success point may mark nearby buckets normal');
+for (let index = 3; index < SEGMENT_COUNT - 3; index += 1) {
+  assert.equal(
+    longGapTones[index],
+    'empty',
+    `15m/18 buckets with only endpoints 900s apart must keep middle bucket ${index} empty, not paint the outage as success`
+  );
+}
+
+const sampleEvery60s = Array.from({ length: Math.floor(WINDOW_MS / 60_000) + 1 }, (_, index) => ({
+  time: START_MS + index * 60_000,
+  value1: 1
+}));
+const continuousTones = tones('success', sampleEvery60s, 60_000);
+assert.equal(continuousTones.length, SEGMENT_COUNT);
+assert.deepEqual(
+  continuousTones,
+  Array.from({ length: SEGMENT_COUNT }, () => 'success'),
+  '60s scrape against ~50s buckets must not insert periodic empty (false grey) buckets'
+);
+
+const queryErrorTones = tones('error', [
+  { time: START_MS, value1: 1 },
+  { time: END_MS, value1: 1 }
+]);
+assert.deepEqual(
+  queryErrorTones,
+  Array.from({ length: SEGMENT_COUNT }, () => 'error'),
+  'loadState=error must keep the whole window as error'
+);
+
+const singlePointTones = tones('success', [{ time: START_MS + WINDOW_MS / 2, value1: 1 }]);
+assert.ok(
+  singlePointTones.some((tone) => tone === 'success'),
+  'a single success point must cover nearby buckets'
+);
+assert.ok(
+  singlePointTones.some((tone) => tone === 'empty'),
+  'a single success point must not paint the entire window success'
+);
+const singleCoverageBuckets = singlePointTones.filter((tone) => tone === 'success').length;
+assert.ok(
+  singleCoverageBuckets <= Math.ceil((BUCKET_MS * 3) / BUCKET_MS),
+  'a single success point must only cover nearby buckets'
+);
+
+const callerFiles = [
+  'src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx',
+  'src/app/monitor/dashboards/objects/mysql/dashboard.tsx',
+  'src/app/monitor/dashboards/objects/mongodb/dashboard.tsx',
+  'src/app/monitor/dashboards/objects/k8s-cluster/dashboard.tsx',
+  'src/app/monitor/dashboards/objects/k3s-cluster/dashboard.tsx'
+];
+
+for (const callerFile of callerFiles) {
+  const source = readFileSync(resolve(process.cwd(), callerFile), 'utf8');
+  assert.match(
+    source,
+    /buildCollectionStatusTimeline\([\s\S]*?currentInstanceInterval\s*\*\s*1000/,
+    `${callerFile} must pass currentInstanceInterval*1000 into buildCollectionStatusTimeline`
+  );
+}
+
+console.log('monitor collection status timeline tests passed');

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
@@ -1005,7 +1005,9 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
     collectionStatusMetric?.loadState,
     collectionStatusMetric?.viewData,
     activeTimeRange?.startMs ?? Date.now() - 15 * 60_000,
-    activeTimeRange?.endMs ?? Date.now()
+    activeTimeRange?.endMs ?? Date.now(),
+    undefined,
+    currentInstanceInterval ? currentInstanceInterval * 1000 : undefined
   );
   const collectionStatusTimelineHint = activeTimeRange
     ? formatCollectionStatusTimelineHint(activeTimeRange.startMs, activeTimeRange.endMs)

--- a/web/src/app/monitor/dashboards/objects/k3s-cluster/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k3s-cluster/dashboard.tsx
@@ -304,7 +304,9 @@ export default function K3sClusterDashboardPage() {
     collectionMetric.loadState,
     collectionMetric.viewData,
     collectionStatusRange?.startMs ?? Date.now() - 15 * 60_000,
-    collectionStatusRange?.endMs ?? Date.now()
+    collectionStatusRange?.endMs ?? Date.now(),
+    undefined,
+    currentInstanceInterval ? currentInstanceInterval * 1000 : undefined
   );
   const collectionStatusTimelineHint = collectionStatusRange
     ? formatCollectionStatusTimelineHint(collectionStatusRange.startMs, collectionStatusRange.endMs)

--- a/web/src/app/monitor/dashboards/objects/k8s-cluster/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k8s-cluster/dashboard.tsx
@@ -303,7 +303,9 @@ export default function K8sClusterDashboardPage() {
     collectionMetric.loadState,
     collectionMetric.viewData,
     collectionStatusRange?.startMs ?? Date.now() - 15 * 60_000,
-    collectionStatusRange?.endMs ?? Date.now()
+    collectionStatusRange?.endMs ?? Date.now(),
+    undefined,
+    currentInstanceInterval ? currentInstanceInterval * 1000 : undefined
   );
   const collectionStatusTimelineHint = collectionStatusRange
     ? formatCollectionStatusTimelineHint(collectionStatusRange.startMs, collectionStatusRange.endMs)

--- a/web/src/app/monitor/dashboards/objects/mongodb/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mongodb/dashboard.tsx
@@ -418,7 +418,9 @@ export default function MongoDashboardPage() {
     collectionStatusMetric?.loadState,
     collectionStatusMetric?.viewData,
     collectionStatusRange?.startMs ?? Date.now() - 15 * 60_000,
-    collectionStatusRange?.endMs ?? Date.now()
+    collectionStatusRange?.endMs ?? Date.now(),
+    undefined,
+    currentInstanceInterval ? currentInstanceInterval * 1000 : undefined
   );
   const collectionStatusTimelineHint = collectionStatusRange
     ? formatCollectionStatusTimelineHint(collectionStatusRange.startMs, collectionStatusRange.endMs)

--- a/web/src/app/monitor/dashboards/objects/mysql/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mysql/dashboard.tsx
@@ -611,7 +611,9 @@ export default function MysqlDashboardPage() {
     collectionStatusMetric?.loadState,
     collectionStatusMetric?.viewData,
     collectionStatusRange?.startMs ?? Date.now() - 15 * 60_000,
-    collectionStatusRange?.endMs ?? Date.now()
+    collectionStatusRange?.endMs ?? Date.now(),
+    undefined,
+    currentInstanceInterval ? currentInstanceInterval * 1000 : undefined
   );
   const collectionStatusTimelineHint = collectionStatusRange
     ? formatCollectionStatusTimelineHint(collectionStatusRange.startMs, collectionStatusRange.endMs)

--- a/web/src/app/monitor/dashboards/shared/utils/collection-status.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/collection-status.ts
@@ -22,9 +22,19 @@ const toTimestampMs = (value: number): number => (value < 1e12 ? value * 1000 : 
 
 /**
  * 采样间隔常大于桶宽（如默认 15m / 18 格 ≈ 50s，而 scrape/step 多为 60s），
- * 仅按「点落在桶内」会出现周期性假灰。用相邻成功点的中位间隔作为覆盖半径。
+ * 仅按「点落在桶内」会出现周期性假灰。用相邻成功点的中位间隔估计覆盖宽度，
+ * 但必须封顶：不能把跨缺数的成功点距离当成采集频率。
+ * 有实例间隔时 cap = max(bucketWidth, interval×1.5)，保证 60s 采样 / 50s 桶不假灰。
  */
-const estimateSampleCoverageMs = (successTimes: number[], bucketWidth: number): number => {
+const estimateSampleCoverageMs = (
+  successTimes: number[],
+  bucketWidth: number,
+  sampleIntervalMs?: number
+): number => {
+  const hasInterval =
+    sampleIntervalMs != null && Number.isFinite(sampleIntervalMs) && sampleIntervalMs > 0;
+  const coverageCap = hasInterval ? Math.max(bucketWidth, sampleIntervalMs * 1.5) : bucketWidth * 3;
+
   if (successTimes.length < 2) return bucketWidth;
   const gaps: number[] = [];
   for (let i = 1; i < successTimes.length; i += 1) {
@@ -34,7 +44,7 @@ const estimateSampleCoverageMs = (successTimes: number[], bucketWidth: number): 
   if (gaps.length === 0) return bucketWidth;
   gaps.sort((a, b) => a - b);
   const medianGap = gaps[Math.floor(gaps.length / 2)];
-  return Math.max(bucketWidth, medianGap);
+  return Math.min(Math.max(bucketWidth, medianGap), coverageCap);
 };
 
 export const getCollectionStatusToneLabel = (tone: CollectionStatusTone): string =>
@@ -68,7 +78,8 @@ export const buildCollectionStatusTimeline = (
   viewData: ChartData[] | undefined,
   startMs: number,
   endMs: number,
-  segmentCount = COLLECTION_STATUS_SEGMENT_COUNT
+  segmentCount = COLLECTION_STATUS_SEGMENT_COUNT,
+  sampleIntervalMs?: number
 ): CollectionStatusTimelineSegment[] => {
   const safeStart = Number(startMs);
   const safeEnd = Number(endMs);
@@ -100,7 +111,7 @@ export const buildCollectionStatusTimeline = (
     }
   }
   successTimes.sort((a, b) => a - b);
-  const coverageMs = estimateSampleCoverageMs(successTimes, bucketWidth);
+  const coverageMs = estimateSampleCoverageMs(successTimes, bucketWidth, sampleIntervalMs);
   const halfCoverage = coverageMs / 2;
   for (const pointMs of successTimes) {
     const coverStart = Math.max(resolvedStart, pointMs - halfCoverage);


### PR DESCRIPTION
## 复现步骤

前置：账号能打开监控模块。准备一台使用共享采集状态卡的专业仪表盘实例（例如 Zookeeper）。选定约 15 分钟窗口，窗口内仅首尾有成功采样、中间长时间缺数（采集中断后恢复）。

1. 登录并选好组织，进入左侧菜单 **视图**。
2. 在对象列表找到 Zookeeper，点行按钮 **仪表盘**，进入 **Zookeeper 监控仪表盘**。
3. 在实例卡 **选择实例** 中选好实例，看 **健康概览** 里的 **采集状态** 卡片。
4. 看 **状态时间线**（图例 **正常** / **无数据** / **异常**）。可点 **刷新** 再看同一窗口。

修复前：首尾有成功点时，中间长缺数也被涂成 **正常**。  
修复后：两端附近可为 **正常**，中间中断段为 **无数据**。常规 60 秒采集不会出现周期性假灰。查询失败时整条时间线仍为 **异常**。

## 修复方案

给成功点覆盖宽度加上限：有实例采集间隔时 `max(bucketWidth, interval×1.5)`，避免把跨缺数的成功点距离当成采样频率。共享 core 与 MySQL / MongoDB / K8s / K3s 集群盘传入 `currentInstanceInterval * 1000`。不改告警判定和卡片文案。

Fixes #5263

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 15 分钟窗仅首尾成功 | **状态时间线** 中间也是 **正常** | 中间为 **无数据** |
| 60 秒采集 / ~50 秒桶 | 可能假灰（旧算法用覆盖补上） | 仍全 **正常**，不周期性假灰 |
| 查询失败 | 全窗 **异常** | 不变 |

## 影响面

- **会变**：所有走 `buildCollectionStatusTimeline` 的专业仪表盘采集状态时间线（含 Zookeeper 及 MySQL / MongoDB / K8s / K3s 集群盘）。
- **不变**：菜单 **视图**，行按钮 **仪表盘**，页标题 **Zookeeper 监控仪表盘**，区块 **健康概览**，卡片 **采集状态**，时间线标题 **状态时间线**，图例 **正常** / **无数据** / **异常**，占位 **选择实例**，按钮 **刷新**。后端告警、权限、REST 不变。
- **不在范围**：未核过的自动刷新下拉文案；无实例 interval 时用 `3×桶宽` 启发式封顶。
