### PR TITLE
bugfix: 公共序列化器按本页作者查询用户显示名

### DIFF
--- a/server/apps/core/tests/test_serializers_service.py
+++ b/server/apps/core/tests/test_serializers_service.py
@@ -1,6 +1,8 @@
 import pydantic.root_model  # noqa
 
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from rest_framework import serializers
 
 from apps.core.utils import serializers as core_ser
@@ -8,7 +10,6 @@ from apps.core.utils.serializers import AuthSerializer, TeamSerializer, Username
 from apps.system_mgmt.models import User
 
 pytestmark = pytest.mark.django_db
-
 
 class _Obj:
     """轻量对象，模拟带 created_by/updated_by/team/id 的 DRF instance。"""
@@ -18,26 +19,51 @@ class _Obj:
             setattr(self, k, v)
 
 
-def _make_serializer_cls(base, method_field=None, **extra):
+def _make_serializer_cls(base, method_field=None, fields=None, **extra):
     """动态生成一个把 _Obj 的字段透传出去的子类，避免依赖具体 Model Meta。"""
-    base_fields = ["created_by", "updated_by", "domain", "updated_by_domain", "id", "team"]
-    meta_fields = base_fields + ([method_field] if method_field else [])
+    base_fields = fields if fields is not None else ["created_by", "updated_by", "domain", "updated_by_domain", "id", "team"]
+    meta_fields = list(base_fields) + ([method_field] if method_field else [])
 
-    class _S(base):
-        created_by = serializers.CharField(required=False)
-        updated_by = serializers.CharField(required=False)
-        domain = serializers.CharField(required=False)
-        updated_by_domain = serializers.CharField(required=False)
-        id = serializers.IntegerField(required=False)
-        team = serializers.ListField(required=False)
+    if fields is None:
+        class _S(base):
+            created_by = serializers.CharField(required=False)
+            updated_by = serializers.CharField(required=False)
+            domain = serializers.CharField(required=False)
+            updated_by_domain = serializers.CharField(required=False)
+            id = serializers.IntegerField(required=False)
+            team = serializers.ListField(required=False)
 
+            class Meta:
+                model = User
+                fields = meta_fields
+    else:
         class Meta:
             model = User
             fields = meta_fields
 
+        field_factories = {
+            "created_by": lambda: serializers.CharField(required=False),
+            "updated_by": lambda: serializers.CharField(required=False),
+            "domain": lambda: serializers.CharField(required=False),
+            "updated_by_domain": lambda: serializers.CharField(required=False),
+            "id": lambda: serializers.IntegerField(required=False),
+            "team": lambda: serializers.ListField(required=False),
+        }
+        attrs = {"Meta": Meta, "__module__": __name__}
+        for name in meta_fields:
+            factory = field_factories.get(name)
+            if factory is not None:
+                attrs[name] = factory()
+        _S = type("_S", (base,), attrs)
+
     for k, v in extra.items():
         setattr(_S, k, v)
     return _S
+
+
+def _user_selects(ctx):
+    table = User._meta.db_table
+    return [query["sql"] for query in ctx.captured_queries if query["sql"].lstrip().upper().startswith("SELECT") and table in query["sql"]]
 
 
 class TestUsernameSerializer:
@@ -60,6 +86,42 @@ class TestUsernameSerializer:
         obj = _Obj(created_by=None, updated_by="bob", updated_by_domain="corp.com", id=1, team=[])
         data = S(obj).data
         assert data["updated_by"] == "Bob B"
+
+    def test_skips_user_query_when_fields_omit_authors(self):
+        User.objects.create(username="alice", display_name="Alice Liddell", domain="domain.com", email="a@x.com")
+        S = _make_serializer_cls(UsernameSerializer, fields=["id", "team"])
+        obj = _Obj(created_by="alice", domain="domain.com", updated_by=None, id=1, team=[])
+        with CaptureQueriesContext(connection) as ctx:
+            S(obj)
+        assert _user_selects(ctx) == []
+
+    @pytest.mark.parametrize("unrelated_count", [1, 10, 100])
+    def test_author_lookup_query_count_does_not_grow_with_unrelated_users(self, unrelated_count):
+        User.objects.bulk_create(
+            [
+                User(username=f"noise_{index}", display_name=f"Noise {index}", domain="domain.com", email=f"n{index}@x.com", password="")
+                for index in range(unrelated_count)
+            ]
+        )
+        User.objects.create(username="alice", display_name="Alice Page", domain="domain.com", email="alice@x.com")
+        S = _make_serializer_cls(UsernameSerializer)
+        obj = _Obj(created_by="alice", domain="domain.com", updated_by=None, id=1, team=[])
+        with CaptureQueriesContext(connection) as ctx:
+            serializer = S([obj], many=True)
+            payload = serializer.data
+        selects = _user_selects(ctx)
+        assert len(selects) == 1
+        assert "WHERE" in selects[0].upper()
+        assert serializer.child.user_map == {"alice@domain.com": "Alice Page"}
+        assert payload[0]["created_by"] == "Alice Page"
+
+    def test_same_username_different_domain_maps_correctly(self):
+        User.objects.create(username="alice", display_name="Alice Default", domain="domain.com", email="a1@x.com")
+        User.objects.create(username="alice", display_name="Alice Corp", domain="corp.com", email="a2@x.com")
+        S = _make_serializer_cls(UsernameSerializer)
+        obj = _Obj(created_by="alice", domain="corp.com", updated_by=None, id=1, team=[])
+        data = S(obj).data
+        assert data["created_by"] == "Alice Corp"
 
 
 class TestTeamSerializer:

--- a/server/apps/core/utils/serializers.py
+++ b/server/apps/core/utils/serializers.py
@@ -1,3 +1,4 @@
+from django.db.models import Q
 from rest_framework import serializers
 from rest_framework.fields import empty
 
@@ -5,14 +6,52 @@ from apps.core.utils.permission_utils import get_permission_rules
 from apps.core.utils.team_utils import get_current_team
 from apps.system_mgmt.models import User
 
+_DEFAULT_DOMAIN = "domain.com"
+
 
 class UsernameSerializer(serializers.ModelSerializer):
     def __init__(self, instance=None, data=empty, **kwargs):
         super().__init__(instance=instance, data=data, **kwargs)
-        user_list = User.objects.all().values("username", "display_name", "domain")
         self.user_map = {}
+        need_created = "created_by" in self.fields
+        need_updated = "updated_by" in self.fields
+        if not need_created and not need_updated:
+            return
+        pairs = self._collect_author_pairs(instance, need_created, need_updated)
+        if not pairs:
+            return
+        query = Q()
+        for username, domain in pairs:
+            query |= Q(username=username, domain=domain)
+        user_list = User.objects.filter(query).values("username", "display_name", "domain")
         for i in user_list:
             self.user_map[f"{i['username']}@{i['domain']}"] = i["display_name"]
+
+    @staticmethod
+    def _iter_instances(instance):
+        if instance is None:
+            return ()
+        if hasattr(instance, "_meta"):
+            return (instance,)
+        if isinstance(instance, (list, tuple)):
+            return instance
+        if hasattr(instance, "__iter__") and not isinstance(instance, (str, bytes, dict)):
+            return instance
+        return (instance,)
+
+    @classmethod
+    def _collect_author_pairs(cls, instance, need_created, need_updated):
+        pairs = set()
+        for obj in cls._iter_instances(instance):
+            if need_created:
+                username = getattr(obj, "created_by", None)
+                if username:
+                    pairs.add((username, getattr(obj, "domain", None) or _DEFAULT_DOMAIN))
+            if need_updated:
+                username = getattr(obj, "updated_by", None)
+                if username:
+                    pairs.add((username, getattr(obj, "updated_by_domain", None) or _DEFAULT_DOMAIN))
+        return pairs
 
     def to_representation(self, instance):
         response = super().to_representation(instance)


### PR DESCRIPTION
## 复现步骤

前置：账号能打开作业模块。平台用户数量明显多于当前脚本列表页（几十或上百即可对照）。

1. 进入作业模块 **脚本管理**（locale `script_management`）。
2. 打开脚本列表并翻页。
3. 对照列表接口序列化时对 `system_mgmt_user` 的查询：是否带作者条件，还是 `SELECT` 全表。

修复前：`UsernameSerializer` 构造时 `User.objects.all()`。脚本列表字段没有 `created_by` / `updated_by`，翻页仍扫描全平台用户。  
修复后：没有作者字段时不查用户；需要显示名时只按本页作者做一次限定查询。

## 修复方案

`super()` 之后先看 `self.fields` 是否含 `created_by` / `updated_by`。都不含则 `user_map={}`。否则从本页 instance 收集 `(username, domain)` / `(updated_by, updated_by_domain)`（缺省 `domain.com`），用一次 `Q` 查询构建映射。找不到用户仍回显原 username。不改权限和团队过滤。

Fixes #5197

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 无作者字段的列表 | `User.objects.all()` | 0 次用户查询 |
| 有作者字段、库里另有 1/10/100 个无关用户 | 扫描行数随 U 增长 | 仍 1 次带 WHERE 的查询 |
| 同名不同 domain | 按 `username@domain` 映射 | 不变 |
| 用户不存在 | 回显原 username | 不变 |

## 影响面

- **会变**：无作者字段的公共序列化不再扫全表用户；有作者字段时只查本页作者。
- **不变**：显示名映射、默认 domain、缺失回退、权限/团队字段。
- **不在范围**：作者只存在于 `SerializerMethodField` 计算结果、不在 instance 属性上的路径。
