### PR TITLE
bugfix: OpenAPI 注册表枚举字段先校验类型再跳过

### DIFF
--- a/server/apps/core/openapi/renderer.py
+++ b/server/apps/core/openapi/renderer.py
@@ -128,14 +128,14 @@ def validate_entry(name: str, entry, internal_services=()):
         return None, "conflicts with internal service"
 
     schema_version = entry.get("schema_version", 1)
-    if schema_version not in SUPPORTED_SCHEMA_VERSIONS:
+    if not isinstance(schema_version, int) or schema_version not in SUPPORTED_SCHEMA_VERSIONS:
         return None, f"unsupported schema_version {schema_version!r}"
 
     if entry.get("enabled", True) is False:
         return None, "disabled"
 
     entry_type = entry.get("type")
-    if entry_type not in VALID_TYPES:
+    if not isinstance(entry_type, str) or entry_type not in VALID_TYPES:
         return None, f"unknown type {entry_type!r}"
 
     base_url = entry.get("base_url")
@@ -145,7 +145,7 @@ def validate_entry(name: str, entry, internal_services=()):
         return None, "base_url not in allowlist"
 
     auth_mode = entry.get("auth_mode")
-    if auth_mode not in VALID_AUTH_MODES:
+    if not isinstance(auth_mode, str) or auth_mode not in VALID_AUTH_MODES:
         return None, f"unknown auth_mode {auth_mode!r}"
 
     secrets = {}

--- a/server/apps/core/openapi/tests/test_renderer.py
+++ b/server/apps/core/openapi/tests/test_renderer.py
@@ -110,6 +110,41 @@ def test_bad_entries_skipped(env, mutation, reason_part):
     assert "routers" not in config["http"]
 
 
+@pytest.mark.parametrize(
+    "mutation, reason_part",
+    [
+        ({"schema_version": []}, "schema_version"),
+        ({"type": []}, "type"),
+        ({"auth_mode": {}}, "auth_mode"),
+    ],
+)
+def test_unhashable_enum_fields_skipped(env, mutation, reason_part):
+    """JSON list/dict 不可哈希：成员判断不得抛 TypeError，整条跳过。"""
+    entry = dict(GOOD, **mutation)
+    normalized, reason = renderer.validate_entry("itsm", entry)
+    assert normalized is None
+    assert reason_part in reason
+
+    config, report = render_one(entry)
+    assert report["rendered"] == []
+    assert reason_part in report["skipped"]["itsm"]
+    assert "routers" not in config["http"]
+
+
+def test_unhashable_entry_does_not_abort_batch(env):
+    """一条不可哈希枚举不得中断同批合法条目的渲染。"""
+    config, report = renderer.render_traefik_config(
+        {
+            "broken": dict(GOOD, schema_version=[]),
+            "itsm": dict(GOOD),
+        }
+    )
+    assert "itsm" in report["rendered"]
+    assert "schema_version" in report["skipped"]["broken"]
+    assert "openapi-v1-itsm" in config["http"]["routers"]
+    assert "openapi-v1-broken" not in config["http"].get("routers", {})
+
+
 def test_disabled_entry_skipped_quietly(env):
     _, report = render_one(dict(GOOD, enabled=False))
     assert report["skipped"]["itsm"] == "disabled"


### PR DESCRIPTION
## 复现步骤

前置：`OPENAPI_AUTH_ADDRESS` 已配置，provider 凭据有效。

1. KV 里同时有一条合法外部服务，以及一条 `schema_version` 为 `[]`（或 `type`/`auth_mode` 为容器）的记录。
2. Traefik 请求 `GET /openapi/v1/_provider/traefik`，或读侧 TTL 到期刷新。
3. 对照动态配置：合法服务是否还被渲染。

修复前：`validate_entry` 对不可哈希值做 set 判断抛 `TypeError`，整批中断。  
修复后：坏记录跳过，同批合法服务仍写入路由。

## 修复方案

`schema_version` 先确认是 `int`，`type` / `auth_mode` 先确认是 `str`，再做成员判断。失败仍走 `(None, reason)`。不改 KV、认证和 TTL。

Fixes #5196

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| `schema_version=[]` | TypeError 中断整批 | 该条 skipped |
| 同批合法服务 | 无法更新 | 仍渲染 |
| 未知标量 `schema_version=2` | 跳过 | 跳过 |

## 影响面

- **会变**：不可哈希枚举从拖垮批次改为单条跳过。
- **不变**：合法 int/str 枚举、disabled、未知字段忽略、允许清单。
- **不在范围**：未改 bool 仍是 int 子类这一既有 Python 行为。
