### PR TITLE
bugfix: get_user_info 消费预取组角色避免逐组查询

### DIFF
--- a/server/apps/console_mgmt/tests/test_get_user_info_group_roles.py
+++ b/server/apps/console_mgmt/tests/test_get_user_info_group_roles.py
@@ -1,0 +1,89 @@
+"""get_user_info 所属组角色收集：prefetch 后不得再对每组发 values_list 查询。"""
+import inspect
+
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from apps.console_mgmt import views
+from apps.console_mgmt.user_info_roles import collect_prefetched_group_role_ids
+from apps.system_mgmt.models import Group, Role
+
+pytestmark = [pytest.mark.django_db]
+
+
+def _prefetch_groups(group_ids):
+    return list(Group.objects.filter(id__in=group_ids).prefetch_related("roles"))
+
+
+def _create_groups_with_roles(group_count, *, empty=False, shared_role=None):
+    groups = []
+    expected_ids = set()
+    for index in range(group_count):
+        group = Group.objects.create(name=f"issue5188-g{index}", parent_id=0)
+        groups.append(group)
+        if empty:
+            continue
+        role = Role.objects.create(name=f"issue5188-r{index}", app="console")
+        group.roles.add(role)
+        expected_ids.add(role.id)
+        if shared_role is not None:
+            group.roles.add(shared_role)
+            expected_ids.add(shared_role.id)
+    return groups, expected_ids
+
+
+def test_empty_groups_do_not_query_roles():
+    with CaptureQueriesContext(connection) as captured:
+        role_ids = collect_prefetched_group_role_ids([])
+
+    assert role_ids == set()
+    assert len(captured.captured_queries) == 0
+
+
+@pytest.mark.parametrize("group_count", [1, 10, 100])
+def test_prefetched_role_collection_query_count_does_not_grow_with_groups(group_count):
+    groups, expected_ids = _create_groups_with_roles(group_count)
+    prefetched = _prefetch_groups([group.id for group in groups])
+
+    with CaptureQueriesContext(connection) as captured:
+        role_ids = collect_prefetched_group_role_ids(prefetched)
+
+    assert role_ids == expected_ids
+    assert len(captured.captured_queries) == 0, (
+        f"G={group_count} 预取后仍发出 {len(captured.captured_queries)} 次查询，"
+        "说明未消费 prefetch 缓存。"
+    )
+
+
+def test_duplicate_roles_across_groups_are_deduped():
+    shared = Role.objects.create(name="issue5188-shared", app="console")
+    only_first = Role.objects.create(name="issue5188-only-first", app="console")
+    first = Group.objects.create(name="issue5188-dup-a", parent_id=0)
+    second = Group.objects.create(name="issue5188-dup-b", parent_id=0)
+    first.roles.add(shared, only_first)
+    second.roles.add(shared)
+    prefetched = _prefetch_groups([first.id, second.id])
+
+    with CaptureQueriesContext(connection) as captured:
+        role_ids = collect_prefetched_group_role_ids(prefetched)
+
+    assert role_ids == {shared.id, only_first.id}
+    assert len(captured.captured_queries) == 0
+
+
+def test_empty_role_groups_return_empty_set_without_queries():
+    empty_group = Group.objects.create(name="issue5188-empty-roles", parent_id=0)
+    prefetched = _prefetch_groups([empty_group.id])
+
+    with CaptureQueriesContext(connection) as captured:
+        role_ids = collect_prefetched_group_role_ids(prefetched)
+
+    assert role_ids == set()
+    assert len(captured.captured_queries) == 0
+
+
+def test_get_user_info_uses_extracted_collector_without_values_list():
+    source = inspect.getsource(views.get_user_info)
+    assert "collect_prefetched_group_role_ids" in source
+    assert "values_list" not in source

--- a/server/apps/console_mgmt/user_info_roles.py
+++ b/server/apps/console_mgmt/user_info_roles.py
@@ -1,0 +1,9 @@
+def collect_prefetched_group_role_ids(groups):
+    """从已 prefetch roles 的组迭代器收集去重后的角色 ID。
+
+    调用方须先 prefetch_related("roles")。本函数只消费预取缓存，不自行查询。
+    """
+    role_ids = set()
+    for group in groups:
+        role_ids.update(role.id for role in group.roles.all())
+    return role_ids

--- a/server/apps/console_mgmt/views.py
+++ b/server/apps/console_mgmt/views.py
@@ -9,6 +9,7 @@ from django.db import transaction
 from django.http import JsonResponse
 from django.utils import timezone as django_timezone
 
+from apps.console_mgmt.user_info_roles import collect_prefetched_group_role_ids
 from apps.core.utils.builtin_app_i18n import localized_app_display_name
 from apps.core.utils.loader import LanguageLoader
 from apps.rpc.system_mgmt import SystemMgmt
@@ -353,8 +354,7 @@ def get_user_info(request):
         role_ids = set(user.role_list) if user.role_list else set()
         if user.group_list:
             groups = Group.objects.filter(id__in=user.group_list).prefetch_related("roles")
-            for group in groups:
-                role_ids.update(group.roles.values_list("id", flat=True))
+            role_ids.update(collect_prefetched_group_role_ids(groups))
 
         # 将role_list中的ID转换为角色信息（包含app显示名称）
         role_info = []


### PR DESCRIPTION
## 复现步骤

前置：账号已登录，且 `system_mgmt.User.group_list` 里有多个组织。

1. 打开控制台，点右上角头像，选 **用户信息**。
2. 抽屉会请求 `/console_mgmt/get_user_info/`，页里 **角色权限** / **应用权限** 来自该接口的 `role_list`。
3. 对照服务端：`prefetch_related("roles")` 之后是否还对每个组发 `values_list`。

修复前：所属组数为 G 时，收集组角色会再发 G 次查询。  
修复后：预取缓存被消费，该段查询数不随 G 增长；`role_list` 内容不变。

## 修复方案

抽出 `collect_prefetched_group_role_ids`，迭代 `group.roles.all()` 取 `role.id`。`get_user_info` 仍先 `prefetch_related("roles")`，再并入用户直接 `role_list` 并去重。不改接口字段。

Fixes #5188

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| G=1/10/100 预取后收集角色 | 循环内查询随 G 增加 | 循环内 0 次查询 |
| 跨组重复角色 | set 去重 | 仍去重 |
| 空组 / 无角色组 | 可跑 | 不发额外查询 |

## 影响面

- **会变**：`get_user_info` 收集所属组角色时不再对每组发投影查询。
- **不变**：菜单项 **用户信息**；抽屉 **角色权限** / **应用权限**；返回字段和去重语义。
- **不在范围**：未测整个接口总查询数；未改 `get_user_group_paths`。
