### PR TITLE
bugfix: 为 API 密钥摘要列补查询索引

### DIFF
--- a/server/apps/base/migrations/0011_alter_userapisecret_api_secret.py
+++ b/server/apps/base/migrations/0011_alter_userapisecret_api_secret.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("base", "0010_hash_user_api_secret"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="userapisecret",
+            name="api_secret",
+            field=models.CharField(db_index=True, max_length=80),
+        ),
+    ]

--- a/server/apps/base/models/user.py
+++ b/server/apps/base/models/user.py
@@ -15,7 +15,7 @@ class UserAPISecret(TimeInfo):
 
     username = models.CharField(max_length=255)
     domain = models.CharField(max_length=255, default="domain.com")
-    api_secret = models.CharField(max_length=80)
+    api_secret = models.CharField(max_length=80, db_index=True)
     team = models.IntegerField(default=0)
 
     @staticmethod

--- a/server/apps/base/tests/test_user_api_secret_lookup_index.py
+++ b/server/apps/base/tests/test_user_api_secret_lookup_index.py
@@ -1,0 +1,115 @@
+"""API 密钥查找必须走 api_secret 普通索引，且认证语义保持不变。"""
+
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from apps.base.models import UserAPISecret
+from apps.base.tests.factories import UserAPISecretFactory
+
+
+def _api_secret_select_count(captured) -> int:
+    table = UserAPISecret._meta.db_table.lower()
+    count = 0
+    for query in captured.captured_queries:
+        sql = query["sql"].lower().replace('"', "").replace("`", "")
+        if "select" in sql and table in sql:
+            count += 1
+    return count
+
+
+def _table_indexes_include_api_secret() -> bool:
+    with connection.cursor() as cursor:
+        constraints = connection.introspection.get_constraints(cursor, UserAPISecret._meta.db_table)
+    for spec in constraints.values():
+        columns = list(spec.get("columns") or [])
+        if "api_secret" not in columns:
+            continue
+        if spec.get("index") or spec.get("unique"):
+            return True
+    return False
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_api_secret_field_has_db_index():
+    field = UserAPISecret._meta.get_field("api_secret")
+    assert field.db_index is True
+    assert field.unique is False
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_api_secret_table_has_lookup_index():
+    assert _table_indexes_include_api_secret()
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+@pytest.mark.parametrize("row_count", [1, 10, 100])
+def test_hashed_lookup_query_count_does_not_grow_with_secret_count(row_count):
+    target_raw = UserAPISecret.generate_api_secret()
+    UserAPISecretFactory(
+        username="lookup-target",
+        domain="index.test",
+        team=0,
+        api_secret=UserAPISecret.hash_api_secret(target_raw),
+    )
+    extras = [
+        UserAPISecret(
+            username=f"lookup-extra-{index}",
+            domain="index.test",
+            team=0,
+            api_secret=UserAPISecret.hash_api_secret(UserAPISecret.generate_api_secret()),
+        )
+        for index in range(row_count - 1)
+    ]
+    if extras:
+        UserAPISecret.objects.bulk_create(extras)
+
+    with CaptureQueriesContext(connection) as captured:
+        found = UserAPISecret.find_by_api_secret(target_raw)
+
+    assert found is not None
+    assert found.username == "lookup-target"
+    assert _api_secret_select_count(captured) == 1
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+@pytest.mark.parametrize("row_count", [1, 10, 100])
+def test_unknown_token_uses_hashed_then_plaintext_lookup(row_count):
+    UserAPISecret.objects.bulk_create(
+        [
+            UserAPISecret(
+                username=f"unknown-extra-{index}",
+                domain="index.test",
+                team=1,
+                api_secret=UserAPISecret.hash_api_secret(UserAPISecret.generate_api_secret()),
+            )
+            for index in range(row_count)
+        ]
+    )
+    unknown = UserAPISecret.generate_api_secret()
+
+    with CaptureQueriesContext(connection) as captured:
+        found = UserAPISecret.find_by_api_secret(unknown)
+
+    assert found is None
+    assert _api_secret_select_count(captured) == 2
+
+
+@pytest.mark.unit
+def test_empty_and_hashed_inputs_are_rejected():
+    assert UserAPISecret.find_by_api_secret("") is None
+    hashed = UserAPISecret.hash_api_secret(UserAPISecret.generate_api_secret())
+    assert UserAPISecret.find_by_api_secret(hashed) is None
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_plaintext_fallback_still_matches_unhashed_row():
+    raw_secret = UserAPISecret.generate_api_secret()
+    stored = UserAPISecretFactory(username="legacy-plain", api_secret=raw_secret)
+
+    assert UserAPISecret.find_by_api_secret(raw_secret) == stored


### PR DESCRIPTION
## 复现步骤

前置：已有 API 密钥记录，调用方用 Token 调接口。

1. 请求带 `API-AUTHORIZATION` 头（对应 `settings.API_TOKEN_HEADER_NAME`，值为 `HTTP_API_AUTHORIZATION`）。
2. 中间件走 `APISecretAuthBackend.authenticate` → `UserAPISecret.find_by_api_secret`。
3. 对照数据库：`api_secret` 列是否有普通索引。密钥变多时，未命中仍要扫完全表才能证明没有匹配行。

修复前：等值查找走未索引列。  
修复后：该列有普通索引；摘要优先、旧明文回退、拒绝把摘要当 token 的语义不变。

## 修复方案

`UserAPISecret.api_secret` 增加 `db_index=True`，并加 `0011_alter_userapisecret_api_secret`。不改唯一约束、不缓存凭据有效性、不加 `unique`。

Fixes #5192

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| `api_secret` 索引 | 无 | 普通索引 |
| N=1/10/100 摘要命中查询数 | 1 | 1 |
| 未知 token 查询数 | 2 | 2 |
| 旧明文回退 | 可命中 | 可命中 |
| 把摘要当 token | 拒绝 | 拒绝 |

## 影响面

- **会变**：部署需执行 0011；大表建索引可能短时写锁。
- **不变**：Token 头名、响应字段、`(username, domain, team)` 唯一约束、认证分支。
- **不在范围**：未对 EXPLAIN 做断言；未做在线/CONCURRENTLY 建索引。
