### PR TITLE
bugfix: OpenAPI KV 枚举失败不再当成空注册表

### DIFF
--- a/server/apps/core/openapi/kv.py
+++ b/server/apps/core/openapi/kv.py
@@ -21,6 +21,7 @@ FETCH_TIMEOUT_SECONDS = 5
 
 
 async def _fetch_async():
+    from nats.js.errors import NoKeysError
     from nats_client.clients import get_nc_client
 
     nc = await get_nc_client()
@@ -38,8 +39,8 @@ async def _fetch_async():
 
         try:
             keys = await kv.keys()
-        except Exception:
-            # 空 bucket 时 nats-py 抛 NoKeysError
+        except NoKeysError:
+            # 空 bucket 时 nats-py 抛 NoKeysError，与「无外部服务」同义
             return {}
 
         entries = {}

--- a/server/apps/core/openapi/tests/test_kv_keys_errors.py
+++ b/server/apps/core/openapi/tests/test_kv_keys_errors.py
@@ -1,0 +1,105 @@
+"""kv.keys 错误分类：空 bucket 与超时/断连不得写成空注册表。"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from nats.js.errors import NoKeysError
+
+from apps.core.openapi import kv, renderer
+
+pytestmark = pytest.mark.unit
+
+SAMPLE_ENTRY = {
+    "schema_version": 1,
+    "type": "http",
+    "base_url": "http://itsm-svc:8000",
+    "auth_mode": "trusted-header",
+    "shared_secret_ref": "env:TEST_ITSM_SECRET",
+    "required_roles": [],
+    "enabled": True,
+}
+
+
+class FakeKV:
+    def __init__(self, keys_side_effect, values=None):
+        self._keys_side_effect = keys_side_effect
+        self._values = dict(values or {})
+
+    async def keys(self):
+        effect = self._keys_side_effect
+        if callable(effect):
+            effect = effect()
+        if isinstance(effect, BaseException):
+            raise effect
+        return list(effect)
+
+    async def get(self, key):
+        return SimpleNamespace(value=json.dumps(self._values[key]).encode())
+
+
+class FakeJS:
+    def __init__(self, store):
+        self._store = store
+
+    async def key_value(self, bucket):
+        return self._store
+
+
+class FakeNC:
+    def __init__(self, store):
+        self._store = store
+
+    def jetstream(self):
+        return FakeJS(self._store)
+
+    async def close(self):
+        return None
+
+
+def install_kv(monkeypatch, keys_side_effect, values=None):
+    store = FakeKV(keys_side_effect, values=values)
+
+    async def fake_get_nc_client(*args, **kwargs):
+        return FakeNC(store)
+
+    monkeypatch.setattr("nats_client.clients.get_nc_client", fake_get_nc_client)
+    return store
+
+
+def test_nokeys_error_returns_empty_registry(monkeypatch):
+    install_kv(monkeypatch, NoKeysError())
+    assert kv.fetch_entries() == {}
+
+
+@pytest.mark.parametrize("exc", [TimeoutError("kv.keys timeout"), Exception("nats disconnected")])
+def test_keys_failure_returns_none(monkeypatch, exc):
+    install_kv(monkeypatch, exc)
+    assert kv.fetch_entries() is None
+
+
+def test_refresh_keeps_snapshot_when_keys_times_out(monkeypatch):
+    monkeypatch.setenv("OPENAPI_BASEURL_ALLOWLIST", "itsm-svc")
+    monkeypatch.setenv("OPENAPI_AUTH_ADDRESS", "http://server:8000/openapi/v1/_auth")
+    monkeypatch.setenv("TEST_ITSM_SECRET", "s3cret")
+    monkeypatch.setattr(renderer, "fetch_entries", kv.fetch_entries)
+
+    state = {"calls": 0}
+
+    def keys_effect():
+        state["calls"] += 1
+        if state["calls"] == 1:
+            return ["itsm"]
+        raise TimeoutError("kv.keys timeout")
+
+    install_kv(monkeypatch, keys_effect, values={"itsm": dict(SAMPLE_ENTRY)})
+
+    first = renderer.refresh_snapshot()
+    assert "openapi-v1-itsm" in first["http"]["routers"]
+    assert renderer._snapshot["services"] == ["itsm"]
+
+    second = renderer.refresh_snapshot()
+    assert state["calls"] == 2
+    assert "openapi-v1-itsm" in second["http"]["routers"]
+    assert renderer._snapshot["services"] == ["itsm"]
+    assert renderer._snapshot["entries"]["itsm"]["base_url"] == "http://itsm-svc:8000"


### PR DESCRIPTION
## 复现步骤

前置：本进程已成功拉过至少一条外部 OpenAPI 服务快照。

1. Traefik 用已配置的 provider 凭据请求 `GET /openapi/v1/_provider/traefik`，或读侧 TTL 到期后刷新。
2. 此时 NATS 仍连着，但 `kv.keys()` 抛超时、断连或权限类异常（不是空 bucket 的 `NoKeysError`）。
3. 对照返回的动态路由：已接入服务是被撤掉，还是沿用最近一次成功快照。

修复前：枚举异常被写成 `{}`，快照被空配置覆盖。  
修复后：这类失败返回 `None`，保留旧快照；真正空 bucket 的 `NoKeysError` 仍是空表。

## 修复方案

`_fetch_async` 只把 `nats.js.errors.NoKeysError` 当成空注册表。其它 `kv.keys` 异常向上抛，由 `fetch_entries` 返回 `None`。不改 renderer、TTL 和认证。

Fixes #5195

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 空 bucket `NoKeysError` | `{}` | `{}` |
| `kv.keys` 超时/断连 | `{}`，清掉旧快照 | `None`，保留旧快照 |
| 已成功的外部路由 | 故障时被撤 | 故障时仍在 |

## 影响面

- **会变**：枚举阶段的基础设施故障不再写成空 OpenAPI 配置。
- **不变**：空 bucket、bucket 创建失败仍按空表；provider 路径、认证、TTL。
- **不在范围**：单条 `kv.get` 失败仍跳过；未改 nats-py 版本。
