### PR TITLE
fix(监控): 阿里云拉地域不再误走腾讯云 SDK

### DIFF
--- a/agents/stargazer/plugins/inputs/aliyun/aliyun_info.py
+++ b/agents/stargazer/plugins/inputs/aliyun/aliyun_info.py
@@ -248,6 +248,11 @@ class CwAliyun(object):
         manager = self.__getattr__("list_all_resources")
         return await manager.list_all_resources(**kwargs)
 
+    def list_regions(self, ids=None):
+        """插件入口：CollectionService 直接调用此类方法，必须走阿里云 ECS DescribeRegions。"""
+        manager = self.__getattr__("list_regions")
+        return manager.list_regions(ids)
+
 
 class Aliyun(object):
     """

--- a/agents/stargazer/service/collection_service.py
+++ b/agents/stargazer/service/collection_service.py
@@ -467,4 +467,8 @@ class CollectionService:
             import traceback
 
             logger.error(f"Error list_regions for {self.plugin_name or self.model_id}: {traceback.format_exc()}")
-            return {"result": [], "success": False, "message": str(e)}
+            message = str(e)
+            model_id = str(self.model_id or "").strip().lower()
+            if model_id == "aliyun" and ("TencentCloudSDKException" in message or "SecretIdNotFound" in message or "SecretId不存在" in message):
+                message = "AccessKey 无效或权限不足，请检查 AccessKey ID / AccessKey Secret"
+            return {"result": [], "success": False, "message": message}

--- a/server/apps/monitor/utils/plugin_controller.py
+++ b/server/apps/monitor/utils/plugin_controller.py
@@ -215,6 +215,9 @@ def _plugin_types(context: dict) -> set[str]:
     types = {
         str(context.get("instance_type") or "").strip().lower(),
         str(context.get("type") or "").strip().lower(),
+        str(context.get("object_name") or "").strip().lower(),
+        str(context.get("name") or "").strip().lower(),
+        str(context.get("monitor_object_name") or "").strip().lower(),
     }
     config_type = context.get("config_type")
     if isinstance(config_type, (list, tuple)):
@@ -223,6 +226,14 @@ def _plugin_types(context: dict) -> set[str]:
         types.add(str(config_type).strip().lower())
     types.discard("")
     return types
+
+
+def _is_aliyun_plugin(plugin_types: set[str]) -> bool:
+    return any("aliyun" in item or "阿里云" in item for item in plugin_types)
+
+
+def _is_qcloud_plugin(plugin_types: set[str]) -> bool:
+    return any("qcloud" in item or "tencent" in item or "腾讯云" in item for item in plugin_types)
 
 
 def _normalize_qcloud_region(value) -> str:
@@ -260,11 +271,11 @@ def _normalize_template_context(context: dict) -> dict:
     if _is_rabbitmq_collect_config(normalized) and normalized.get("url") not in (None, ""):
         normalized["url"] = normalize_rabbitmq_management_url(normalized.get("url"))
     plugin_types = _plugin_types(normalized)
-    # 腾讯云地域：表单未填时回落广州，与 Stargazer 采集缺省一致。
-    if "qcloud" in plugin_types:
-        normalized["region"] = _normalize_qcloud_region(normalized.get("region"))
-    elif "aliyun" in plugin_types:
+    # 阿里云对象即使 UI 残留 qcloud instance_type，也必须单选并回落杭州。
+    if _is_aliyun_plugin(plugin_types):
         normalized["region"] = _normalize_aliyun_region(normalized.get("region"))
+    elif _is_qcloud_plugin(plugin_types):
+        normalized["region"] = _normalize_qcloud_region(normalized.get("region"))
     return normalized
 
 
@@ -375,7 +386,8 @@ class Controller:
             template_content = ensure_snmp_interface_filter_jinja(template_content)
         template_content = ensure_qcloud_region_jinja(template_content)
         if 'region = "{{ region }}"' in template_content and not str(_context.get("region") or "").strip():
-            _context["region"] = "ap-guangzhou"
+            plugin_types = _plugin_types(_context)
+            _context["region"] = "cn-hangzhou" if _is_aliyun_plugin(plugin_types) else "ap-guangzhou"
 
         safe_context = sanitize_template_context(_context)
         if escape_toml_strings:

--- a/web/src/app/alarm/components/k8sGuide/index.tsx
+++ b/web/src/app/alarm/components/k8sGuide/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useMemo, useState } from 'react';
-import { Button, Checkbox, Descriptions, Input, Spin, Tag } from 'antd';
+import { Button, Checkbox, Descriptions, Empty, Input, Spin, Tag } from 'antd';
 import CompactEmptyState from '@/components/compact-empty-state';
 import { CopyOutlined, DownloadOutlined } from '@ant-design/icons';
 import { useTranslation } from '../../../../utils/i18n';

--- a/web/src/app/monitor/(pages)/integration/asset/updateConfig.tsx
+++ b/web/src/app/monitor/(pages)/integration/asset/updateConfig.tsx
@@ -108,6 +108,7 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
     regionOptions,
     loadingRegions,
     refreshRegions,
+    multiple: regionMultiple,
   } = useCloudRegionOptions({
     enabled: Boolean(regionProvider && modalVisible),
     provider: regionProvider || 'qcloud',
@@ -134,6 +135,7 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
         region_option: {
           loading: loadingRegions,
           onRefresh: refreshRegions,
+          multiple: regionMultiple,
           refreshTip: t(
             'monitor.integrations.refreshStoredCloudRegionsTip',
             '刷新可用地域'
@@ -149,6 +151,7 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
     regionOptions,
     loadingRegions,
     refreshRegions,
+    regionMultiple,
     jsonConfig.buildPluginUI,
     t,
   ]);

--- a/web/src/app/monitor/(pages)/integration/asset/updateConfig.tsx
+++ b/web/src/app/monitor/(pages)/integration/asset/updateConfig.tsx
@@ -14,7 +14,7 @@ import { useTranslation } from '@/utils/i18n';
 import OperateModal from '@/components/operate-modal';
 import useApiClient from '@/utils/request';
 import { usePluginFromJson } from '@/app/monitor/hooks/integration/usePluginFromJson';
-import { cloudRegionProviderFromPlugin, resolveStoredCollectConfigId, useCloudRegionOptions } from '@/app/monitor/hooks/integration/useQcloudRegionOptions';
+import { cloudRegionProviderFromPlugin, cloudRegionProviderHintsFromRow, resolveStoredCollectConfigId, useCloudRegionOptions } from '@/app/monitor/hooks/integration/useQcloudRegionOptions';
 import {
   getSnmpFilterMutexConflicts,
   trackSnmpFilterMutexLastChanged
@@ -75,12 +75,7 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
       const collector = _form.collector;
       const collect_type = _form.collect_type;
       const monitor_object_id = _form.monitor_object_id;
-      setRegionHints({
-        objectName: String(
-          _form.monitor_object_name || _form.object_name || _form.name || ''
-        ),
-        pluginName: String(_form.plugin_name || collector || ''),
-      });
+      setRegionHints(cloudRegionProviderHintsFromRow(_form as Record<string, unknown>));
       const _pluginId = _form.monitor_plugin_id || `${monitor_object_id}_${collector}_${collect_type}`;
       setPluginId(_pluginId);
       setConfigLoading(true);

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
@@ -243,6 +243,7 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
     regionOptions,
     loadingRegions,
     refreshRegions,
+    multiple: regionMultiple,
   } = useCloudRegionOptions({
     enabled: Boolean(regionProvider),
     provider: regionProvider || 'qcloud',
@@ -267,6 +268,7 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
         region_option: {
           loading: loadingRegions,
           onRefresh: refreshRegions,
+          multiple: regionMultiple,
         },
       },
     });
@@ -283,6 +285,7 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
     regionOptions,
     loadingRegions,
     refreshRegions,
+    regionMultiple,
     jsonConfig.buildPluginUI,
   ]);
 

--- a/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
+++ b/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
@@ -31,6 +31,8 @@ export type FormFieldOptionControls = Record<
     loading?: boolean;
     onRefresh?: () => void;
     refreshTip?: string;
+    /** 云地域：true=腾讯云多选，false=阿里云单选；用来覆盖 UI.json 残留的 mode。 */
+    multiple?: boolean;
   }
 >;
 
@@ -455,9 +457,17 @@ export const useConfigRenderer = () => {
             (Boolean(showRefresh) ||
               resolvedOptionsKey === 'region_option' ||
               name === 'region');
+          const regionMultiple = optionControl?.multiple;
+          const selectMode = allowCustomTags
+            ? ('tags' as const)
+            : typeof regionMultiple === 'boolean'
+              ? regionMultiple
+                ? ('multiple' as const)
+                : undefined
+              : widget_props.mode;
           const selectProps = {
             ...restSelectProps,
-            mode: allowCustomTags ? ('tags' as const) : widget_props.mode,
+            mode: selectMode,
             tokenSeparators: allowCustomTags
               ? widget_props.tokenSeparators || [',']
               : widget_props.tokenSeparators,
@@ -470,7 +480,7 @@ export const useConfigRenderer = () => {
             showSearch: true as const,
             optionFilterProp: 'label' as const,
             maxTagCount:
-              widget_props.mode === 'multiple'
+              selectMode === 'multiple'
                 ? widget_props.maxTagCount || 'responsive'
                 : widget_props.maxTagCount,
             style: formWidgetWidthStyle(widgetStyle),

--- a/web/src/app/monitor/hooks/integration/usePluginFromJson.tsx
+++ b/web/src/app/monitor/hooks/integration/usePluginFromJson.tsx
@@ -246,6 +246,7 @@ export const usePluginFromJson = () => {
             loading?: boolean;
             onRefresh?: () => void;
             refreshTip?: string;
+            multiple?: boolean;
           }
         >;
       }

--- a/web/src/app/monitor/hooks/integration/useQcloudRegionOptions.ts
+++ b/web/src/app/monitor/hooks/integration/useQcloudRegionOptions.ts
@@ -523,6 +523,7 @@ export function useCloudRegionOptions(options: {
     regionOptions,
     loadingRegions,
     refreshRegions: () => fetchRegions({ silent: false }),
+    multiple,
   };
 }
 

--- a/web/src/app/monitor/hooks/integration/useQcloudRegionOptions.ts
+++ b/web/src/app/monitor/hooks/integration/useQcloudRegionOptions.ts
@@ -23,6 +23,18 @@ function addCloudProviderTokens(tokens: Set<string>, value: unknown) {
   }
 }
 
+function isAliyunToken(token: string) {
+  return token.includes('aliyun') || token.includes('阿里云');
+}
+
+function isQcloudToken(token: string) {
+  return (
+    token.includes('qcloud') ||
+    token.includes('tencent') ||
+    token.includes('腾讯云')
+  );
+}
+
 /**
  * 按监控对象/插件身份选择地域拉取通道。
  * 阿里云对象即使 UI.json 仍残留 qcloud instance_type，也必须走阿里云 DescribeRegions，
@@ -48,11 +60,27 @@ export function cloudRegionProviderFromPlugin(
   } else if (config?.config_type) {
     addCloudProviderTokens(tokens, config.config_type);
   }
-  if ([...tokens].some((token) => token.includes('aliyun'))) return 'aliyun';
-  if ([...tokens].some((token) => token.includes('qcloud') || token.includes('tencent'))) {
-    return 'qcloud';
-  }
+  const list = [...tokens];
+  if (list.some(isAliyunToken)) return 'aliyun';
+  if (list.some(isQcloudToken)) return 'qcloud';
   return null;
+}
+
+/** 资产编辑行：抽屉传的是 objName，不是 monitor_object_name。 */
+export function cloudRegionProviderHintsFromRow(
+  row?: Record<string, unknown> | null
+): CloudRegionProviderHints {
+  if (!row) return {};
+  return {
+    objectName: String(
+      row.objName ||
+        row.monitor_object_name ||
+        row.object_name ||
+        row.name ||
+        ''
+    ),
+    pluginName: String(row.plugin_name || row.collector || ''),
+  };
 }
 
 export interface RegionOption {


### PR DESCRIPTION
## Summary

- 监控接入/编辑共用同一套 `useCloudRegionOptions`：按对象名识别云厂商，阿里云身份优先于插件 UI 残留的 `qcloud`。
- 腾讯云走 `qcloud_regions` + CVM DescribeRegions（可多选）；阿里云走 `aliyun_regions` + ECS DescribeRegions（强制单选，即使 UI.json 仍是 multiple）。
- 资产编辑弹窗读取抽屉传入的 `objName`；Stargazer 阿里云插件补 `list_regions`，失败时不再把腾讯云 SDK 原文抛给用户。
- 采集模板按对象名优先识别阿里云，空地域回落 `cn-hangzhou`；腾讯云仍回落 `ap-guangzhou`。

## Test plan

- [ ] 监控 → 集成 → 腾讯云 TCP/CVM：密钥后自动拉地域，可多选，刷新不冲掉已选
- [ ] 监控 → 集成 → 阿里云：走阿里云 DescribeRegions，下拉为单选，不再出现 `TencentCloudSDKException` / `SecretId不存在`
- [ ] 阿里云资产「更新配置」：用已存配置拉地域；密钥无效提示 AccessKey 相关文案
- [ ] 腾讯云资产「更新配置」行为不变

## 提交范围

已核对相对 `TencentBlueKing/bk-lite` `master` 的 diff，仅含监控阿里云/腾讯云拉地域对齐。测试文件、Storybook mock、企业图标未纳入。首个 commit 含一行 K8s 引导页 `Empty` 导入，仅为通过当前 `master` 全仓 type-check。