### PR TITLE
bugfix: 批量组件操作进度按服务端分页展示全部节点

### DIFF
--- a/web/scripts/node-operation-progress-pagination-test.ts
+++ b/web/scripts/node-operation-progress-pagination-test.ts
@@ -1,0 +1,149 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  buildCollectorTaskNodesPageQuery,
+  resolveCollectorTaskNodesPage
+} from '../src/app/node-manager/(pages)/cloudregion/node/operationProgress/collectorTaskNodesPage.ts';
+
+const PAGE_SIZE = 20;
+const TOTAL_NODES = 21;
+
+const makeItems = (count: number, start = 1) =>
+  Array.from({ length: count }, (_, index) => ({
+    node_id: `node-${start + index}`,
+    status: 'running'
+  }));
+
+const simulateCollectorPoll = (pagination: {
+  current: number;
+  pageSize: number;
+}) => buildCollectorTaskNodesPageQuery(pagination);
+
+const simulateControllerRequest = () => ({});
+
+const pageOneQuery = buildCollectorTaskNodesPageQuery({
+  current: 1,
+  pageSize: PAGE_SIZE
+});
+assert.equal(pageOneQuery.page, 1, '21 台且 page_size=20 时第一页请求必须带 page=1');
+assert.equal(
+  pageOneQuery.page_size,
+  PAGE_SIZE,
+  '21 台且 page_size=20 时请求必须带 page_size=20'
+);
+
+const pageOneResolved = resolveCollectorTaskNodesPage({
+  items: makeItems(20),
+  count: TOTAL_NODES
+});
+assert.equal(pageOneResolved.items.length, 20, '当前页 items 仍是 20');
+assert.equal(
+  pageOneResolved.total,
+  TOTAL_NODES,
+  'count=21 时表格 total 必须是 21，不能用当前页 items.length'
+);
+
+const pageTwoQuery = buildCollectorTaskNodesPageQuery({
+  current: 2,
+  pageSize: PAGE_SIZE
+});
+assert.equal(pageTwoQuery.page, 2, '切到第 2 页时请求必须带 page=2');
+assert.equal(pageTwoQuery.page_size, PAGE_SIZE);
+
+const pageTwoResolved = resolveCollectorTaskNodesPage({
+  items: makeItems(1, 21),
+  count: TOTAL_NODES
+});
+assert.equal(pageTwoResolved.items.length, 1);
+assert.equal(pageTwoResolved.total, TOTAL_NODES);
+
+const pollWhileOnPageTwo = simulateCollectorPoll({
+  current: 2,
+  pageSize: PAGE_SIZE
+});
+assert.equal(
+  pollWhileOnPageTwo.page,
+  2,
+  '轮询必须保持当前页，不能回到第 1 页'
+);
+
+const oversizedQuery = buildCollectorTaskNodesPageQuery({
+  current: 1,
+  pageSize: 501
+});
+assert.equal(
+  oversizedQuery.page_size,
+  500,
+  '不得超过后端 page_size 上限 500'
+);
+
+const controllerBody = simulateControllerRequest();
+assert.equal(
+  Object.prototype.hasOwnProperty.call(controllerBody, 'page'),
+  false,
+  '控制器路径不发 page'
+);
+assert.equal(
+  Object.prototype.hasOwnProperty.call(controllerBody, 'page_size'),
+  false,
+  '控制器路径不发 page_size'
+);
+
+const apiSource = readFileSync(
+  resolve(process.cwd(), 'src/app/node-manager/api/useNodeApi.ts'),
+  'utf8'
+);
+const collectorInstallFn = apiSource.slice(
+  apiSource.indexOf('const getCollectorNodes'),
+  apiSource.indexOf('const getCollectorOperationNodes')
+);
+const collectorOperationFn = apiSource.slice(
+  apiSource.indexOf('const getCollectorOperationNodes'),
+  apiSource.indexOf('const batchBindCollector')
+);
+const controllerFn = apiSource.slice(
+  apiSource.indexOf('const getControllerNodes'),
+  apiSource.indexOf('const getCollectorNodes')
+);
+
+assert.match(
+  collectorInstallFn,
+  /page_size/,
+  'getCollectorNodes 必须把 page_size 放进 POST body'
+);
+assert.match(
+  collectorOperationFn,
+  /page_size/,
+  'getCollectorOperationNodes 必须把 page_size 放进 POST body'
+);
+assert.doesNotMatch(
+  controllerFn,
+  /page_size/,
+  'getControllerNodes 不得发分页参数'
+);
+
+const progressSource = readFileSync(
+  resolve(
+    process.cwd(),
+    'src/app/node-manager/(pages)/cloudregion/node/operationProgress/index.tsx'
+  ),
+  'utf8'
+);
+assert.match(
+  progressSource,
+  /buildCollectorTaskNodesPageQuery/,
+  'OperationProgress 必须用抽出模块构造当前页查询'
+);
+assert.match(
+  progressSource,
+  /resolveCollectorTaskNodesPage/,
+  'OperationProgress 必须用抽出模块解析 items+count'
+);
+assert.match(
+  progressSource,
+  /pagination=\{isControllerOperation \? undefined : pagination\}/,
+  '仅组件安装/启停把 pagination 传给 CustomTable'
+);
+
+console.log('node operation progress pagination tests passed');

--- a/web/src/app/node-manager/(pages)/cloudregion/node/operationProgress/collectorTaskNodesPage.ts
+++ b/web/src/app/node-manager/(pages)/cloudregion/node/operationProgress/collectorTaskNodesPage.ts
@@ -1,0 +1,56 @@
+export interface CollectorTaskNodesPageInput {
+  current: number;
+  pageSize: number;
+}
+
+export interface CollectorTaskNodesPageQuery {
+  page?: number;
+  page_size?: number;
+}
+
+export interface CollectorTaskNodesPageResponse<T = unknown> {
+  items?: T[] | null;
+  count?: number;
+}
+
+export interface CollectorTaskNodesPageResult<T = unknown> {
+  items: T[];
+  total: number;
+}
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 500;
+
+export function buildCollectorTaskNodesPageQuery(
+  input: CollectorTaskNodesPageInput
+): CollectorTaskNodesPageQuery {
+  const page = Number.isFinite(input.current)
+    ? Math.max(DEFAULT_PAGE, Math.trunc(input.current))
+    : DEFAULT_PAGE;
+  const rawPageSize = Number.isFinite(input.pageSize)
+    ? Math.trunc(input.pageSize)
+    : DEFAULT_PAGE_SIZE;
+  const pageSize = Math.min(
+    MAX_PAGE_SIZE,
+    Math.max(1, rawPageSize || DEFAULT_PAGE_SIZE)
+  );
+  return {
+    page,
+    page_size: pageSize
+  };
+}
+
+export function resolveCollectorTaskNodesPage<T = unknown>(
+  response: CollectorTaskNodesPageResponse<T> | null | undefined
+): CollectorTaskNodesPageResult<T> {
+  const items = Array.isArray(response?.items) ? response.items : [];
+  const total =
+    typeof response?.count === 'number' && Number.isFinite(response.count)
+      ? response.count
+      : items.length;
+  return {
+    items,
+    total
+  };
+}

--- a/web/src/app/node-manager/(pages)/cloudregion/node/operationProgress/index.tsx
+++ b/web/src/app/node-manager/(pages)/cloudregion/node/operationProgress/index.tsx
@@ -11,7 +11,7 @@ import {
 } from '@ant-design/icons';
 import useApiClient from '@/utils/request';
 import { useTranslation } from '@/utils/i18n';
-import { ModalRef, TableDataItem } from '@/app/node-manager/types';
+import { ModalRef, Pagination, TableDataItem } from '@/app/node-manager/types';
 import { OPERATE_SYSTEMS } from '@/app/node-manager/constants/cloudregion';
 import { useGroupNames } from '@/app/node-manager/hooks/node';
 import useCommandCopyDialog from '@/app/node-manager/hooks/useCommandCopyDialog';
@@ -41,6 +41,10 @@ import {
   normalizeInstallerStatus
 } from '@/app/node-manager/utils/installerProgress';
 import { createOperationProgressRequestGuard } from './operationProgressRequestGuard';
+import {
+  buildCollectorTaskNodesPageQuery,
+  resolveCollectorTaskNodesPage
+} from './collectorTaskNodesPage';
 
 // 操作类型
 export type OperationType =
@@ -147,6 +151,13 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
   const requestGenerationRef = useRef(0);
   const [pageLoading, setPageLoading] = useState<boolean>(false);
   const [tableData, setTableData] = useState<ControllerInstallProgressRow[]>([]);
+  const [pagination, setPagination] = useState<Pagination>({
+    current: 1,
+    total: 0,
+    pageSize: 20
+  });
+  const paginationRef = useRef(pagination);
+  paginationRef.current = pagination;
   // 使用 ref 保存 currentViewingNode 的最新值，避免闭包问题
   const currentViewingNodeRef = useRef<ControllerInstallProgressRow | null>(null);
   const [copyingNodeIds, setCopyingNodeIds] = useState<Array<string | number>>([]);
@@ -611,7 +622,14 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
         stopProgressRequests();
       };
     }
-  }, [taskIds, isLoading, isInstallController, installMethod]);
+  }, [
+    taskIds,
+    isLoading,
+    isInstallController,
+    installMethod,
+    pagination.current,
+    pagination.pageSize
+  ]);
 
   const clearTimer = () => {
     if (timerRef.current) clearInterval(timerRef.current);
@@ -754,28 +772,39 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
           }
         }
       } else {
-        // 组件操作的逻辑
-        if (operationType === 'installCollector') {
-          // 安装采集器使用原接口
-          const response = await getCollectorNodes({ taskId: taskIds });
-          if (!requestGuardRef.current.shouldContinue(currentGeneration)) {
-            return;
-          }
-          data = response?.items || [];
-          taskStatus = response?.status || 'running';
-          taskSummary = response?.summary || null;
-        } else {
-          // 启动、停止、重启使用新接口
-          const response = await getCollectorOperationNodes({
-            taskId: taskIds
-          });
-          if (!requestGuardRef.current.shouldContinue(currentGeneration)) {
-            return;
-          }
-          data = response?.items || [];
-          taskStatus = response?.status || 'running';
-          taskSummary = response?.summary || null;
+        // 组件操作：按当前页向服务端分页拉取，用 count 作为表格 total
+        const pageQuery = buildCollectorTaskNodesPageQuery({
+          current: paginationRef.current.current,
+          pageSize: paginationRef.current.pageSize
+        });
+        const response =
+          operationType === 'installCollector'
+            ? await getCollectorNodes({
+                taskId: taskIds,
+                page: pageQuery.page,
+                page_size: pageQuery.page_size
+              })
+            : await getCollectorOperationNodes({
+                taskId: taskIds,
+                page: pageQuery.page,
+                page_size: pageQuery.page_size
+              });
+        if (!requestGuardRef.current.shouldContinue(currentGeneration)) {
+          return;
         }
+        const resolvedPage =
+          resolveCollectorTaskNodesPage<ControllerInstallProgressRow>(response);
+        data = resolvedPage.items;
+        taskStatus = response?.status || 'running';
+        taskSummary = response?.summary || null;
+        setPagination((prev) =>
+          prev.total === resolvedPage.total
+            ? prev
+            : {
+                ...prev,
+                total: resolvedPage.total
+              }
+        );
       }
 
       if (!requestGuardRef.current.shouldContinue(currentGeneration)) {
@@ -924,6 +953,17 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
     };
     return operationTextMap[operationType];
   }, [operationType, t]);
+
+  const handleTableChange = (nextPagination: {
+    current?: number;
+    pageSize?: number;
+  }) => {
+    setPagination((prev) => ({
+      ...prev,
+      current: nextPagination.current ?? prev.current,
+      pageSize: nextPagination.pageSize ?? prev.pageSize
+    }));
+  };
 
   const handleFinish = () => {
     const installingCount = tableData.filter(
@@ -1092,6 +1132,8 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
           loading={pageLoading}
           columns={columns}
           dataSource={tableData}
+          pagination={isControllerOperation ? undefined : pagination}
+          onChange={isControllerOperation ? undefined : handleTableChange}
         />
       </div>
       <div className="pt-[16px] flex justify-center">

--- a/web/src/app/node-manager/api/useNodeApi.ts
+++ b/web/src/app/node-manager/api/useNodeApi.ts
@@ -108,9 +108,21 @@ const useNodeApi = () => {
   };
 
   // 获取采集器安装节点信息（返回完整响应，包含status和summary）
-  const getCollectorNodes = async (params: { taskId: string | number }) => {
+  const getCollectorNodes = async (params: {
+    taskId: string | number;
+    page?: number;
+    page_size?: number;
+  }) => {
+    const body: { page?: number; page_size?: number } = {};
+    if (params.page !== undefined) {
+      body.page = params.page;
+    }
+    if (params.page_size !== undefined) {
+      body.page_size = params.page_size;
+    }
     const res = await post(
-      `/node_mgmt/api/installer/collector/install/${params.taskId}/nodes/`
+      `/node_mgmt/api/installer/collector/install/${params.taskId}/nodes/`,
+      body
     );
     // 返回完整响应，让调用方处理 status 和 summary
     return (
@@ -125,9 +137,19 @@ const useNodeApi = () => {
   // 获取采集器操作节点信息（启动、停止、重启，返回完整响应，包含status和summary）
   const getCollectorOperationNodes = async (params: {
     taskId: string | number;
+    page?: number;
+    page_size?: number;
   }) => {
+    const body: { page?: number; page_size?: number } = {};
+    if (params.page !== undefined) {
+      body.page = params.page;
+    }
+    if (params.page_size !== undefined) {
+      body.page_size = params.page_size;
+    }
     const res = await post(
-      `/node_mgmt/api/node/collector/action/${params.taskId}/nodes/`
+      `/node_mgmt/api/node/collector/action/${params.taskId}/nodes/`,
+      body
     );
     // 返回完整响应，让调用方处理 status 和 summary
     return (


### PR DESCRIPTION
## 复现步骤

前置：账号能打开节点管理。云区域下至少有 21 台同操作系统、同 CPU 架构、可批量操作组件的节点。

1. 进入节点管理，打开左侧 **云区域** → **节点**。
2. 把节点列表每页条数调到能一次勾选 21 台，选中 21 台后点 **安装组件**（或 **启动组件** / **停止组件** / **重启组件**），进入进度页 **操作列表**。
3. 看表格是否只有 20 行，底部分页合计是否出现 **共 21 项**，能否翻到第 2 页看到第 21 台。
4. 在第 2 页对第 21 台点 **查看日志** 或失败时的 **重试**。

修复前：只渲染默认 20 条，没有分页，第 21 台看不到日志和重试；服务端 summary 仍统计全部节点。  
修复后：按当前页向服务端请求 `page` / `page_size`，表格 total 用 `count`。第 2 页可看到第 21 台。轮询停留在当前页。控制器安装/卸载进度仍不走这套分页。

## 修复方案

抽出 `collectorTaskNodesPage`：按当前页构造 `page` / `page_size`（上限 500），并用响应 `count` 作为表格 total。`getCollectorNodes` / `getCollectorOperationNodes` 把分页参数放进 POST body。仅组件安装/启停把 `pagination` 传给 CustomTable。不改后端、不一次拉全量。

Fixes #5299

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 21 台、默认每页 20 | 只看到 20 行，无分页 | **共 21 项**，可翻第 2 页 |
| 第 21 台 **查看日志** / **重试** | 不可达 | 翻到第 2 页后可操作 |
| 轮询 | 一直请求默认第 1 页 20 条 | 保持当前页 |
| 控制器 **安装列表** / **卸载列表** | 无分页请求 | 仍不发 `page` / `page_size` |

## 影响面

- **会变**：组件安装、启动、停止、重启的进度表按服务端分页展示全部授权节点。
- **不变**：子菜单 **云区域** / **节点**；操作 **安装组件** / **启动组件** / **停止组件** / **重启组件**；列表 **操作列表**；行操作 **查看日志** / **重试**；分页合计 **共 {n} 项**。控制器进度、后端默认上限 20 / 最大 500、权限过滤不变。
- **不在范围**：结束确认仍按当前页行统计进行中节点；未新做状态筛选；未做浏览器 E2E。
