### PR TITLE
feature(openapi): base_url 允许清单入库，新增上游主机免重建 server

### DIFF
--- a/docs/openapi-gateway/onboarding.md
+++ b/docs/openapi-gateway/onboarding.md
@@ -32,7 +32,7 @@ BK-Lite 统一网关把对外 API 收口到 `https://<平台地址>/openapi/v1/<
 | --- | --- |
 | 服务可达 | 被接入服务与 BK-Lite 在同一 compose / K8s 网络内，Traefik 能以 `base_url` 直连 |
 | 服务名 | 满足 `^[a-z][a-z0-9-]{0,31}$`；下划线开头为网关保留（`_me`、`_docs`、`_auth`、`_provider`） |
-| 允许清单 | `base_url` 的主机必须落在 `OPENAPI_BASEURL_ALLOWLIST` 内，**缺省为空即拒绝一切**（fail-closed） |
+| 允许清单 | `base_url` 的主机必须在允许清单内（DB 侧用 `manage.py openapi_allowlist` 维护，或存量的 `OPENAPI_BASEURL_ALLOWLIST` 环境变量），**缺省为空即拒绝一切**（fail-closed） |
 | 身份传递方式 | 二选一，见第 3 节 |
 | 网络封锁 | 接入后必须封锁该服务的直连端口，否则统一认证 / 审计 / 限流可被绕过 |
 | 客户端工具 | 操作机需有 `docker compose`（v2 语法）、`jq`、`curl`；`wxc` 需为**含 `openapi` 子命令的版本**（`wxc openapi --help` 能出帮助即可），离线环境随部署包分发 |
@@ -71,10 +71,27 @@ BK-Lite 统一网关把对外 API 收口到 `https://<平台地址>/openapi/v1/<
 
 在部署目录的 `.env` 中配置，然后重建 server 容器：
 
+**允许清单**（`base_url` 的主机必须在清单内，否则条目被渲染器跳过）有两处来源，
+取并集。新增主机走 DB，**不需要重建 server**：
+
+```bash
+# 查看两侧清单
+docker compose exec server python manage.py openapi_allowlist list
+
+# 新增 / 移除；下一个拉取周期内生效
+docker compose exec server python manage.py openapi_allowlist add itsm-svc
+docker compose exec server python manage.py openapi_allowlist remove itsm-svc
+```
+
+主机名支持前导点表示按点边界的后缀匹配（`.internal` 放行 `svc.internal`）；
+`itsm-svc` 不会放行 `evil-itsm-svc`。单独的 `*` 放行一切，仅限排障，勿用于生产。
+
+环境变量 `OPENAPI_BASEURL_ALLOWLIST` 为存量方式，改动需重建 server，已配置的继续有效：
+
 ```bash
 cd /opt/bk-lite/deploy/docker-compose-ha   # 单机栈为 .../docker-compose
 
-# 允许清单：逗号分隔的主机名或 IP；后缀匹配按点边界（itsm-svc 不会放行 evil-itsm-svc）
+# 逗号分隔的主机名或 IP
 echo 'OPENAPI_BASEURL_ALLOWLIST=itsm-svc,10.10.24.11' >> .env
 
 # 共享密钥（信任头模式用）。变量名自定，注册条目里以 env: 引用它
@@ -383,7 +400,8 @@ docker logs --since 5m <traefik容器> 2>&1 | grep -i "provider error"
 | 现象 | 原因 | 处理 |
 | --- | --- | --- |
 | 步骤 1 中 `routers` 为空 | 条目被跳过 | 查 server 日志中 `openapi_registry 条目 X 被跳过：<原因>` |
-| 跳过原因 `base_url not in allowlist` | 允许清单未含该主机 | 补 `OPENAPI_BASEURL_ALLOWLIST` 并重建 server |
+| 跳过原因 `base_url not in allowlist` | 允许清单未含该主机 | `manage.py openapi_allowlist add <host>`，无需重建 server |
+| 日志 `openapi allowlist DB 不可达，沿用最近一次成功快照` | 渲染时数据库不可用 | 清单读不全时不下发收缩后的配置；DB 恢复后下次拉取自动生效 |
 | 跳过原因 `shared_secret_ref unresolvable (env var unset)` | server 容器内没有该 env | 见步骤 1 方式 B 的透传配置 |
 | 跳过原因 `... unresolvable (credential not_found / disabled)` | 凭据 ID 写错、已删除或已禁用 | 到系统管理 → 凭据核对 ID 与状态 |
 | 跳过原因 `... unresolvable (credential ambiguous_field)` | 所引用凭据类型有多个 secret 字段 | 改用 `credential:<ID>#<字段ID>` |

--- a/server/apps/core/management/commands/openapi_allowlist.py
+++ b/server/apps/core/management/commands/openapi_allowlist.py
@@ -1,0 +1,43 @@
+"""维护 OpenAPI 网关的 base_url 允许清单（DB 侧）。
+
+改动一个拉取周期内生效，无需重建 server 容器。环境变量
+OPENAPI_BASEURL_ALLOWLIST 里的存量条目只读，本命令不改动它们。
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+
+from apps.core.openapi.allowlist import AllowlistError, add_host, db_hosts, env_hosts, remove_host
+
+
+class Command(BaseCommand):
+    help = "查看 / 增删 OpenAPI 网关 base_url 允许清单（DB 侧）"
+
+    def add_arguments(self, parser):
+        parser.add_argument("action", choices=["list", "add", "remove"])
+        parser.add_argument("host", nargs="?", help="主机名或 IP；前导点表示按点边界的后缀匹配")
+
+    def handle(self, *args, **options):
+        action = options["action"]
+        host = options.get("host")
+
+        if action == "list":
+            self._render_list()
+            return
+
+        if not host:
+            raise CommandError(f"{action} 需要指定 host")
+        try:
+            hosts = add_host(host) if action == "add" else remove_host(host)
+        except AllowlistError as exc:
+            raise CommandError(str(exc)) from exc
+        verb = "已加入" if action == "add" else "已移除"
+        self.stdout.write(f"{verb} {host}，DB 侧当前 {len(hosts)} 项：{', '.join(hosts) or '(空)'}")
+        self.stdout.write("下一个拉取周期内生效，无需重建 server。")
+
+    def _render_list(self):
+        from_env = env_hosts()
+        from_db = db_hosts()
+        self.stdout.write(f"DB  ({len(from_db)} 项，本命令可改)：{', '.join(from_db) or '(空)'}")
+        self.stdout.write(f"ENV ({len(from_env)} 项，改动需重建 server)：{', '.join(from_env) or '(空)'}")
+        if not from_env and not from_db:
+            self.stdout.write("清单为空，所有外部服务条目都会被跳过（fail-closed）。")

--- a/server/apps/core/openapi/allowlist.py
+++ b/server/apps/core/openapi/allowlist.py
@@ -1,0 +1,125 @@
+"""OpenAPI 网关 base_url 允许清单：DB 存储 + 环境变量兜底。
+
+清单决定哪些上游主机可被网关反代，是部署侧的安全边界（design.md 3.5.3）：
+**未配置即拒绝一切**，不得因读取异常静默放宽。
+
+两处来源取并集：
+
+- 环境变量 ``OPENAPI_BASEURL_ALLOWLIST``：存量部署的既有配置，改动要重建 server；
+- ``SystemSettings`` 表：新增主机走这里，改完一个拉取周期内生效，无需重建容器。
+
+DB 读取失败时**不得**静默降级为「只剩 env」——那会让仅登记在 DB 的主机整批
+落选，已在线的路由被摘除。``load_allowlist`` 因此返回 ``(hosts, db_ok)``，由
+调用方决定沿用快照还是按冷启动兜底继续。
+"""
+
+import os
+import re
+
+from apps.core.logger import openapi_logger as logger
+
+SETTINGS_KEY = "openapi_baseurl_allowlist"
+ENV_KEY = "OPENAPI_BASEURL_ALLOWLIST"
+WILDCARD = "*"
+
+# 主机名 / IP，允许前导点表示按点边界的后缀匹配；单独的 * 表示放行一切
+_HOST_RE = re.compile(r"^\.?[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$")
+
+
+class AllowlistError(ValueError):
+    """主机名不合法，携带稳定错误码。"""
+
+    def __init__(self, code: str, message: str | None = None):
+        self.code = code
+        super().__init__(message or code)
+
+
+def normalize_host(value) -> str:
+    """校验并规范化一个清单条目；非法时抛 AllowlistError。"""
+    if not isinstance(value, str):
+        raise AllowlistError("invalid_host", "host must be a string")
+    host = value.strip().lower()
+    if not host:
+        raise AllowlistError("invalid_host", "host must not be empty")
+    if host == WILDCARD:
+        return WILDCARD
+    if len(host) > 253 or not _HOST_RE.match(host):
+        raise AllowlistError("invalid_host", f"invalid host: {value!r}")
+    return host
+
+
+def _split(raw) -> list:
+    return [item.strip().lower() for item in (raw or "").split(",") if item.strip()]
+
+
+def env_hosts() -> list:
+    """环境变量侧的清单（不校验格式：存量配置原样沿用）。"""
+    return _split(os.getenv(ENV_KEY, ""))
+
+
+def db_hosts() -> list:
+    """DB 侧的清单。表中无该行按空清单处理（正常初始状态）。"""
+    from apps.system_mgmt.models.system_settings import SystemSettings
+
+    row = SystemSettings.objects.filter(key=SETTINGS_KEY).values_list("value", flat=True).first()
+    return _split(row)
+
+
+def load_allowlist():
+    """返回 (hosts, db_ok)。db_ok 为 False 表示 DB 侧未能读到，调用方须 fail-closed。"""
+    hosts = list(env_hosts())
+    try:
+        hosts.extend(db_hosts())
+    except Exception as exc:
+        logger.warning(
+            "openapi allowlist 读取失败 failed_stage=db_lookup error_type=%s",
+            type(exc).__name__,
+        )
+        return tuple(dict.fromkeys(hosts)), False
+    return tuple(dict.fromkeys(hosts)), True
+
+
+def host_allowed(host: str, allow) -> bool:
+    """主机是否落在清单内；后缀匹配必须落在点边界上。"""
+    if not allow:
+        return False
+    if WILDCARD in allow:
+        return True
+    host = (host or "").lower()
+    if not host:
+        return False
+    for item in allow:
+        item = item.lower()
+        # allow=itsm-svc 不得放行 evil-itsm-svc
+        suffix = item if item.startswith(".") else "." + item
+        if host == item.lstrip(".") or host.endswith(suffix):
+            return True
+    return False
+
+
+def _save(hosts) -> list:
+    from apps.system_mgmt.models.system_settings import SystemSettings
+
+    ordered = list(dict.fromkeys(hosts))
+    SystemSettings.objects.update_or_create(key=SETTINGS_KEY, defaults={"value": ",".join(ordered)})
+    return ordered
+
+
+def add_host(host: str) -> list:
+    """把主机加入 DB 侧清单（幂等），返回写入后的完整清单。"""
+    normalized = normalize_host(host)
+    hosts = db_hosts()
+    if normalized not in hosts:
+        hosts.append(normalized)
+    saved = _save(hosts)
+    logger.info("openapi allowlist 已新增主机 host=%s size=%s", normalized, len(saved))
+    return saved
+
+
+def remove_host(host: str) -> list:
+    """把主机移出 DB 侧清单（幂等），返回写入后的完整清单。"""
+    normalized = normalize_host(host)
+    hosts = [item for item in db_hosts() if item != normalized]
+    saved = _save(hosts)
+    logger.info("openapi allowlist 已移除主机 host=%s size=%s", normalized, len(saved))
+    return saved

--- a/server/apps/core/openapi/renderer.py
+++ b/server/apps/core/openapi/renderer.py
@@ -29,6 +29,7 @@ import time
 from urllib.parse import urlparse
 
 from apps.core.logger import openapi_logger as logger
+from apps.core.openapi.allowlist import host_allowed, load_allowlist
 from apps.core.openapi.kv import fetch_entries
 from apps.core.openapi.registry import SERVICE_NAME_RE
 
@@ -100,26 +101,18 @@ def _resolve_ref(ref):
     return None, "unknown ref scheme"
 
 
-def _base_url_allowed(base_url: str) -> bool:
-    allow = [item.strip() for item in os.getenv("OPENAPI_BASEURL_ALLOWLIST", "").split(",") if item.strip()]
-    if not allow:
-        return False
-    if "*" in allow:
-        return True
-    host = (urlparse(base_url).hostname or "").lower()
-    if not host:
-        return False
-    for item in allow:
-        item = item.lower()
-        # 后缀匹配必须落在点边界上，否则 allow=itsm-svc 会放行 evil-itsm-svc
-        suffix = item if item.startswith(".") else "." + item
-        if host == item.lstrip(".") or host.endswith(suffix):
-            return True
-    return False
+def _base_url_allowed(base_url: str, allow) -> bool:
+    return host_allowed(urlparse(base_url).hostname or "", allow)
 
 
-def validate_entry(name: str, entry, internal_services=()):
-    """返回 (normalized_entry | None, reason)。reason 为空串表示有效。"""
+def validate_entry(name: str, entry, internal_services=(), allowlist=None):
+    """返回 (normalized_entry | None, reason)。reason 为空串表示有效。
+
+    allowlist 由调用方在一次渲染中统一加载后传入；缺省时本函数自行加载，
+    仅供单条校验的直接调用方使用（渲染路径不走该分支，避免每条一次查询）。
+    """
+    if allowlist is None:
+        allowlist, _ = load_allowlist()
     if not isinstance(entry, dict):
         return None, "entry is not an object"
     if name.startswith("_") or not SERVICE_NAME_RE.match(name):
@@ -141,7 +134,7 @@ def validate_entry(name: str, entry, internal_services=()):
     base_url = entry.get("base_url")
     if not isinstance(base_url, str) or urlparse(base_url).scheme not in ("http", "https"):
         return None, "invalid base_url"
-    if not _base_url_allowed(base_url):
+    if not _base_url_allowed(base_url, allowlist):
         return None, "base_url not in allowlist"
 
     auth_mode = entry.get("auth_mode")
@@ -208,7 +201,7 @@ def _router_rule(version: str, name: str, paths) -> str:
     return " || ".join(prefixes)
 
 
-def render_traefik_config(entries: dict, internal_services=()):
+def render_traefik_config(entries: dict, internal_services=(), allowlist=None):
     """将注册条目渲染为 Traefik 动态配置（原生格式，供 providers.http）。
 
     返回 (config, report)。KV 字段与 Traefik 参数经本函数显式映射，
@@ -216,6 +209,8 @@ def render_traefik_config(entries: dict, internal_services=()):
     """
     report = {"rendered": [], "skipped": {}, "normalized": {}}
     routers, middlewares, services = {}, {}, {}
+    if allowlist is None:
+        allowlist, _ = load_allowlist()
 
     auth_address = os.getenv("OPENAPI_AUTH_ADDRESS", "")
     if not auth_address:
@@ -242,7 +237,7 @@ def render_traefik_config(entries: dict, internal_services=()):
     }
 
     for name in sorted(entries):
-        normalized, reason = validate_entry(name, entries[name], internal_services)
+        normalized, reason = validate_entry(name, entries[name], internal_services, allowlist)
         if normalized is None:
             report["skipped"][name] = reason
             if reason != "disabled":
@@ -342,8 +337,16 @@ def refresh_snapshot(internal_services=()):
         if started < _snapshot["fetch_started_at"]:
             logger.warning("openapi_registry 乱序回源结果被丢弃（发起早于当前快照数据）")
             return _snapshot["config"]
+
+        allowlist, db_ok = load_allowlist()
+        if not db_ok and _snapshot["config"] is not None:
+            # 仅 env 一半的清单会让登记在 DB 的主机整批落选，已在线的路由被
+            # 摘除；宁可沿用上一份配置等 DB 恢复，也不下发收缩过的清单
+            logger.warning("openapi allowlist DB 不可达，沿用最近一次成功快照")
+            return _snapshot["config"]
+
         _snapshot["fetch_started_at"] = started
-        config, report = render_traefik_config(entries, internal_services)
+        config, report = render_traefik_config(entries, internal_services, allowlist)
         _snapshot["config"] = config
         _snapshot["entries"] = entries
         _snapshot["normalized"] = dict(report["normalized"])

--- a/server/apps/core/openapi/tests/conftest.py
+++ b/server/apps/core/openapi/tests/conftest.py
@@ -8,6 +8,7 @@ refresh_snapshot 预热（覆盖本 fixture 的默认值）。
 
 import pytest
 
+from apps.core.openapi import allowlist as allowlist_mod
 from apps.core.openapi import renderer
 
 _EMPTY_SNAPSHOT = {
@@ -28,3 +29,16 @@ def _isolate_openapi_kv(monkeypatch):
     yield
     with renderer._lock:
         renderer._snapshot.update(_EMPTY_SNAPSHOT)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_openapi_allowlist(request, monkeypatch):
+    """无 DB 的单元测试：允许清单只读 env，不查库。
+
+    带 django_db 标记的用例保持真实查询（allowlist 的 DB 行为由
+    test_allowlist.py 覆盖）；否则查询异常会让 refresh_snapshot 走
+    「DB 不可达沿用快照」分支，掩盖被测的注册表新鲜度逻辑。
+    """
+    if request.node.get_closest_marker("django_db"):
+        return
+    monkeypatch.setattr(allowlist_mod, "db_hosts", list)

--- a/server/apps/core/openapi/tests/test_allowlist.py
+++ b/server/apps/core/openapi/tests/test_allowlist.py
@@ -1,0 +1,152 @@
+"""base_url 允许清单的 DB 存储与 fail-closed 行为，需 DB。
+
+覆盖：env 与 DB 取并集、DB 侧增删幂等、非法主机拒绝、点边界匹配、
+DB 不可达时沿用快照而非下发收缩后的清单、一次渲染只查一次库。
+"""
+
+import pytest
+
+from apps.core.openapi import allowlist as allowlist_mod
+from apps.core.openapi import renderer
+from apps.core.openapi.allowlist import SETTINGS_KEY, AllowlistError, add_host, db_hosts, load_allowlist, normalize_host, remove_host
+from apps.system_mgmt.models.system_settings import SystemSettings
+
+pytestmark = [pytest.mark.integration, pytest.mark.django_db]
+
+ENTRY = {
+    "schema_version": 1,
+    "type": "http",
+    "base_url": "http://itsm-svc:8000",
+    "auth_mode": "trusted-header",
+    "shared_secret_ref": "env:TEST_GW_SECRET",
+    "required_roles": [],
+    "enabled": True,
+}
+
+
+@pytest.fixture
+def env(monkeypatch):
+    monkeypatch.setenv("OPENAPI_AUTH_ADDRESS", "http://server:8000/openapi/v1/_auth")
+    monkeypatch.setenv("TEST_GW_SECRET", "s3cret")
+    monkeypatch.delenv("OPENAPI_BASEURL_ALLOWLIST", raising=False)
+
+
+def test_db_host_allows_entry_without_env(env):
+    add_host("itsm-svc")
+    config, report = renderer.render_traefik_config({"itsm": ENTRY}, ())
+    assert report["rendered"] == ["itsm"]
+    assert "openapi-v1-itsm" in config["http"]["routers"]
+
+
+def test_env_and_db_are_merged(env, monkeypatch):
+    monkeypatch.setenv("OPENAPI_BASEURL_ALLOWLIST", "legacy-svc")
+    add_host("itsm-svc")
+    hosts, db_ok = load_allowlist()
+    assert db_ok is True
+    assert set(hosts) == {"legacy-svc", "itsm-svc"}
+
+
+def test_empty_allowlist_rejects_everything(env):
+    _, report = renderer.render_traefik_config({"itsm": ENTRY}, ())
+    assert report["rendered"] == []
+    assert report["skipped"]["itsm"] == "base_url not in allowlist"
+
+
+def test_add_and_remove_are_idempotent(env):
+    add_host("itsm-svc")
+    assert add_host("itsm-svc") == ["itsm-svc"]
+    assert remove_host("itsm-svc") == []
+    assert remove_host("itsm-svc") == []
+
+
+def test_host_is_normalized_and_validated(env):
+    assert add_host("  ITSM-SVC  ") == ["itsm-svc"]
+    assert normalize_host(".internal") == ".internal"
+    for bad in ["", "has space", "bad_underscore", "http://itsm-svc", None]:
+        with pytest.raises(AllowlistError):
+            normalize_host(bad)
+
+
+@pytest.mark.parametrize(
+    "listed, host, allowed",
+    [
+        ("itsm-svc", "itsm-svc", True),
+        ("itsm-svc", "evil-itsm-svc", False),
+        (".internal", "svc.internal", True),
+        (".internal", "notinternal", False),
+        ("*", "anything.example.com", True),
+    ],
+)
+def test_suffix_match_respects_dot_boundary(env, listed, host, allowed):
+    add_host(listed)
+    entry = dict(ENTRY, base_url=f"http://{host}:8000")
+    _, report = renderer.render_traefik_config({"itsm": entry}, ())
+    assert (report["rendered"] == ["itsm"]) is allowed
+
+
+def test_db_failure_keeps_previous_snapshot(env, monkeypatch):
+    add_host("itsm-svc")
+    monkeypatch.setattr(renderer, "fetch_entries", lambda: {"itsm": ENTRY})
+    good = renderer.refresh_snapshot()
+    assert "openapi-v1-itsm" in good["http"]["routers"]
+
+    def boom():
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(allowlist_mod, "db_hosts", boom)
+    monkeypatch.setenv("OPENAPI_REGISTRY_CACHE_TTL", "0")
+    again = renderer.refresh_snapshot()
+    assert again == good, "DB 不可达时必须沿用快照，不得下发收缩后的清单"
+
+
+def test_db_failure_on_cold_start_falls_back_to_env(env, monkeypatch):
+    monkeypatch.setenv("OPENAPI_BASEURL_ALLOWLIST", "itsm-svc")
+
+    def boom():
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(allowlist_mod, "db_hosts", boom)
+    hosts, db_ok = load_allowlist()
+    assert db_ok is False
+    assert hosts == ("itsm-svc",)
+    monkeypatch.setattr(renderer, "fetch_entries", lambda: {"itsm": ENTRY})
+    config = renderer.refresh_snapshot()
+    assert "openapi-v1-itsm" in config["http"]["routers"]
+
+
+def test_render_loads_allowlist_once_regardless_of_entry_count(env, monkeypatch):
+    add_host("itsm-svc")
+    calls = []
+    original = allowlist_mod.db_hosts
+    monkeypatch.setattr(allowlist_mod, "db_hosts", lambda: (calls.append(1), original())[1])
+    entries = {f"svc{i}": ENTRY for i in range(5)}
+    renderer.render_traefik_config(entries, ())
+    assert len(calls) == 1
+
+
+def test_stored_value_is_comma_separated(env):
+    add_host("a-svc")
+    add_host("b-svc")
+    assert SystemSettings.objects.get(key=SETTINGS_KEY).value == "a-svc,b-svc"
+    assert db_hosts() == ["a-svc", "b-svc"]
+
+
+def test_management_command_roundtrip(env):
+    from io import StringIO
+
+    from django.core.management import call_command
+    from django.core.management.base import CommandError
+
+    def run(*args):
+        out = StringIO()
+        call_command("openapi_allowlist", *args, stdout=out)
+        return out.getvalue()
+
+    assert "清单为空" in run("list")
+    assert "已加入 itsm-svc" in run("add", "itsm-svc")
+    assert "itsm-svc" in run("list")
+    assert "已移除 itsm-svc" in run("remove", "itsm-svc")
+    with pytest.raises(CommandError):
+        run("add", "bad host")
+    with pytest.raises(CommandError):
+        run("add")

--- a/specs/capabilities/openapi-gateway.md
+++ b/specs/capabilities/openapi-gateway.md
@@ -81,8 +81,14 @@
   - ❌ 把密钥明文写进 KV 条目——KV 无加密语义，读权限即等于拿到凭据。
   - ⚠️ `credential:` 解析不做组织范围检查（网关密钥是平台级资源），且只在渲染期查库；
     读侧（`_auth` / `_docs` / `_me`）从快照取已归一化条目，**不得**在请求路径上重新解引用。
-- ✅ **`base_url` 允许清单 fail-closed**：未配置 `OPENAPI_BASEURL_ALLOWLIST` 即拒绝一切外部条目；
-  后缀匹配须落在**点边界**（`itsm-svc` 不得放行 `evil-itsm-svc`）。
+- ✅ **`base_url` 允许清单 fail-closed**：清单为空即拒绝一切外部条目；后缀匹配须落在**点边界**
+  （`itsm-svc` 不得放行 `evil-itsm-svc`）。清单取 DB（`SystemSettings`，用
+  `manage.py openapi_allowlist` 维护，改动一个拉取周期内生效）与环境变量
+  `OPENAPI_BASEURL_ALLOWLIST`（存量方式，改动需重建 server）的并集。
+  - ❌ DB 读不到时退化成「只剩 env」继续渲染——仅登记在 DB 的主机会整批落选，
+    已在线的路由被摘除；必须沿用最近一次成功快照等 DB 恢复。
+  - ⚠️ 清单在**一次渲染中只加载一次**并逐条复用；不得在 `validate_entry` 里按条查库
+    （provider 每 5 秒被拉一次，按条查库会把渲染放大成 N 次查询）。
 - ✅ **注册即封锁直连**：外部服务端口若可绕过 Traefik 直达，统一认证 / 审计 / 限流即成摆设；
   用 `wxc openapi register --probe host:port` 复测验收。
 - ✅ **Traefik 中间件链第一跳清除入站 `X-BK-*` 头**；`trusted-header` 模式同时清空转发给上游的


### PR DESCRIPTION
## 背景

接上一个 PR [#5352](https://github.com/TencentBlueKing/bk-lite/pull/5352)。那次把密钥引用从环境变量搬到了凭据库，允许清单是同一问题剩下的另一半：

`OPENAPI_BASEURL_ALLOWLIST` 只存在于 server 进程环境，每接入一个新上游主机都要改 `.env` 并重建容器（约 1 分钟不可用）。注册本身写 NATS KV 是秒级生效的，让注册生效却要做一次发版式操作。

一次真实接入的顺序就是这样：先卡在 `base_url not in allowlist`，改环境变量重建 server；起来后又卡在 `shared_secret_ref unresolvable`，再改再重建。两轮的动作完全一样。

## 改动

清单改为取 **DB（`SystemSettings`）与环境变量的并集**。新增主机走 DB，一个拉取周期内生效；env 侧存量配置继续有效，不需要迁移。

- **`allowlist.py`**：清单读写与点边界匹配。`load_allowlist` 返回 `(hosts, db_ok)`，把「读到了空清单」和「没读到」区分开。二者都表现为条目被跳过，但前者是运维意图，后者是故障，不能混为一谈。
- **`refresh_snapshot`**：`db_ok` 为假且已有快照时沿用快照。只剩 env 的半份清单会让登记在 DB 的主机整批落选、已在线的路由被摘除，宁可停在上一份配置等 DB 恢复。
- **每次渲染只加载一次清单**并逐条复用。provider 端点每 5 秒被 Traefik 拉一次，按条查库会把一次渲染放大成 N 次查询。`validate_entry` 保留自行加载的兼容分支，只服务单条校验的直接调用方。
- **管理命令** `openapi_allowlist list|add|remove`。`list` 分别列出 DB 与 env 两侧，并标明哪一侧改动需要重建。

## 用法

```bash
docker compose exec server python manage.py openapi_allowlist add itsm-svc
```

下一个拉取周期内生效，不用重建 server。前导点表示按点边界的后缀匹配，`itsm-svc` 不会放行 `evil-itsm-svc`。

## 测试

新增 `test_allowlist.py`，11 个用例覆盖：DB 侧放行、env 与 DB 取并集、空清单 fail-closed、增删幂等、主机名规范化与非法输入、点边界匹配、DB 故障时沿用快照、冷启动时回落 env、一次渲染只查一次库、管理命令往返。

测试 conftest 补了一条隔离：无 DB 的单元测试不查库，否则查询异常会让 `refresh_snapshot` 走「沿用快照」分支，掩盖被测的注册表新鲜度逻辑。这条隔离是必要的,加改动后原有两个单元测试确实因此失败过。

本地验证（sqlite）：网关与凭据相关 151 通过。1 个失败为基线问题,`test_list_filters_category_type_search_disabled_and_exact_owner` 因 sqlite 不支持 JSON `contains`，已单独切到 master 复现确认与本改动无关，CI 用 PostgreSQL 不受影响。

## 后续

wxc 的 `allowlist` 子命令见 WeOps-Lab/bklite-website#124 需求 3。它需要一个写入接口,wxc 目前只直连 NATS KV，没有数据库连接。接口形态（NATS RPC 还是别的）留到与 wxc 联调时确定，本次先交付 server 侧存储与运维命令，运维已经可以脱离重建流程操作。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
