### PR TITLE
bugfix: 图片数据集发布解压 ZIP 增加字节和成员预算

### DIFF
--- a/server/apps/mlops/tasks/image_classification.py
+++ b/server/apps/mlops/tasks/image_classification.py
@@ -25,6 +25,7 @@ from apps.mlops.tasks.base import (
     prepare_claim_storage,
     save_dataset_release_object,
 )
+from apps.mlops.utils.zip_extract_budget import ZipExtractBudget, extract_zip_with_budget
 
 ZIP_COPY_CHUNK_SIZE = 64 * 1024
 
@@ -96,6 +97,7 @@ def publish_dataset_release_async(self, release_id, train_file_id, val_file_id, 
             statistics = {"total_images": 0, "classes": set(), "splits": {}}
 
             # 处理 train/val/test 三个数据集
+            extract_budget = ZipExtractBudget.from_env()
             for data_obj, split_name in [
                 (train_obj, "train"),
                 (val_obj, "val"),
@@ -115,8 +117,7 @@ def publish_dataset_release_async(self, release_id, train_file_id, val_file_id, 
                     with data_obj.train_data.open("rb") as source, open(temp_zip, "wb") as target:
                         shutil.copyfileobj(source, target, length=ZIP_COPY_CHUNK_SIZE)
 
-                    with zipfile.ZipFile(temp_zip, "r") as zipf:
-                        zipf.extractall(temp_extract)
+                    extract_zip_with_budget(temp_zip, temp_extract, extract_budget)
 
                     # 根据 metadata 重组为 ImageFolder 格式
                     split_stats = _reorganize_images(temp_extract, split_root, data_obj.metadata)

--- a/server/apps/mlops/tasks/object_detection.py
+++ b/server/apps/mlops/tasks/object_detection.py
@@ -25,6 +25,7 @@ from apps.mlops.tasks.base import (
     prepare_claim_storage,
     save_dataset_release_object,
 )
+from apps.mlops.utils.zip_extract_budget import ZipExtractBudget, extract_zip_with_budget
 
 ZIP_COPY_CHUNK_SIZE = 64 * 1024
 
@@ -275,6 +276,7 @@ def publish_dataset_release_async(self, release_id, train_file_id, val_file_id, 
                 "test": test_mapping,
             }
 
+            extract_budget = ZipExtractBudget.from_env()
             for data_obj, split_name in [
                 (train_obj, "train"),
                 (val_obj, "val"),
@@ -291,8 +293,7 @@ def publish_dataset_release_async(self, release_id, train_file_id, val_file_id, 
                     with data_obj.train_data.open("rb") as source, open(temp_zip, "wb") as target:
                         shutil.copyfileobj(source, target, length=ZIP_COPY_CHUNK_SIZE)
 
-                    with zipfile.ZipFile(temp_zip, "r") as zipf:
-                        zipf.extractall(temp_extract)
+                    extract_zip_with_budget(temp_zip, temp_extract, extract_budget)
 
                     # 重组为 YOLO 格式（images/split/ + labels/split/）
                     try:

--- a/server/apps/mlops/tests/test_dataset_zip_extract_budget.py
+++ b/server/apps/mlops/tests/test_dataset_zip_extract_budget.py
@@ -1,0 +1,189 @@
+"""图片分类 / 目标检测发布解压 ZIP 的成员数与实际字节预算。"""
+
+from __future__ import annotations
+
+import inspect
+import tempfile
+import zipfile
+from pathlib import Path
+
+import pydantic.root_model  # noqa
+import pytest
+
+from apps.mlops.tasks import image_classification as image_task
+from apps.mlops.tasks import object_detection as object_task
+from apps.mlops.utils.zip_extract_budget import (
+    ZIP_EXTRACT_CHUNK_SIZE,
+    ZipExtractBudget,
+    ZipExtractBudgetExceeded,
+    extract_zip_with_budget,
+)
+
+pytestmark = pytest.mark.unit
+
+_CHUNK_SIZE = 64 * 1024
+
+
+def _write_zip(path: Path, files: dict[str, bytes]) -> None:
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for name, data in files.items():
+            archive.writestr(name, data)
+
+
+def _budget(**overrides) -> ZipExtractBudget:
+    params = {
+        "mode": "enforce",
+        "max_members": 1000,
+        "max_member_bytes": 1024 * 1024,
+        "max_total_bytes": 4 * 1024 * 1024,
+    }
+    params.update(overrides)
+    return ZipExtractBudget(**params)
+
+
+def test_three_small_splits_extract_successfully(tmp_path):
+    budget = _budget()
+    extracted = []
+    for split in ("train", "val", "test"):
+        zip_path = tmp_path / f"{split}.zip"
+        _write_zip(zip_path, {f"{split}.txt": f"{split}-payload".encode()})
+        dest = tmp_path / f"{split}_extract"
+        extract_zip_with_budget(zip_path, dest, budget)
+        extracted.append(dest / f"{split}.txt")
+
+    assert [path.read_text() for path in extracted] == [
+        "train-payload",
+        "val-payload",
+        "test-payload",
+    ]
+    assert budget.member_count == 3
+    assert budget.total_bytes == sum(len(f"{split}-payload".encode()) for split in ("train", "val", "test"))
+
+
+def test_cumulative_bytes_across_splits_exceed(tmp_path):
+    budget = _budget(max_total_bytes=1500)
+    first_zip = tmp_path / "train.zip"
+    second_zip = tmp_path / "val.zip"
+    _write_zip(first_zip, {"a.bin": b"a" * 1000})
+    _write_zip(second_zip, {"b.bin": b"b" * 1000})
+
+    extract_zip_with_budget(first_zip, tmp_path / "train_extract", budget)
+    with pytest.raises(ZipExtractBudgetExceeded) as exc:
+        extract_zip_with_budget(second_zip, tmp_path / "val_extract", budget)
+    assert "total_bytes" in str(exc.value)
+
+
+def test_too_many_small_members_exceed(tmp_path):
+    files = {f"f{i}.txt": b"x" for i in range(20)}
+    zip_path = tmp_path / "many.zip"
+    _write_zip(zip_path, files)
+    dest = tmp_path / "extract"
+    with pytest.raises(ZipExtractBudgetExceeded) as exc:
+        extract_zip_with_budget(zip_path, dest, _budget(max_members=5))
+    assert "members" in str(exc.value)
+
+
+def test_high_ratio_member_counts_actual_bytes_not_declared_size(tmp_path, monkeypatch):
+    payload = b"\x00" * (256 * 1024)
+    zip_path = tmp_path / "bomb.zip"
+    _write_zip(zip_path, {"bomb.bin": payload})
+
+    original_infolist = zipfile.ZipFile.infolist
+
+    def lying_infolist(self):
+        infos = original_infolist(self)
+        for info in infos:
+            info.file_size = 1
+        return infos
+
+    monkeypatch.setattr(zipfile.ZipFile, "infolist", lying_infolist)
+
+    dest = tmp_path / "extract"
+    with pytest.raises(ZipExtractBudgetExceeded) as exc:
+        extract_zip_with_budget(
+            zip_path,
+            dest,
+            _budget(max_member_bytes=8 * 1024, max_total_bytes=8 * 1024),
+        )
+    message = str(exc.value)
+    assert "member_bytes" in message or "total_bytes" in message
+
+
+def test_extract_reads_in_64kib_chunks(tmp_path, monkeypatch):
+    zip_path = tmp_path / "chunked.zip"
+    _write_zip(zip_path, {"blob.bin": b"n" * (200 * 1024)})
+    requested = []
+    original_read = zipfile.ZipExtFile.read
+
+    def tracked_read(self, n=-1):
+        requested.append(n)
+        return original_read(self, n)
+
+    monkeypatch.setattr(zipfile.ZipExtFile, "read", tracked_read)
+    extract_zip_with_budget(zip_path, tmp_path / "extract", _budget())
+
+    assert requested
+    assert all(0 < size <= _CHUNK_SIZE for size in requested)
+    assert ZIP_EXTRACT_CHUNK_SIZE == _CHUNK_SIZE
+
+
+def test_exceed_cleans_dest_and_caller_temp_leaves_no_residue(tmp_path):
+    zip_path = tmp_path / "big.zip"
+    _write_zip(zip_path, {"big.bin": b"z" * 50_000})
+    dest = tmp_path / "extract"
+    dest.mkdir()
+    with pytest.raises(ZipExtractBudgetExceeded):
+        extract_zip_with_budget(zip_path, dest, _budget(max_total_bytes=100))
+    leftover_files = [path for path in dest.rglob("*") if path.is_file()]
+    assert leftover_files == []
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        caller_temp = Path(temp_dir)
+        nested = caller_temp / "extract"
+        nested.mkdir()
+        with pytest.raises(ZipExtractBudgetExceeded):
+            extract_zip_with_budget(zip_path, nested, _budget(max_total_bytes=100))
+        leftover_nested = [path for path in nested.rglob("*") if path.is_file()]
+        assert leftover_nested == []
+    assert not caller_temp.exists()
+
+
+def test_observe_mode_still_extracts_when_over_budget(tmp_path):
+    zip_path = tmp_path / "over.zip"
+    _write_zip(zip_path, {"a.bin": b"a" * 1000})
+    dest = tmp_path / "extract"
+    extract_zip_with_budget(
+        zip_path,
+        dest,
+        _budget(mode="observe", max_total_bytes=100),
+    )
+    assert (dest / "a.bin").read_bytes() == b"a" * 1000
+
+
+def test_from_env_defaults_to_enforce(monkeypatch):
+    monkeypatch.delenv("MLOPS_DATASET_ZIP_BUDGET_MODE", raising=False)
+    budget = ZipExtractBudget.from_env()
+    assert budget.mode == "enforce"
+    assert budget.max_members > 0
+    assert budget.max_member_bytes > 0
+    assert budget.max_total_bytes > 0
+
+
+def test_path_escape_is_rejected(tmp_path):
+    zip_path = tmp_path / "escape.zip"
+    with zipfile.ZipFile(zip_path, "w") as archive:
+        archive.writestr("../escape.txt", b"nope")
+    dest = tmp_path / "extract"
+    dest.mkdir()
+    with pytest.raises(ValueError):
+        extract_zip_with_budget(zip_path, dest, _budget())
+    assert not (tmp_path / "escape.txt").exists()
+
+
+def test_publish_tasks_no_longer_call_extractall():
+    image_src = inspect.getsource(image_task.publish_dataset_release_async)
+    object_src = inspect.getsource(object_task.publish_dataset_release_async)
+    assert "extractall" not in image_src
+    assert "extractall" not in object_src
+    assert "extract_zip_with_budget" in image_src
+    assert "extract_zip_with_budget" in object_src

--- a/server/apps/mlops/utils/zip_extract_budget.py
+++ b/server/apps/mlops/utils/zip_extract_budget.py
@@ -1,0 +1,183 @@
+"""图片数据集发布 ZIP 解压预算：按实际写出字节与成员数计数。"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import zipfile
+from pathlib import Path
+
+from apps.core.logger import mlops_logger as logger
+
+ZIP_EXTRACT_CHUNK_SIZE = 64 * 1024
+
+ENV_MODE = "MLOPS_DATASET_ZIP_BUDGET_MODE"
+ENV_MAX_MEMBERS = "MLOPS_DATASET_ZIP_MAX_MEMBERS"
+ENV_MAX_MEMBER_BYTES = "MLOPS_DATASET_ZIP_MAX_MEMBER_BYTES"
+ENV_MAX_TOTAL_BYTES = "MLOPS_DATASET_ZIP_MAX_TOTAL_BYTES"
+
+DEFAULT_MODE = "enforce"
+DEFAULT_MAX_MEMBERS = 50_000
+DEFAULT_MAX_MEMBER_BYTES = 100 * 1024 * 1024
+DEFAULT_MAX_TOTAL_BYTES = 2 * 1024 * 1024 * 1024
+
+_ALLOWED_MODES = {"observe", "enforce"}
+
+
+class ZipExtractBudgetExceeded(ValueError):
+    """ZIP 解压超出成员数或实际写出字节预算。"""
+
+    def __init__(self, kind: str, actual: int, limit: int, member: str = ""):
+        self.kind = kind
+        self.actual = actual
+        self.limit = limit
+        self.member = member
+        super().__init__(
+            f"dataset zip extract budget exceeded kind={kind} actual={actual} limit={limit} member={member}"
+        )
+
+
+class ZipExtractUnsafePath(ValueError):
+    """ZIP 成员路径逃逸或非法。"""
+
+
+class ZipExtractBudget:
+    """跨 train/val/test 共用的解压预算。"""
+
+    def __init__(self, *, mode: str, max_members: int, max_member_bytes: int, max_total_bytes: int):
+        self.mode = mode
+        self.max_members = max_members
+        self.max_member_bytes = max_member_bytes
+        self.max_total_bytes = max_total_bytes
+        self.member_count = 0
+        self.total_bytes = 0
+        self._logged: set[tuple[str, str]] = set()
+
+    @classmethod
+    def from_env(cls) -> ZipExtractBudget:
+        mode_raw = (os.getenv(ENV_MODE, DEFAULT_MODE) or DEFAULT_MODE).strip().lower()
+        if mode_raw not in _ALLOWED_MODES:
+            logger.warning(
+                "event=dataset_zip_budget_invalid_mode value=%s fallback=%s",
+                mode_raw,
+                DEFAULT_MODE,
+            )
+            mode_raw = DEFAULT_MODE
+        return cls(
+            mode=mode_raw,
+            max_members=_env_positive_int(ENV_MAX_MEMBERS, DEFAULT_MAX_MEMBERS),
+            max_member_bytes=_env_positive_int(ENV_MAX_MEMBER_BYTES, DEFAULT_MAX_MEMBER_BYTES),
+            max_total_bytes=_env_positive_int(ENV_MAX_TOTAL_BYTES, DEFAULT_MAX_TOTAL_BYTES),
+        )
+
+    def note_member(self, member: str) -> None:
+        next_count = self.member_count + 1
+        self._check("members", next_count, self.max_members, member)
+        self.member_count = next_count
+
+    def note_written_bytes(self, written: int, member: str) -> None:
+        self._check("member_bytes", written, self.max_member_bytes, member)
+        self._check("total_bytes", self.total_bytes + written, self.max_total_bytes, member)
+
+    def commit_written_bytes(self, written: int) -> None:
+        self.total_bytes += written
+
+    def _check(self, kind: str, actual: int, limit: int, member: str) -> None:
+        if actual <= limit:
+            return
+        key = (kind, member)
+        if key not in self._logged:
+            self._logged.add(key)
+            logger.warning(
+                "event=dataset_zip_budget_exceeded kind=%s mode=%s actual=%s limit=%s member=%s",
+                kind,
+                self.mode,
+                actual,
+                limit,
+                member,
+            )
+        if self.mode == "enforce":
+            raise ZipExtractBudgetExceeded(kind, actual, limit, member)
+
+
+def extract_zip_with_budget(zip_path: str | Path, dest_dir: str | Path, budget: ZipExtractBudget) -> None:
+    """按块解压 ZIP，累计实际写出字节；enforce 超额时清理目标目录并抛错。"""
+    dest = Path(dest_dir)
+    dest.mkdir(parents=True, exist_ok=True)
+    dest_resolved = dest.resolve()
+    try:
+        with zipfile.ZipFile(zip_path, "r") as archive:
+            for info in archive.infolist():
+                member_name = info.filename or ""
+                target = _resolve_member_path(dest_resolved, member_name)
+                budget.note_member(member_name)
+                if info.is_dir() or member_name.endswith("/") or member_name.endswith("\\"):
+                    target.mkdir(parents=True, exist_ok=True)
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                written = 0
+                # ZipExtFile 按 ZipInfo.file_size 截断；预算只认实际写出字节，打开前去掉该截断。
+                info.file_size = _uncapped_file_size(info.file_size, budget)
+                with archive.open(info, "r") as source, open(target, "wb") as output:
+                    while True:
+                        chunk = source.read(ZIP_EXTRACT_CHUNK_SIZE)
+                        if not chunk:
+                            break
+                        written += len(chunk)
+                        budget.note_written_bytes(written, member_name)
+                        output.write(chunk)
+                budget.commit_written_bytes(written)
+    except Exception:
+        _clear_extracted_tree(dest_resolved)
+        raise
+
+
+def _uncapped_file_size(declared_size: int, budget: ZipExtractBudget) -> int:
+    declared = max(int(declared_size or 0), 0)
+    if budget.mode != "enforce":
+        return max(declared, (1 << 62) - 1)
+    remaining_total = max(0, budget.max_total_bytes - budget.total_bytes)
+    read_cap = min(budget.max_member_bytes, remaining_total) + ZIP_EXTRACT_CHUNK_SIZE
+    return max(declared, read_cap)
+
+
+def _env_positive_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("event=dataset_zip_budget_invalid_int env=%s fallback=%s", name, default)
+        return default
+    if value <= 0:
+        logger.warning("event=dataset_zip_budget_invalid_int env=%s fallback=%s", name, default)
+        return default
+    return value
+
+
+def _resolve_member_path(dest_resolved: Path, member_name: str) -> Path:
+    if not member_name or "\x00" in member_name:
+        raise ZipExtractUnsafePath("dataset zip member path is empty or contains NUL")
+    normalized = member_name.replace("\\", "/")
+    if normalized.startswith("/") or normalized.startswith("//"):
+        raise ZipExtractUnsafePath(f"dataset zip member path is absolute member={member_name}")
+    if len(normalized) >= 3 and normalized[1] == ":" and normalized[2] == "/":
+        raise ZipExtractUnsafePath(f"dataset zip member path is absolute member={member_name}")
+    target = (dest_resolved / normalized).resolve()
+    if not target.is_relative_to(dest_resolved):
+        raise ZipExtractUnsafePath(f"dataset zip member path escapes dest member={member_name}")
+    return target
+
+
+def _clear_extracted_tree(dest: Path) -> None:
+    if not dest.exists() or not dest.is_dir():
+        return
+    for child in dest.iterdir():
+        try:
+            if child.is_symlink() or child.is_file():
+                child.unlink()
+            else:
+                shutil.rmtree(child)
+        except OSError:
+            logger.warning("event=dataset_zip_extract_cleanup_failed path=%s", child)


### PR DESCRIPTION
## 复现步骤

前置：账号能打开 MLOps，且对图片分类数据集有发布权限。准备一份有效训练 ZIP：含少量训练图片，同时塞入大量可压缩的非图片成员，或单个高压缩比成员。

1. 进入 **MLOps**（locale `mlops`）→ **图片分类**（`image_classification`）。
2. 打开 **数据集版本管理**（`datasetsRelease`），点 **发布**（`release`）。
3. 对照发布任务临时目录：筛图前是否已经把 ZIP 里所有成员写盘。

修复前：`ZipFile.extractall` 先解压全部成员，分块下载只限制读入。  
修复后：按实际写出字节和成员数累计，超额在筛图前终止并清理解压目录。

## 修复方案

图片分类和目标检测发布共用 `ZipExtractBudget`。按 64KiB 块写出，计数用实际字节，不信声明大小。train/val/test 共用同一预算。默认 `enforce`；`MLOPS_DATASET_ZIP_BUDGET_MODE=observe` 只记日志仍解压。拒绝路径逃逸。不改 Celery 签名和重组格式。

Fixes #5207

## 修复前后

| 点 | 修复前 | 修复后 |
|---|---|---|
| 无关/高压缩成员 | 筛图前全部写盘 | 超额终止 |
| 三个 split | 各自无上限 | 共用任务预算 |
| 声明 `file_size` 撒谎 | 仍按实际写出 | 按实际写出计费 |
| 合法小包 | 发布成功 | 发布成功 |

## 影响面

- **会变**：超预算的发布失败收口；默认上限 5 万成员、单成员 100MiB、合计 2GiB。
- **不变**：权限、文件归属、ImageFolder/YOLO 输出、回调签名。
- **不在范围**：`observe` 仍会解压超额包；更小临时卷需自行收紧环境变量。
