### PR TITLE
bugfix: 退出节点操作进度后忽略迟到的状态响应

### DIFF
--- a/web/scripts/node-operation-progress-stale-poll-test.ts
+++ b/web/scripts/node-operation-progress-stale-poll-test.ts
@@ -1,0 +1,278 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createOperationProgressRequestGuard } from '../src/app/node-manager/(pages)/cloudregion/node/operationProgress/operationProgressRequestGuard.ts';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pagePath = resolve(
+  here,
+  '../src/app/node-manager/(pages)/cloudregion/node/operationProgress/index.tsx',
+);
+
+const AUTO_ADVANCE_DELAY = 5000;
+
+interface ProgressRow {
+  status: string;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function createFakeTimers() {
+  let nextId = 1;
+  const intervals = new Map<number, { callback: () => void; ms: number }>();
+  const timeouts = new Map<number, { callback: () => void; ms: number }>();
+
+  return {
+    intervals,
+    timeouts,
+    setInterval(callback: () => void, ms: number) {
+      const id = nextId++;
+      intervals.set(id, { callback, ms });
+      return id;
+    },
+    clearInterval(id: unknown) {
+      intervals.delete(id as number);
+    },
+    setTimeout(callback: () => void, ms: number) {
+      const id = nextId++;
+      timeouts.set(id, { callback, ms });
+      return id;
+    },
+    clearTimeout(id: unknown) {
+      timeouts.delete(id as number);
+    },
+    fireTimeouts() {
+      for (const [id, timer] of [...timeouts]) {
+        timeouts.delete(id);
+        timer.callback();
+      }
+    },
+  };
+}
+
+function createProgressSession() {
+  const guard = createOperationProgressRequestGuard();
+  const timers = createFakeTimers();
+  const state = {
+    tableData: [] as ProgressRow[],
+    intervalSchedules: 0,
+    onNextCount: 0,
+    fetchCount: 0,
+  };
+  let intervalId: number | null = null;
+  let autoAdvanceId: number | null = null;
+  let currentGeneration = 0;
+
+  const clearIntervalTimer = () => {
+    if (intervalId != null) {
+      timers.clearInterval(intervalId);
+      intervalId = null;
+    }
+  };
+
+  const clearAutoAdvanceTimer = () => {
+    if (autoAdvanceId != null) {
+      timers.clearTimeout(autoAdvanceId);
+      autoAdvanceId = null;
+    }
+  };
+
+  const stopProgressRequests = () => {
+    guard.invalidate();
+    clearIntervalTimer();
+    clearAutoAdvanceTimer();
+  };
+
+  const schedulePolling = (generation: number) => {
+    if (!guard.shouldContinue(generation)) {
+      return;
+    }
+    clearIntervalTimer();
+    state.intervalSchedules += 1;
+    intervalId = timers.setInterval(() => {
+      if (!guard.shouldContinue(generation)) {
+        return;
+      }
+      state.fetchCount += 1;
+    }, 5000);
+  };
+
+  const scheduleAutoAdvance = (generation: number) => {
+    if (!guard.shouldContinue(generation)) {
+      return;
+    }
+    clearAutoAdvanceTimer();
+    autoAdvanceId = timers.setTimeout(() => {
+      autoAdvanceId = null;
+      if (!guard.shouldContinue(generation)) {
+        return;
+      }
+      state.onNextCount += 1;
+    }, AUTO_ADVANCE_DELAY);
+  };
+
+  const getNodeList = async (
+    generation: number,
+    fetchFn: () => Promise<ProgressRow[]>,
+    options?: { autoAdvance?: boolean },
+  ) => {
+    const rows = await fetchFn();
+    if (!guard.shouldContinue(generation)) {
+      return;
+    }
+    state.tableData = rows;
+    schedulePolling(generation);
+    if (options?.autoAdvance) {
+      scheduleAutoAdvance(generation);
+    }
+  };
+
+  return {
+    state,
+    timers,
+    guard,
+    begin() {
+      currentGeneration = guard.begin();
+      return currentGeneration;
+    },
+    unmount: stopProgressRequests,
+    finish: stopProgressRequests,
+    getNodeList,
+    schedulePolling,
+    generation: () => currentGeneration,
+  };
+}
+
+function assertPageWiresGuard(pageSource: string) {
+  assert.match(
+    pageSource,
+    /from ['"]\.\/operationProgressRequestGuard['"]/,
+    'index 必须 import 抽出的 operationProgressRequestGuard',
+  );
+  assert.match(pageSource, /createOperationProgressRequestGuard/, '必须创建 request guard');
+  assert.match(pageSource, /\.begin\(\)/, 'effect 启动必须 begin');
+  assert.match(pageSource, /\.invalidate\(\)/, '卸载与结束操作必须 invalidate');
+  assert.match(pageSource, /shouldContinue\(/, 'await 后必须检查 shouldContinue');
+  assert.match(pageSource, /autoAdvanceTimerRef/, '必须保存 auto-advance timeout');
+  assert.match(
+    pageSource,
+    /clearTimeout\(autoAdvanceTimerRef/,
+    '卸载必须清 auto-advance timeout',
+  );
+  assert.match(
+    pageSource,
+    /getNodeList\('timer',\s*currentGeneration\)/,
+    'schedulePolling 回调必须携带 generation',
+  );
+  assert.doesNotMatch(
+    pageSource,
+    /AbortController|\.abort\(/,
+    '不得 abort 后端请求',
+  );
+}
+
+async function main() {
+  const lateInterval = createProgressSession();
+  const lateIntervalFetch = deferred<ProgressRow[]>();
+  const lateIntervalGeneration = lateInterval.begin();
+  lateInterval.schedulePolling(lateIntervalGeneration);
+  const lateIntervalPending = lateInterval.getNodeList(
+    lateIntervalGeneration,
+    () => lateIntervalFetch.promise,
+  );
+  lateInterval.unmount();
+  const intervalSchedulesAfterUnmount = lateInterval.state.intervalSchedules;
+  lateIntervalFetch.resolve([{ status: 'running' }]);
+  await lateIntervalPending;
+  assert.equal(
+    lateInterval.timers.intervals.size,
+    0,
+    '卸载后迟到状态不得重建 interval',
+  );
+  assert.equal(
+    lateInterval.state.intervalSchedules,
+    intervalSchedulesAfterUnmount,
+    '卸载后迟到状态不得再次 schedulePolling',
+  );
+
+  const lateSuccess = createProgressSession();
+  const lateSuccessFetch = deferred<ProgressRow[]>();
+  const lateSuccessGeneration = lateSuccess.begin();
+  const lateSuccessPending = lateSuccess.getNodeList(
+    lateSuccessGeneration,
+    () => lateSuccessFetch.promise,
+    { autoAdvance: true },
+  );
+  lateSuccess.unmount();
+  lateSuccessFetch.resolve([{ status: 'success' }]);
+  await lateSuccessPending;
+  lateSuccess.timers.fireTimeouts();
+  assert.equal(lateSuccess.state.onNextCount, 0, '卸载后迟到成功不得 onNext');
+  assert.equal(lateSuccess.timers.timeouts.size, 0, '卸载后迟到成功不得再挂 auto-advance');
+
+  const clearAdvance = createProgressSession();
+  const clearAdvanceGeneration = clearAdvance.begin();
+  await clearAdvance.getNodeList(
+    clearAdvanceGeneration,
+    async () => [{ status: 'success' }],
+    { autoAdvance: true },
+  );
+  assert.equal(clearAdvance.timers.timeouts.size, 1, '成功后应挂起 auto-advance timeout');
+  clearAdvance.unmount();
+  assert.equal(clearAdvance.timers.timeouts.size, 0, '卸载必须清 auto-advance timeout');
+  clearAdvance.timers.fireTimeouts();
+  assert.equal(clearAdvance.state.onNextCount, 0, '已卸载的 auto-advance 不得 onNext');
+
+  const replaced = createProgressSession();
+  const staleFetch = deferred<ProgressRow[]>();
+  const staleGeneration = replaced.begin();
+  const stalePending = replaced.getNodeList(staleGeneration, () => staleFetch.promise, {
+    autoAdvance: true,
+  });
+  const latestFetch = deferred<ProgressRow[]>();
+  const latestGeneration = replaced.begin();
+  const latestPending = replaced.getNodeList(
+    latestGeneration,
+    () => latestFetch.promise,
+    { autoAdvance: true },
+  );
+  staleFetch.resolve([{ status: 'success' }]);
+  await stalePending;
+  assert.equal(replaced.state.onNextCount, 0, '旧 generation 迟到成功不得 onNext');
+  latestFetch.resolve([{ status: 'success' }]);
+  await latestPending;
+  replaced.timers.fireTimeouts();
+  assert.equal(replaced.state.onNextCount, 1, '新 generation 成功仍可自动下一步');
+  assert.equal(replaced.timers.intervals.size, 1, '新 generation 仍可轮询');
+
+  const alive = createProgressSession();
+  const aliveGeneration = alive.begin();
+  await alive.getNodeList(
+    aliveGeneration,
+    async () => [{ status: 'success' }],
+    { autoAdvance: true },
+  );
+  assert.equal(alive.timers.intervals.size, 1, '有效 generation 仍可轮询');
+  alive.timers.fireTimeouts();
+  assert.equal(alive.state.onNextCount, 1, '有效 generation 仍可自动下一步');
+
+  const pageSource = readFileSync(pagePath, 'utf8');
+  assertPageWiresGuard(pageSource);
+
+  console.log('node operation progress stale poll test passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/web/src/app/node-manager/(pages)/cloudregion/node/operationProgress/index.tsx
+++ b/web/src/app/node-manager/(pages)/cloudregion/node/operationProgress/index.tsx
@@ -40,6 +40,7 @@ import {
   normalizeControllerInstallRows,
   normalizeInstallerStatus
 } from '@/app/node-manager/utils/installerProgress';
+import { createOperationProgressRequestGuard } from './operationProgressRequestGuard';
 
 // 操作类型
 export type OperationType =
@@ -141,6 +142,9 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
   const retryModalRef = useRef<ModalRef>(null);
   const operationGuidanceRef = useRef<ModalRef>(null);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const autoAdvanceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const requestGuardRef = useRef(createOperationProgressRequestGuard());
+  const requestGenerationRef = useRef(0);
   const [pageLoading, setPageLoading] = useState<boolean>(false);
   const [tableData, setTableData] = useState<ControllerInstallProgressRow[]>([]);
   // 使用 ref 保存 currentViewingNode 的最新值，避免闭包问题
@@ -599,10 +603,12 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
 
   useEffect(() => {
     if (taskIds && !isLoading) {
-      getNodeList('refresh');
-      schedulePolling();
+      requestGenerationRef.current = requestGuardRef.current.begin();
+      const generation = requestGenerationRef.current;
+      getNodeList('refresh', generation);
+      schedulePolling(undefined, generation);
       return () => {
-        clearTimer();
+        stopProgressRequests();
       };
     }
   }, [taskIds, isLoading, isInstallController, installMethod]);
@@ -610,6 +616,19 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
   const clearTimer = () => {
     if (timerRef.current) clearInterval(timerRef.current);
     timerRef.current = null;
+  };
+
+  const clearAutoAdvanceTimer = () => {
+    if (autoAdvanceTimerRef.current) {
+      clearTimeout(autoAdvanceTimerRef.current);
+      autoAdvanceTimerRef.current = null;
+    }
+  };
+
+  const stopProgressRequests = () => {
+    requestGuardRef.current.invalidate();
+    clearTimer();
+    clearAutoAdvanceTimer();
   };
 
   const getPollingInterval = (rows?: ControllerInstallProgressRow[]) => {
@@ -642,17 +661,29 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
       : CONTROLLER_INSTALL_CONNECTIVITY_POLL_INTERVAL;
   };
 
-  const schedulePolling = (rows?: ControllerInstallProgressRow[]) => {
+  const schedulePolling = (
+    rows?: ControllerInstallProgressRow[],
+    generation?: number
+  ) => {
+    const currentGeneration = generation ?? requestGenerationRef.current;
     clearTimer();
+    if (!requestGuardRef.current.shouldContinue(currentGeneration)) {
+      return;
+    }
     timerRef.current = setInterval(() => {
-      getNodeList('timer');
+      if (!requestGuardRef.current.shouldContinue(currentGeneration)) {
+        return;
+      }
+      getNodeList('timer', currentGeneration);
     }, getPollingInterval(rows));
   };
 
   // 重新启动轮询（重试成功后调用）
   const restartPolling = () => {
-    getNodeList('refresh');
-    schedulePolling();
+    requestGenerationRef.current = requestGuardRef.current.begin();
+    const generation = requestGenerationRef.current;
+    getNodeList('refresh', generation);
+    schedulePolling(undefined, generation);
   };
 
   const checkDetail = (type: string, row: ControllerInstallProgressRow) => {
@@ -675,7 +706,11 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
     });
   };
 
-  const getNodeList = async (refreshType: string) => {
+  const getNodeList = async (refreshType: string, generation?: number) => {
+    const currentGeneration = generation ?? requestGenerationRef.current;
+    if (!requestGuardRef.current.shouldContinue(currentGeneration)) {
+      return;
+    }
     try {
       setPageLoading(refreshType !== 'timer');
       let data: ControllerInstallProgressRow[] = [];
@@ -693,12 +728,18 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
         if (installMethod === 'remoteInstall' || isUninstallController) {
           // 远程安装或卸载控制器，都使用 getControllerNodes 接口
           data = await getControllerNodes({ taskId: taskIds });
+          if (!requestGuardRef.current.shouldContinue(currentGeneration)) {
+            return;
+          }
         } else {
           // 手动安装控制器
           if (manualTaskList.length > 0) {
             const statusData = await getManualInstallStatus({
               node_ids: taskIds
             });
+            if (!requestGuardRef.current.shouldContinue(currentGeneration)) {
+              return;
+            }
             data = manualTaskList.map((item: TableDataItem) => {
               const statusInfo = statusData.find(
                 (status: ControllerManualInstallStatusItem) =>
@@ -717,6 +758,9 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
         if (operationType === 'installCollector') {
           // 安装采集器使用原接口
           const response = await getCollectorNodes({ taskId: taskIds });
+          if (!requestGuardRef.current.shouldContinue(currentGeneration)) {
+            return;
+          }
           data = response?.items || [];
           taskStatus = response?.status || 'running';
           taskSummary = response?.summary || null;
@@ -725,10 +769,17 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
           const response = await getCollectorOperationNodes({
             taskId: taskIds
           });
+          if (!requestGuardRef.current.shouldContinue(currentGeneration)) {
+            return;
+          }
           data = response?.items || [];
           taskStatus = response?.status || 'running';
           taskSummary = response?.summary || null;
         }
+      }
+
+      if (!requestGuardRef.current.shouldContinue(currentGeneration)) {
+        return;
       }
 
       const newTableData = normalizeControllerInstallRows(
@@ -742,7 +793,7 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
       setTableData(newTableData);
 
       if (refreshType === 'timer' || refreshType === 'refresh') {
-        schedulePolling(newTableData);
+        schedulePolling(newTableData, currentGeneration);
       }
 
       // 如果弹窗正在查看某个节点的日志,实时更新该节点的日志（仅远程安装模式）
@@ -781,9 +832,16 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
           ['success', 'installed'].includes(item.status || '')
         );
         if (allSuccess && newTableData.length > 0) {
+          if (!requestGuardRef.current.shouldContinue(currentGeneration)) {
+            return;
+          }
           clearTimer();
-          // 延迟5秒再跳转
-          setTimeout(() => {
+          clearAutoAdvanceTimer();
+          autoAdvanceTimerRef.current = setTimeout(() => {
+            autoAdvanceTimerRef.current = null;
+            if (!requestGuardRef.current.shouldContinue(currentGeneration)) {
+              return;
+            }
             onNext();
           }, AUTO_ADVANCE_DELAY);
         }
@@ -798,15 +856,24 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
             taskSummary.total === taskSummary.success &&
             taskSummary.total > 0
           ) {
-            // 延迟5秒再跳转
-            setTimeout(() => {
+            if (!requestGuardRef.current.shouldContinue(currentGeneration)) {
+              return;
+            }
+            clearAutoAdvanceTimer();
+            autoAdvanceTimerRef.current = setTimeout(() => {
+              autoAdvanceTimerRef.current = null;
+              if (!requestGuardRef.current.shouldContinue(currentGeneration)) {
+                return;
+              }
               onNext();
             }, AUTO_ADVANCE_DELAY);
           }
         }
       }
     } finally {
-      setPageLoading(false);
+      if (requestGuardRef.current.shouldContinue(currentGeneration)) {
+        setPageLoading(false);
+      }
     }
   };
 
@@ -866,7 +933,7 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
 
     // 如果没有进行中的节点，直接返回，不需要二次确认
     if (installingCount === 0) {
-      clearTimer();
+      stopProgressRequests();
       cancel();
       return;
     }
@@ -887,7 +954,7 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
       okText: t('node-manager.cloudregion.node.confirmFinish'),
       cancelText: t('common.cancel'),
       onOk: () => {
-        clearTimer();
+        stopProgressRequests();
         cancel();
       }
     });

--- a/web/src/app/node-manager/(pages)/cloudregion/node/operationProgress/operationProgressRequestGuard.ts
+++ b/web/src/app/node-manager/(pages)/cloudregion/node/operationProgress/operationProgressRequestGuard.ts
@@ -1,0 +1,35 @@
+export interface OperationProgressRequestGuard {
+  begin: () => number;
+  invalidate: () => void;
+  shouldContinue: (generation?: number) => boolean;
+}
+
+export const createOperationProgressRequestGuard =
+  (): OperationProgressRequestGuard => {
+    let generation = 0;
+    let alive = false;
+
+    return {
+      begin: () => {
+        alive = true;
+        generation += 1;
+        return generation;
+      },
+      invalidate: () => {
+        alive = false;
+        generation += 1;
+      },
+      shouldContinue: (expectedGeneration?: number) => {
+        if (!alive) {
+          return false;
+        }
+        if (
+          expectedGeneration !== undefined &&
+          expectedGeneration !== generation
+        ) {
+          return false;
+        }
+        return true;
+      },
+    };
+  };


### PR DESCRIPTION
## 复现步骤

前置：账号能打开节点管理，云区域下有可操作节点，并能发起组件或控制器任务。

1. 进入节点管理，打开左侧 **云区域** → **节点**。
2. 选中节点，发起 **安装组件**、**启动组件**、**停止组件** 或 **重启组件**（控制器则走安装/卸载），进入进度页。列表标题为 **操作列表**（安装为 **安装列表**，卸载为 **卸载列表**）。
3. 在状态请求尚未返回时，点 **结束操作**（安装为 **结束安装**，卸载为 **结束卸载**）。若仍有进行中的节点，确认框标题为 **确认结束安装？**（启动/停止/重启/卸载各有对应标题），点 **确认结束**；无进行中节点则直接离开。也可导航离开该进度页。
4. 让刚才的节点状态请求在离开后正常返回。

修复前：页面已离开，迟到响应仍会重建 interval，继续后台拉状态；控制器全部成功时还可能在卸载后触发自动下一步。控制器含 error/timeout 且不再重试时不满足全部成功，遗留轮询可持续到文档销毁。  
修复后：卸载或点结束并确认后，迟到响应不再重建轮询、不再自动跳转；已挂起的 5 秒自动下一步会被清掉。进行中的合法任务进度、重试、查看日志不受影响，后端任务不会被取消。

## 修复方案

抽出 `operationProgressRequestGuard`：generation + alive。进度 effect 启动时 `begin`；卸载和 **结束操作** 时 `invalidate`，并同时清 interval 与 auto-advance timeout。`getNodeList` 每个 await 之后、写入表格 / 重排轮询 / `onNext` 之前检查存活；轮询回调携带 generation。不 abort 后端请求。

Fixes #5298

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 点 **结束操作** 后迟到 running | 重建 interval，后台继续拉状态 | 丢弃，不再重建 interval |
| 离开后迟到全部成功 | 仍可能 5 秒后自动下一步 | 不 `onNext`，并清掉已挂 timeout |
| 再次进入新任务 | 旧回调仍可能重排轮询 | 旧 generation 丢弃，只有新流程轮询 |
| 停留在进度页的合法任务 | 2–5 秒轮询、重试、**查看日志** | 不变 |

## 影响面

- **会变**：节点进度页卸载或结束后，在途状态响应不再重建后台轮询或自动跳转。
- **不变**：子菜单 **云区域** / **节点**；批量操作 **安装组件** / **启动组件** / **停止组件** / **重启组件**；列表 **操作列表** / **安装列表** / **卸载列表**；按钮 **结束操作** / **结束安装** / **结束卸载**；确认 **确认结束**；取消 **取消**；行操作 **查看日志** / **重试**。后端任务、REST、权限不变。
- **不在范围**：在途 HTTP 仍会完成，只是结果被丢弃；未做浏览器 E2E。
