### PR TITLE
bugfix: 包管理翻页后保留当前页

### DIFF
--- a/web/scripts/node-package-list-pagination-test.ts
+++ b/web/scripts/node-package-list-pagination-test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { resolvePackageListPagination } from '../src/app/node-manager/components/sidecar/packageListPagination';
+
+const pageTwo = { current: 2, total: 40, pageSize: 20 };
+const pageTwoSuccess = resolvePackageListPagination(pageTwo, {
+  count: 40,
+  itemCount: 20,
+});
+assert.equal(pageTwoSuccess.current, 2, '第 2 页成功后 current 仍为 2');
+assert.equal(pageTwoSuccess.total, 40, '成功响应只更新 total');
+assert.equal(pageTwoSuccess.pageSize, 20);
+assert.equal(pageTwo.current, 2, '不应就地修改原分页对象');
+
+const pageSizeChanged = resolvePackageListPagination(
+  { current: 3, total: 0, pageSize: 50 },
+  { count: 100, itemCount: 50 }
+);
+assert.equal(
+  pageSizeChanged.current,
+  3,
+  'pageSize 变化时保留传入的 current'
+);
+assert.equal(pageSizeChanged.pageSize, 50);
+assert.equal(pageSizeChanged.total, 100);
+
+const emptiedLastPage = resolvePackageListPagination(
+  { current: 3, total: 41, pageSize: 20 },
+  { count: 40, itemCount: 0 }
+);
+assert.equal(
+  emptiedLastPage.current,
+  2,
+  '删空末页且 count>0 时应落到最后一页'
+);
+assert.equal(emptiedLastPage.total, 40);
+
+const emptyCatalog = resolvePackageListPagination(
+  { current: 1, total: 0, pageSize: 20 },
+  { count: 0, itemCount: 0 }
+);
+assert.equal(emptyCatalog.current, 1);
+assert.equal(emptyCatalog.total, 0);
+
+const detailSource = readFileSync(
+  resolve(process.cwd(), 'src/app/node-manager/components/sidecar/detail.tsx'),
+  'utf8'
+);
+const getTableDataMatch = detailSource.match(
+  /const getTableData = async \(\) => \{[\s\S]*?\n  \};/
+);
+assert.ok(getTableDataMatch, '找不到 getTableData');
+assert.match(
+  getTableDataMatch[0],
+  /resolvePackageListPagination/,
+  'getTableData 应使用抽出的分页函数'
+);
+assert.doesNotMatch(
+  getTableDataMatch[0],
+  /current:\s*1/,
+  'getTableData 成功回调不应再写死 current:1'
+);
+
+console.log('node package list pagination tests passed');

--- a/web/src/app/node-manager/components/sidecar/detail.tsx
+++ b/web/src/app/node-manager/components/sidecar/detail.tsx
@@ -7,6 +7,7 @@ import { useDetailColumns } from '@/app/node-manager/hooks';
 import useNodeManagerApi from '@/app/node-manager/api';
 import useApiClient from '@/utils/request';
 import type { Pagination, TableDataItem } from '@/app/node-manager/types';
+import { resolvePackageListPagination } from '@/app/node-manager/components/sidecar/packageListPagination';
 import CollectorModal from '@/app/node-manager/components/sidecar/collectorModal';
 import { ModalRef } from '@/app/node-manager/types';
 import PermissionWrapper from '@/components/permission';
@@ -65,11 +66,12 @@ const Collectordetail = () => {
       const res = await Promise.all([getPackage]);
       const packageInfo = res[0];
       setTableData(packageInfo?.items || []);
-      setPagination((prev: Pagination) => ({
-        ...prev,
-        total: packageInfo?.count || 0,
-        current: 1
-      }));
+      setPagination((prev: Pagination) =>
+        resolvePackageListPagination(prev, {
+          count: packageInfo?.count || 0,
+          itemCount: (packageInfo?.items || []).length
+        })
+      );
     } finally {
       setTableLoading(false);
     }

--- a/web/src/app/node-manager/components/sidecar/packageListPagination.ts
+++ b/web/src/app/node-manager/components/sidecar/packageListPagination.ts
@@ -1,0 +1,28 @@
+export interface PackageListPagination {
+  current: number;
+  total: number;
+  pageSize: number;
+}
+
+export interface PackageListPageResult {
+  count: number;
+  itemCount: number;
+}
+
+export const resolvePackageListPagination = (
+  prev: PackageListPagination,
+  { count, itemCount }: PackageListPageResult
+): PackageListPagination => {
+  const total = count || 0;
+  const pageSize = prev.pageSize > 0 ? prev.pageSize : 1;
+  const current =
+    itemCount === 0 && total > 0 && prev.current > 1
+      ? Math.max(1, Math.ceil(total / pageSize))
+      : prev.current;
+
+  return {
+    ...prev,
+    total,
+    current,
+  };
+};


### PR DESCRIPTION
## 复现步骤

前置：账号能打开节点管理。组件库或控制器下某个对象、操作系统和架构已有超过 20 个包版本。

1. 进入节点管理，打开左侧 **组件库** → **包管理**（或 **控制器** → **包管理**）。
2. 打开某个对象的包列表，确认底部分页出现 **共 {n} 项** 且不止一页。
3. 点第 2 页（或任一后续页），看列表是否停在该页，还是马上回到第 1 页。
4. 需要时点 **上传包** 增加版本，或删除末页最后一条后再看页码。

修复前：点第 2 页请求成功后 `current` 被写成 1，effect 再拉第 1 页。  
修复后：成功响应只更新 total，保留当前页。删空末页且仍有数据时落到最后一页。

## 修复方案

抽出 `resolvePackageListPagination`：成功只写 total，保留 current；当前页无数据且 count>0 且 current>1 时落到最后一页。`Collectordetail.getTableData` 改用该函数。组件库和控制器包管理共用此组件。不改 CustomTable 和后端分页。

Fixes #5312

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 点第 2 页成功 | 立刻回到第 1 页，并再请求 page=1 | 停在第 2 页 |
| 合计 | 会更新 total | 仍更新 **共 {n} 项** |
| 删空末页 | 仍可能回第 1 页 | 落到新的最后一页 |
| **上传包** | 权限与接口不变 | 不变 |

## 影响面

- **会变**：组件库/控制器包管理翻页后保留当前页。
- **不变**：子菜单 **组件库** / **包管理**、**控制器** / **包管理**；按钮 **上传包**；分页合计 **共 {n} 项**。后端 items/count、上传删除权限。
- **不在范围**：同实例切换对象时不会自动回第一页；未做浏览器 E2E。
