### PR TITLE
bugfix: 告警列表上下文缓存覆盖全部当前页行

### DIFF
--- a/web/scripts/monitor-alert-list-cache-stamp-test.ts
+++ b/web/scripts/monitor-alert-list-cache-stamp-test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { fingerprintAlertListRows } from '../src/app/monitor/(pages)/event/alert/alertListStamp';
+
+const header = '级别 | 告警名称 | 资产';
+const row1 = '严重 | CPU 高 | host-a';
+const row2 = '警告 | 磁盘高 | host-b';
+const row3 = '提示 | 内存高 | host-c';
+const row4 = '严重 | 网络中断 | host-d';
+const row4Changed = '警告 | 网络延迟 | host-d';
+
+const headerPlus3 = [header, row1, row2, row3];
+const headerPlus4 = [header, row1, row2, row3, row4];
+const fourthRowChanged = [header, row1, row2, row3, row4Changed];
+const firstThreeChanged = [header, '严重 | CPU 更高 | host-a', row2, row3, row4];
+
+assert.notEqual(
+  fingerprintAlertListRows(headerPlus3),
+  fingerprintAlertListRows(headerPlus4),
+  '表头+3 行与表头+4 行指纹必须不同',
+);
+
+assert.notEqual(
+  fingerprintAlertListRows(headerPlus4),
+  fingerprintAlertListRows(fourthRowChanged),
+  '只改第四行指纹必须变化',
+);
+
+assert.notEqual(
+  fingerprintAlertListRows(headerPlus4),
+  fingerprintAlertListRows(firstThreeChanged),
+  '只改前三行指纹必须变化',
+);
+
+assert.equal(
+  fingerprintAlertListRows(headerPlus4),
+  fingerprintAlertListRows([...headerPlus4]),
+  '完全相同快照指纹必须相同',
+);
+
+const root = join(fileURLToPath(new URL('.', import.meta.url)), '..');
+const pilotSource = readFileSync(
+  join(root, 'src/app/monitor/(pages)/event/alert/alert.pilot.ts'),
+  'utf8',
+);
+const stampSource = readFileSync(
+  join(root, 'src/app/monitor/(pages)/event/alert/alertListStamp.ts'),
+  'utf8',
+);
+
+assert.match(
+  pilotSource,
+  /from ['"]\.\/alertListStamp['"]/,
+  'readAlertListStamp 必须使用抽出的 fingerprintAlertListRows',
+);
+assert.match(
+  pilotSource,
+  /rowFingerprint:\s*fingerprintAlertListRows\(rows\)/,
+  'readAlertListStamp 必须用抽出函数生成 rowFingerprint',
+);
+assert.doesNotMatch(
+  pilotSource,
+  /slice\(\s*0\s*,\s*4\s*\)/,
+  'alert.pilot.ts 不得再用 slice(0, 4) 截断行指纹',
+);
+assert.doesNotMatch(
+  stampSource,
+  /slice\(\s*0\s*,\s*4\s*\)/,
+  '抽出模块不得再用 slice(0, 4) 截断行指纹',
+);
+
+console.log('monitor-alert-list-cache-stamp: pass');

--- a/web/src/app/monitor/(pages)/event/alert/alert.pilot.ts
+++ b/web/src/app/monitor/(pages)/event/alert/alert.pilot.ts
@@ -4,6 +4,7 @@ import type {
   PageContextMessage,
   PageContextToolkit,
 } from '@/components/ai-page-context/types';
+import { fingerprintAlertListRows } from './alertListStamp';
 
 const TITLE_PREFIX = 'monitor-alert:';
 const HOST_TABS = new Set(['activeAlarms', 'historicalAlarms']);
@@ -120,7 +121,7 @@ export const readAlertListStamp = (): AlertListStamp => {
     objectLabel: cleanLabel(document.querySelector('[class*="filters"] .ant-tree-node-selected')?.textContent || ''),
     filterText: readFilterFields().join('；'),
     rangeText: readRangeText(),
-    rowFingerprint: rows.slice(0, 4).join('|'),
+    rowFingerprint: fingerprintAlertListRows(rows),
     chartText: '',
     loading: Boolean(table?.querySelector('.ant-spin-spinning')),
     emptyText: cleanLabel(table?.querySelector('.ant-empty-description')?.textContent || '')

--- a/web/src/app/monitor/(pages)/event/alert/alertListStamp.ts
+++ b/web/src/app/monitor/(pages)/event/alert/alertListStamp.ts
@@ -1,0 +1,2 @@
+export const fingerprintAlertListRows = (rows: string[]): string =>
+  rows.join('|');


### PR DESCRIPTION
## 复现步骤

前置：账号能打开监控模块，同一对象下活跃告警当前页至少 4 条。

1. 进入监控，打开左侧 **事件** → **告警**，停在 **告警列表**，页签 **活跃告警**（也可对照 **历史告警**）。
2. 让助手采集一次当前页上下文。
3. 在另一会话认领或更新当前页第 4 条及以后的告警，原页面完成定时刷新，前三条和总数不变。
4. 再让助手采集一次，对照回答里的处理人/更新时间是否仍是旧内容。

修复前：缓存标识只看表头加前三行，第四行及以后变了仍命中旧缓存。  
修复后：指纹覆盖当前页全部已采集行，第四行变化会使缓存失效。

## 修复方案

抽出 `fingerprintAlertListRows`，对同一快照的全部行生成 `rowFingerprint`。`readAlertListStamp` 不再 `slice(0, 4)`。不改 registry、告警 API 和权限。

Fixes #5326

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 只改第 4 行 | 助手仍拿到旧表格 | 再次采集为新内容 |
| 只改前三行 | 缓存失效 | 仍失效 |
| 页签 **活跃告警** / **历史告警** | 其它筛选门控不变 | 不变 |

## 影响面

- **会变**：监控告警列表页面上下文缓存会识别当前页全部行的变化。
- **不变**：子菜单 **事件** / **告警**；页 **告警列表**；页签 **活跃告警** / **历史告警**。告警 API、权限、动作列排除、加载态。
- **不在范围**：超长当前页会使缓存键变长；未做浏览器助手端到端。
