### PR TITLE
bugfix: 组件重试后按新任务更新对应节点进度

### DIFF
--- a/web/scripts/node-operation-progress-retry-task-test.ts
+++ b/web/scripts/node-operation-progress-retry-task-test.ts
@@ -1,0 +1,189 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  mergeCollectorRetryRows,
+  readCollectorRetryTaskId,
+} from '../src/app/node-manager/(pages)/cloudregion/node/operationProgress/collectorRetryTaskState.ts';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pagePath = resolve(
+  here,
+  '../src/app/node-manager/(pages)/cloudregion/node/operationProgress/index.tsx',
+);
+
+interface ProgressRow {
+  node_id: string;
+  status: string;
+  result?: { steps?: Array<{ action: string }> };
+}
+
+function applyCollectorRetry(
+  currentRows: ProgressRow[],
+  payload: unknown,
+  retryRows: ProgressRow[],
+): ProgressRow[] {
+  const retryTaskId = readCollectorRetryTaskId(payload);
+  if (!retryTaskId) {
+    return currentRows;
+  }
+  return mergeCollectorRetryRows(currentRows, retryRows);
+}
+
+function assertPageWiresCollectorRetry(pageSource: string) {
+  assert.match(
+    pageSource,
+    /from ['"]\.\/collectorRetryTaskState['"]/,
+    'index 必须 import 抽出的 collectorRetryTaskState',
+  );
+  assert.match(
+    pageSource,
+    /readCollectorRetryTaskId\(/,
+    'handleCollectorRetry 必须读取返回的 task_id',
+  );
+  assert.match(
+    pageSource,
+    /mergeCollectorRetryRows\(/,
+    'getNodeList 必须按节点合并新任务行',
+  );
+  assert.match(
+    pageSource,
+    /const\s+\w+\s*=\s*await\s+installCollector\(/,
+    '安装组件重试必须保存 installCollector 返回值',
+  );
+  assert.match(
+    pageSource,
+    /const\s+\w+\s*=\s*await\s+batchOperationCollector\(/,
+    '启动/停止/重启重试必须保存 batchOperationCollector 返回值',
+  );
+  assert.match(
+    pageSource,
+    /getCollectorNodes\(\{\s*taskId:\s*taskIds\s*\}\)/,
+    '安装进度仍须查询旧 taskIds',
+  );
+  assert.match(
+    pageSource,
+    /getCollectorOperationNodes\(\{\s*taskId:\s*taskIds\s*\}\)/,
+    '启停重启进度仍须查询旧 taskIds',
+  );
+  assert.match(
+    pageSource,
+    /createOperationProgressRequestGuard/,
+    '必须保留 requestGuard',
+  );
+  assert.doesNotMatch(
+    pageSource,
+    /AbortController|\.abort\(/,
+    '不得 abort 后端请求',
+  );
+}
+
+async function main() {
+  const originalRows: ProgressRow[] = [
+    {
+      node_id: 'node-failed',
+      status: 'error',
+      result: { steps: [{ action: 'old-error' }] },
+    },
+    {
+      node_id: 'node-ok',
+      status: 'success',
+      result: { steps: [{ action: 'old-success' }] },
+    },
+  ];
+  const retryRunningRows: ProgressRow[] = [
+    {
+      node_id: 'node-failed',
+      status: 'running',
+      result: { steps: [{ action: 'retry-running' }] },
+    },
+  ];
+
+  assert.equal(
+    readCollectorRetryTaskId({ task_id: 101 }),
+    '101',
+    '安装组件重试必须读到新 task_id',
+  );
+  assert.equal(
+    readCollectorRetryTaskId({ task_id: 'action-7' }),
+    'action-7',
+    '启动/停止/重启重试必须读到新 task_id',
+  );
+  assert.equal(
+    readCollectorRetryTaskId({ task_id: 'restart-9' }),
+    'restart-9',
+    '重启组件重试必须读到新 task_id',
+  );
+
+  const mergedInstall = applyCollectorRetry(
+    originalRows,
+    { task_id: 101 },
+    retryRunningRows,
+  );
+  const retriedInstall = mergedInstall.find((row) => row.node_id === 'node-failed');
+  const siblingInstall = mergedInstall.find((row) => row.node_id === 'node-ok');
+  assert.equal(retriedInstall?.status, 'running', '被重试行应变为新任务状态');
+  assert.equal(
+    retriedInstall?.result?.steps?.[0]?.action,
+    'retry-running',
+    '被重试行日志必须跟随新任务',
+  );
+  assert.equal(siblingInstall?.status, 'success', '同批其他节点仍保留旧任务状态');
+  assert.equal(
+    siblingInstall?.result?.steps?.[0]?.action,
+    'old-success',
+    '同批其他节点日志不得被新任务替换',
+  );
+  assert.deepEqual(
+    mergedInstall.map((row) => row.node_id),
+    ['node-failed', 'node-ok'],
+    '合并不得隐藏同批其他节点',
+  );
+
+  const mergedAction = applyCollectorRetry(
+    originalRows,
+    { task_id: 'action-7' },
+    retryRunningRows,
+  );
+  assert.equal(
+    mergedAction.find((row) => row.node_id === 'node-failed')?.status,
+    'running',
+    '启停重启重试后被重试行也必须合并新状态',
+  );
+  assert.equal(
+    mergedAction.find((row) => row.node_id === 'node-ok')?.status,
+    'success',
+    '启停重启重试后其他节点仍保留旧状态',
+  );
+
+  const missingPayloads: unknown[] = [undefined, null, {}, { task_id: '' }];
+  for (const payload of missingPayloads) {
+    const mergedMissing = applyCollectorRetry(
+      originalRows,
+      payload,
+      retryRunningRows,
+    );
+    assert.equal(
+      mergedMissing.find((row) => row.node_id === 'node-failed')?.status,
+      'error',
+      '缺少 task_id 时不得覆盖旧行',
+    );
+    assert.equal(
+      mergedMissing.find((row) => row.node_id === 'node-ok')?.status,
+      'success',
+      '缺少 task_id 时其他节点保持不变',
+    );
+  }
+
+  const pageSource = readFileSync(pagePath, 'utf8');
+  assertPageWiresCollectorRetry(pageSource);
+
+  console.log('node operation progress retry task test passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/web/scripts/node-operation-progress-retry-task-test.ts
+++ b/web/scripts/node-operation-progress-retry-task-test.ts
@@ -78,6 +78,11 @@ function assertPageWiresCollectorRetry(pageSource: string) {
     /AbortController|\.abort\(/,
     '不得 abort 后端请求',
   );
+  assert.doesNotMatch(
+    pageSource,
+    /import \{\s*import \{/,
+    'index 不得出现重复 import {',
+  );
 }
 
 async function main() {

--- a/web/scripts/node-operation-progress-retry-task-test.ts
+++ b/web/scripts/node-operation-progress-retry-task-test.ts
@@ -60,13 +60,13 @@ function assertPageWiresCollectorRetry(pageSource: string) {
   );
   assert.match(
     pageSource,
-    /getCollectorNodes\(\{\s*taskId:\s*taskIds\s*\}\)/,
-    '安装进度仍须查询旧 taskIds',
+    /getCollectorNodes\(\{\s*taskId:\s*taskIds[\s\S]*?page:[\s\S]*?page_size:/,
+    '安装进度仍须查询旧 taskIds（可带当前页 page/page_size）',
   );
   assert.match(
     pageSource,
-    /getCollectorOperationNodes\(\{\s*taskId:\s*taskIds\s*\}\)/,
-    '启停重启进度仍须查询旧 taskIds',
+    /getCollectorOperationNodes\(\{\s*taskId:\s*taskIds[\s\S]*?page:[\s\S]*?page_size:/,
+    '启停重启进度仍须查询旧 taskIds（可带当前页 page/page_size）',
   );
   assert.match(
     pageSource,

--- a/web/src/app/node-manager/(pages)/cloudregion/node/operationProgress/collectorRetryTaskState.ts
+++ b/web/src/app/node-manager/(pages)/cloudregion/node/operationProgress/collectorRetryTaskState.ts
@@ -1,0 +1,49 @@
+export interface CollectorRetryRowIdentity {
+  node_id?: string | number;
+}
+
+export function readCollectorRetryTaskId(payload: unknown): string | null {
+  if (payload === null || payload === undefined || typeof payload !== 'object') {
+    return null;
+  }
+  if (!('task_id' in payload)) {
+    return null;
+  }
+  const taskId = payload.task_id;
+  if (typeof taskId === 'number' && Number.isFinite(taskId)) {
+    return String(taskId);
+  }
+  if (typeof taskId === 'string') {
+    const trimmed = taskId.trim();
+    return trimmed === '' ? null : trimmed;
+  }
+  return null;
+}
+
+export function mergeCollectorRetryRows<T extends CollectorRetryRowIdentity>(
+  currentRows: T[],
+  retryRows: T[],
+): T[] {
+  if (retryRows.length === 0) {
+    return currentRows;
+  }
+
+  const retryByNodeId = new Map<string, T>();
+  for (const row of retryRows) {
+    if (row.node_id === undefined || row.node_id === null || row.node_id === '') {
+      continue;
+    }
+    retryByNodeId.set(String(row.node_id), row);
+  }
+  if (retryByNodeId.size === 0) {
+    return currentRows;
+  }
+
+  return currentRows.map((row) => {
+    if (row.node_id === undefined || row.node_id === null || row.node_id === '') {
+      return row;
+    }
+    const overlay = retryByNodeId.get(String(row.node_id));
+    return overlay ? { ...row, ...overlay } : row;
+  });
+}

--- a/web/src/app/node-manager/(pages)/cloudregion/node/operationProgress/index.tsx
+++ b/web/src/app/node-manager/(pages)/cloudregion/node/operationProgress/index.tsx
@@ -42,7 +42,6 @@ import {
 } from '@/app/node-manager/utils/installerProgress';
 import { createOperationProgressRequestGuard } from './operationProgressRequestGuard';
 import {
-import {
   buildCollectorTaskNodesPageQuery,
   resolveCollectorTaskNodesPage
 } from './collectorTaskNodesPage';

--- a/web/src/app/node-manager/(pages)/cloudregion/node/operationProgress/index.tsx
+++ b/web/src/app/node-manager/(pages)/cloudregion/node/operationProgress/index.tsx
@@ -42,9 +42,14 @@ import {
 } from '@/app/node-manager/utils/installerProgress';
 import { createOperationProgressRequestGuard } from './operationProgressRequestGuard';
 import {
+import {
   buildCollectorTaskNodesPageQuery,
   resolveCollectorTaskNodesPage
 } from './collectorTaskNodesPage';
+import {
+  mergeCollectorRetryRows,
+  readCollectorRetryTaskId
+} from './collectorRetryTaskState';
 
 // 操作类型
 export type OperationType =
@@ -149,6 +154,7 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
   const autoAdvanceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const requestGuardRef = useRef(createOperationProgressRequestGuard());
   const requestGenerationRef = useRef(0);
+  const collectorRetryTaskIdsRef = useRef<Map<string, string>>(new Map());
   const [pageLoading, setPageLoading] = useState<boolean>(false);
   const [tableData, setTableData] = useState<ControllerInstallProgressRow[]>([]);
   const [pagination, setPagination] = useState<Pagination>({
@@ -805,6 +811,27 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
                 total: resolvedPage.total
               }
         );
+        const retryTaskIds = Array.from(
+          new Set(collectorRetryTaskIdsRef.current.values())
+        );
+        if (retryTaskIds.length > 0) {
+          const fetchRetryNodes =
+            operationType === 'installCollector'
+              ? getCollectorNodes
+              : getCollectorOperationNodes;
+          for (const retryTaskId of retryTaskIds) {
+            const retryResponse = await fetchRetryNodes({
+              taskId: retryTaskId
+            });
+            if (!requestGuardRef.current.shouldContinue(currentGeneration)) {
+              return;
+            }
+            data = mergeCollectorRetryRows(
+              data,
+              retryResponse?.items || []
+            );
+          }
+        }
       }
 
       if (!requestGuardRef.current.shouldContinue(currentGeneration)) {
@@ -876,8 +903,14 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
         }
       } else {
         // 组件操作：根据返回的 status 和 summary 判断
-        // 当 status 为 'finished' 时，停止轮询
-        if (taskStatus === 'finished') {
+        const hasActiveCollectorRows = newTableData.some(
+          (item) =>
+            !['error', 'success', 'installed', 'timeout'].includes(
+              item.status || ''
+            )
+        );
+        // 当旧批次已结束但仍有重试行在跑时，继续轮询新任务
+        if (taskStatus === 'finished' && !hasActiveCollectorRows) {
           clearTimer();
           // 只有当 total === success 时才自动进入下一步
           if (
@@ -1031,6 +1064,13 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
     try {
       setRetryingNodeIds((prev) => [...prev, String(nodeId)]);
 
+      const rememberCollectorRetryTask = (payload: unknown) => {
+        const retryTaskId = readCollectorRetryTaskId(payload);
+        if (retryTaskId) {
+          collectorRetryTaskIdsRef.current.set(String(nodeId), retryTaskId);
+        }
+      };
+
       if (operationType === 'installCollector') {
         // 安装组件重试
         if (!collectorPackageId) {
@@ -1040,10 +1080,11 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
           });
           return;
         }
-        await installCollector({
+        const retryPayload = await installCollector({
           collector_package: collectorPackageId,
           nodes: [String(nodeId)]
         });
+        rememberCollectorRetryTask(retryPayload);
       } else {
         // 启动/停止/重启组件重试
         if (!collectorId) {
@@ -1058,11 +1099,12 @@ const OperationProgress: React.FC<OperationProgressProps> = ({
           stopCollector: 'stop',
           restartCollector: 'restart'
         };
-        await batchOperationCollector({
+        const retryPayload = await batchOperationCollector({
           node_ids: [String(nodeId)],
           collector_id: collectorId,
           operation: operationMap[operationType]
         });
+        rememberCollectorRetryTask(retryPayload);
       }
 
       notification.success({


### PR DESCRIPTION
## 复现步骤

前置：账号能打开节点管理。云区域下有节点，且组件安装或启停任务中至少有一台失败或超时。

1. 进入节点管理，打开左侧 **云区域** → **节点**。
2. 对节点发起 **安装组件**（或 **启动组件** / **停止组件** / **重启组件**），进入进度页 **操作列表**。
3. 等某一行失败或超时后，点该行 **重试**，看到提示 **重试成功**。
4. 再看该行状态，并点 **查看日志**，对照是否仍是旧失败内容。同批其他成功节点应仍在列表中。

修复前：重试接口已创建新 `task_id`，进度仍轮询旧任务，失败行和日志不更新。  
修复后：该行按新任务状态和日志更新，其他节点仍显示原批次。旧批次结束后若该行还在跑，会继续轮询。

## 修复方案

抽出 `collectorRetryTaskState`：读取重试返回的 `task_id`，按 `node_id` 把新任务行覆盖到旧批次对应行。`handleCollectorRetry` 保存新任务身份；`getNodeList` 仍查询旧 `taskIds`，再拉新任务并合并。不改后端，不把新任务写成旧 task。保留卸载失效的 requestGuard。

Fixes #5300

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 点 **重试** 后该行 | 仍是旧失败/超时 | 跟随新任务状态 |
| **查看日志** | 仍是旧尝试 | 显示新尝试步骤 |
| 同批其他节点 | 仍在列表 | 不变，不被隐藏 |
| 缺少 `task_id` | 只提示 **重试成功** | 不覆盖旧行 |

## 影响面

- **会变**：组件安装/启动/停止/重启进度里，单节点重试行会显示新任务结果。
- **不变**：子菜单 **云区域** / **节点**；操作 **安装组件** / **启动组件** / **停止组件** / **重启组件**；列表 **操作列表**；行按钮 **重试** / **查看日志**；提示 **重试成功**。控制器重试、后端任务历史、原批次其他节点。
- **不在范围**：自动下一步仍看旧批次 summary；未做浏览器 E2E。
