### PR TITLE
bugfix: 接入详情事件列表忽略迟到的旧筛选响应

### DIFF
--- a/web/scripts/alarm-integration-event-list-stale-test.ts
+++ b/web/scripts/alarm-integration-event-list-stale-test.ts
@@ -1,0 +1,169 @@
+import * as assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createLatestRequestGuard } from '../src/context/latestRequestGuard.ts';
+import {
+  commitIntegrationEventListSettled,
+  commitIntegrationEventListSuccess,
+} from '../src/app/alarm/(pages)/integration/detail/integrationEventListRequest.ts';
+
+interface EventRow {
+  id: number;
+  title: string;
+}
+
+interface ViewState {
+  eventList: EventRow[];
+  total: number;
+  eventLoading: boolean;
+  error: string | null;
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pagePath = resolve(here, '../src/app/alarm/(pages)/integration/detail/page.tsx');
+const utilPath = resolve(
+  here,
+  '../src/app/alarm/(pages)/integration/detail/integrationEventListRequest.ts',
+);
+
+function createEventListSession() {
+  const guard = createLatestRequestGuard();
+  let state: ViewState = {
+    eventList: [],
+    total: 0,
+    eventLoading: false,
+    error: null,
+  };
+
+  const start = () => {
+    const requestId = guard.begin();
+    state = { ...state, eventLoading: true };
+    return requestId;
+  };
+
+  const succeed = (requestId: number, items: EventRow[], total: number) => {
+    commitIntegrationEventListSuccess(guard, requestId, () => {
+      state = {
+        ...state,
+        eventList: items,
+        total,
+        error: null,
+      };
+    });
+    commitIntegrationEventListSettled(guard, requestId, () => {
+      state = { ...state, eventLoading: false };
+    });
+  };
+
+  const fail = (requestId: number) => {
+    commitIntegrationEventListSettled(guard, requestId, () => {
+      state = { ...state, error: 'loadFailed', eventLoading: false };
+    });
+  };
+
+  return {
+    getState: () => state,
+    start,
+    succeed,
+    fail,
+    unmount: () => guard.invalidate(),
+  };
+}
+
+function assertPageUsesGeneration(source: string) {
+  assert.match(
+    source,
+    /from ['"]@\/context\/latestRequestGuard['"]/,
+    'page 必须复用 @/context/latestRequestGuard，不得复制新 guard',
+  );
+  assert.match(source, /createLatestRequestGuard/, 'page 必须创建 latest request guard');
+  assert.match(source, /\.begin\(\)/, 'fetchEventList 必须按单调序号 begin');
+  assert.match(
+    source,
+    /from ['"]\.\/integrationEventListRequest['"]/,
+    'page 必须调用抽出的 integrationEventListRequest',
+  );
+  assert.match(source, /commitIntegrationEventListSuccess\(/, '成功响应必须经 commitIntegrationEventListSuccess 提交');
+  assert.match(source, /commitIntegrationEventListSettled\(/, '结束 loading 必须经 commitIntegrationEventListSettled 提交');
+  assert.match(source, /\.invalidate\(\)/, '筛选、页码、源变化和卸载必须 invalidate');
+  assert.match(source, /k8sMetaRequestSeqRef/, 'K8s 元数据请求序号必须保留');
+  assert.doesNotMatch(
+    source,
+    /setEventList\(\s*res\.items/,
+    'fetchEventList 不得手写无序号的 setEventList(res.items)',
+  );
+  assert.doesNotMatch(
+    source,
+    /function createLatestRequestGuard|const createLatestRequestGuard\s*=/,
+    '不得在 page 内复制一套序号 guard',
+  );
+}
+
+function assertHelperAcceptsGuard(source: string) {
+  assert.match(source, /LatestRequestGuard/, '抽出函数必须接受 LatestRequestGuard');
+  assert.match(source, /requestId/, '抽出函数必须接受 requestId');
+  assert.doesNotMatch(
+    source,
+    /createLatestRequestGuard\s*=|function createLatestRequestGuard/,
+    'integrationEventListRequest 不得复制一套序号 guard',
+  );
+}
+
+async function main() {
+  assert.equal(typeof createLatestRequestGuard, 'function', '必须 import createLatestRequestGuard');
+  assert.equal(typeof commitIntegrationEventListSuccess, 'function', '必须 import commitIntegrationEventListSuccess');
+  assert.equal(typeof commitIntegrationEventListSettled, 'function', '必须 import commitIntegrationEventListSettled');
+
+  const search = createEventListSession();
+  const staleSearch = search.start();
+  const latestSearch = search.start();
+  search.succeed(latestSearch, [{ id: 2, title: 'new-title' }], 1);
+  search.succeed(staleSearch, [{ id: 1, title: 'old-title' }], 9);
+  assert.deepEqual(
+    search.getState().eventList,
+    [{ id: 2, title: 'new-title' }],
+    'old 晚于 new 返回时列表必须保持 new',
+  );
+  assert.equal(search.getState().total, 1, 'old 晚于 new 返回时 total 必须保持 new');
+  assert.equal(search.getState().eventLoading, false);
+
+  const latestFailed = createEventListSession();
+  const staleSuccess = latestFailed.start();
+  const failedLatest = latestFailed.start();
+  latestFailed.fail(failedLatest);
+  latestFailed.succeed(staleSuccess, [{ id: 3, title: 'stale-ok' }], 8);
+  assert.equal(latestFailed.getState().error, 'loadFailed', '当前请求失败仍可提交错误可见态');
+  assert.deepEqual(latestFailed.getState().eventList, [], '旧成功不能在最新失败之后写回列表');
+  assert.equal(latestFailed.getState().total, 0);
+  assert.equal(latestFailed.getState().eventLoading, false, 'loading 必须由当前请求结束');
+
+  const inflight = createEventListSession();
+  const staleFail = inflight.start();
+  inflight.start();
+  inflight.fail(staleFail);
+  assert.equal(inflight.getState().eventLoading, true, '旧失败不得把仍在途的最新请求 loading 清掉');
+  assert.equal(inflight.getState().error, null, '旧失败不得展示为当前错误');
+
+  const unmounted = createEventListSession();
+  const lateId = unmounted.start();
+  unmounted.unmount();
+  unmounted.succeed(lateId, [{ id: 4, title: 'late' }], 1);
+  unmounted.fail(lateId);
+  assert.deepEqual(unmounted.getState().eventList, [], '卸载/invalidate 后旧成功不得写回');
+  assert.equal(unmounted.getState().total, 0);
+  assert.equal(unmounted.getState().error, null, '卸载后迟到失败不得写回');
+  assert.equal(unmounted.getState().eventLoading, true, '卸载后不得用迟到 finally 收口仍有效的会话状态');
+
+  const pageSource = readFileSync(pagePath, 'utf8');
+  const utilSource = readFileSync(utilPath, 'utf8');
+  assertPageUsesGeneration(pageSource);
+  assertHelperAcceptsGuard(utilSource);
+
+  console.log('alarm integration event list stale test passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/web/src/app/alarm/(pages)/integration/detail/integrationEventListRequest.ts
+++ b/web/src/app/alarm/(pages)/integration/detail/integrationEventListRequest.ts
@@ -1,0 +1,17 @@
+import type { LatestRequestGuard } from '@/context/latestRequestGuard';
+
+export function commitIntegrationEventListSuccess(
+  guard: LatestRequestGuard,
+  requestId: number,
+  apply: () => void,
+): boolean {
+  return guard.commitIfCurrent(requestId, apply);
+}
+
+export function commitIntegrationEventListSettled(
+  guard: LatestRequestGuard,
+  requestId: number,
+  settle: () => void,
+): boolean {
+  return guard.commitIfCurrent(requestId, settle);
+}

--- a/web/src/app/alarm/(pages)/integration/detail/page.tsx
+++ b/web/src/app/alarm/(pages)/integration/detail/page.tsx
@@ -25,7 +25,12 @@ import { useSearchParams } from 'next/navigation';
 import { useTranslation } from '@/utils/i18n';
 import { useLocalizedTime } from '@/hooks/useLocalizedTime';
 import { useCommon } from '@/app/alarm/context/common';
+import { createLatestRequestGuard } from '@/context/latestRequestGuard';
 import { useUserInfoContext } from '@/context/userInfo';
+import {
+  commitIntegrationEventListSettled,
+  commitIntegrationEventListSuccess,
+} from './integrationEventListRequest';
 import { AlertSourceIntegrationGuide, K8sMeta, SourceItem, TeamSecretItem } from '@/app/alarm/types/integration';
 import { useAlarmApi } from '@/app/alarm/api/alarms';
 import { EventItem } from '@/app/alarm/types/alarms';
@@ -63,6 +68,7 @@ const IntegrationDetail: FC = () => {
   const [integrationGuideLoading, setIntegrationGuideLoading] = useState<boolean>(false);
   const [activeTab, setActiveTab] = useState<string>('event');
   const [eventList, setEventList] = useState<EventItem[]>([]);
+  const [eventListRequestGuard] = useState(createLatestRequestGuard);
   const [eventLoading, setEventLoading] = useState<boolean>(false);
   const [hasLoadedEvents, setHasLoadedEvents] = useState<boolean>(false);
   const [hasInitializedK8sTab, setHasInitializedK8sTab] = useState<boolean>(false);
@@ -264,6 +270,7 @@ const IntegrationDetail: FC = () => {
   };
 
   const fetchEventList = async () => {
+    const requestId = eventListRequestGuard.begin();
     setEventLoading(true);
     try {
       const params: any = {
@@ -281,11 +288,18 @@ const IntegrationDetail: FC = () => {
         }
       }
       const res = await getEventList(params);
-      setEventList(res.items || []);
-      setPagination((prev) => ({ ...prev, total: res.count }));
-      setHasLoadedEvents(true);
+      commitIntegrationEventListSuccess(eventListRequestGuard, requestId, () => {
+        const items = res.items || [];
+        setEventList(items);
+        setPagination((prev) => ({ ...prev, total: res.count }));
+        setHasLoadedEvents(true);
+      });
+    } catch (error) {
+      console.error(error);
     } finally {
-      setEventLoading(false);
+      commitIntegrationEventListSettled(eventListRequestGuard, requestId, () => {
+        setEventLoading(false);
+      });
     }
   };
 
@@ -293,6 +307,9 @@ const IntegrationDetail: FC = () => {
     if ((activeTab === 'event' || isK8sSource) && source?.source_id) {
       fetchEventList();
     }
+    return () => {
+      eventListRequestGuard.invalidate();
+    };
   }, [
     activeTab,
     source,


### PR DESCRIPTION
## 复现步骤

前置：账号能打开告警模块的接入详情，事件页至少有两条不同标题的事件。

1. 进入 **集成**，打开 **告警源详情**，切到页签 **事件**。
2. 筛选属性选 **标题**，输入标题 A 后回车。
3. 请求未完成时再输入标题 B 并回车。
4. 让 B 的结果先回来，A 的结果后回来，对照列表、总数是否仍对应 B。

修复前：旧筛选晚返回会写回列表和总数，输入框仍是新条件。  
修复后：只有当前请求序号能提交列表、总数和 loading。

## 修复方案

抽出 `commitIntegrationEventListSuccess` / `commitIntegrationEventListSettled`，复用 `@/context/latestRequestGuard`。筛选、页码、源变化和卸载时作废旧序号。不改事件 API、权限、SearchFilter 和 K8s 元数据序号。

Fixes #5331

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 标题 B 先返回、A 后返回 | 列表退回 A | 列表保持 B |
| 当前请求失败 | 旧成功仍可能写回 | 旧成功被丢弃，loading 由当前请求结束 |
| 离开页面后迟到响应 | 仍可能 setState | invalidate 后忽略 |

## 影响面

- **会变**：告警源详情 **事件** 页连续筛选时只展示最新请求结果。
- **不变**：菜单 **集成**；详情 **告警源详情**；页签 **事件**；筛选属性 **标题**；回车提交。事件 API、`items`/`count`、K8s 元数据 seq。
- **不在范围**：未做浏览器端到端；未给 SearchFilter 加 loading 禁用。
