### PR TITLE
fix(监控): 资产更新配置可拉取并选择云地域

### DIFF
--- a/server/apps/core/utils/crypto/aes_crypto.py
+++ b/server/apps/core/utils/crypto/aes_crypto.py
@@ -1,22 +1,23 @@
 import hashlib
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 
-from apps.core.logger import logger
-from config.components.base import SECRET_KEY
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad, unpad
+
+from apps.core.logger import logger
+from config.components.base import SECRET_KEY
 
 
 class AESCryptor:
     def __init__(self):
         if not SECRET_KEY:
             raise ValueError("SECRET_KEY 不能为空")
-        
+
         # 使用SHA256代替MD5提升安全性
         self.__key = hashlib.sha256(SECRET_KEY.encode("utf8")).digest()[:32]
 
     def encode(self, plaintext):
-        """ AES encryption """
+        """AES encryption"""
         if not plaintext:
             raise ValueError("待加密文本不能为空")
 
@@ -29,27 +30,31 @@ class AESCryptor:
             logger.error(f"AES 编码失败: {e}")
             raise
 
-    def decode(self, ciphertext):
-        """ AES decryption """
+    def _decrypt(self, ciphertext):
         if not ciphertext:
             raise ValueError("待解密文本不能为空")
+        padding_needed = 4 - len(ciphertext) % 4
+        if padding_needed != 4:
+            ciphertext += "=" * padding_needed
+        decoded_data = urlsafe_b64decode(ciphertext)
+        if len(decoded_data) < AES.block_size:
+            raise ValueError("加密数据格式错误：长度不足")
+        iv = decoded_data[: AES.block_size]
+        actual_ciphertext = decoded_data[AES.block_size :]
+        cipher = AES.new(self.__key, AES.MODE_CBC, iv)
+        return unpad(cipher.decrypt(actual_ciphertext), AES.block_size).decode("utf8")
 
+    def decode(self, ciphertext):
+        """AES decryption"""
         try:
-            # 补齐 base64 填充
-            padding_needed = 4 - len(ciphertext) % 4
-            if padding_needed != 4:
-                ciphertext += "=" * padding_needed
-
-            decoded_data = urlsafe_b64decode(ciphertext)
-
-            if len(decoded_data) < AES.block_size:
-                raise ValueError("加密数据格式错误：长度不足")
-
-            iv = decoded_data[:AES.block_size]
-            actual_ciphertext = decoded_data[AES.block_size:]
-            cipher = AES.new(self.__key, AES.MODE_CBC, iv)
-            result = unpad(cipher.decrypt(actual_ciphertext), AES.block_size).decode("utf8")
-            return result
+            return self._decrypt(ciphertext)
         except Exception as e:
             logger.error(f"AES 解码失败: {e}")
             raise
+
+    def try_decode(self, ciphertext):
+        """解密失败返回 None，不打错误日志（表单可能传来明文 SecretKey）。"""
+        try:
+            return self._decrypt(ciphertext)
+        except Exception:
+            return None

--- a/server/apps/monitor/services/aliyun_regions.py
+++ b/server/apps/monitor/services/aliyun_regions.py
@@ -4,8 +4,37 @@ from __future__ import annotations
 
 from apps.core.exceptions.base_app_exception import ValidationAppException
 from apps.core.logger import monitor_logger as logger
-from apps.monitor.services.qcloud_regions import _resolve_stargazer_cloud_name
+from apps.monitor.services.qcloud_regions import (
+    _normalize_collect_config_ids,
+    _resolve_stargazer_cloud_name,
+    maybe_decrypt_posted_cloud_secret,
+    resolve_stored_cloud_credentials,
+)
 from apps.rpc.stargazer import Stargazer
+
+_ALIYUN_AUTH_FAILED = "AccessKey 无效或权限不足，请检查 AccessKey ID / AccessKey Secret"
+
+
+def _public_aliyun_region_error(message) -> str:
+    """阿里云地域拉取失败时的用户可见文案，禁止泄漏腾讯云 SDK 异常原文。"""
+    text = str(message or "").strip()
+    lowered = text.lower()
+    if (
+        "TencentCloudSDKException" in text
+        or "SecretIdNotFound" in text
+        or "SecretId不存在" in text
+        or "invalidaccesskey" in lowered
+        or "signaturedoesnotmatch" in lowered
+        or "authfailure" in lowered
+        or "forbidden.ram" in lowered
+        or "specified access key is not found" in lowered
+    ):
+        return _ALIYUN_AUTH_FAILED
+    if not text:
+        return "获取阿里云地域失败"
+    if "SDKException" in text or "requestId" in text:
+        return "获取阿里云地域失败，请检查 AccessKey 是否正确且具备 ECS DescribeRegions 权限"
+    return text
 
 
 def _normalize_aliyun_regions(regions: list) -> list[dict]:
@@ -13,23 +42,12 @@ def _normalize_aliyun_regions(regions: list) -> list[dict]:
     for region in regions or []:
         if not isinstance(region, dict):
             continue
-        resource_id = (
-            region.get("resource_id")
-            or region.get("RegionId")
-            or region.get("Region")
-            or ""
-        )
-        resource_name = (
-            region.get("resource_name")
-            or region.get("LocalName")
-            or resource_id
-        )
+        resource_id = region.get("resource_id") or region.get("RegionId") or region.get("Region") or ""
+        resource_name = region.get("resource_name") or region.get("LocalName") or resource_id
         resource_id = str(resource_id or "").strip()
         if not resource_id:
             continue
-        state = str(
-            region.get("status") or region.get("RegionStatus") or region.get("RegionState") or ""
-        ).strip().lower()
+        state = str(region.get("status") or region.get("RegionStatus") or region.get("RegionState") or "").strip().lower()
         if state and state not in ("available", "avail"):
             continue
         normalized.append(
@@ -48,12 +66,17 @@ class AliyunRegionService:
     def list_regions(
         cls,
         *,
-        username: str,
-        password: str,
+        username: str = "",
+        password: str = "",
         cloud_region_id=None,
+        collect_config_id=None,
+        actor_context=None,
     ) -> list[dict]:
+        config_ids = _normalize_collect_config_ids(collect_config_id)
+        if config_ids:
+            username, password = resolve_stored_cloud_credentials(config_ids, actor_context)
         access_key = str(username or "").strip()
-        access_secret = str(password or "").strip()
+        access_secret = maybe_decrypt_posted_cloud_secret(password)
         if not access_key or not access_secret:
             raise ValidationAppException("AccessKey ID 与 AccessKey Secret 均必填")
 
@@ -69,8 +92,7 @@ class AliyunRegionService:
             result = Stargazer(instance_id=instance_id).list_regions(credential)
         except Exception as exc:
             logger.error(
-                "event=aliyun_list_regions_rpc_failed failed_stage=stargazer_list_regions "
-                "cloud_name=%s error_type=%s",
+                "event=aliyun_list_regions_rpc_failed failed_stage=stargazer_list_regions " "cloud_name=%s error_type=%s",
                 cloud_name,
                 type(exc).__name__,
                 exc_info=True,
@@ -81,8 +103,7 @@ class AliyunRegionService:
             raise ValidationAppException("获取阿里云地域失败")
 
         if result.get("success") is False:
-            message = result.get("error") or result.get("message") or "获取阿里云地域失败"
-            raise ValidationAppException(str(message))
+            raise ValidationAppException(_public_aliyun_region_error(result.get("error") or result.get("message")))
 
         regions_payload = result.get("regions") or {}
         if not isinstance(regions_payload, dict):
@@ -91,8 +112,7 @@ class AliyunRegionService:
             raise ValidationAppException("获取阿里云地域失败")
 
         if regions_payload.get("success") is False:
-            message = regions_payload.get("message") or result.get("error") or "获取阿里云地域失败"
-            raise ValidationAppException(str(message))
+            raise ValidationAppException(_public_aliyun_region_error(regions_payload.get("message") or result.get("error")))
 
         raw_regions = regions_payload.get("result")
         if raw_regions is None and isinstance(result.get("result"), list):

--- a/server/apps/monitor/services/qcloud_regions.py
+++ b/server/apps/monitor/services/qcloud_regions.py
@@ -2,10 +2,41 @@
 
 from __future__ import annotations
 
+import re
+
 from apps.core.exceptions.base_app_exception import ValidationAppException
 from apps.core.logger import monitor_logger as logger
+from apps.core.utils.crypto.aes_crypto import AESCryptor
 from apps.rpc.node_mgmt import NodeMgmt
 from apps.rpc.stargazer import Stargazer
+
+_STORED_CREDENTIALS_MISSING_TEMPLATE = (
+    "event=cloud_region_stored_credentials_missing failed_stage=load_collect_config " "config_id=%s error_type=missing_child"
+)
+_ENV_PASSWORD_PLAIN_FALLBACK_TEMPLATE = "event=cloud_region_env_password_plain_fallback failed_stage=decrypt_env_password " "error_type=%s"
+
+
+_AES_BLOB_RE = re.compile(r"^[A-Za-z0-9_-]{40,}$")
+
+
+def maybe_decrypt_posted_cloud_secret(raw) -> str:
+    """编辑回填的 SecretKey 是 AES 密文；明文密钥原样返回。"""
+    text = str(raw or "").strip()
+    if not text:
+        return ""
+    if not _AES_BLOB_RE.fullmatch(text):
+        return text
+    decoded = AESCryptor().try_decode(text)
+    return decoded if decoded else text
+
+
+def _normalize_collect_config_ids(value) -> list[str]:
+    if value in (None, ""):
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return [str(item).strip() for item in value if item not in (None, "") and str(item).strip()]
+    text = str(value).strip()
+    return [text] if text else []
 
 
 def _normalize_qcloud_regions(regions: list) -> list[dict]:
@@ -67,17 +98,79 @@ def _resolve_stargazer_cloud_name(cloud_region_id=None) -> str:
     return "default"
 
 
+def _extract_child_username(child: dict) -> str:
+    content = child.get("content")
+    if not isinstance(content, dict):
+        return ""
+    config = content.get("config")
+    if not isinstance(config, dict):
+        return ""
+    headers = config.get("http_headers")
+    if not isinstance(headers, dict):
+        return ""
+    return str(headers.get("username") or "").strip()
+
+
+def _extract_child_password(child: dict) -> str:
+    env_config = child.get("env_config")
+    if not isinstance(env_config, dict):
+        return ""
+    aes_obj = AESCryptor()
+    for key, value in env_config.items():
+        if "password" not in str(key).lower() or not value:
+            continue
+        raw = str(value)
+        try:
+            return aes_obj.decode(raw)
+        except Exception as exc:
+            logger.debug(
+                _ENV_PASSWORD_PLAIN_FALLBACK_TEMPLATE,
+                type(exc).__name__,
+            )
+            return raw
+    return ""
+
+
+def resolve_stored_cloud_credentials(collect_config_id, actor_context=None) -> tuple[str, str]:
+    """从已授权的采集子配置解密云账号密钥；不信任前端回填的密文。"""
+    from apps.monitor.services.node_mgmt import InstanceConfigService
+
+    ids = _normalize_collect_config_ids(collect_config_id)
+    if not ids:
+        raise ValidationAppException("配置不存在或无权限")
+
+    payload = InstanceConfigService.get_config_content(ids, actor_context)
+    child = payload.get("child") if isinstance(payload, dict) else None
+    if not isinstance(child, dict):
+        logger.warning(
+            _STORED_CREDENTIALS_MISSING_TEMPLATE,
+            ",".join(ids)[:64],
+        )
+        raise ValidationAppException("配置不存在或无权限")
+
+    username = _extract_child_username(child)
+    password = _extract_child_password(child)
+    if not username or not password:
+        raise ValidationAppException("配置中缺少云账号密钥")
+    return username, password
+
+
 class QCloudRegionService:
     @classmethod
     def list_regions(
         cls,
         *,
-        username: str,
-        password: str,
+        username: str = "",
+        password: str = "",
         cloud_region_id=None,
+        collect_config_id=None,
+        actor_context=None,
     ) -> list[dict]:
+        config_ids = _normalize_collect_config_ids(collect_config_id)
+        if config_ids:
+            username, password = resolve_stored_cloud_credentials(config_ids, actor_context)
         secret_id = str(username or "").strip()
-        secret_key = str(password or "").strip()
+        secret_key = maybe_decrypt_posted_cloud_secret(password)
         if not secret_id or not secret_key:
             raise ValidationAppException("SecretId 与 SecretKey 均必填")
 

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/qcloud/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/qcloud/UI.json
@@ -13,9 +13,9 @@
       "label": "SecretId",
       "type": "input",
       "required": true,
-      "editable": false,
-      "description": "腾讯云 API 密钥 SecretId。填写后与 SecretKey 一起用于拉取可用地域。",
-      "description_en": "Tencent Cloud API SecretId. Used with SecretKey to load available regions.",
+      "editable": true,
+      "description": "腾讯云 API 密钥 SecretId。新建时与 SecretKey 一起用于拉取可用地域；编辑已有配置时可直接修改。",
+      "description_en": "Tencent Cloud API SecretId. Used with SecretKey to load available regions; can be changed when editing an existing config.",
       "transform_on_edit": {
         "origin_path": "child.content.config.http_headers.username"
       },
@@ -26,10 +26,10 @@
       "label": "SecretKey",
       "type": "password",
       "required": true,
-      "editable": false,
+      "editable": true,
       "encrypted": true,
-      "description": "腾讯云 API 密钥 SecretKey。填写后与 SecretId 一起用于拉取可用地域。",
-      "description_en": "Tencent Cloud API SecretKey. Used with SecretId to load available regions.",
+      "description": "腾讯云 API 密钥 SecretKey。新建时与 SecretId 一起用于拉取可用地域；编辑已有配置时点击编辑图标可更换。",
+      "description_en": "Tencent Cloud API SecretKey. Used with SecretId to load available regions; click edit to replace it on an existing config.",
       "transform_on_edit": {
         "origin_path": "child.env_config.PASSWORD__{{config_id}}"
       },
@@ -43,8 +43,8 @@
       "editable": true,
       "options_key": "region_option",
       "options": [],
-      "description": "填写 SecretId / SecretKey 后会自动拉取可用地域；也可点击右侧刷新图标手动更新。可多选，将采集所选全部地域的资源与监控指标。",
-      "description_en": "Available regions load automatically after SecretId / SecretKey are filled; use the refresh icon to reload. Multiple regions can be selected and will all be collected.",
+      "description": "新建时填写密钥后会自动拉取可用地域；编辑已有配置时未改密钥也可直接刷新。可多选，将采集所选全部地域的资源与监控指标。",
+      "description_en": "Available regions load automatically after keys are filled on create; existing configs can refresh without re-entering keys. Multiple regions can be selected and will all be collected.",
       "widget_props": {
         "placeholder": "请选择腾讯云地域（可多选）",
         "placeholder_en": "Select Tencent Cloud regions",

--- a/server/apps/monitor/views/plugin.py
+++ b/server/apps/monitor/views/plugin.py
@@ -12,13 +12,14 @@ from apps.monitor.filters.plugin import MonitorPluginFilter
 from apps.monitor.models import MonitorPlugin, MonitorPluginUITemplate
 from apps.monitor.models.monitor_object import MonitorObject
 from apps.monitor.serializers.plugin import MonitorPluginListSerializer, MonitorPluginSerializer
+from apps.monitor.services.aliyun_regions import AliyunRegionService
 from apps.monitor.services.custom_snmp_plugin import CustomSnmpPluginService
 from apps.monitor.services.plugin import MonitorPluginService
 from apps.monitor.services.plugin_guide import PluginGuideService
-from apps.monitor.services.aliyun_regions import AliyunRegionService
 from apps.monitor.services.qcloud_regions import QCloudRegionService
 from apps.monitor.services.template_access_guide import TemplateAccessGuideService
 from apps.monitor.utils.pagination import parse_page_params
+from apps.monitor.views.node_mgmt import _build_actor_context
 from config.drf.pagination import CustomPageNumberPagination
 
 
@@ -378,14 +379,18 @@ class MonitorPluginViewSet(viewsets.ModelViewSet):
     def qcloud_regions(self, request):
         """按腾讯云账号密钥动态拉取可用地域（DescribeRegions）。"""
         payload = request.data if isinstance(request.data, dict) else {}
+        collect_config_id = payload.get("collect_config_ids") or payload.get("collect_config_id") or payload.get("config_id") or ""
         username = payload.get("username") or payload.get("secret_id") or ""
         password = payload.get("password") or payload.get("ENV_PASSWORD") or payload.get("secret_key") or ""
         cloud_region_id = payload.get("cloud_region_id")
+        actor_context = _build_actor_context(request) if collect_config_id else None
         try:
             regions = QCloudRegionService.list_regions(
                 username=username,
                 password=password,
                 cloud_region_id=cloud_region_id,
+                collect_config_id=collect_config_id,
+                actor_context=actor_context,
             )
         except ValidationAppException as exc:
             return WebUtils.response_error(error_message=str(exc), status_code=400)
@@ -398,20 +403,18 @@ class MonitorPluginViewSet(viewsets.ModelViewSet):
     def aliyun_regions(self, request):
         """按阿里云账号密钥动态拉取可用地域（DescribeRegions）。"""
         payload = request.data if isinstance(request.data, dict) else {}
+        collect_config_id = payload.get("collect_config_ids") or payload.get("collect_config_id") or payload.get("config_id") or ""
         username = payload.get("username") or payload.get("access_key") or payload.get("secret_id") or ""
-        password = (
-            payload.get("password")
-            or payload.get("ENV_PASSWORD")
-            or payload.get("access_secret")
-            or payload.get("secret_key")
-            or ""
-        )
+        password = payload.get("password") or payload.get("ENV_PASSWORD") or payload.get("access_secret") or payload.get("secret_key") or ""
         cloud_region_id = payload.get("cloud_region_id")
+        actor_context = _build_actor_context(request) if collect_config_id else None
         try:
             regions = AliyunRegionService.list_regions(
                 username=username,
                 password=password,
                 cloud_region_id=cloud_region_id,
+                collect_config_id=collect_config_id,
+                actor_context=actor_context,
             )
         except ValidationAppException as exc:
             return WebUtils.response_error(error_message=str(exc), status_code=400)

--- a/web/src/app/monitor/(pages)/integration/asset/updateConfig.tsx
+++ b/web/src/app/monitor/(pages)/integration/asset/updateConfig.tsx
@@ -14,7 +14,7 @@ import { useTranslation } from '@/utils/i18n';
 import OperateModal from '@/components/operate-modal';
 import useApiClient from '@/utils/request';
 import { usePluginFromJson } from '@/app/monitor/hooks/integration/usePluginFromJson';
-import { cloudRegionProviderFromPlugin, useCloudRegionOptions } from '@/app/monitor/hooks/integration/useQcloudRegionOptions';
+import { cloudRegionProviderFromPlugin, resolveStoredCollectConfigId, useCloudRegionOptions } from '@/app/monitor/hooks/integration/useQcloudRegionOptions';
 import {
   getSnmpFilterMutexConflicts,
   trackSnmpFilterMutexLastChanged
@@ -35,6 +35,8 @@ interface PluginConfig {
   form_fields?: PluginFormField[];
   instance_type?: string;
   config_type?: string[];
+  object_name?: string;
+  name?: string;
 }
 
 const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
@@ -50,6 +52,14 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
   const [configForm, setConfigForm] = useState<TableDataItem>({});
   const [currentConfig, setCurrentConfig] = useState<PluginConfig | null>(null);
   const [configLoading, setConfigLoading] = useState<boolean>(false);
+  const [regionHints, setRegionHints] = useState<{
+    objectName?: string;
+    pluginName?: string;
+  }>({});
+  const [collectConfigId, setCollectConfigId] = useState<
+    string | string[] | undefined
+  >();
+  const editFormSeedKeyRef = useRef('');
 
   useImperativeHandle(ref, () => ({
     showModal: async ({ form, title }) => {
@@ -58,9 +68,19 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
       setModalVisible(true);
       setConfirmLoading(false);
       setConfigForm(_form.config_content || {});
+      setCollectConfigId(
+        resolveStoredCollectConfigId(_form) ??
+          resolveStoredCollectConfigId(_form.config_content)
+      );
       const collector = _form.collector;
       const collect_type = _form.collect_type;
       const monitor_object_id = _form.monitor_object_id;
+      setRegionHints({
+        objectName: String(
+          _form.monitor_object_name || _form.object_name || _form.name || ''
+        ),
+        pluginName: String(_form.plugin_name || collector || ''),
+      });
       const _pluginId = _form.monitor_plugin_id || `${monitor_object_id}_${collector}_${collect_type}`;
       setPluginId(_pluginId);
       setConfigLoading(true);
@@ -82,7 +102,13 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
   }));
 
   // 获取配置信息
-  const regionProvider = cloudRegionProviderFromPlugin(currentConfig);
+  const regionProvider = cloudRegionProviderFromPlugin(currentConfig, regionHints);
+  const resolvedCollectConfigId =
+    collectConfigId ??
+    resolveStoredCollectConfigId({
+      config_content: configForm,
+      child: (configForm as { child?: { id?: unknown } })?.child,
+    });
   const {
     regionOptions,
     loadingRegions,
@@ -91,6 +117,8 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
     enabled: Boolean(regionProvider && modalVisible),
     provider: regionProvider || 'qcloud',
     form,
+    credentialSource: 'stored',
+    collectConfigId: resolvedCollectConfigId,
   });
 
   const configsInfo = useMemo(() => {
@@ -111,6 +139,10 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
         region_option: {
           loading: loadingRegions,
           onRefresh: refreshRegions,
+          refreshTip: t(
+            'monitor.integrations.refreshStoredCloudRegionsTip',
+            '刷新可用地域'
+          ),
         },
       },
     });
@@ -123,6 +155,7 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
     loadingRegions,
     refreshRegions,
     jsonConfig.buildPluginUI,
+    t,
   ]);
 
   const formItems = useMemo(() => {
@@ -135,10 +168,31 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
   );
 
   useEffect(() => {
-    if (configsInfo?.getDefaultForm && configForm && !configLoading) {
-      initData(cloneDeep(configForm));
+    if (!modalVisible) {
+      editFormSeedKeyRef.current = '';
+      return;
     }
-  }, [configsInfo, configForm, configLoading]);
+    if (configLoading || !currentConfig || !pluginId || !configForm) {
+      return;
+    }
+    const collectKey = Array.isArray(collectConfigId)
+      ? collectConfigId.join(',')
+      : String(collectConfigId ?? '');
+    const seedKey = `${pluginId}::${collectKey}`;
+    // 地域 options / loading 变化会重建 configsInfo；不得据此回填，否则刚选的地域会被冲掉。
+    if (editFormSeedKeyRef.current === seedKey) {
+      return;
+    }
+    editFormSeedKeyRef.current = seedKey;
+    initData(cloneDeep(configForm));
+  }, [
+    modalVisible,
+    configLoading,
+    currentConfig,
+    pluginId,
+    configForm,
+    collectConfigId,
+  ]);
 
   const initData = (row: TableDataItem) => {
     const activeFormData = configsInfo.getDefaultForm?.(row) || {};
@@ -159,6 +213,7 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
     setModalVisible(false);
     setPluginId('');
     setCurrentConfig(null);
+    setCollectConfigId(undefined);
   };
 
   const handleSubmit = () => {
@@ -215,6 +270,9 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
       title={title}
       visible={modalVisible}
       zIndex={2000}
+      styles={{
+        body: { overflow: 'visible', maxHeight: 'calc(80vh - 108px)' },
+      }}
       onCancel={handleCancel}
       footer={
         <div>

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
@@ -116,6 +116,7 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
   const currentGroup = useRef(userContext?.selectedGroup);
   const groupId = [currentGroup?.current?.id || ''];
   const pluginId = searchParams.get('plugin_id') || '';
+  const pluginName = searchParams.get('plugin_name') || '';
   const objectId = searchParams.get('id') || '';
   const objectName = searchParams.get('name') || '';
   const enableIfmibFromUrl = searchParams.get('enable_ifmib') !== 'false';
@@ -234,7 +235,10 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
     return currentConfig;
   }, [configLoading, currentConfig]);
 
-  const regionProvider = cloudRegionProviderFromPlugin(baseConfig);
+  const regionProvider = cloudRegionProviderFromPlugin(baseConfig, {
+    objectName,
+    pluginName,
+  });
   const {
     regionOptions,
     loadingRegions,

--- a/web/src/app/monitor/api/integration.ts
+++ b/web/src/app/monitor/api/integration.ts
@@ -277,18 +277,26 @@ const useIntegrationApi = () => {
         return await get(`/monitor/api/collect_detect/${String(taskId)}/`);
       },
       listQcloudRegions: async (data: {
-        username: string;
-        password: string;
+        username?: string;
+        password?: string;
+        collect_config_id?: string;
+        collect_config_ids?: string[];
         cloud_region_id?: number | string;
       }) => {
-        return await post('/monitor/api/monitor_plugin/qcloud_regions/', data);
+        return await post('/monitor/api/monitor_plugin/qcloud_regions/', data, {
+          suppressErrorNotification: true,
+        });
       },
       listAliyunRegions: async (data: {
-        username: string;
-        password: string;
+        username?: string;
+        password?: string;
+        collect_config_id?: string;
+        collect_config_ids?: string[];
         cloud_region_id?: number | string;
       }) => {
-        return await post('/monitor/api/monitor_plugin/aliyun_regions/', data);
+        return await post('/monitor/api/monitor_plugin/aliyun_regions/', data, {
+          suppressErrorNotification: true,
+        });
       },
     } satisfies FlowIntegrationApi),
     [del, get, post, put]

--- a/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
+++ b/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
@@ -30,6 +30,7 @@ export type FormFieldOptionControls = Record<
   {
     loading?: boolean;
     onRefresh?: () => void;
+    refreshTip?: string;
   }
 >;
 
@@ -47,9 +48,22 @@ const SelectWithRefresh = React.forwardRef<any, SelectWithRefreshProps>(
     { onRefresh, refreshLabel, refreshTip, regionLoading, ...selectProps },
     ref
   ) {
+    const popupWrapRef = React.useRef<HTMLDivElement>(null);
     return (
-      <div className="mr-[10px] inline-flex items-center gap-1">
-        <Select ref={ref} {...selectProps} />
+      <div
+        ref={popupWrapRef}
+        className="relative z-[20] mr-[10px] inline-flex items-center gap-1"
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <Select
+          ref={ref}
+          {...selectProps}
+          virtual={selectProps.virtual ?? false}
+          getPopupContainer={
+            selectProps.getPopupContainer ||
+            (() => popupWrapRef.current || document.body)
+          }
+        />
         <Tooltip title={refreshTip}>
           <Button
             type="text"
@@ -498,10 +512,13 @@ export const useConfigRenderer = () => {
                   'monitor.integrations.fetchCloudRegions',
                   '获取地域'
                 )}
-                refreshTip={t(
-                  'monitor.integrations.refreshCloudRegionsTip',
-                  '根据已填密钥刷新可用地域'
-                )}
+                refreshTip={
+                  optionControl.refreshTip ||
+                  t(
+                    'monitor.integrations.refreshCloudRegionsTip',
+                    '根据已填密钥刷新可用地域'
+                  )
+                }
                 regionLoading={regionLoading}
               >
                 {optionNodes}

--- a/web/src/app/monitor/hooks/integration/usePluginFromJson.tsx
+++ b/web/src/app/monitor/hooks/integration/usePluginFromJson.tsx
@@ -245,6 +245,7 @@ export const usePluginFromJson = () => {
           {
             loading?: boolean;
             onRefresh?: () => void;
+            refreshTip?: string;
           }
         >;
       }

--- a/web/src/app/monitor/hooks/integration/useQcloudRegionOptions.ts
+++ b/web/src/app/monitor/hooks/integration/useQcloudRegionOptions.ts
@@ -1,26 +1,57 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 import { Form, FormInstance, message } from 'antd';
 import { useTranslation } from '@/utils/i18n';
 import useIntegrationApi from '@/app/monitor/api/integration';
+import { showRequestErrorToast } from '@/utils/requestErrorToast';
 
 const MASKED_PASSWORD_RE = /^\*+$/;
+const STORED_SECRET_RE = /^[A-Za-z0-9_-]{40,}$/;
 
 export type CloudRegionProvider = 'qcloud' | 'aliyun';
 
-export function cloudRegionProviderFromPlugin(config?: {
-  instance_type?: string;
-  config_type?: string | string[];
-} | null): CloudRegionProvider | null {
-  if (!config) return null;
-  const types = new Set<string>();
-  if (config.instance_type) types.add(String(config.instance_type).toLowerCase());
-  if (Array.isArray(config.config_type)) {
-    for (const item of config.config_type) types.add(String(item).toLowerCase());
-  } else if (config.config_type) {
-    types.add(String(config.config_type).toLowerCase());
+export interface CloudRegionProviderHints {
+  objectName?: string;
+  pluginName?: string;
+}
+
+function addCloudProviderTokens(tokens: Set<string>, value: unknown) {
+  const text = String(value || '').trim().toLowerCase();
+  if (!text) return;
+  tokens.add(text);
+  for (const part of text.split(/[^a-z0-9]+/)) {
+    if (part) tokens.add(part);
   }
-  if (types.has('aliyun')) return 'aliyun';
-  if (types.has('qcloud')) return 'qcloud';
+}
+
+/**
+ * 按监控对象/插件身份选择地域拉取通道。
+ * 阿里云对象即使 UI.json 仍残留 qcloud instance_type，也必须走阿里云 DescribeRegions，
+ * 否则会把 AccessKey 送到腾讯云 SDK，弹出 TencentCloudSDKException。
+ */
+export function cloudRegionProviderFromPlugin(
+  config?: {
+    instance_type?: string;
+    config_type?: string | string[];
+    object_name?: string;
+    name?: string;
+  } | null,
+  extras?: CloudRegionProviderHints
+): CloudRegionProvider | null {
+  const tokens = new Set<string>();
+  addCloudProviderTokens(tokens, extras?.objectName);
+  addCloudProviderTokens(tokens, extras?.pluginName);
+  addCloudProviderTokens(tokens, config?.object_name);
+  addCloudProviderTokens(tokens, config?.name);
+  addCloudProviderTokens(tokens, config?.instance_type);
+  if (Array.isArray(config?.config_type)) {
+    for (const item of config.config_type) addCloudProviderTokens(tokens, item);
+  } else if (config?.config_type) {
+    addCloudProviderTokens(tokens, config.config_type);
+  }
+  if ([...tokens].some((token) => token.includes('aliyun'))) return 'aliyun';
+  if ([...tokens].some((token) => token.includes('qcloud') || token.includes('tencent'))) {
+    return 'qcloud';
+  }
   return null;
 }
 
@@ -29,12 +60,147 @@ export interface RegionOption {
   value: string;
 }
 
+export type CloudRegionCredentialSource = 'form' | 'stored';
+
+export interface CloudRegionRequestInput {
+  credentialSource?: CloudRegionCredentialSource;
+  collectConfigId?: string | number | string[];
+  username?: unknown;
+  password?: unknown;
+  cloudRegionId?: number | string;
+  preferFormCredentials?: boolean;
+}
+
+export interface CloudRegionRequestPayload {
+  collect_config_id?: string;
+  collect_config_ids?: string[];
+  username?: string;
+  password?: string;
+  cloud_region_id?: number | string;
+}
+
 function isUsableSecret(value: unknown): value is string {
   if (typeof value !== 'string') return false;
   const trimmed = value.trim();
   if (!trimmed) return false;
   if (MASKED_PASSWORD_RE.test(trimmed)) return false;
   return true;
+}
+
+function secretText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+/** 编辑回填的 AES 密文通常 ≥40 位 urlsafe base64；腾讯云明文 SecretKey 约 32 位。 */
+export function looksLikeStoredCloudSecret(value: unknown): boolean {
+  return isUsableSecret(value) && STORED_SECRET_RE.test(value.trim());
+}
+
+function withCloudRegionId(
+  payload: CloudRegionRequestPayload,
+  cloudRegionId?: number | string
+): CloudRegionRequestPayload {
+  if (cloudRegionId === undefined || cloudRegionId === '') {
+    return payload;
+  }
+  return { ...payload, cloud_region_id: cloudRegionId };
+}
+
+function normalizeCollectConfigIds(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item ?? '').trim()).filter(Boolean);
+  }
+  const single = String(value ?? '').trim();
+  return single ? [single] : [];
+}
+
+/**
+ * 资产编辑行里取出已存采集配置 ID。优先 child.id，否则用 config_ids。
+ */
+export function resolveStoredCollectConfigId(row?: {
+  config_content?: unknown;
+  child?: { id?: unknown };
+  config_ids?: unknown[];
+  config_id?: unknown;
+} | null): string | string[] | undefined {
+  const content = row?.config_content as { child?: { id?: unknown } } | undefined;
+  const childId = String(content?.child?.id ?? row?.child?.id ?? '').trim();
+  if (childId) return childId;
+  const ids = (Array.isArray(row?.config_ids) ? row.config_ids : [])
+    .map((item) => String(item ?? '').trim())
+    .filter(Boolean);
+  if (ids.length === 1) return ids[0];
+  if (ids.length > 1) return ids;
+  const single = String(row?.config_id ?? '').trim();
+  return single || undefined;
+}
+
+/**
+ * 接入页密钥齐全后自动拉地域；资产编辑页打开时只回显已选，避免空密钥打出「均必填」。
+ */
+export function shouldAutoFetchCloudRegions(
+  credentialSource: CloudRegionCredentialSource | undefined,
+  request: CloudRegionRequestPayload | null
+): boolean {
+  if (!request) return false;
+  if (credentialSource === 'stored') return false;
+  if (looksLikeStoredCloudSecret(request.password)) return false;
+  return true;
+}
+
+/**
+ * 接入页用表单明文密钥拉地域。
+ * 资产编辑页默认只传已存配置 ID（回填的 SecretKey 是 AES 密文，不能发给云厂商）。
+ * 用户在编辑页改过 SecretKey 后，改走表单明文，避免仍用旧密钥拉地域。
+ */
+export function buildCloudRegionRequest(
+  input: CloudRegionRequestInput
+): CloudRegionRequestPayload | null {
+  const ids = normalizeCollectConfigIds(input.collectConfigId);
+  const formReady = isUsableSecret(input.username) && isUsableSecret(input.password);
+  const preferForm =
+    Boolean(input.preferFormCredentials) &&
+    formReady &&
+    !looksLikeStoredCloudSecret(input.password);
+  if (preferForm) {
+    return withCloudRegionId(
+      {
+        username: secretText(input.username),
+        password: secretText(input.password),
+      },
+      input.cloudRegionId
+    );
+  }
+  const useStored = input.credentialSource === 'stored' || ids.length > 0;
+  if (useStored) {
+    if (ids.length) {
+      const payload =
+        ids.length === 1
+          ? { collect_config_id: ids[0] }
+          : { collect_config_ids: ids };
+      return withCloudRegionId(payload, input.cloudRegionId);
+    }
+    if (formReady) {
+      return withCloudRegionId(
+        {
+          username: secretText(input.username),
+          password: secretText(input.password),
+        },
+        input.cloudRegionId
+      );
+    }
+    return null;
+  }
+  if (!formReady) {
+    return null;
+  }
+  return withCloudRegionId(
+    {
+      username: secretText(input.username),
+      password: secretText(input.password),
+    },
+    input.cloudRegionId
+  );
 }
 
 function regionSelection(value: unknown): string[] {
@@ -62,6 +228,10 @@ const COPY = {
       'monitor.integrations.qcloudRegionFetchFailed',
       '获取腾讯云地域失败',
     ],
+    needStoredConfig: [
+      'monitor.integrations.qcloudRegionNeedStoredConfig',
+      '无法读取已存密钥，已保留当前地域',
+    ],
   },
   aliyun: {
     needCredentials: [
@@ -77,6 +247,10 @@ const COPY = {
       'monitor.integrations.aliyunRegionFetchFailed',
       '获取阿里云地域失败',
     ],
+    needStoredConfig: [
+      'monitor.integrations.aliyunRegionNeedStoredConfig',
+      '无法读取已存密钥，已保留当前地域',
+    ],
   },
 } as const;
 
@@ -84,31 +258,97 @@ const COPY = {
  * 云监控接入：密钥齐全后按账号动态拉取可用地域。
  * 腾讯云可多选；阿里云一配置一地域，只保留单选。
  */
+function seedSelectedRegionOptions(
+  form: FormInstance,
+  setRegionOptions: Dispatch<SetStateAction<RegionOption[]>>
+) {
+  const selected = regionSelection(form.getFieldValue('region'));
+  if (selected.length === 0) return;
+  setRegionOptions((prev) => {
+    const existing = new Set(prev.map((item) => item.value));
+    const missing = selected.filter((item) => !existing.has(item));
+    if (missing.length === 0) {
+      return prev;
+    }
+    return [
+      ...prev,
+      ...missing.map((item) => ({ label: item, value: item })),
+    ];
+  });
+}
+
+/**
+ * 云监控接入：密钥齐全后按账号动态拉取可用地域。
+ * 腾讯云可多选；阿里云一配置一地域，只保留单选。
+ * 资产编辑页传 credentialSource=stored，用已存配置解密，绝不回填密文。
+ */
 export function useCloudRegionOptions(options: {
   enabled: boolean;
   form: FormInstance;
   cloudRegionId?: number | string;
   provider: CloudRegionProvider;
+  credentialSource?: CloudRegionCredentialSource;
+  collectConfigId?: string | number | string[];
 }) {
-  const { enabled, form, cloudRegionId, provider } = options;
+  const {
+    enabled,
+    form,
+    cloudRegionId,
+    provider,
+    credentialSource = 'form',
+    collectConfigId,
+  } = options;
   const { t } = useTranslation();
   const { listQcloudRegions, listAliyunRegions } = useIntegrationApi();
   const [regionOptions, setRegionOptions] = useState<RegionOption[]>([]);
   const [loadingRegions, setLoadingRegions] = useState(false);
   const requestSeq = useRef(0);
   const lastAutoKey = useRef('');
+  const initialPasswordRef = useRef<string | null>(null);
   const multiple = provider === 'qcloud';
   const copy = COPY[provider];
 
   const username = Form.useWatch('username', form);
   const password = Form.useWatch('ENV_PASSWORD', form);
+  const regionValue = Form.useWatch('region', form);
+
+  useEffect(() => {
+    if (!enabled) {
+      initialPasswordRef.current = null;
+      return;
+    }
+    if (initialPasswordRef.current === null && isUsableSecret(password)) {
+      initialPasswordRef.current = password.trim();
+    }
+  }, [enabled, password]);
+
+  const preferFormCredentials =
+    credentialSource === 'form' ||
+    (!looksLikeStoredCloudSecret(password) &&
+      isUsableSecret(password) &&
+      initialPasswordRef.current !== null &&
+      password.trim() !== initialPasswordRef.current);
 
   const fetchRegions = useCallback(
     async (opts?: { silent?: boolean }) => {
       if (!enabled) return;
-      if (!isUsableSecret(username) || !isUsableSecret(password)) {
+      const request = buildCloudRegionRequest({
+        credentialSource,
+        collectConfigId,
+        username,
+        password,
+        cloudRegionId,
+        preferFormCredentials,
+      });
+      if (!request) {
+        seedSelectedRegionOptions(form, setRegionOptions);
         if (!opts?.silent) {
-          message.warning(t(copy.needCredentials[0], copy.needCredentials[1]));
+          const missingStored = credentialSource === 'stored';
+          message.warning(
+            missingStored
+              ? t(copy.needStoredConfig[0], copy.needStoredConfig[1])
+              : t(copy.needCredentials[0], copy.needCredentials[1])
+          );
         }
         return;
       }
@@ -117,11 +357,7 @@ export function useCloudRegionOptions(options: {
       setLoadingRegions(true);
       try {
         const listFn = provider === 'aliyun' ? listAliyunRegions : listQcloudRegions;
-        const data = await listFn({
-          username: username.trim(),
-          password: password.trim(),
-          cloud_region_id: cloudRegionId,
-        });
+        const data = await listFn(request);
         if (seq !== requestSeq.current) return;
         const next = (Array.isArray(data) ? data : [])
           .map((item: any) => ({
@@ -149,6 +385,7 @@ export function useCloudRegionOptions(options: {
         }
 
         if (next.length === 0) {
+          seedSelectedRegionOptions(form, setRegionOptions);
           message.warning(t(copy.empty[0], copy.empty[1]));
           return;
         }
@@ -161,8 +398,20 @@ export function useCloudRegionOptions(options: {
         }
       } catch (error: any) {
         if (seq !== requestSeq.current) return;
-        setRegionOptions([]);
-        message.error(error?.message || t(copy.fetchFailed[0], copy.fetchFailed[1]));
+        seedSelectedRegionOptions(form, setRegionOptions);
+        if (opts?.silent) return;
+        const raw = String(error?.message || '');
+        const leakedTencentSdk =
+          provider === 'aliyun' &&
+          /TencentCloudSDKException|SecretIdNotFound|SecretId不存在/i.test(raw);
+        showRequestErrorToast(
+          leakedTencentSdk
+            ? t(
+              'monitor.integrations.aliyunRegionAuthFailed',
+              'AccessKey 无效或权限不足，请检查 AccessKey ID / AccessKey Secret'
+            )
+            : raw || t(copy.fetchFailed[0], copy.fetchFailed[1])
+        );
       } finally {
         if (seq === requestSeq.current) {
           setLoadingRegions(false);
@@ -171,16 +420,20 @@ export function useCloudRegionOptions(options: {
     },
     [
       cloudRegionId,
+      collectConfigId,
       copy.empty,
       copy.fetchFailed,
       copy.fetched,
       copy.needCredentials,
+      copy.needStoredConfig,
+      credentialSource,
       enabled,
       form,
       listAliyunRegions,
       listQcloudRegions,
       multiple,
       password,
+      preferFormCredentials,
       provider,
       t,
       username,
@@ -193,30 +446,50 @@ export function useCloudRegionOptions(options: {
       lastAutoKey.current = '';
       return;
     }
-    if (!isUsableSecret(username) || !isUsableSecret(password)) {
-      const selected = regionSelection(form.getFieldValue('region'));
-      if (selected.length > 0) {
-        setRegionOptions((prev) => {
-          const existing = new Set(prev.map((item) => item.value));
-          const missing = selected.filter((item) => !existing.has(item));
-          if (missing.length === 0) {
-            return prev;
-          }
-          return [
-            ...prev,
-            ...missing.map((item) => ({ label: item, value: item })),
-          ];
-        });
-      }
+    const request = buildCloudRegionRequest({
+      credentialSource,
+      collectConfigId,
+      username,
+      password,
+      cloudRegionId,
+      preferFormCredentials,
+    });
+    if (!request) {
+      seedSelectedRegionOptions(form, setRegionOptions);
       return;
     }
-    const autoKey = `${provider}::${username.trim()}::${password.trim()}::${cloudRegionId ?? ''}`;
+    const autoKey = request.collect_config_id
+      ? `stored::${provider}::${request.collect_config_id}::${request.cloud_region_id ?? ''}`
+      : request.collect_config_ids
+        ? `stored::${provider}::${request.collect_config_ids.join(',')}::${request.cloud_region_id ?? ''}`
+        : `${provider}::${request.username}::${request.password}::${request.cloud_region_id ?? ''}`;
     if (lastAutoKey.current === autoKey) {
+      return;
+    }
+    if (!shouldAutoFetchCloudRegions(credentialSource, request)) {
+      seedSelectedRegionOptions(form, setRegionOptions);
+      lastAutoKey.current = autoKey;
       return;
     }
     lastAutoKey.current = autoKey;
     void fetchRegions({ silent: true });
-  }, [enabled, username, password, cloudRegionId, fetchRegions, form, provider]);
+  }, [
+    cloudRegionId,
+    collectConfigId,
+    credentialSource,
+    enabled,
+    fetchRegions,
+    form,
+    password,
+    preferFormCredentials,
+    provider,
+    username,
+  ]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    seedSelectedRegionOptions(form, setRegionOptions);
+  }, [enabled, form, regionValue]);
 
   return {
     regionOptions,
@@ -229,6 +502,8 @@ export function useQcloudRegionOptions(options: {
   enabled: boolean;
   form: FormInstance;
   cloudRegionId?: number | string;
+  credentialSource?: CloudRegionCredentialSource;
+  collectConfigId?: string | number | string[];
 }) {
   return useCloudRegionOptions({ ...options, provider: 'qcloud' });
 }


### PR DESCRIPTION
## Summary
- 编辑资产采集配置时，用已存配置解密密钥拉取腾讯云/阿里云地域，不再把回填密文当明文发给云厂商。
- 密钥字段允许在编辑页修改；地域下拉挂在弹层内，避免点不中选项，并防止地域列表刷新把已选值冲掉。

## Test plan
- [ ] 打开腾讯云资产「更新配置」，不改密钥点击刷新，能拉到地域列表
- [ ] 下拉中选择其他地域，标签会更新，确认后配置保存成功
- [ ] 点编辑图标更换 SecretKey 后再刷新，按新密钥拉地域
- [ ] 新建接入页仍可用表单明文密钥自动/手动拉地域