### PR TITLE
bugfix: RPC 字符串脱敏覆盖引号包围的敏感键

### DIFF
--- a/server/apps/job_mgmt/tests/test_rpc_sensitive_contract_service.py
+++ b/server/apps/job_mgmt/tests/test_rpc_sensitive_contract_service.py
@@ -63,6 +63,59 @@ def test_ansible_task_callback_masks_sensitive_output_in_logs_and_results():
     assert persisted["error_message"] == "passphrase=***"
 
 
+@pytest.mark.integration
+@pytest.mark.django_db
+def test_ansible_task_callback_masks_json_quoted_keys_in_persisted_results():
+    execution = authorize_execution(JobExecution.objects.create(
+        name="rpc-sensitive-json-test",
+        job_type=JobType.SCRIPT,
+        trigger_source=TriggerSource.MANUAL,
+        target_source=TargetSource.MANUAL,
+        status=ExecutionStatus.RUNNING,
+        target_list=[{"target_id": 1, "name": "host-1", "ip": "10.0.0.1"}],
+        total_count=1,
+        team=[1],
+        started_at=timezone.now(),
+    ))
+    callback_payload = with_callback_identity(execution, {
+        "task_id": execution.id,
+        "task_type": "adhoc",
+        "status": "success",
+        "success": True,
+        "error": '{"ansible_password": "JSON-ERROR-MARKER"}',
+        "result": [
+            {
+                "host": "10.0.0.1",
+                "status": "success",
+                "stdout": '{"password": "JSON-STDOUT-MARKER"}',
+                "stderr": '{"private_key_content": "JSON-STDERR-MARKER"}',
+                "exit_code": 0,
+                "error_message": '{"passphrase": "JSON-ERR-MARKER"}',
+            }
+        ],
+    })
+
+    with patch("apps.job_mgmt.services.ansible_callback_service.logger") as mock_logger, patch(
+        "apps.job_mgmt.services.completion_outbox_service._schedule_deliveries"
+    ):
+        result = ansible_task_callback(callback_payload)
+
+    execution.refresh_from_db()
+    first_log = " ".join(str(arg) for arg in mock_logger.info.call_args_list[0][0])
+    persisted = execution.execution_results[0]
+
+    assert result == {"success": True, "message": "回调处理成功"}
+    assert "JSON-STDOUT-MARKER" not in first_log
+    assert "JSON-ERROR-MARKER" not in first_log
+    assert "***" in first_log
+    assert "JSON-STDOUT-MARKER" not in persisted["stdout"]
+    assert "JSON-STDERR-MARKER" not in persisted["stderr"]
+    assert "JSON-ERR-MARKER" not in persisted["error_message"]
+    assert persisted["stdout"] == '{"password": "***"}'
+    assert persisted["stderr"] == '{"private_key_content": "***"}'
+    assert persisted["error_message"] == '{"passphrase": "***"}'
+
+
 class _DummyResponse:
     def __init__(self, payload):
         self.data = json.dumps(payload).encode()

--- a/server/apps/rpc/sensitive.py
+++ b/server/apps/rpc/sensitive.py
@@ -21,10 +21,11 @@ _DIRECT_MASK_KEYS = {
 _RECURSE_ONLY_KEYS = {"host_credentials"}
 
 _SENSITIVE_ASSIGNMENT_RE = re.compile(
-    r"(?P<key>"
+    r"(?P<q>['\"])?(?P<key>"
     r"password|passphrase|private_key|private_key_content|private_key_passphrase|inventory_content|"
     r"ansible_password|ansible_ssh_passphrase|ansible_become_password"
-    r")(?P<sep>\s*[:=]\s*)(?P<value>'[^']*'|\"[^\"]*\"|[^,\s}\]]+)",
+    r")(?(q)(?P=q))(?P<sep>\s*[:=]\s*)"
+    r"(?P<value>\"(?:[^\"\\]|\\.)*\"|'(?:[^'\\]|\\.)*'|[^,\s}\]]+)",
     re.IGNORECASE,
 )
 _PRIVATE_KEY_BLOCK_RE = re.compile(
@@ -35,11 +36,12 @@ _PRIVATE_KEY_BLOCK_RE = re.compile(
 
 def _mask_match(match: re.Match[str]) -> str:
     value = match.group("value")
-    if value.startswith(("'", '"')) and value.endswith(value[0]):
+    if value.startswith(("'", '"')) and len(value) >= 2 and value.endswith(value[0]):
         masked = f"{value[0]}{MASKED_VALUE}{value[0]}"
     else:
         masked = MASKED_VALUE
-    return f"{match.group('key')}{match.group('sep')}{masked}"
+    quote = match.group("q") or ""
+    return f"{quote}{match.group('key')}{quote}{match.group('sep')}{masked}"
 
 
 def _sanitize_string(value: str) -> str:

--- a/server/apps/rpc/tests/test_sensitive_pure.py
+++ b/server/apps/rpc/tests/test_sensitive_pure.py
@@ -99,6 +99,52 @@ def test_string_assignment_colon_separator():
     assert out == f"ansible_password: {MASKED_VALUE}"
 
 
+def test_string_json_quoted_key_masked():
+    marker = "JSON-PASSWORD-MARKER"
+    out = sanitize_sensitive_data(f'{{"password": "{marker}", "host": "web-1"}}')
+    assert marker not in out
+    assert out == f'{{"password": "{MASKED_VALUE}", "host": "web-1"}}'
+
+
+def test_string_python_repr_quoted_key_masked():
+    marker = "PY-PASSWORD-MARKER"
+    out = sanitize_sensitive_data(f"{{'password': '{marker}', 'host': 'web-1'}}")
+    assert marker not in out
+    assert out == f"{{'password': '{MASKED_VALUE}', 'host': 'web-1'}}"
+
+
+def test_string_embedded_json_object_in_log_masked():
+    marker = "EMBEDDED-JSON-MARKER"
+    text = f'host=web-1 output={{"password": "{marker}"}} done'
+    out = sanitize_sensitive_data(text)
+    assert marker not in out
+    assert out.startswith("host=web-1 output=")
+    assert out.endswith("} done")
+    assert MASKED_VALUE in out
+
+
+def test_string_embedded_python_repr_in_log_masked():
+    marker = "EMBEDDED-PY-MARKER"
+    text = f"callback payload {{'password': '{marker}'}} next"
+    out = sanitize_sensitive_data(text)
+    assert marker not in out
+    assert out.startswith("callback payload ")
+    assert out.endswith("} next")
+    assert MASKED_VALUE in out
+
+
+def test_string_json_escaped_quotes_in_value_masked():
+    out = sanitize_sensitive_data('{"password": "say \\"JSON-ESC-MARKER\\""}')
+    assert "JSON-ESC-MARKER" not in out
+    assert out == f'{{"password": "{MASKED_VALUE}"}}'
+
+
+def test_string_python_repr_escaped_quotes_in_value_masked():
+    out = sanitize_sensitive_data(r"{'password': 'say \'PY-ESC-MARKER\''}")
+    assert "PY-ESC-MARKER" not in out
+    assert out == f"{{'password': '{MASKED_VALUE}'}}"
+
+
 def test_string_non_sensitive_unchanged():
     assert sanitize_sensitive_data("hello world") == "hello world"
 


### PR DESCRIPTION
## 复现步骤

前置：账号能打开作业模块。准备一次会在目标主机 stdout 打出 JSON 的脚本作业，例如 `{"password": "plain-secret"}`。输出短于回调截断阈值。

1. 进入作业模块 **作业记录**（locale `jobRecord`）。
2. 打开该次执行详情，看主机输出。
3. 对照 `JobExecution.execution_results` 里的 `stdout` / `stderr` / `error_message`。

修复前：`password=plain-secret` 会被打成 `***`，但 `{"password": "plain-secret"}` 原样入库。  
修复后：引号包围的敏感键值同样替换为 `***`，JSON 结构保留。

## 修复方案

公共字符串脱敏正则补上成对引号键，并允许值里的转义引号。dict/list 递归、现有赋值格式、PEM 块、空值不掩码不变。不改回调身份和执行结果结构。

Fixes #5198

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| `{"password": "MARKER"}` | 明文保留 | `"password": "***"` |
| `{'password': 'MARKER'}` | 明文保留 | `'password': '***'` |
| `password=MARKER` | `password=***` | 不变 |
| 非敏感文本 / 空值 / PEM | 原行为 | 不变 |

## 影响面

- **会变**：作业回调持久化的字符串里，JSON/Python repr 敏感键值改为 `***`。
- **不变**：RPC subject、回调身份、组织权限、执行结果字段结构。
- **不在范围**：`\u0022` 转义键、YAML、无引号 JSON5；历史结果不会自动回刷。
