### PR TITLE
bugfix: 日志策略通知人索引统一数字与字符串主键

### DIFF
--- a/web/scripts/log-notifier-search-index-test.ts
+++ b/web/scripts/log-notifier-search-index-test.ts
@@ -11,7 +11,7 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 interface UserItem {
-  id: string;
+  id: string | number;
   username: string;
   display_name: string;
 }
@@ -21,7 +21,7 @@ interface NotifierSearchFns {
   matchNotifierUser: (user: UserItem | undefined, input: string) => boolean;
   filterNotifierOption: (
     input: string,
-    option: { value?: string } | undefined,
+    option: { value?: string | number } | undefined,
     userIndex: Map<string, UserItem>,
   ) => boolean;
 }
@@ -30,6 +30,10 @@ const here = dirname(fileURLToPath(import.meta.url));
 const formPath = resolve(
   here,
   '../src/app/log/(pages)/event/strategy/detail/notificationForm.tsx',
+);
+const searchPath = resolve(
+  here,
+  '../src/app/log/(pages)/event/strategy/detail/notifierSearch.ts',
 );
 
 function makeUsers(n: number): UserItem[] {
@@ -113,7 +117,12 @@ async function main(): Promise<void> {
     username: 'bob.li',
     display_name: '李四',
   };
-  const namedIndex = fns.buildNotifierUserIndex([alice, bob]);
+  const numericAlice: UserItem = {
+    id: 17,
+    username: 'alice.numeric',
+    display_name: 'Numeric Alice',
+  };
+  const namedIndex = fns.buildNotifierUserIndex([alice, bob, numericAlice]);
 
   assert.equal(
     fns.filterNotifierOption('alice dis', { value: 'alice-id' }, namedIndex),
@@ -145,8 +154,39 @@ async function main(): Promise<void> {
     false,
     '未知 id 不应命中',
   );
+  assert.equal(
+    fns.filterNotifierOption('numeric alice', { value: 17 }, namedIndex),
+    true,
+    '数字主键 17 应按 display_name 命中',
+  );
+  assert.equal(
+    fns.filterNotifierOption('numeric alice', { value: '17' }, namedIndex),
+    true,
+    '字符串 "17" 应按 display_name 命中数字主键用户',
+  );
+  assert.equal(
+    fns.filterNotifierOption('ALICE.NUMERIC', { value: 17 }, namedIndex),
+    true,
+    '数字主键 17 应按 username 大小写不敏感命中',
+  );
+  assert.equal(
+    fns.filterNotifierOption('alice.numeric', { value: '17' }, namedIndex),
+    true,
+    '字符串 "17" 应按 username 命中数字主键用户',
+  );
 
   const source = readFileSync(formPath, 'utf8');
+  const searchSource = readFileSync(searchPath, 'utf8');
+  assert.match(
+    searchSource,
+    /String\(user\.id\)/,
+    'buildNotifierUserIndex 必须用 String(user.id) 规范化索引键',
+  );
+  assert.doesNotMatch(
+    searchSource,
+    /\[user\.id,\s*user\]/,
+    '不得把未规范化的 user.id 当 Map 键',
+  );
   assert.doesNotMatch(
     source,
     /userList\.find/,

--- a/web/src/app/log/(pages)/event/strategy/detail/notifierSearch.ts
+++ b/web/src/app/log/(pages)/event/strategy/detail/notifierSearch.ts
@@ -5,7 +5,7 @@ interface NotifierOption {
 }
 
 export function buildNotifierUserIndex(users: UserItem[]): Map<string, UserItem> {
-  return new Map(users.map((user) => [user.id, user]));
+  return new Map(users.map((user) => [String(user.id), user]));
 }
 
 export function matchNotifierUser(user: UserItem | undefined, input: string): boolean {

--- a/web/src/app/log/types/index.ts
+++ b/web/src/app/log/types/index.ts
@@ -47,7 +47,7 @@ export interface TreeItem {
 }
 
 export interface UserItem {
-  id: string;
+  id: number | string;
   username: string;
   display_name: string;
   [key: string]: unknown;


### PR DESCRIPTION
## 复现步骤

前置：账号能编辑日志告警策略，组织候选里有用数字主键返回的本地用户。

1. 进入 **事件** → **策略**，打开 **创建策略** 或 **编辑策略**。
2. 在 **处理人** 选择框输入该用户的姓名或用户名。
3. 打开通知，**通知渠道** 选 **电子邮件**，在 **通知者** 选择框同样输入姓名。

修复前：API 返回数字主键时，选择框按姓名搜不到该用户。  
修复后：建索引和查找都按字符串规范化主键，数字 PK 与字符串 PK 都能命中。

## 修复方案

`buildNotifierUserIndex` 使用 `String(user.id)` 建键；`filterNotifierOption` 仍用 `String(option.value)` 查找。`UserItem.id` 类型改为 `number | string`。不改选项提交的原始 id、UUID `user_id`、权限和后端。

Fixes #5333

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 数字 PK 17，输入显示名 | `filterNotifierOption` 为 false | true |
| 数字 PK，option.value 为 `"17"` | 能命中 | 仍能命中 |
| 字符串 PK `alice-id` | 能命中 | 仍能命中 |

## 影响面

- **会变**：日志策略 **处理人** / **通知者** 搜索对数字主键候选生效。
- **不变**：菜单 **事件** / **策略**；页 **创建策略** / **编辑策略**；渠道 **电子邮件**。提交的原始 id、UUID `user_id`、组织候选限制。
- **不在范围**：未做浏览器端到端；未改后端用户接口。
