### PR TITLE
bugfix: 拓扑网络线确认时保留两端接口配置

### DIFF
--- a/web/scripts/ops-topology-edge-interface-test.ts
+++ b/web/scripts/ops-topology-edge-interface-test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { applyEdgeConfigConfirm } from '../src/app/ops-analysis/(pages)/view/topology/utils/edgeConfigConfirm';
+
+const oldSourceInterface = { type: 'existing' as const, value: 'eth0' };
+const oldTargetInterface = { type: 'existing' as const, value: 'eth1' };
+const newSourceInterface = { type: 'custom' as const, value: 'GigabitEthernet0/1' };
+const newTargetInterface = { type: 'custom' as const, value: 'GigabitEthernet0/2' };
+const vertices = [{ x: 10, y: 20 }];
+
+const previousEdgeData = {
+  id: 'edge-1',
+  lineType: 'network_line' as const,
+  lineName: '',
+  arrowDirection: 'single' as const,
+  styleConfig: {
+    lineColor: '#8c8c8c',
+    lineWidth: 1,
+    lineStyle: 'line' as const,
+    enableAnimation: false,
+  },
+  sourceNode: { id: 'n1', name: '节点1' },
+  targetNode: { id: 'n2', name: '节点2' },
+  sourceInterface: oldSourceInterface,
+  targetInterface: oldTargetInterface,
+};
+
+const confirmedValues = {
+  ...previousEdgeData,
+  sourceInterface: newSourceInterface,
+  targetInterface: newTargetInterface,
+};
+
+const setDataPayload = applyEdgeConfigConfirm(
+  previousEdgeData,
+  confirmedValues,
+  vertices,
+);
+const setCurrentEdgeDataPayload = applyEdgeConfigConfirm(
+  previousEdgeData,
+  confirmedValues,
+  vertices,
+);
+
+assert.deepEqual(
+  setDataPayload.sourceInterface,
+  newSourceInterface,
+  'network_line 确认后 setData 载荷应含新 sourceInterface',
+);
+assert.deepEqual(
+  setDataPayload.targetInterface,
+  newTargetInterface,
+  'network_line 确认后 setData 载荷应含新 targetInterface',
+);
+assert.deepEqual(
+  setCurrentEdgeDataPayload.sourceInterface,
+  newSourceInterface,
+  'setCurrentEdgeData 应同步含新 sourceInterface',
+);
+assert.deepEqual(
+  setCurrentEdgeDataPayload.targetInterface,
+  newTargetInterface,
+  'setCurrentEdgeData 应同步含新 targetInterface',
+);
+assert.notDeepEqual(
+  setDataPayload.sourceInterface,
+  oldSourceInterface,
+  '确认后不得残留旧 sourceInterface',
+);
+assert.notDeepEqual(
+  setDataPayload.targetInterface,
+  oldTargetInterface,
+  '确认后不得残留旧 targetInterface',
+);
+
+const legacyEdge = {
+  id: 'edge-legacy',
+  lineType: 'network_line' as const,
+  sourceNode: { id: 'n1', name: '节点1' },
+  targetNode: { id: 'n2', name: '节点2' },
+};
+const legacyConfirm = applyEdgeConfigConfirm(
+  legacyEdge,
+  {
+    lineType: 'network_line',
+    lineName: '',
+    styleConfig: previousEdgeData.styleConfig,
+  },
+  [],
+);
+assert.equal(
+  legacyConfirm.sourceInterface,
+  undefined,
+  '缺接口的旧边确认未提交接口时应保持 undefined',
+);
+assert.equal(
+  legacyConfirm.targetInterface,
+  undefined,
+  '缺接口的旧边确认未提交接口时应保持 undefined',
+);
+
+const root = process.cwd();
+const hookSource = fs.readFileSync(
+  path.join(
+    root,
+    'src/app/ops-analysis/(pages)/view/topology/hooks/useGraphInteractions.ts',
+  ),
+  'utf8',
+);
+
+assert.match(
+  hookSource,
+  /import \{ applyEdgeConfigConfirm \} from '\.\.\/utils\/edgeConfigConfirm'/,
+  'useGraphInteractions 应使用抽出的 applyEdgeConfigConfirm',
+);
+
+const confirmFn = hookSource.match(
+  /const handleEdgeConfigConfirm = useCallback\([\s\S]*?\},\s*\[[^\]]*\]\s*\);/,
+)?.[0];
+assert.ok(confirmFn, '应能定位 handleEdgeConfigConfirm');
+assert.match(
+  confirmFn,
+  /applyEdgeConfigConfirm/,
+  'handleEdgeConfigConfirm 应调用抽出函数',
+);
+assert.doesNotMatch(
+  confirmFn,
+  /edge\.setData\(\{/,
+  'setData 不得再手写漏接口字段的对象字面量',
+);
+assert.doesNotMatch(
+  confirmFn,
+  /setCurrentEdgeData\(\{/,
+  'setCurrentEdgeData 不得再手写漏接口字段的对象字面量',
+);
+
+console.log('ops topology edge interface validation passed');

--- a/web/src/app/ops-analysis/(pages)/view/topology/hooks/useGraphInteractions.ts
+++ b/web/src/app/ops-analysis/(pages)/view/topology/hooks/useGraphInteractions.ts
@@ -9,12 +9,14 @@ import { v4 as uuidv4 } from 'uuid';
 import { useTranslation } from '@/utils/i18n';
 import { createEdgeLabel, getEdgeStyleWithConfig } from '../utils/topologyUtils';
 import { createEdgeByType } from '../utils/registerEdge';
+import { applyEdgeConfigConfirm } from '../utils/edgeConfigConfirm';
 import { COLORS, SPACING } from '../constants/nodeDefaults';
 import {
   TopologyState,
   MenuClickEvent,
   UseContextMenuAndModalReturn,
   Point,
+  EdgeData,
 } from '@/app/ops-analysis/types/topology';
 
 const removeAllEdgeLabels = (edge: Edge) => {
@@ -82,30 +84,20 @@ export const useContextMenuAndModal = (
   } = state;
 
   const handleEdgeConfigConfirm = useCallback(
-    (values: {
-      lineType: 'common_line' | 'network_line';
-      lineName?: string;
-      styleConfig?: {
-        lineColor?: string;
-        lineWidth?: number;
-        lineStyle?: 'line' | 'dotted' | 'point';
-        enableAnimation?: boolean;
-      }
-    }) => {
+    (values: EdgeData) => {
       if (!currentEdgeData?.id || !graphInstance) return;
 
       const edge = graphInstance.getCellById(currentEdgeData.id) as Edge;
       if (!edge) return;
 
       const currentVertices = edge.getVertices();
+      const confirmedEdgeData = applyEdgeConfigConfirm(
+        edge.getData(),
+        values,
+        currentVertices,
+      );
 
-      edge.setData({
-        ...edge.getData(),
-        lineType: values.lineType,
-        lineName: values.lineName,
-        styleConfig: values.styleConfig,
-        vertices: currentVertices
-      });
+      edge.setData(confirmedEdgeData);
 
       if (values.styleConfig) {
         const lineAttrs: Attr.ComplexAttrs = {
@@ -152,12 +144,9 @@ export const useContextMenuAndModal = (
         }
       }
 
-      setCurrentEdgeData({
-        ...currentEdgeData,
-        lineType: values.lineType,
-        lineName: values.lineName,
-        styleConfig: values.styleConfig
-      });
+      setCurrentEdgeData(
+        applyEdgeConfigConfirm(currentEdgeData, values, currentVertices),
+      );
     },
     [currentEdgeData, graphInstance, setCurrentEdgeData]
   );

--- a/web/src/app/ops-analysis/(pages)/view/topology/utils/edgeConfigConfirm.ts
+++ b/web/src/app/ops-analysis/(pages)/view/topology/utils/edgeConfigConfirm.ts
@@ -1,0 +1,41 @@
+export interface EdgeConfigConfirmValues {
+  lineType: 'common_line' | 'network_line';
+  lineName?: string;
+  styleConfig?: {
+    lineColor?: string;
+    lineWidth?: number;
+    lineStyle?: 'line' | 'dotted' | 'point';
+    enableAnimation?: boolean;
+  };
+  sourceInterface?: {
+    type: 'existing' | 'custom';
+    value: string;
+  };
+  targetInterface?: {
+    type: 'existing' | 'custom';
+    value: string;
+  };
+}
+
+export function applyEdgeConfigConfirm<T extends object>(
+  previousData: T | null | undefined,
+  values: EdgeConfigConfirmValues,
+  vertices?: Array<{ x: number; y: number }>,
+): T & {
+  lineType: EdgeConfigConfirmValues['lineType'];
+  lineName?: string;
+  styleConfig?: EdgeConfigConfirmValues['styleConfig'];
+  vertices?: Array<{ x: number; y: number }>;
+  sourceInterface?: EdgeConfigConfirmValues['sourceInterface'];
+  targetInterface?: EdgeConfigConfirmValues['targetInterface'];
+} {
+  return {
+    ...(previousData ?? ({} as T)),
+    lineType: values.lineType,
+    lineName: values.lineName,
+    styleConfig: values.styleConfig,
+    vertices,
+    sourceInterface: values.sourceInterface,
+    targetInterface: values.targetInterface,
+  };
+}


### PR DESCRIPTION
## 复现步骤

前置：账号能打开运营分析，并有 `EditChart` 权限编辑一张含网络连线的拓扑图。

1. 进入 **运营分析**，打开一张 **拓扑图**，用工具栏 **编辑** 进入编辑。
2. 右键已有连线，选 **配置边**，抽屉标题为 **连线配置**。
3. **线条类型** 选 `network_line`；**节点1** / **节点2** 的 **接口** 选 **自定义**，填入新接口名。
4. 点 **确认**。再右键同一条线打开 **配置边**，对照两端接口是否仍是刚才填的值。
5. 点 **保存**，提示 **拓扑图保存成功** 后重新打开该图，再看接口。

修复前：确认只写回线条类型和样式，两端接口被丢掉，重开和保存都还是旧值。  
修复后：确认会把 `sourceInterface` / `targetInterface` 写入边数据和当前编辑态。

## 修复方案

抽出 `applyEdgeConfigConfirm`，确认时把两端接口一并写入 `edge.setData` 和 `setCurrentEdgeData`。不改权限、URL、后端和连线配置表单。

Fixes #5330

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 确认自定义两端接口后重开 **连线配置** | 仍是旧接口 | 显示本次填写 |
| 保存后再打开拓扑 | 接口未写入画布 | 接口随边数据保存 |
| 旧边本来没有接口 | 可继续缺字段 | 未提交接口时仍为缺省 |

## 影响面

- **会变**：运营分析拓扑图在确认 **配置边** 后会保留本次源端/目标端接口。
- **不变**：菜单 **运营分析**；抽屉 **连线配置**；**线条类型** 选项 `network_line`；权限 `EditChart`；保存成功文案 **拓扑图保存成功**。
- **不在范围**：未做浏览器端到端；`UseContextMenuAndModalReturn` 对外声明仍是较窄参数类型，运行时已接收完整 `EdgeData`。
