### PR TITLE
bugfix: 登录弹窗卸载后忽略迟到的第三方认证响应

### DIFF
--- a/web/scripts/login-auth-stale-response-test.ts
+++ b/web/scripts/login-auth-stale-response-test.ts
@@ -1,0 +1,244 @@
+/**
+ * 登录认证弹窗卸载后必须丢弃迟到的第三方认证响应。
+ *
+ * 覆盖:
+ *   - 卸载后迟到 start 不得 window.open，且不得留下 interval
+ *   - 卸载后迟到 success 不得 onSessionSync
+ *   - 新流程替换旧流程后旧回调丢弃
+ *   - 有效 generation 仍可 open / poll / sync
+ */
+import * as assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createLoginAuthRequestGuard } from '../src/app/(core)/auth/signin/login-auth/loginAuthRequestGuard.ts';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const hookPath = resolve(
+  here,
+  '../src/app/(core)/auth/signin/login-auth/useLoginAuthValidation.ts',
+);
+const guardPath = resolve(
+  here,
+  '../src/app/(core)/auth/signin/login-auth/loginAuthRequestGuard.ts',
+);
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+interface LoginAuthSession {
+  openedUrls: string[];
+  intervalIds: number[];
+  otpCount: number;
+  syncCount: number;
+  start: (loginUrl: string, startPromise: Promise<void>) => Promise<number>;
+  applyOtp: (generation: number) => void;
+  applySuccess: (generation: number, pollPromise: Promise<void>) => Promise<void>;
+  unmount: () => void;
+  replaceStart: (loginUrl: string, startPromise: Promise<void>) => Promise<number>;
+}
+
+function createLoginAuthSession(): LoginAuthSession {
+  const guard = createLoginAuthRequestGuard();
+  const openedUrls: string[] = [];
+  const intervalIds: number[] = [];
+  const counts = { otpCount: 0, syncCount: 0 };
+  let nextIntervalId = 1;
+
+  const clearIntervals = () => {
+    intervalIds.length = 0;
+  };
+
+  const startWithGeneration = async (loginUrl: string, startPromise: Promise<void>) => {
+    const generation = guard.begin();
+    await startPromise;
+    if (!guard.shouldContinue(generation)) {
+      return generation;
+    }
+    openedUrls.push(loginUrl);
+    if (!guard.shouldContinue(generation)) {
+      return generation;
+    }
+    intervalIds.push(nextIntervalId);
+    nextIntervalId += 1;
+    return generation;
+  };
+
+  return {
+    openedUrls,
+    intervalIds,
+    get otpCount() {
+      return counts.otpCount;
+    },
+    get syncCount() {
+      return counts.syncCount;
+    },
+    async start(loginUrl, startPromise) {
+      guard.invalidate();
+      return startWithGeneration(loginUrl, startPromise);
+    },
+    applyOtp(generation) {
+      if (!guard.shouldContinue(generation)) {
+        return;
+      }
+      counts.otpCount += 1;
+    },
+    async applySuccess(generation, pollPromise) {
+      await pollPromise;
+      if (!guard.shouldContinue(generation)) {
+        return;
+      }
+      counts.syncCount += 1;
+    },
+    unmount() {
+      guard.invalidate();
+      clearIntervals();
+    },
+    async replaceStart(loginUrl, startPromise) {
+      clearIntervals();
+      guard.invalidate();
+      return startWithGeneration(loginUrl, startPromise);
+    },
+  };
+}
+
+function extractFunctionBody(source: string, name: string): string {
+  const marker = `const ${name} =`;
+  const start = source.indexOf(marker);
+  assert.notEqual(start, -1, `缺少 ${name}`);
+  let depth = 0;
+  let started = false;
+  for (let index = start; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === '{') {
+      depth += 1;
+      started = true;
+    } else if (char === '}') {
+      depth -= 1;
+      if (started && depth === 0) {
+        return source.slice(start, index + 1);
+      }
+    }
+  }
+  throw new Error(`未能解析 ${name}`);
+}
+
+function assertShouldContinueBefore(body: string, token: string, label: string) {
+  const continueIndex = body.lastIndexOf('shouldContinue', body.indexOf(token));
+  const tokenIndex = body.indexOf(token);
+  assert.ok(
+    continueIndex !== -1 && tokenIndex !== -1 && continueIndex < tokenIndex,
+    `${label} 必须在 ${token} 之前检查 shouldContinue`,
+  );
+}
+
+async function main() {
+  const guard = createLoginAuthRequestGuard();
+  const staleGeneration = guard.begin();
+  guard.invalidate();
+  assert.equal(
+    guard.shouldContinue(staleGeneration),
+    false,
+    '卸载 invalidate 后迟到 generation 不得继续',
+  );
+
+  const liveGuard = createLoginAuthRequestGuard();
+  const liveGeneration = liveGuard.begin();
+  assert.equal(
+    liveGuard.shouldContinue(liveGeneration),
+    true,
+    '有效 generation 必须可以继续',
+  );
+
+  const unmountedStart = createLoginAuthSession();
+  const lateStart = deferred<void>();
+  const lateStartGenerationPromise = unmountedStart.start('https://idp.example/login', lateStart.promise);
+  unmountedStart.unmount();
+  lateStart.resolve();
+  await lateStartGenerationPromise;
+  assert.deepEqual(unmountedStart.openedUrls, [], '卸载后迟到 start 不得 window.open');
+  assert.deepEqual(unmountedStart.intervalIds, [], '卸载后迟到 start 不得留下 interval');
+
+  const unmountedSuccess = createLoginAuthSession();
+  const startReady = deferred<void>();
+  const successGenerationPromise = unmountedSuccess.start('https://idp.example/ok', startReady.promise);
+  startReady.resolve();
+  const successGeneration = await successGenerationPromise;
+  assert.deepEqual(unmountedSuccess.openedUrls, ['https://idp.example/ok']);
+  assert.equal(unmountedSuccess.intervalIds.length, 1, '有效 start 可以留下轮询 interval');
+
+  const latePoll = deferred<void>();
+  const applySuccessPromise = unmountedSuccess.applySuccess(successGeneration, latePoll.promise);
+  unmountedSuccess.unmount();
+  latePoll.resolve();
+  await applySuccessPromise;
+  assert.equal(unmountedSuccess.syncCount, 0, '卸载后迟到 success 不得 onSessionSync');
+
+  const replaced = createLoginAuthSession();
+  const oldStart = deferred<void>();
+  const oldGenerationPromise = replaced.start('https://idp.example/old', oldStart.promise);
+  const newStart = deferred<void>();
+  const newGenerationPromise = replaced.replaceStart('https://idp.example/new', newStart.promise);
+  oldStart.resolve();
+  const oldGeneration = await oldGenerationPromise;
+  newStart.resolve();
+  const newGeneration = await newGenerationPromise;
+  assert.deepEqual(replaced.openedUrls, ['https://idp.example/new'], '新流程替换后旧 start 不得 open');
+  assert.deepEqual(replaced.intervalIds, [1], '只有新流程可以留下 interval');
+
+  const oldPoll = deferred<void>();
+  const oldSyncPromise = replaced.applySuccess(oldGeneration, oldPoll.promise);
+  oldPoll.resolve();
+  await oldSyncPromise;
+  assert.equal(replaced.syncCount, 0, '被替换的旧流程不得 onSessionSync');
+
+  replaced.applyOtp(oldGeneration);
+  assert.equal(replaced.otpCount, 0, '被替换的旧流程不得 onOtpRequired');
+
+  const livePoll = deferred<void>();
+  const liveSyncPromise = replaced.applySuccess(newGeneration, livePoll.promise);
+  livePoll.resolve();
+  await liveSyncPromise;
+  assert.equal(replaced.syncCount, 1, '有效 generation 仍可 onSessionSync');
+  replaced.applyOtp(newGeneration);
+  assert.equal(replaced.otpCount, 1, '有效 generation 仍可 onOtpRequired');
+
+  const hookSource = readFileSync(hookPath, 'utf8');
+  const guardSource = readFileSync(guardPath, 'utf8');
+
+  assert.match(guardSource, /generation/, 'guard 必须维护 generation');
+  assert.match(guardSource, /alive/, 'guard 必须维护 alive');
+  assert.match(hookSource, /from ['"]\.\/loginAuthRequestGuard['"]/, 'hook 必须 import 抽出的 guard');
+  assert.match(hookSource, /createLoginAuthRequestGuard/, 'hook 必须创建 login auth request guard');
+  assert.match(
+    hookSource,
+    /return\s*\(\)\s*=>\s*\{[\s\S]*requestGuard\.invalidate\(\)[\s\S]*window\.clearInterval/,
+    '卸载必须 invalidate，并仍 clearInterval',
+  );
+
+  const startBody = extractFunctionBody(hookSource, 'startLoginAuth');
+  assert.match(startBody, /requestGuard\.invalidate\(\)/, '新 start 必须 invalidate 旧流程');
+  assert.match(startBody, /requestGuard\.begin\(\)/, '新 start 必须 begin 新 generation');
+  assertShouldContinueBefore(startBody, 'window.open', 'startLoginAuth');
+  assertShouldContinueBefore(startBody, 'setInterval', 'startLoginAuth');
+
+  const pollBody = extractFunctionBody(hookSource, 'pollStatus');
+  assert.match(pollBody, /shouldContinue/, 'pollStatus 每个 await 后必须检查存活');
+
+  const terminalBody = extractFunctionBody(hookSource, 'resolveTerminalStatus');
+  assertShouldContinueBefore(terminalBody, 'onOtpRequired', 'resolveTerminalStatus');
+  assertShouldContinueBefore(terminalBody, 'onSessionSync', 'resolveTerminalStatus');
+
+  console.log('login-auth-stale-response-test: ok');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/web/src/app/(core)/auth/signin/login-auth/loginAuthRequestGuard.ts
+++ b/web/src/app/(core)/auth/signin/login-auth/loginAuthRequestGuard.ts
@@ -1,0 +1,24 @@
+export interface LoginAuthRequestGuard {
+  begin: () => number;
+  invalidate: () => void;
+  shouldContinue: (generation: number) => boolean;
+}
+
+export function createLoginAuthRequestGuard(): LoginAuthRequestGuard {
+  let generation = 0;
+  let alive = true;
+
+  return {
+    begin() {
+      generation += 1;
+      alive = true;
+      return generation;
+    },
+    invalidate() {
+      alive = false;
+    },
+    shouldContinue(targetGeneration: number) {
+      return alive && targetGeneration === generation;
+    },
+  };
+}

--- a/web/src/app/(core)/auth/signin/login-auth/useLoginAuthValidation.ts
+++ b/web/src/app/(core)/auth/signin/login-auth/useLoginAuthValidation.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { toSafeRelativeCallbackUrl } from "@/utils/authRedirect";
+import { createLoginAuthRequestGuard } from "./loginAuthRequestGuard";
 import {
   resolveBindingsLoadState,
   resolveInitialBindingId,
@@ -70,6 +71,7 @@ export function useLoginAuthValidation({
   const [activeRequest, setActiveRequest] = useState<ActiveRequestMeta | null>(null);
   const pollingTimerRef = useRef<number | null>(null);
   const pollingInFlightRef = useRef(false);
+  const [requestGuard] = useState(createLoginAuthRequestGuard);
   const selectedBinding = resolveSelectedBinding(bindings, selectedBindingId);
 
   const stopPolling = () => {
@@ -148,13 +150,20 @@ export function useLoginAuthValidation({
     void loadBindings();
   }, [enabled]);
 
-  useEffect(() => () => {
-    if (pollingTimerRef.current !== null) {
-      window.clearInterval(pollingTimerRef.current);
-    }
-  }, []);
+  useEffect(() => {
+    return () => {
+      requestGuard.invalidate();
+      if (pollingTimerRef.current !== null) {
+        window.clearInterval(pollingTimerRef.current);
+      }
+    };
+  }, [requestGuard]);
 
-  const resolveTerminalStatus = async (statusData: LoginAuthStatusResponseData) => {
+  const resolveTerminalStatus = async (statusData: LoginAuthStatusResponseData, generation: number) => {
+    if (!requestGuard.shouldContinue(generation)) {
+      return;
+    }
+
     const status = statusData.status;
 
     if (status === "expired" || status === "failed" || status === "cancelled") {
@@ -178,6 +187,9 @@ export function useLoginAuthValidation({
 
     const loginResult = statusData.login_result;
     if (isOtpChallengeResult(loginResult)) {
+      if (!requestGuard.shouldContinue(generation)) {
+        return;
+      }
       onOtpRequired(loginResult as LoginAuthLoginResult);
       return;
     }
@@ -187,13 +199,19 @@ export function useLoginAuthValidation({
       return;
     }
 
+    if (!requestGuard.shouldContinue(generation)) {
+      return;
+    }
     const synced = await onSessionSync(loginResult as LoginAuthLoginResult);
+    if (!requestGuard.shouldContinue(generation)) {
+      return;
+    }
     if (!synced) {
       resetSelectionState("failed", messages.syncFailed);
     }
   };
 
-  const pollStatus = async (requestMeta: ActiveRequestMeta) => {
+  const pollStatus = async (requestMeta: ActiveRequestMeta, generation: number) => {
     if (pollingInFlightRef.current) {
       return;
     }
@@ -212,6 +230,9 @@ export function useLoginAuthValidation({
         },
       );
       const responseData = await response.json();
+      if (!requestGuard.shouldContinue(generation)) {
+        return;
+      }
 
       if (!response.ok || !responseData?.result) {
         stopPolling();
@@ -225,8 +246,11 @@ export function useLoginAuthValidation({
       }
 
       stopPolling();
-      await resolveTerminalStatus(statusData);
+      await resolveTerminalStatus(statusData, generation);
     } catch (error) {
+      if (!requestGuard.shouldContinue(generation)) {
+        return;
+      }
       console.error("Failed to poll login auth status:", error);
       resetSelectionState("failed", messages.queryStatusFailed);
     } finally {
@@ -245,6 +269,8 @@ export function useLoginAuthValidation({
 
   const startLoginAuth = async (binding: LoginAuthBindingItem) => {
     stopPolling();
+    requestGuard.invalidate();
+    const generation = requestGuard.begin();
     setErrorMessage("");
     setSelectedBindingId(binding.id);
     setActiveBindingId(binding.id);
@@ -272,6 +298,9 @@ export function useLoginAuthValidation({
         }),
       });
       const responseData = await response.json();
+      if (!requestGuard.shouldContinue(generation)) {
+        return;
+      }
 
       if (!response.ok || !responseData?.result) {
         resetSelectionState("failed", responseData?.message || messages.startFailed);
@@ -279,6 +308,9 @@ export function useLoginAuthValidation({
       }
 
       const startData = responseData.data as StartLoginAuthResponseData;
+      if (!requestGuard.shouldContinue(generation)) {
+        return;
+      }
       const openedWindow = window.open(startData.login_url, "_blank");
       if (!openedWindow) {
         resetSelectionState("failed", messages.popupBlocked);
@@ -295,11 +327,17 @@ export function useLoginAuthValidation({
       setActiveRequest(nextRequest);
       setViewState("waiting");
 
-      void pollStatus(nextRequest);
+      void pollStatus(nextRequest, generation);
+      if (!requestGuard.shouldContinue(generation)) {
+        return;
+      }
       pollingTimerRef.current = window.setInterval(() => {
-        void pollStatus(nextRequest);
+        void pollStatus(nextRequest, generation);
       }, 3000);
     } catch (error) {
+      if (!requestGuard.shouldContinue(generation)) {
+        return;
+      }
       console.error("Failed to start login auth:", error);
       resetSelectionState("failed", messages.startFailed);
     }


### PR DESCRIPTION
## 复现步骤

前置：已登录并打开受保护页面。准备同一账号的第二个浏览器标签页，使本页会话过期后弹出登录框。

1. 在本页等到出现弹窗 **登录已过期**，说明为 **当前页面需要重新验证身份后继续操作。**
2. 看区块 **登陆方式**，点按钮 **点击继续登录**。状态会变成 **正在启动认证**，随后 **等待认证完成** / **等待中...**。
3. 在另一标签页用同一账号完成恢复，使本页弹窗关闭（跨标签恢复或 focus probe）。
4. 让本页尚未返回的 start 或 status 请求在有效期内迟到。

修复前：弹窗已关，迟到的 start 仍会 `window.open` 并留下每 3 秒的轮询；迟到的 success 仍会同步会话并再次 `signIn`。  
修复后：卸载或新流程替换后，迟到响应不再打开认证窗、不再留下 interval、不再 `onSessionSync`。正常第三方登录、OTP 与有效流程不受影响。

## 修复方案

抽出 `loginAuthRequestGuard`：用 generation + alive 标记当前流程。卸载和新 start 时 `invalidate`；每个 await 之后、在 `window.open` / `setInterval` / `onOtpRequired` / `onSessionSync` 之前检查 `shouldContinue`。卸载仍 `clearInterval`。不改弹窗外壳、OTP、poll_token、接口字段和五分钟 TTL。

Fixes #5279

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 弹窗已关后迟到 start | 仍 `window.open`，留下 3 秒 interval | 不打开窗口，不留下 interval |
| 弹窗已关后迟到 success | 仍 `onSessionSync` / `signIn` | 丢弃，不写会话 |
| 再次点 **点击继续登录** | 旧流程回调仍可能执行 | 旧 generation 丢弃，只有新流程继续 |
| 正常第三方登录 / OTP | 可完成 | 不变 |

## 影响面

- **会变**：会话过期弹窗里第三方认证的在途 start/status，卸载或被新流程替换后不再产生外部副作用。
- **不变**：弹窗标题 **登录已过期**，说明 **当前页面需要重新验证身份后继续操作。**，区块 **登陆方式**，按钮 **点击继续登录**，状态 **正在启动认证** / **等待认证完成** / **等待中...** / **正在完成登录**。OTP、poll_token、接口字段、五分钟 TTL、SigninClient UI 和 `auth.tsx` 弹窗外壳。
- **不在范围**：已进入 `onSessionSync` 的有效登录不会被 AbortController 撤销；`fetchBindings` 卸载后 setState 仍走既有路径。
