### PR TITLE
bugfix(memory-leak): 钉钉 Stream 启动保持单进程幂等

### DIFF
--- a/server/apps/opspilot/services/dingtalk_chat_flow_utils.py
+++ b/server/apps/opspilot/services/dingtalk_chat_flow_utils.py
@@ -11,6 +11,7 @@ import requests
 from django.http import JsonResponse
 
 from apps.core.logger import opspilot_logger as logger
+from apps.core.logger import safe_exception_info
 from apps.opspilot.models import Bot, BotWorkFlow
 from apps.opspilot.utils.base_chat_flow_utils import BaseChatFlowUtils
 from apps.opspilot.utils.chat_flow_utils.engine.factory import create_chat_flow_engine
@@ -20,6 +21,10 @@ DINGTALK_ALLOWED_DOMAINS = [
     "oapi.dingtalk.com",
     "api.dingtalk.com",
 ]
+
+# 单进程内每个 Bot 只保留一个活动客户端；当前不保证多进程唯一性。
+_dingtalk_stream_clients: dict[int, object] = {}
+_dingtalk_stream_clients_lock = threading.RLock()
 
 
 def is_valid_dingtalk_url(url: str) -> bool:
@@ -424,41 +429,68 @@ def start_dingtalk_stream_client(bot_id, bot_chat_flow, dingtalk_config):
     Returns:
         bool: 是否成功启动
     """
+    failed_stage = "read_config"
     try:
         client_id = dingtalk_config.get("client_id")
         client_secret = dingtalk_config.get("client_secret")
 
         if not client_id or not client_secret:
-            logger.error(f"钉钉Stream启动失败：缺少client_id或client_secret，Bot {bot_id}")
+            logger.warning(
+                "event=dingtalk_stream_start_rejected bot_id=%s " "failed_stage=validate_config error_type=missing_credentials",
+                bot_id,
+            )
             return False
 
-        # 创建凭证和客户端
-        credential = dingtalk_stream.Credential(client_id, client_secret)
-        client = dingtalk_stream.DingTalkStreamClient(credential)
+        failed_stage = "acquire_start_lock"
+        with _dingtalk_stream_clients_lock:
+            if bot_id in _dingtalk_stream_clients:
+                logger.debug("event=dingtalk_stream_start_reused bot_id=%s", bot_id)
+                return True
 
-        # 注册事件处理器
-        client.register_all_event_handler(DingTalkStreamEventHandler(bot_id))
+            failed_stage = "build_client"
+            credential = dingtalk_stream.Credential(client_id, client_secret)
+            client = dingtalk_stream.DingTalkStreamClient(credential)
+            client.register_all_event_handler(DingTalkStreamEventHandler(bot_id))
 
-        # 注册回调处理器
-        callback_handler = DingTalkStreamCallbackHandler(bot_id, bot_chat_flow, dingtalk_config)
-        client.register_callback_handler(dingtalk_stream.ChatbotMessage.TOPIC, callback_handler)
+            callback_handler = DingTalkStreamCallbackHandler(bot_id, bot_chat_flow, dingtalk_config)
+            client.register_callback_handler(dingtalk_stream.ChatbotMessage.TOPIC, callback_handler)
 
-        # 在新线程中启动客户端
-        def start_client():
+            def start_client():
+                try:
+                    logger.debug("event=dingtalk_stream_client_starting bot_id=%s", bot_id)
+                    client.start_forever()
+                except Exception as error:
+                    logger.error(
+                        "event=dingtalk_stream_runtime_failed bot_id=%s " "failed_stage=start_forever error_type=%s",
+                        bot_id,
+                        type(error).__name__,
+                        exc_info=safe_exception_info(error),
+                    )
+                finally:
+                    with _dingtalk_stream_clients_lock:
+                        if _dingtalk_stream_clients.get(bot_id) is client:
+                            _dingtalk_stream_clients.pop(bot_id)
+                    logger.info("event=dingtalk_stream_client_exited bot_id=%s", bot_id)
+
+            thread = threading.Thread(target=start_client, daemon=True)
+            _dingtalk_stream_clients[bot_id] = client
+            failed_stage = "thread_start"
             try:
-                logger.info(f"钉钉Stream客户端启动中，Bot {bot_id}")
-                client.start_forever()
-            except Exception as e:
-                logger.error(f"钉钉Stream客户端运行异常，Bot {bot_id}，错误: {str(e)}")
-                logger.exception(e)
+                thread.start()
+            except Exception:
+                if _dingtalk_stream_clients.get(bot_id) is client:
+                    _dingtalk_stream_clients.pop(bot_id)
+                raise
 
-        thread = threading.Thread(target=start_client, daemon=True)
-        thread.start()
-
-        logger.info(f"钉钉Stream客户端已启动，Bot {bot_id}")
+        logger.info("event=dingtalk_stream_start_accepted bot_id=%s", bot_id)
         return True
 
-    except Exception as e:
-        logger.error(f"钉钉Stream客户端启动失败，Bot {bot_id}，错误: {str(e)}")
-        logger.exception(e)
+    except Exception as error:
+        logger.error(
+            "event=dingtalk_stream_start_failed bot_id=%s failed_stage=%s error_type=%s",
+            bot_id,
+            failed_stage,
+            type(error).__name__,
+            exc_info=safe_exception_info(error),
+        )
         return False

--- a/server/apps/opspilot/tests/test_dingtalk_stream_and_reply.py
+++ b/server/apps/opspilot/tests/test_dingtalk_stream_and_reply.py
@@ -7,10 +7,14 @@
 - send_reply 缺 webhook 不发信；
 - handle_dingtalk_message 已处理消息跳过投递；
 - Stream Event/Callback：非文本、空文本、成功回复、异常状态码；
-- start_dingtalk_stream_client：缺凭证、启动成功、启动异常。
+- start_dingtalk_stream_client：缺凭证、幂等/并发启动、退出清理、启动异常。
 """
 import asyncio
 import json
+import logging
+import time
+from threading import Barrier
+from threading import Thread as WorkerThread
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -18,6 +22,7 @@ import dingtalk_stream
 import pytest
 from django.http import JsonResponse
 
+from apps.opspilot.services import dingtalk_chat_flow_utils as dingtalk_utils_module
 from apps.opspilot.services.dingtalk_chat_flow_utils import (
     DingTalkChatFlowUtils,
     DingTalkStreamCallbackHandler,
@@ -146,9 +151,24 @@ class TestStreamHandlers:
 
 
 class TestStartStreamClient:
+    @pytest.fixture(autouse=True)
+    def _清理活动客户端(self):
+        registry = getattr(dingtalk_utils_module, "_dingtalk_stream_clients", None)
+        lock = getattr(dingtalk_utils_module, "_dingtalk_stream_clients_lock", None)
+        if registry is not None and lock is not None:
+            with lock:
+                registry.clear()
+        yield
+        if registry is not None and lock is not None:
+            with lock:
+                registry.clear()
+
     def test_缺凭证返回False(self):
         assert start_dingtalk_stream_client(1, None, {}) is False
         assert start_dingtalk_stream_client(1, None, {"client_id": "a"}) is False
+
+    def test_异常配置保持返回False(self):
+        assert start_dingtalk_stream_client(1, None, None) is False
 
     def test_启动成功注册处理器并开线程(self, mocker):
         credential = MagicMock()
@@ -178,23 +198,247 @@ class TestStartStreamClient:
         assert thread_cls.call_args.kwargs["daemon"] is True
         thread.start.assert_called_once()
 
-    def test_启动异常返回False(self, mocker):
-        mocker.patch(
-            "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.Credential",
-            side_effect=RuntimeError("auth fail"),
-        )
-        assert start_dingtalk_stream_client(1, None, {"client_id": "a", "client_secret": "b"}) is False
-
-    def test_线程内start_forever异常被吞(self, mocker):
+    def test_同一Bot重复启动只创建一个客户端(self, mocker):
         client = MagicMock()
-        client.start_forever.side_effect = RuntimeError("stream down")
+        credential = mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.Credential",
+            return_value=MagicMock(),
+        )
+        client_cls = mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.DingTalkStreamClient",
+            return_value=client,
+        )
+        thread = MagicMock()
+        thread_cls = mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.threading.Thread",
+            return_value=thread,
+        )
+
+        config = {"client_id": "cid", "client_secret": "sec", "node_id": "n1"}
+        results = [start_dingtalk_stream_client(70, SimpleNamespace(), config) for _ in range(25)]
+
+        assert results == [True] * 25
+        credential.assert_called_once_with("cid", "sec")
+        client_cls.assert_called_once()
+        thread_cls.assert_called_once()
+        thread.start.assert_called_once()
+
+    def test_同一Bot重复启动仅记录DEBUG(self, mocker, caplog):
         mocker.patch(
             "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.Credential",
             return_value=MagicMock(),
         )
         mocker.patch(
             "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.DingTalkStreamClient",
+            return_value=MagicMock(),
+        )
+        mocker.patch("apps.opspilot.services.dingtalk_chat_flow_utils.threading.Thread", return_value=MagicMock())
+        caplog.set_level(logging.DEBUG, logger="opspilot")
+
+        config = {"client_id": "cid", "client_secret": "sec", "node_id": "n1"}
+        assert start_dingtalk_stream_client(70, SimpleNamespace(), config) is True
+        assert start_dingtalk_stream_client(70, SimpleNamespace(), config) is True
+
+        records = [record for record in caplog.records if "event=dingtalk_stream_start_reused" in record.getMessage()]
+        assert len(records) == 1
+        assert records[0].levelno == logging.DEBUG
+
+    def test_不同Bot分别创建客户端(self, mocker):
+        mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.Credential",
+            return_value=MagicMock(),
+        )
+        client_cls = mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.DingTalkStreamClient",
+            side_effect=[MagicMock(), MagicMock()],
+        )
+        stream_threads = [MagicMock(), MagicMock()]
+        mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.threading.Thread",
+            side_effect=stream_threads,
+        )
+
+        config = {"client_id": "cid", "client_secret": "sec", "node_id": "n1"}
+        assert start_dingtalk_stream_client(70, SimpleNamespace(), config) is True
+        assert start_dingtalk_stream_client(71, SimpleNamespace(), config) is True
+
+        assert client_cls.call_count == 2
+        for stream_thread in stream_threads:
+            stream_thread.start.assert_called_once()
+
+    def test_并发启动同一Bot只创建一个客户端(self, mocker):
+        client = MagicMock()
+
+        def slow_credential(*_args):
+            time.sleep(0.03)
+            return MagicMock()
+
+        credential = mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.Credential",
+            side_effect=slow_credential,
+        )
+        client_cls = mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.DingTalkStreamClient",
             return_value=client,
+        )
+        stream_thread = MagicMock()
+        mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.threading.Thread",
+            return_value=stream_thread,
+        )
+        start_gate = Barrier(8)
+        results = []
+
+        def invoke():
+            start_gate.wait()
+            results.append(
+                start_dingtalk_stream_client(
+                    71,
+                    SimpleNamespace(),
+                    {"client_id": "cid", "client_secret": "sec", "node_id": "n1"},
+                )
+            )
+
+        workers = [WorkerThread(target=invoke) for _ in range(8)]
+        for worker in workers:
+            worker.start()
+        for worker in workers:
+            worker.join(timeout=2)
+
+        assert len(results) == 8
+        assert all(results)
+        credential.assert_called_once_with("cid", "sec")
+        client_cls.assert_called_once()
+        stream_thread.start.assert_called_once()
+
+    def test_客户端线程退出后允许重新启动(self, mocker):
+        clients = [MagicMock(), MagicMock()]
+        mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.Credential",
+            return_value=MagicMock(),
+        )
+        client_cls = mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.DingTalkStreamClient",
+            side_effect=clients,
+        )
+        threads = []
+
+        class _ControlledThread:
+            def __init__(self, target=None, daemon=None):
+                self.target = target
+                self.daemon = daemon
+                threads.append(self)
+
+            def start(self):
+                pass
+
+        mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.threading.Thread",
+            side_effect=_ControlledThread,
+        )
+
+        config = {"client_id": "cid", "client_secret": "sec", "node_id": "n1"}
+        assert start_dingtalk_stream_client(72, SimpleNamespace(), config) is True
+        threads[0].target()
+        assert start_dingtalk_stream_client(72, SimpleNamespace(), config) is True
+
+        assert client_cls.call_count == 2
+        assert len(threads) == 2
+
+    def test_旧客户端退出不会清理新客户端登记(self, mocker):
+        clients = [MagicMock(), MagicMock()]
+        mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.Credential",
+            return_value=MagicMock(),
+        )
+        mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.DingTalkStreamClient",
+            side_effect=clients,
+        )
+        threads = []
+
+        class _ControlledThread:
+            def __init__(self, target=None, daemon=None):
+                self.target = target
+                threads.append(self)
+
+            def start(self):
+                pass
+
+        mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.threading.Thread",
+            side_effect=_ControlledThread,
+        )
+        config = {"client_id": "cid", "client_secret": "sec", "node_id": "n1"}
+
+        assert start_dingtalk_stream_client(74, SimpleNamespace(), config) is True
+        with dingtalk_utils_module._dingtalk_stream_clients_lock:
+            dingtalk_utils_module._dingtalk_stream_clients.pop(74)
+        assert start_dingtalk_stream_client(74, SimpleNamespace(), config) is True
+        threads[0].target()
+
+        assert dingtalk_utils_module._dingtalk_stream_clients[74] is clients[1]
+
+    def test_线程启动失败会释放登记并允许重试(self, mocker):
+        mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.Credential",
+            return_value=MagicMock(),
+        )
+        client_cls = mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.DingTalkStreamClient",
+            side_effect=[MagicMock(), MagicMock()],
+        )
+        failed_thread = MagicMock()
+        failed_thread.start.side_effect = RuntimeError("thread start failed")
+        running_thread = MagicMock()
+        mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.threading.Thread",
+            side_effect=[failed_thread, running_thread],
+        )
+
+        config = {"client_id": "cid", "client_secret": "sec", "node_id": "n1"}
+        assert start_dingtalk_stream_client(73, SimpleNamespace(), config) is False
+        assert start_dingtalk_stream_client(73, SimpleNamespace(), config) is True
+
+        assert client_cls.call_count == 2
+        running_thread.start.assert_called_once()
+
+    def test_启动异常返回False且日志脱敏(self, mocker, caplog):
+        secret_sentinel = "client_secret=DO_NOT_LOG_5376"
+        original_error = RuntimeError(secret_sentinel)
+        mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.Credential",
+            side_effect=original_error,
+        )
+        caplog.set_level(logging.ERROR, logger="opspilot")
+
+        assert start_dingtalk_stream_client(1, None, {"client_id": "a", "client_secret": "b"}) is False
+
+        records = [record for record in caplog.records if "event=dingtalk_stream_start_failed" in record.getMessage()]
+        assert len(records) == 1
+        record = records[0]
+        assert record.msg == "event=dingtalk_stream_start_failed bot_id=%s failed_stage=%s error_type=%s"
+        assert record.args == (1, "build_client", "RuntimeError")
+        assert record.exc_info is not None
+        assert record.exc_info[2] is original_error.__traceback__
+        assert original_error.args == (secret_sentinel,)
+        assert secret_sentinel not in record.getMessage()
+        assert all(secret_sentinel not in str(arg) for arg in record.args)
+        assert secret_sentinel not in logging.Formatter().format(record)
+        assert secret_sentinel not in caplog.text
+
+    def test_线程内start_forever异常退出后允许重启(self, mocker, caplog):
+        secret_sentinel = "access_token=DO_NOT_LOG_RUNTIME_5376"
+        original_error = RuntimeError(secret_sentinel)
+        clients = [MagicMock(), MagicMock()]
+        clients[0].start_forever.side_effect = original_error
+        mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.Credential",
+            return_value=MagicMock(),
+        )
+        client_cls = mocker.patch(
+            "apps.opspilot.services.dingtalk_chat_flow_utils.dingtalk_stream.DingTalkStreamClient",
+            side_effect=clients,
         )
 
         class _ImmediateThread:
@@ -208,5 +452,23 @@ class TestStartStreamClient:
             "apps.opspilot.services.dingtalk_chat_flow_utils.threading.Thread",
             side_effect=lambda target=None, daemon=None: _ImmediateThread(target, daemon),
         )
-        assert start_dingtalk_stream_client(4, SimpleNamespace(), {"client_id": "a", "client_secret": "b"}) is True
-        client.start_forever.assert_called_once()
+        caplog.set_level(logging.ERROR, logger="opspilot")
+        config = {"client_id": "a", "client_secret": "b"}
+        assert start_dingtalk_stream_client(4, SimpleNamespace(), config) is True
+        assert start_dingtalk_stream_client(4, SimpleNamespace(), config) is True
+
+        assert client_cls.call_count == 2
+        clients[0].start_forever.assert_called_once()
+        clients[1].start_forever.assert_called_once()
+        records = [record for record in caplog.records if "event=dingtalk_stream_runtime_failed" in record.getMessage()]
+        assert len(records) == 1
+        record = records[0]
+        assert record.msg == "event=dingtalk_stream_runtime_failed bot_id=%s failed_stage=start_forever error_type=%s"
+        assert record.args == (4, "RuntimeError")
+        assert record.exc_info is not None
+        assert record.exc_info[2] is original_error.__traceback__
+        assert original_error.args == (secret_sentinel,)
+        assert secret_sentinel not in record.getMessage()
+        assert all(secret_sentinel not in str(arg) for arg in record.args)
+        assert secret_sentinel not in logging.Formatter().format(record)
+        assert secret_sentinel not in caplog.text


### PR DESCRIPTION
## 问题

钉钉 Stream 启动入口缺少进程内生命周期所有权。同一 Bot 被重复或并发启动时，每次都会创建新的客户端、后台线程和长连接，导致资源随调用次数持续累积。

## 根因（设计层）

启动函数只负责“创建并启动”，没有记录“哪个 Bot 已拥有活动客户端”，也没有在线程退出或启动失败时释放所有权。因此入口既不幂等，也无法区分旧、新两代客户端。

## 怎么修的

- 新增按 `bot_id` 索引的进程内活动客户端登记表，并用可重入锁串行化“检查—创建—登记—启动”。
- 同一 Bot 已有活动客户端时直接复用；不同 Bot 仍可独立启动。
- 在线程正常退出、异常退出或 `Thread.start()` 失败时释放登记。
- 清理时校验客户端对象身份，避免旧线程退出误删新一代客户端。
- 启动与运行异常使用稳定事件字段和脱敏 traceback，重复启动降为 DEBUG，避免日志放大。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["execute_chat_flow_dingtalk\nchat_flow.py"]
    end

    subgraph N["Stream 生命周期层"]
        N1["start_dingtalk_stream_client\ndingtalk_chat_flow_utils.py"]
        N2["按 bot_id 检查并登记活动客户端"]
        N3["DingTalkStreamClient.start_forever"]
    end

    subgraph C["清理层"]
        C1["按客户端身份释放登记"]
    end

    T1 --> N1 --> N2 --> N3
    N3 -. "正常或异常退出" .-> C1
    N2 -. "线程启动失败" .-> C1
```

## 影响范围

- 仅修改 OpsPilot 钉钉 Stream 启动服务和对应测试。
- HTTP 路由、请求参数、响应结构及原有 `bool` 返回契约保持不变。
- 当前只保证单进程内幂等；多进程或多副本之间的全局唯一性不在本次范围。

## 验证

- `apps/opspilot/tests/test_dingtalk_stream_and_reply.py` 与 `apps/opspilot/tests/test_chat_channel_public_contracts.py`：38 passed。
- 25 次串行启动同一 Bot：仅创建 1 个客户端和 1 个线程。
- 8 路并发启动同一 Bot：仅创建 1 个客户端和 1 个线程，无死锁。
- 正常退出、运行异常、线程启动失败及旧新客户端代次隔离均有回归测试。
- 改动行覆盖率：100%。新增测试在修复前可稳定复现重复创建、异常配置抛出和日志泄露风险。

## 三轨门禁

- Standards：PASS（96/100）。
- Spec：PASS（99/100）。
- Runtime Contract：PASS（98/100）。

Fixes #5376
