### PR TITLE
bugfix: K8s接入指南失败态改用 CompactEmptyState

### DIFF
--- a/web/scripts/k8s-meta-retry-test.ts
+++ b/web/scripts/k8s-meta-retry-test.ts
@@ -150,6 +150,12 @@ const main = async () => {
   );
   assert.match(guideSource, /failed/, 'K8sGuide 必须有稳定失败态');
   assert.match(guideSource, /common\.retry/, '失败态必须提供显式重试');
+  assert.match(
+    guideSource,
+    /CompactEmptyState description=\{t\('integration\.k8sMetaLoadFailed'\)\}/,
+    '失败态必须走 CompactEmptyState',
+  );
+  assert.doesNotMatch(guideSource, /<Empty[\s>]/, 'K8sGuide 不得直接使用 antd Empty');
   assert.match(zhLocale, /"k8sMetaLoadFailed"/);
   assert.match(enLocale, /"k8sMetaLoadFailed"/);
   assert.doesNotMatch(

--- a/web/src/app/alarm/components/k8sGuide/index.tsx
+++ b/web/src/app/alarm/components/k8sGuide/index.tsx
@@ -68,13 +68,13 @@ const K8sGuide: React.FC<K8sGuideProps> = ({
 
   if (failed) {
     return (
-      <Empty description={t('integration.k8sMetaLoadFailed')}>
+      <CompactEmptyState description={t('integration.k8sMetaLoadFailed')}>
         {onRetry ? (
           <Button type="primary" onClick={onRetry}>
             {t('common.retry')}
           </Button>
         ) : null}
-      </Empty>
+      </CompactEmptyState>
     );
   }
 

--- a/web/src/components/compact-empty-state/index.tsx
+++ b/web/src/components/compact-empty-state/index.tsx
@@ -6,11 +6,13 @@ import { Empty } from 'antd';
 export interface CompactEmptyStateProps {
   description: React.ReactNode;
   className?: string;
+  children?: React.ReactNode;
 }
 
 const CompactEmptyState: React.FC<CompactEmptyStateProps> = ({
   description,
   className = '',
+  children,
 }) => {
   return (
     <div className={`py-1 ${className}`.trim()}>
@@ -30,7 +32,9 @@ const CompactEmptyState: React.FC<CompactEmptyStateProps> = ({
             {description}
           </span>
         }
-      />
+      >
+        {children}
+      </Empty>
     </div>
   );
 };

--- a/web/src/stories/feedback-family.stories.tsx
+++ b/web/src/stories/feedback-family.stories.tsx
@@ -50,6 +50,12 @@ const FamilyOverview = () => {
                 description="No records are available for the current table view."
                 className="py-6"
               />
+              <CompactEmptyState
+                description="Failed to load integration metadata."
+                className="py-6"
+              >
+                <Button type="primary">Retry</Button>
+              </CompactEmptyState>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary

- Cycle 37 把 `k8sGuide` 无数据态收成 `CompactEmptyState` 并删掉 antd `Empty` 导入；同日合入的失败重试仍写 `<Empty>`，生产 `type-check` 失败（#5360）。
- 公共空态组件补 `children`，失败态带重试按钮走 `CompactEmptyState`，不再回补 `Empty` 导入。
- 失败重试语义不变：文案、重试按钮、`failed` 门闩都不动。

Fixes #5360

## Test plan

- [x] `pnpm exec tsx scripts/k8s-meta-retry-test.ts` → `k8s-meta-retry-test: ok`
- [x] `k8sGuide` 不再引用 antd `Empty`；失败态使用 `CompactEmptyState`
- [ ] `pnpm run type-check` / 生产构建可通过
- [ ] 告警集成 K8s 指南：元数据失败停在失败态并显示重试；点重试仍只再请求一次


Made with [Cursor](https://cursor.com)