### PR TITLE
feature(openapi): 网关密钥引用支持 credential:，接入新服务免重建 server

### DIFF
--- a/docs/openapi-gateway/onboarding.md
+++ b/docs/openapi-gateway/onboarding.md
@@ -42,7 +42,32 @@ BK-Lite 统一网关把对外 API 收口到 `https://<平台地址>/openapi/v1/<
 
 ## 2. 接入四步
 
-### 步骤 1：配置允许清单与密钥（server 侧 env）
+### 步骤 1：配置允许清单与密钥
+
+密钥有两种存放方式，注册条目里用不同前缀引用，可按服务各自选择：
+
+| 方式 | 引用写法 | 生效 | 轮转 | 适用 |
+| --- | --- | --- | --- | --- |
+| **系统管理凭据（推荐）** | `credential:<凭据ID>` | 建好凭据即可引用，**无需重建 server** | 页面改值，一个拉取周期内生效 | 常规内网系统 |
+| server 环境变量 | `env:<变量名>` | 需透传并重建 server | 改 `.env` 并重建 server | 需与平台数据库隔离的高敏密钥 |
+
+两种方式安全水位不同：凭据方式的明文以平台 `SECRET_KEY` 加密落库，与系统管理里其它凭据
+同级；环境变量方式只存在于 server 容器环境。允许清单 `OPENAPI_BASEURL_ALLOWLIST`
+不论哪种方式都必须配在 server 环境里。
+
+**方式 A：系统管理凭据**
+
+1. 系统管理 → 凭据 → 新建，类型选「OpenAPI 网关密钥」，密钥字段填 32 位随机串，
+   归属组织任选（网关按凭据 ID 引用，不做组织范围检查）；
+2. 记下凭据 ID（形如 `crd-gateway_secret-<hex>`），步骤 2 写
+   `"shared_secret_ref": "credential:crd-gateway_secret-<hex>"`；
+3. 允许清单仍按下方方式 B 的第一条配置并重建 server（仅首次接入需要）。
+
+若复用其它类型的凭据，且该类型有多个 secret 字段，需用 `#` 指定字段：
+`credential:<凭据ID>#<字段ID>`。凭据被禁用或删除后该服务条目会被渲染器跳过（fail-closed），
+调用返回 404。
+
+**方式 B：server 环境变量**
 
 在部署目录的 `.env` 中配置，然后重建 server 容器：
 
@@ -133,7 +158,7 @@ done
 | `strip_prefix` | 否 | 默认 `true`：转发前去掉 `/openapi/v1/<服务名>` 前缀 |
 | `paths` | 否 | 接口级白名单（`/x/*` 形式）；**省略表示该前缀下全部路径都被反代** |
 | `auth_mode` | 是 | `trusted-header` 或 `service-token`，见第 3 节 |
-| `shared_secret_ref` | 条件 | `trusted-header` 模式必填，形如 `env:VAR`，**只存引用不存明文** |
+| `shared_secret_ref` | 条件 | `trusted-header` 模式必填，形如 `credential:<凭据ID>` 或 `env:VAR`，**只存引用不存明文** |
 | `token_ref` | 条件 | `service-token` 模式必填，同上 |
 | `required_roles` | 否 | 服务级粗粒度授权；**空数组 = 放行任意已认证身份** |
 | `rate_limit` | 否 | `{average, burst}`，按调用方分桶 |
@@ -359,7 +384,10 @@ docker logs --since 5m <traefik容器> 2>&1 | grep -i "provider error"
 | --- | --- | --- |
 | 步骤 1 中 `routers` 为空 | 条目被跳过 | 查 server 日志中 `openapi_registry 条目 X 被跳过：<原因>` |
 | 跳过原因 `base_url not in allowlist` | 允许清单未含该主机 | 补 `OPENAPI_BASEURL_ALLOWLIST` 并重建 server |
-| 跳过原因 `shared_secret_ref unresolvable` | server 容器内没有该 env | 见步骤 1 的透传配置 |
+| 跳过原因 `shared_secret_ref unresolvable (env var unset)` | server 容器内没有该 env | 见步骤 1 方式 B 的透传配置 |
+| 跳过原因 `... unresolvable (credential not_found / disabled)` | 凭据 ID 写错、已删除或已禁用 | 到系统管理 → 凭据核对 ID 与状态 |
+| 跳过原因 `... unresolvable (credential ambiguous_field)` | 所引用凭据类型有多个 secret 字段 | 改用 `credential:<ID>#<字段ID>` |
+| 跳过原因 `... unresolvable (credential lookup failed)` | 渲染时数据库不可用 | 查 server 日志 `failed_stage=credential_lookup`；DB 恢复后下次拉取自动生效 |
 | 步骤 2 中查不到 router | Traefik 未拉到配置 | 查步骤 3 的错误；注意 server 重启期间的 `connection refused` 属正常瞬时现象 |
 | `provider error` 报连接被拒 | server 未就绪 | 等待 server 启动完成，Traefik 会自动重试 |
 | **此前正常的外部服务突然全部 404** | 发生过 HA 主备切换，新主注册表为空 | 在新主执行 `wxc openapi list` 核对，缺失则重新 register（见步骤 3 的 HA 注意事项） |
@@ -408,7 +436,11 @@ docker exec "$(docker compose ps -q nats)" nats kv del openapi_registry <服务�
 
 **变更** `base_url` / `paths` / 限流 / 密钥引用：改条目重新 `register` 即可，一个拉取周期内生效，无需发版或重启（HA 栈仍需两端各做一次）。
 
-**共享密钥 / 服务令牌轮转**（`shared_secret_ref`、`token_ref` 指向的 env 值）：轮转**不是**改 KV 条目就能完成的，它需要重建 server 并与上游协同，属于有停顿窗口的操作：
+**共享密钥 / 服务令牌轮转**：
+
+- 引用为 `credential:` 时：在系统管理 → 凭据页改值，一个拉取周期内生效，server 不用重建。
+  仍需与上游协同（上游同时接受新旧密钥，或安排窗口），否则改值到上游切换之间调用会失败；
+- 引用为 `env:` 时：轮转**不是**改 KV 条目就能完成的，它需要重建 server 并与上游协同，属于有停顿窗口的操作：
 
 1. 与上游约定**双密钥并存窗口**（上游同时接受新旧两个密钥），无此能力则须安排停机窗口；
 2. 改 `.env` 中该变量的值；

--- a/server/apps/core/openapi/renderer.py
+++ b/server/apps/core/openapi/renderer.py
@@ -44,24 +44,64 @@ _snapshot = {
     "config": None,
     "services": [],
     "entries": {},
+    # 渲染时已归一化（含解引用后的密钥）的有效条目；读侧按名直取，
+    # 不在请求路径上重新解引用（credential: 引用会查库）
+    "normalized": {},
     "checked_at": 0.0,
     "fetch_started_at": 0.0,
 }
 
 
+REF_ENV_PREFIX = "env:"
+REF_CREDENTIAL_PREFIX = "credential:"
+
+
+def _resolve_credential_ref(spec: str):
+    """解析 "credential:<credential_id>[#<field_id>]"，返回 (value | None, detail)。
+
+    走系统管理「凭据」的服务端专用解析（不做组织范围检查：网关密钥是平台级
+    资源，注册权即使用权）；已禁用、不存在、字段歧义一律解析失败。DB 异常
+    按不可解析处理并告警，不外抛——渲染层的 fail-closed 语义与 env: 一致。
+    """
+    from apps.system_mgmt.services.credential_service import CredentialServiceError, resolve_secret_field
+
+    credential_id, _, field_id = spec.partition("#")
+    if not credential_id:
+        return None, "empty credential id"
+    try:
+        value = resolve_secret_field(credential_id, field_id or None)
+    except CredentialServiceError as exc:
+        return None, f"credential {exc.code}"
+    except Exception as exc:  # DB 不可达等：不可解析而非崩溃
+        logger.warning(
+            "openapi_registry 凭据引用解析失败 failed_stage=credential_lookup error_type=%s",
+            type(exc).__name__,
+        )
+        return None, "credential lookup failed"
+    return (value or None), ("" if value else "credential secret empty")
+
+
 def _resolve_ref(ref):
-    """解析 "env:VAR" 形式的引用；不可解析返回 None。"""
-    if not isinstance(ref, str) or not ref.startswith("env:"):
-        return None
-    return os.getenv(ref[len("env:"):]) or None
+    """解析密钥引用，返回 (value | None, detail)。
+
+    支持两种形式：
+    - "env:VAR"：server 进程环境变量；
+    - "credential:<credential_id>[#<field_id>]"：系统管理凭据（密文落库，
+      改值无需重建 server）。
+    未知前缀或明文一律不可解析。
+    """
+    if not isinstance(ref, str):
+        return None, "ref is not a string"
+    if ref.startswith(REF_ENV_PREFIX):
+        value = os.getenv(ref[len(REF_ENV_PREFIX) :]) or None
+        return value, ("" if value else "env var unset")
+    if ref.startswith(REF_CREDENTIAL_PREFIX):
+        return _resolve_credential_ref(ref[len(REF_CREDENTIAL_PREFIX) :])
+    return None, "unknown ref scheme"
 
 
 def _base_url_allowed(base_url: str) -> bool:
-    allow = [
-        item.strip()
-        for item in os.getenv("OPENAPI_BASEURL_ALLOWLIST", "").split(",")
-        if item.strip()
-    ]
+    allow = [item.strip() for item in os.getenv("OPENAPI_BASEURL_ALLOWLIST", "").split(",") if item.strip()]
     if not allow:
         return False
     if "*" in allow:
@@ -110,33 +150,26 @@ def validate_entry(name: str, entry, internal_services=()):
 
     secrets = {}
     if auth_mode == "trusted-header":
-        secret = _resolve_ref(entry.get("shared_secret_ref"))
+        secret, detail = _resolve_ref(entry.get("shared_secret_ref"))
         if not secret:
-            return None, "shared_secret_ref unresolvable"
+            return None, f"shared_secret_ref unresolvable ({detail})"
         secrets["shared_secret"] = secret
     else:  # service-token
-        token = _resolve_ref(entry.get("token_ref"))
+        token, detail = _resolve_ref(entry.get("token_ref"))
         if not token:
-            return None, "token_ref unresolvable"
+            return None, f"token_ref unresolvable ({detail})"
         secrets["service_token"] = token
 
     paths = entry.get("paths")
-    if paths is not None and (
-        not isinstance(paths, list) or not all(isinstance(p, str) and p for p in paths)
-    ):
+    if paths is not None and (not isinstance(paths, list) or not all(isinstance(p, str) and p for p in paths)):
         return None, "invalid paths"
 
     rate_limit = entry.get("rate_limit")
-    if rate_limit is not None and (
-        not isinstance(rate_limit, dict)
-        or not all(isinstance(rate_limit.get(k), int) for k in ("average", "burst"))
-    ):
+    if rate_limit is not None and (not isinstance(rate_limit, dict) or not all(isinstance(rate_limit.get(k), int) for k in ("average", "burst"))):
         return None, "invalid rate_limit"
 
     versions = entry.get("gateway_versions")
-    if versions is not None and (
-        not isinstance(versions, list) or not all(isinstance(v, str) for v in versions)
-    ):
+    if versions is not None and (not isinstance(versions, list) or not all(isinstance(v, str) for v in versions)):
         return None, "invalid gateway_versions"
     active = [v for v in (versions or ACTIVE_GATEWAY_VERSIONS) if v in ACTIVE_GATEWAY_VERSIONS]
     if not active:
@@ -181,7 +214,7 @@ def render_traefik_config(entries: dict, internal_services=()):
     返回 (config, report)。KV 字段与 Traefik 参数经本函数显式映射，
     两端命名不耦合。
     """
-    report = {"rendered": [], "skipped": {}}
+    report = {"rendered": [], "skipped": {}, "normalized": {}}
     routers, middlewares, services = {}, {}, {}
 
     auth_address = os.getenv("OPENAPI_AUTH_ADDRESS", "")
@@ -243,26 +276,16 @@ def render_traefik_config(entries: dict, internal_services=()):
                 }
             }
         else:
-            middlewares[inject] = {
-                "headers": {
-                    "customRequestHeaders": {
-                        "Authorization": f"Bearer {normalized['secrets']['service_token']}"
-                    }
-                }
-            }
+            middlewares[inject] = {"headers": {"customRequestHeaders": {"Authorization": f"Bearer {normalized['secrets']['service_token']}"}}}
         chain.append(inject)
 
-        services[f"openapi-{name}"] = {
-            "loadBalancer": {"servers": [{"url": normalized["base_url"]}]}
-        }
+        services[f"openapi-{name}"] = {"loadBalancer": {"servers": [{"url": normalized["base_url"]}]}}
 
         for version in normalized["versions"]:
             router_chain = list(chain)
             if normalized["strip_prefix"]:
                 strip = f"openapi-{name}-strip-{version}"
-                middlewares[strip] = {
-                    "stripPrefix": {"prefixes": [f"/openapi/{version}/{name}"]}
-                }
+                middlewares[strip] = {"stripPrefix": {"prefixes": [f"/openapi/{version}/{name}"]}}
                 router_chain.append(strip)
             routers[f"openapi-{version}-{name}"] = {
                 "rule": _router_rule(version, name, normalized["paths"]),
@@ -270,6 +293,7 @@ def render_traefik_config(entries: dict, internal_services=()):
                 "middlewares": router_chain,
             }
         report["rendered"].append(name)
+        report["normalized"][name] = normalized
 
     return _pack(routers, middlewares, services), report
 
@@ -322,6 +346,7 @@ def refresh_snapshot(internal_services=()):
         config, report = render_traefik_config(entries, internal_services)
         _snapshot["config"] = config
         _snapshot["entries"] = entries
+        _snapshot["normalized"] = dict(report["normalized"])
         _snapshot["services"] = list(report["rendered"])
         return config
 
@@ -375,10 +400,15 @@ def _ensure_snapshot_fresh():
 
 
 def _background_refresh_run():
+    from django.db import connections
+
     try:
         refresh_snapshot(internal_services=_internal_services())
     except Exception:  # 后台对账绝不外抛
         logger.exception("openapi_registry 后台对账失败")
+    finally:
+        # credential: 引用解析会在本线程开 DB 连接；线程即将结束，显式归还
+        connections.close_all()
 
 
 def _refresh_in_background():
@@ -386,12 +416,9 @@ def _refresh_in_background():
 
 
 def _get_entry_normalized(name: str):
+    """读侧按名取渲染期已归一化的条目；未渲染成功（被跳过）即视为不存在。"""
     with _lock:
-        entry = _snapshot["entries"].get(name)
-    if entry is None:
-        return None
-    normalized, _ = validate_entry(name, entry)
-    return normalized
+        return _snapshot["normalized"].get(name)
 
 
 def get_external_services():

--- a/server/apps/core/openapi/tests/conftest.py
+++ b/server/apps/core/openapi/tests/conftest.py
@@ -14,6 +14,7 @@ _EMPTY_SNAPSHOT = {
     "config": None,
     "services": [],
     "entries": {},
+    "normalized": {},
     "checked_at": 0.0,
     "fetch_started_at": 0.0,
 }

--- a/server/apps/core/openapi/tests/test_renderer.py
+++ b/server/apps/core/openapi/tests/test_renderer.py
@@ -61,12 +61,8 @@ def test_good_entry_full_structure(env):
     # 注入共享密钥的同时必须清除调用方的平台凭据，避免上游拿到 API 令牌后冒充调用方
     assert inject == {"X-BK-Gateway-Auth": "s3cret", "Authorization": ""}
 
-    assert http["middlewares"]["openapi-itsm-strip-v1"]["stripPrefix"]["prefixes"] == [
-        "/openapi/v1/itsm"
-    ]
-    assert http["services"]["openapi-itsm"]["loadBalancer"]["servers"] == [
-        {"url": "http://itsm-svc:8000"}
-    ]
+    assert http["middlewares"]["openapi-itsm-strip-v1"]["stripPrefix"]["prefixes"] == ["/openapi/v1/itsm"]
+    assert http["services"]["openapi-itsm"]["loadBalancer"]["servers"] == [{"url": "http://itsm-svc:8000"}]
 
 
 def test_service_token_mode_injects_authorization(env):
@@ -74,9 +70,7 @@ def test_service_token_mode_injects_authorization(env):
     entry.pop("shared_secret_ref")
     config, report = render_one(entry)
     assert report["rendered"] == ["itsm"]
-    inject = config["http"]["middlewares"]["openapi-itsm-inject"]["headers"][
-        "customRequestHeaders"
-    ]
+    inject = config["http"]["middlewares"]["openapi-itsm-inject"]["headers"]["customRequestHeaders"]
     assert inject == {"Authorization": "Bearer tok-abc"}
 
 
@@ -84,10 +78,7 @@ def test_no_paths_renders_whole_prefix(env):
     entry = dict(GOOD)
     entry.pop("paths")
     config, _ = render_one(entry)
-    assert (
-        config["http"]["routers"]["openapi-v1-itsm"]["rule"]
-        == "PathPrefix(`/openapi/v1/itsm`)"
-    )
+    assert config["http"]["routers"]["openapi-v1-itsm"]["rule"] == "PathPrefix(`/openapi/v1/itsm`)"
 
 
 def test_unknown_fields_ignored(env):
@@ -142,11 +133,11 @@ def test_reserved_name_rejected(env):
 @pytest.mark.parametrize(
     "host, allowed",
     [
-        ("itsm-svc", True),           # 精确匹配
-        ("a.itsm-svc", True),         # 点边界后缀
-        ("evil-itsm-svc", False),     # 同尾但非点边界，必须拒绝
+        ("itsm-svc", True),  # 精确匹配
+        ("a.itsm-svc", True),  # 点边界后缀
+        ("evil-itsm-svc", False),  # 同尾但非点边界，必须拒绝
         ("xitsm-svc", False),
-        ("svc.internal", True),       # allowlist 中的 .internal 后缀
+        ("svc.internal", True),  # allowlist 中的 .internal 后缀
         ("evilinternal", False),
     ],
 )
@@ -226,6 +217,7 @@ def clock(monkeypatch):
             "config": None,
             "services": [],
             "entries": {},
+            "normalized": {},
             "checked_at": 0.0,
             "fetch_started_at": 0.0,
         },

--- a/server/apps/core/openapi/tests/test_secret_refs.py
+++ b/server/apps/core/openapi/tests/test_secret_refs.py
@@ -1,0 +1,181 @@
+"""密钥引用解析（credential: 方案）测试，需 DB。
+
+覆盖：credential: 引用渲染成功、不存在 / 已禁用 / 字段歧义 / 未知字段 /
+DB 异常时 fail-closed、env: 行为不变、读侧不在请求路径重新解引用。
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from apps.core.openapi import renderer
+from apps.system_mgmt.models.credential import CredentialType
+from apps.system_mgmt.models.user import Group
+from apps.system_mgmt.services.credential_service import (
+    CredentialServiceError,
+    create_credential,
+    resolve_secret_field,
+    seed_builtin_types,
+    set_disabled,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.django_db]
+
+ENTRY = {
+    "schema_version": 1,
+    "type": "http",
+    "base_url": "http://itsm-svc:8000",
+    "auth_mode": "trusted-header",
+    "required_roles": [],
+    "enabled": True,
+}
+
+
+def _actor(group_id):
+    return SimpleNamespace(
+        current_team=group_id,
+        group_list=[group_id],
+        is_superuser=True,
+        username="gw-test",
+        domain="domain.com",
+    )
+
+
+@pytest.fixture
+def env(monkeypatch):
+    monkeypatch.setenv("OPENAPI_BASEURL_ALLOWLIST", "itsm-svc")
+    monkeypatch.setenv("OPENAPI_AUTH_ADDRESS", "http://server:8000/openapi/v1/_auth")
+
+
+@pytest.fixture
+def owner():
+    seed_builtin_types()
+    return Group.objects.create(name="gw-owner", parent_id=0, is_delete=False)
+
+
+def _gateway_secret(owner, value="s3cret-from-db", name="itsm"):
+    return create_credential(
+        {"name": name, "type": "gateway_secret", "group_id": owner.id, "fields": {"secret": value}},
+        _actor(owner.id),
+    )
+
+
+def _render(entry):
+    return renderer.render_traefik_config({"itsm": entry}, ())
+
+
+def test_credential_ref_renders_shared_secret(env, owner):
+    cred = _gateway_secret(owner)
+    entry = dict(ENTRY, shared_secret_ref=f"credential:{cred.credential_id}")
+    config, report = _render(entry)
+    assert report["rendered"] == ["itsm"]
+    inject = config["http"]["middlewares"]["openapi-itsm-inject"]["headers"]["customRequestHeaders"]
+    assert inject["X-BK-Gateway-Auth"] == "s3cret-from-db"
+    assert inject["Authorization"] == ""
+
+
+def test_credential_ref_service_token_mode(env, owner):
+    cred = _gateway_secret(owner, value="tok-from-db")
+    entry = dict(ENTRY, auth_mode="service-token", token_ref=f"credential:{cred.credential_id}")
+    config, report = _render(entry)
+    assert report["rendered"] == ["itsm"]
+    inject = config["http"]["middlewares"]["openapi-itsm-inject"]["headers"]["customRequestHeaders"]
+    assert inject["Authorization"] == "Bearer tok-from-db"
+
+
+def test_explicit_field_selects_secret_on_multi_secret_type(env, owner):
+    typ = CredentialType.objects.create(
+        key="two-secrets",
+        name="two",
+        categories=["other"],
+        fields=[
+            {"id": "a", "kind": "secret", "required": True},
+            {"id": "b", "kind": "secret", "required": True},
+        ],
+    )
+    cred = create_credential(
+        {"name": "x", "type": typ.key, "group_id": owner.id, "fields": {"a": "AAA", "b": "BBB"}},
+        _actor(owner.id),
+    )
+    assert resolve_secret_field(cred.credential_id, "b") == "BBB"
+    with pytest.raises(CredentialServiceError) as exc:
+        resolve_secret_field(cred.credential_id)
+    assert exc.value.code == "ambiguous_field"
+    with pytest.raises(CredentialServiceError) as exc:
+        resolve_secret_field(cred.credential_id, "nope")
+    assert exc.value.code == "unknown_field"
+
+    _, report = _render(dict(ENTRY, shared_secret_ref=f"credential:{cred.credential_id}"))
+    assert report["skipped"]["itsm"] == "shared_secret_ref unresolvable (credential ambiguous_field)"
+    config, report = _render(dict(ENTRY, shared_secret_ref=f"credential:{cred.credential_id}#b"))
+    assert report["rendered"] == ["itsm"]
+    inject = config["http"]["middlewares"]["openapi-itsm-inject"]["headers"]["customRequestHeaders"]
+    assert inject["X-BK-Gateway-Auth"] == "BBB"
+
+
+@pytest.mark.parametrize(
+    "ref, reason",
+    [
+        ("credential:crd-gateway_secret-missing", "shared_secret_ref unresolvable (credential not_found)"),
+        ("credential:", "shared_secret_ref unresolvable (empty credential id)"),
+        ("vault:whatever", "shared_secret_ref unresolvable (unknown ref scheme)"),
+        ("plain-text-secret", "shared_secret_ref unresolvable (unknown ref scheme)"),
+        ("env:GW_TEST_UNSET_VAR", "shared_secret_ref unresolvable (env var unset)"),
+    ],
+)
+def test_unresolvable_refs_skip_entry(env, owner, ref, reason):
+    config, report = _render(dict(ENTRY, shared_secret_ref=ref))
+    assert report["rendered"] == []
+    assert report["skipped"]["itsm"] == reason
+    assert "routers" not in config["http"]
+
+
+def test_disabled_credential_is_fail_closed(env, owner):
+    cred = _gateway_secret(owner)
+    set_disabled(cred.credential_id, True, actor=_actor(owner.id))
+    _, report = _render(dict(ENTRY, shared_secret_ref=f"credential:{cred.credential_id}"))
+    assert report["skipped"]["itsm"] == "shared_secret_ref unresolvable (credential disabled)"
+
+
+def test_db_failure_is_unresolvable_not_crash(env, owner, monkeypatch, caplog):
+    cred = _gateway_secret(owner)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr("apps.system_mgmt.services.credential_service.resolve_secret_field", boom)
+    with caplog.at_level("WARNING", logger="openapi"):
+        _, report = _render(dict(ENTRY, shared_secret_ref=f"credential:{cred.credential_id}"))
+    assert report["skipped"]["itsm"] == "shared_secret_ref unresolvable (credential lookup failed)"
+    logged = [r for r in caplog.records if "failed_stage=credential_lookup" in r.getMessage()]
+    assert logged and "error_type=RuntimeError" in logged[0].getMessage()
+    assert "s3cret-from-db" not in caplog.text and "db down" not in caplog.text
+
+
+def test_env_ref_unchanged(env, owner, monkeypatch):
+    monkeypatch.setenv("GW_TEST_SECRET", "from-env")
+    config, report = _render(dict(ENTRY, shared_secret_ref="env:GW_TEST_SECRET"))
+    assert report["rendered"] == ["itsm"]
+    inject = config["http"]["middlewares"]["openapi-itsm-inject"]["headers"]["customRequestHeaders"]
+    assert inject["X-BK-Gateway-Auth"] == "from-env"
+
+
+def test_read_side_uses_rendered_snapshot_without_reresolving(env, owner, monkeypatch):
+    cred = _gateway_secret(owner)
+    entries = {"itsm": dict(ENTRY, shared_secret_ref=f"credential:{cred.credential_id}")}
+    monkeypatch.setattr(renderer, "fetch_entries", lambda: entries)
+    renderer.refresh_snapshot()
+
+    calls = []
+
+    def counting(*args, **kwargs):
+        calls.append(args)
+        raise AssertionError("read path must not resolve secrets")
+
+    monkeypatch.setattr("apps.system_mgmt.services.credential_service.resolve_secret_field", counting)
+    monkeypatch.setenv("OPENAPI_REGISTRY_CACHE_TTL", "3600")
+    entry = renderer.get_external_entry("itsm")
+    assert entry is not None
+    assert entry["secrets"]["shared_secret"] == "s3cret-from-db"
+    assert renderer.get_external_entry("nope") is None
+    assert calls == []

--- a/server/apps/system_mgmt/services/credential_builtin.py
+++ b/server/apps/system_mgmt/services/credential_builtin.py
@@ -2,7 +2,6 @@
 
 from copy import deepcopy
 
-
 BUILTIN_TYPES = {
     "ssh": {
         "name": "SSH",
@@ -144,6 +143,13 @@ BUILTIN_TYPES = {
         "categories": ["database", "other"],
         "fields": [
             {"id": "token", "name": "Token", "kind": "secret", "required": True},
+        ],
+    },
+    "gateway_secret": {
+        "name": "OpenAPI 网关密钥",
+        "categories": ["other"],
+        "fields": [
+            {"id": "secret", "name": "共享密钥 / 服务令牌", "kind": "secret", "required": True},
         ],
     },
     "oauth_client": {

--- a/server/apps/system_mgmt/services/credential_service.py
+++ b/server/apps/system_mgmt/services/credential_service.py
@@ -14,7 +14,7 @@ from apps.system_mgmt.models.credential import Credential, CredentialType
 from apps.system_mgmt.models.user import Group
 from apps.system_mgmt.services.credential_builtin import builtin_type_payloads
 from apps.system_mgmt.services.credential_crypto import decrypt_instance_fields, encrypt_instance_fields, public_instance_fields
-from apps.system_mgmt.services.credential_schema import SchemaError, validate_instance_fields, validate_type_fields
+from apps.system_mgmt.services.credential_schema import SchemaError, secret_field_ids, validate_instance_fields, validate_type_fields
 from apps.system_mgmt.services.credential_scope import is_current_team_authorized, manageable_owner_group_ids, usable_owner_group_ids
 
 
@@ -473,6 +473,31 @@ def resolve_credential(credential_id, current_team, actor=None, *, group_list=No
     result = _public_credential(credential)
     result["fields"] = decrypt_instance_fields(credential.type.fields, credential.fields)
     return result
+
+
+def resolve_secret_field(credential_id, field_id=None):
+    """服务端专用：解出一个 secret 字段的明文（OpenAPI 网关 credential: 引用）。
+
+    不做组织范围检查——网关密钥是平台级资源，能写注册表即有权引用。
+    未指定 field_id 时该类型必须恰有一个 secret 字段，否则报 ambiguous_field。
+    结果只应进入进程内渲染快照，禁止写日志或返回给客户端。
+    """
+    credential = _load_credential(credential_id)
+    if credential.disabled:
+        raise CredentialServiceError("disabled")
+    secret_ids = secret_field_ids(credential.type.fields)
+    if field_id:
+        if field_id not in secret_ids:
+            raise CredentialServiceError("unknown_field")
+    elif len(secret_ids) == 1:
+        field_id = secret_ids[0]
+    else:
+        raise CredentialServiceError("ambiguous_field")
+    values = decrypt_instance_fields(credential.type.fields, credential.fields)
+    value = values.get(field_id)
+    if not isinstance(value, str) or not value:
+        raise CredentialServiceError("empty")
+    return value
 
 
 def query_credentials(filters=None, actor=None, **values):

--- a/server/apps/system_mgmt/tests/test_credential_service.py
+++ b/server/apps/system_mgmt/tests/test_credential_service.py
@@ -79,11 +79,13 @@ def test_seed_builtin_types_is_idempotent_and_authoritative():
         "network_cli",
         "token",
         "oauth_client",
+        "gateway_secret",
     }
     assert CredentialType.objects.get(key="platform_api").categories == ["cloud", "storage"]
     assert CredentialType.objects.get(key="network_cli").categories == ["network"]
     assert CredentialType.objects.get(key="token").categories == ["database", "other"]
     assert CredentialType.objects.get(key="oauth_client").categories == ["cloud"]
+    assert CredentialType.objects.get(key="gateway_secret").categories == ["other"]
     ssh_fields = {field["id"]: field for field in CredentialType.objects.get(key="ssh").fields}
     assert ssh_fields["username"]["name"] == "用户名"
     assert ssh_fields["auth_method"]["name"] == "认证方式"

--- a/specs/capabilities/openapi-gateway.md
+++ b/specs/capabilities/openapi-gateway.md
@@ -75,8 +75,12 @@
 
 ## 5. 外部服务注册与部署侧红线
 
-- ✅ **注册条目只存引用不存明文**：`shared_secret_ref` / `token_ref` 用 `env:VAR` 形式。
+- ✅ **注册条目只存引用不存明文**：`shared_secret_ref` / `token_ref` 用 `credential:<凭据ID>[#<字段ID>]`
+  （系统管理凭据，密文落库，改值无需重建 server）或 `env:VAR`（server 环境变量）形式；
+  渲染器只认这两种前缀，其余一律不可解析。
   - ❌ 把密钥明文写进 KV 条目——KV 无加密语义，读权限即等于拿到凭据。
+  - ⚠️ `credential:` 解析不做组织范围检查（网关密钥是平台级资源），且只在渲染期查库；
+    读侧（`_auth` / `_docs` / `_me`）从快照取已归一化条目，**不得**在请求路径上重新解引用。
 - ✅ **`base_url` 允许清单 fail-closed**：未配置 `OPENAPI_BASEURL_ALLOWLIST` 即拒绝一切外部条目；
   后缀匹配须落在**点边界**（`itsm-svc` 不得放行 `evil-itsm-svc`）。
 - ✅ **注册即封锁直连**：外部服务端口若可绕过 Traefik 直达，统一认证 / 审计 / 限流即成摆设；


### PR DESCRIPTION
## 背景

注册条目的 `shared_secret_ref` / `token_ref` 此前只支持 `env:VAR`，密钥明文只能从 server 进程环境注入。带来的问题是：

- 每接入一个外部服务，都要改 `.env`、在 `compose/server.yaml` 补一行透传、重建 server（约 1 分钟不可用）。这与「写 NATS KV 秒级生效、不发版」的注册链路完全不对等；
- 密钥轮转同样要重建 server，必须与上游协同安排停顿窗口；
- 变量名漏透传时，条目被渲染器静默跳过，现场表现为「注册成功但调用 404」，只有翻 server 日志才能看到 `shared_secret_ref unresolvable`。

一次真实接入中，这条路径连续卡了两轮，两轮的修复动作都是改环境变量并重建容器。

## 改动

新增 `credential:<凭据ID>[#<字段ID>]` 引用形式，复用 [#5199](https://github.com/TencentBlueKing/bk-lite/pull/5199) 引入的 system_mgmt 凭据体系：明文经 `SECRET_KEY` 加密落库，页面可维护，改值一个拉取周期内生效，server 不用重建。

`env:` 保持原样，两种形式共存，存量环境不受影响。`design.md` 3.5.3 原本就写明引用可以是「环境变量或 secret」，本次补齐第二种。

具体：

- **renderer**：`_resolve_ref` 改为按前缀分发并返回失败细节。跳过原因从笼统的 `shared_secret_ref unresolvable` 细化到 `(credential not_found)` / `(credential disabled)` / `(credential ambiguous_field)` / `(env var unset)` 等具体成因，便于现场定位。凭据不存在、已禁用、字段歧义、DB 异常一律 fail-closed，不降级为无凭据转发。
- **读侧**：渲染期已归一化的条目缓存进快照，`_auth` / `_docs` / `_me` 按名直取。否则每次 ForwardAuth 都会多一次查库——外部服务的每个请求都要过 ForwardAuth，这条路径必须无 DB 依赖。
- **后台对账线程**结束时显式归还 DB 连接。
- **system_mgmt**：新增内置凭据类型 `gateway_secret`（OpenAPI 网关密钥），与服务端专用的 `resolve_secret_field`。后者不做组织范围检查，因为网关密钥是平台级资源，能写注册表即有权引用。

## 用法

系统管理 → 凭据 → 新建「OpenAPI 网关密钥」，拿到凭据 ID 后注册条目写：

```json
"shared_secret_ref": "credential:crd-gateway_secret-<hex>"
```

引用其它类型的凭据、且该类型有多个 secret 字段时，用 `#` 指定：`credential:<ID>#<字段ID>`。

## 测试

新增 `server/apps/core/openapi/tests/test_secret_refs.py`，覆盖两种 auth_mode 的渲染、多 secret 字段的字段选择、五类不可解析引用、禁用凭据、DB 异常不崩且日志不泄露密钥、读侧不重新解引用。

本地验证（sqlite）：网关与凭据相关测试 135 通过。三个失败与本改动无关，为本地环境所致：两条 governance 因未安装 alerts 应用，一条凭据列表因 sqlite 不支持 JSON `contains`。

## 后续

配套的 wxc 侧改造见 WeOps-Lab/bklite-website#124。其中一项是阻塞项：wxc 的本地预检目前硬校验 `env:` 前缀，需放行 `credential:`，否则新形式的条目会被客户端拦下。同一 issue 还记录了「注册时自动生成密钥并输出」「list 展示密钥引用」「base_url 允许清单入库」三项，其中允许清单目前仍是 server 环境变量，是本轮之后剩下的最后一处「改配置要重建 server」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
