### PR TITLE
bugfix: 定时任务保存时提交并发策略

### DIFF
--- a/web/scripts/job-cron-concurrency-policy-test.ts
+++ b/web/scripts/job-cron-concurrency-policy-test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { resolveScheduledTaskConcurrencyPolicy } from '../src/app/job/utils/scheduledTaskPayload';
+
+const root = process.cwd();
+const read = (relativePath: string) => readFileSync(path.join(root, relativePath), 'utf8');
+
+const createSource = read('src/app/job/(pages)/execution/cron-task/create/page.tsx');
+const editSource = read('src/app/job/(pages)/execution/cron-task/edit/page.tsx');
+const zh = JSON.parse(read('src/app/job/locales/zh.json'));
+const menu = JSON.parse(read('src/app/job/constants/menu.json'));
+
+const executionMenu = menu.zh.find((item: { name: string }) => item.name === 'execution');
+const cronTaskMenu = executionMenu?.children?.find((item: { name: string }) => item.name === 'cron_task');
+const createMenu = executionMenu?.children?.find((item: { name: string }) => item.name === 'cron_task_create');
+const editMenu = executionMenu?.children?.find((item: { name: string }) => item.name === 'cron_task_edit');
+
+assert.equal(executionMenu?.title, '作业执行');
+assert.equal(cronTaskMenu?.title, '定时任务');
+assert.equal(createMenu?.title, '创建定时任务');
+assert.equal(editMenu?.title, '编辑定时任务');
+assert.equal(zh.job.concurrencyStrategy, '并发策略');
+assert.equal(zh.job.skipIfRunning, '跳过（上次未完成则跳过本次）');
+assert.equal(zh.job.runAnyway, '运行（无论上次是否完成）');
+assert.equal(zh.job.queueWait, '排队（等待上次完成后执行）');
+assert.equal(zh.job.saveAndEnable, '保存并启用');
+assert.equal(zh.job.saveOnly, '仅保存');
+assert.equal(zh.job.cancel, '取消');
+
+function buildCreatePayload(concurrencyPolicy: unknown) {
+  return {
+    name: 'create-task',
+    concurrency_policy: resolveScheduledTaskConcurrencyPolicy(concurrencyPolicy),
+  };
+}
+
+function buildEditPayload(existingPolicy: unknown, nextPolicy: unknown) {
+  const current = resolveScheduledTaskConcurrencyPolicy(existingPolicy);
+  return {
+    name: 'edit-task',
+    concurrency_policy: resolveScheduledTaskConcurrencyPolicy(nextPolicy ?? current),
+  };
+}
+
+const createQueue = buildCreatePayload('queue');
+assert.equal(createQueue.concurrency_policy, 'queue');
+
+const createRun = buildCreatePayload('run');
+assert.equal(createRun.concurrency_policy, 'run');
+
+const createSkip = buildCreatePayload('skip');
+assert.equal(createSkip.concurrency_policy, 'skip');
+
+const createDefault = buildCreatePayload(undefined);
+assert.equal(createDefault.concurrency_policy, 'skip');
+
+const editSkipToRun = buildEditPayload('skip', 'run');
+assert.equal(editSkipToRun.concurrency_policy, 'run');
+
+const editSkipToQueue = buildEditPayload('skip', 'queue');
+assert.equal(editSkipToQueue.concurrency_policy, 'queue');
+
+assert.equal(resolveScheduledTaskConcurrencyPolicy('bogus'), 'skip');
+assert.equal(resolveScheduledTaskConcurrencyPolicy(''), 'skip');
+assert.equal(resolveScheduledTaskConcurrencyPolicy(null), 'skip');
+assert.equal(resolveScheduledTaskConcurrencyPolicy(undefined), 'skip');
+assert.equal(resolveScheduledTaskConcurrencyPolicy(1), 'skip');
+
+assert.match(createSource, /from '@\/app\/job\/utils\/scheduledTaskPayload'/);
+assert.match(editSource, /from '@\/app\/job\/utils\/scheduledTaskPayload'/);
+assert.match(createSource, /resolveScheduledTaskConcurrencyPolicy/);
+assert.match(editSource, /resolveScheduledTaskConcurrencyPolicy/);
+assert.match(
+  createSource,
+  /const formData: ScheduledTaskFormData = \{[\s\S]*concurrency_policy:\s*resolveScheduledTaskConcurrencyPolicy\(values\.concurrency_policy\)/,
+);
+assert.match(
+  editSource,
+  /const formData: ScheduledTaskFormData = \{[\s\S]*concurrency_policy:\s*resolveScheduledTaskConcurrencyPolicy\(values\.concurrency_policy\)/,
+);
+assert.match(
+  createSource,
+  /initialValues=\{\{[\s\S]*concurrency_policy:\s*'skip'/,
+);
+assert.doesNotMatch(
+  createSource,
+  /<Form\.Item label=\{t\('job\.concurrencyStrategy'\)\} name="concurrency_policy">\s*<Select defaultValue="skip">/,
+);
+
+console.log('job-cron-concurrency-policy-test passed');

--- a/web/src/app/job/(pages)/execution/cron-task/create/page.tsx
+++ b/web/src/app/job/(pages)/execution/cron-task/create/page.tsx
@@ -25,7 +25,7 @@ import dayjs from 'dayjs';
 import HostSelectionModal, { HostItem, TargetSourceType } from '@/app/job/components/jobHostSelectionModalRuntime';
 import { AddTargetHostButton, TargetSourceSelector } from '@/app/job/components/target-selection-controls';
 import { createDefaultExecutionName } from '@/app/job/utils/execution-name';
-import { buildScheduledTaskTemplatePayload } from '@/app/job/utils/scheduledTaskPayload';
+import { buildScheduledTaskTemplatePayload, resolveScheduledTaskConcurrencyPolicy } from '@/app/job/utils/scheduledTaskPayload';
 import { useUserInfoContext } from '@/context/userInfo';
 
 const CreateCronTaskPage = () => {
@@ -232,6 +232,7 @@ const CreateCronTaskPage = () => {
         target_list: targetList,
         timeout: values.timeout || 60,
         is_enabled: enableAfterSave,
+        concurrency_policy: resolveScheduledTaskConcurrencyPolicy(values.concurrency_policy),
         team: selectedGroup ? [Number(selectedGroup.id)] : [],
       };
 
@@ -296,6 +297,7 @@ const CreateCronTaskPage = () => {
           initialValues={{
             name: defaultTaskName,
             timeout: 300,
+            concurrency_policy: 'skip',
             dailyTime: dayjs().hour(2).minute(0),
             hourlyInterval: 1,
             hourlyMinute: 0,
@@ -520,7 +522,7 @@ const CreateCronTaskPage = () => {
           </Form.Item>
 
           <Form.Item label={t('job.concurrencyStrategy')} name="concurrency_policy">
-            <Select defaultValue="skip">
+            <Select>
               <Select.Option value="skip">{t('job.skipIfRunning')}</Select.Option>
               <Select.Option value="run">{t('job.runAnyway')}</Select.Option>
               <Select.Option value="queue">{t('job.queueWait')}</Select.Option>

--- a/web/src/app/job/(pages)/execution/cron-task/edit/page.tsx
+++ b/web/src/app/job/(pages)/execution/cron-task/edit/page.tsx
@@ -25,7 +25,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import dayjs from 'dayjs';
 import HostSelectionModal, { HostItem, TargetSourceType } from '@/app/job/components/jobHostSelectionModalRuntime';
 import { AddTargetHostButton, TargetSourceSelector } from '@/app/job/components/target-selection-controls';
-import { buildScheduledTaskTemplatePayload, restoreScheduledTaskTemplateUi } from '@/app/job/utils/scheduledTaskPayload';
+import { buildScheduledTaskTemplatePayload, resolveScheduledTaskConcurrencyPolicy, restoreScheduledTaskTemplateUi } from '@/app/job/utils/scheduledTaskPayload';
 import { useUserInfoContext } from '@/context/userInfo';
 
 const EditCronTaskContent = () => {
@@ -333,6 +333,7 @@ const EditCronTaskContent = () => {
         target_list: targetList,
         timeout: values.timeout || 60,
         is_enabled: enableAfterSave,
+        concurrency_policy: resolveScheduledTaskConcurrencyPolicy(values.concurrency_policy),
         team: selectedGroup ? [Number(selectedGroup.id)] : [],
       };
 
@@ -641,7 +642,7 @@ const EditCronTaskContent = () => {
           </Form.Item>
 
           <Form.Item label={t('job.concurrencyStrategy')} name="concurrency_policy">
-            <Select defaultValue="skip">
+            <Select>
               <Select.Option value="skip">{t('job.skipIfRunning')}</Select.Option>
               <Select.Option value="run">{t('job.runAnyway')}</Select.Option>
               <Select.Option value="queue">{t('job.queueWait')}</Select.Option>

--- a/web/src/app/job/types/index.ts
+++ b/web/src/app/job/types/index.ts
@@ -331,6 +331,7 @@ export interface PlaybookFilePreview {
 // Scheduled Task types
 export type JobType = 'script' | 'playbook' | 'file';
 export type ScheduleType = 'once' | 'cron';
+export type ScheduledTaskConcurrencyPolicy = 'skip' | 'run' | 'queue';
 
 export interface ScheduledTask {
   id: number;
@@ -394,6 +395,7 @@ export interface ScheduledTaskFormData {
   target_path?: string;
   timeout?: number;
   is_enabled?: boolean;
+  concurrency_policy?: ScheduledTaskConcurrencyPolicy;
   team?: number[];
 }
 

--- a/web/src/app/job/utils/scheduledTaskPayload.ts
+++ b/web/src/app/job/utils/scheduledTaskPayload.ts
@@ -1,6 +1,15 @@
-import type { JobType, ScheduledTaskFormData } from '../types';
+import type { JobType, ScheduledTaskConcurrencyPolicy, ScheduledTaskFormData } from '../types';
 
 export type CronTemplateType = 'script' | 'playbook';
+
+export function resolveScheduledTaskConcurrencyPolicy(
+  value: unknown,
+): ScheduledTaskConcurrencyPolicy {
+  if (value === 'skip' || value === 'run' || value === 'queue') {
+    return value;
+  }
+  return 'skip';
+}
 
 export interface BuildScheduledTaskTemplateInput {
   jobType: JobType;


### PR DESCRIPTION
## 复现步骤

前置：账号能打开作业模块，并能创建/编辑定时脚本任务。

1. 进入作业，打开左侧 **作业执行** → **定时任务**。
2. 点进入 **创建定时任务**。在 **并发策略** 中选 **排队（等待上次完成后执行）** 或 **运行（无论上次是否完成）**，填好其余必填项后点 **保存并启用** 或 **仅保存**。
3. 回到列表再打开 **编辑定时任务**，把 **并发策略** 从 **跳过（上次未完成则跳过本次）** 改成排队或运行，再保存。
4. 对照保存请求或再次打开编辑页，看并发策略是否仍是默认跳过/旧值。

修复前：表单能选三种策略，保存 payload 不带 `concurrency_policy`；新建任务落库默认 skip，编辑也不会改已有策略。  
修复后：创建/编辑请求都带所选 `skip` / `run` / `queue`。创建页默认仍是跳过。已有任务未编辑时保留库里的值。

## 修复方案

`ScheduledTaskFormData` 补上 `concurrency_policy`。抽出 `resolveScheduledTaskConcurrencyPolicy`，只接受 skip/run/queue，其它回退 skip。创建和编辑的 `formData` 显式提交该字段。创建表单 `initialValues` 默认 skip，不再只靠 Select `defaultValue`。

Fixes #5301

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 创建选 **排队（等待上次完成后执行）** 后保存 | payload 无该字段，实际 skip | 提交 `queue` |
| 创建选 **运行（无论上次是否完成）** 后保存 | 实际 skip | 提交 `run` |
| 编辑把跳过改成排队/运行 | 库里策略不变 | 提交新值 |
| 未改并发策略 | 创建默认 skip | 仍默认 **跳过（上次未完成则跳过本次）** |

## 影响面

- **会变**：定时任务创建/编辑保存会提交并发策略。
- **不变**：子菜单 **作业执行** / **定时任务**；页 **创建定时任务** / **编辑定时任务**；字段 **并发策略**；选项 **跳过（上次未完成则跳过本次）** / **运行（无论上次是否完成）** / **排队（等待上次完成后执行）**；按钮 **保存并启用** / **仅保存** / **取消**。后端 skip/run/queue、权限和团队边界。历史任务不批量改写。
- **不在范围**：未做真实调度重叠触发 E2E。
