### PR TITLE
bugfix(memory-leak): 收口 SSE 合流子任务生命周期

### DIFF
--- a/server/apps/opspilot/metis/llm/chain/graph.py
+++ b/server/apps/opspilot/metis/llm/chain/graph.py
@@ -293,21 +293,21 @@ async def _merge_async_streams(
             raise langgraph_error
 
     finally:
-        # 清理: 设置停止信号并取消任务
+        # 父流结束后统一收口所有子任务，避免断连时继续等待 LangGraph 自然结束。
         stop_event.set()
-        browser_task.cancel()
+        child_tasks = (langgraph_task, browser_task)
+        cancelled_by_cleanup = set()
+        for child_task in child_tasks:
+            if not child_task.done():
+                cancelled_by_cleanup.add(child_task)
+                child_task.cancel()
 
-        # 等待任务完成。旧逻辑 `except Exception: pass` 会吞掉轻量直答/节点内
-        # LLM 失败，表现为 RUN_STARTED→RUN_FINISHED、无正文、llm_call_count=0。
-        try:
-            await langgraph_task
-        except Exception as e:
-            langgraph_error = e
-
-        try:
-            await browser_task
-        except asyncio.CancelledError:
-            pass
+        task_results = await asyncio.gather(*child_tasks, return_exceptions=True)
+        langgraph_result = task_results[0]
+        if isinstance(langgraph_result, asyncio.CancelledError) and langgraph_task not in cancelled_by_cleanup:
+            raise langgraph_result
+        if langgraph_error is None and isinstance(langgraph_result, Exception):
+            langgraph_error = langgraph_result
 
     if langgraph_error is not None:
         raise langgraph_error

--- a/server/apps/opspilot/tests/test_merge_async_stream_lifecycle.py
+++ b/server/apps/opspilot/tests/test_merge_async_stream_lifecycle.py
@@ -1,0 +1,152 @@
+import asyncio
+
+import pytest
+
+from apps.opspilot.metis.llm.chain import graph as graph_module
+from apps.opspilot.metis.llm.chain.graph import _merge_async_streams
+
+pytestmark = pytest.mark.unit
+
+
+class _ObservableEventQueue(asyncio.Queue):
+    def __init__(self, stop_event):
+        super().__init__()
+        self.stop_event = stop_event
+        self.cleanup_cancelled = asyncio.Event()
+
+    async def get(self):
+        try:
+            return await super().get()
+        except asyncio.CancelledError:
+            if self.stop_event.is_set():
+                self.cleanup_cancelled.set()
+            raise
+
+
+@pytest.mark.asyncio
+async def test_下游关闭会取消阻塞中的LangGraph任务():
+    release = asyncio.Event()
+    finalized = asyncio.Event()
+    stop_event = asyncio.Event()
+    event_queue = _ObservableEventQueue(stop_event)
+
+    async def langgraph_stream():
+        try:
+            yield "first"
+            await release.wait()
+        finally:
+            finalized.set()
+
+    merged = _merge_async_streams(langgraph_stream(), event_queue, stop_event)
+    assert await anext(merged) == ("langgraph", "first")
+
+    try:
+        await asyncio.wait_for(merged.aclose(), timeout=1)
+    finally:
+        release.set()
+
+    await asyncio.wait_for(finalized.wait(), timeout=1)
+    await asyncio.wait_for(event_queue.cleanup_cancelled.wait(), timeout=1)
+    assert stop_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_外部取消会收口所有子任务():
+    release = asyncio.Event()
+    finalized = asyncio.Event()
+    started = asyncio.Event()
+    stop_event = asyncio.Event()
+    event_queue = _ObservableEventQueue(stop_event)
+
+    async def langgraph_stream():
+        try:
+            started.set()
+            yield "first"
+            await release.wait()
+        finally:
+            finalized.set()
+
+    async def consume():
+        return [item async for item in _merge_async_streams(langgraph_stream(), event_queue, stop_event)]
+
+    consumer = asyncio.create_task(consume())
+    await asyncio.wait_for(started.wait(), timeout=0.2)
+    consumer.cancel()
+
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(asyncio.shield(consumer), timeout=1)
+    finally:
+        release.set()
+        if not consumer.done():
+            try:
+                await asyncio.wait_for(consumer, timeout=0.2)
+            except asyncio.CancelledError:
+                pass
+
+    assert finalized.is_set()
+    await asyncio.wait_for(event_queue.cleanup_cancelled.wait(), timeout=1)
+    assert stop_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_LangGraph自然完成保持事件顺序():
+    async def langgraph_stream():
+        yield "first"
+        yield "second"
+
+    stop_event = asyncio.Event()
+    items = [item async for item in _merge_async_streams(langgraph_stream(), asyncio.Queue(), stop_event)]
+
+    assert items == [("langgraph", "first"), ("langgraph", "second")]
+    assert stop_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_LangGraph原始异常继续向调用方传播():
+    original_error = RuntimeError("upstream failed")
+
+    async def langgraph_stream():
+        yield "first"
+        raise original_error
+
+    merged = _merge_async_streams(langgraph_stream(), asyncio.Queue(), asyncio.Event())
+
+    assert await anext(merged) == ("langgraph", "first")
+    with pytest.raises(RuntimeError) as exc_info:
+        await anext(merged)
+
+    assert exc_info.value is original_error
+
+
+@pytest.mark.asyncio
+async def test_LangGraph主动取消继续向调用方传播():
+    original_error = asyncio.CancelledError("upstream cancelled")
+
+    async def langgraph_stream():
+        yield "first"
+        raise original_error
+
+    merged = _merge_async_streams(langgraph_stream(), asyncio.Queue(), asyncio.Event())
+
+    assert await anext(merged) == ("langgraph", "first")
+    with pytest.raises(asyncio.CancelledError) as exc_info:
+        await anext(merged)
+
+    assert isinstance(exc_info.value, asyncio.CancelledError)
+
+
+@pytest.mark.asyncio
+async def test_等待上游期间保持发送keepalive(monkeypatch):
+    release = asyncio.Event()
+
+    async def langgraph_stream():
+        await release.wait()
+        if False:
+            yield None
+
+    monkeypatch.setattr(graph_module, "SSE_KEEPALIVE_INTERVAL_SECONDS", 0.01)
+    merged = _merge_async_streams(langgraph_stream(), asyncio.Queue(), asyncio.Event())
+
+    assert await asyncio.wait_for(anext(merged), timeout=1) == ("keepalive", "waiting_model")
+    await asyncio.wait_for(merged.aclose(), timeout=1)


### PR DESCRIPTION
## 问题

OpsPilot 的 SSE 合流生成器同时拥有 LangGraph 消费任务和浏览器事件任务，但下游断开或停止消费时只取消浏览器任务，随后继续等待可能长期阻塞的 LangGraph 任务。请求已经结束后，模型/工具执行上下文仍可能存活。

## 根因（设计层）

父生成器没有把自己的终止生命周期完整传播给全部子任务，也没有统一等待子任务结束。正常完成、上游异常、下游关闭和外部取消因此走了不同的清理语义。

## 怎么修的

- 父流退出时统一设置停止信号，并取消所有尚未完成的子任务。
- 使用统一 `gather` 等待两个子任务终止，避免未读取的任务异常和残留任务。
- 区分“清理阶段主动取消”与“上游自身取消”：只抑制清理产生的取消，上游 `CancelledError` 继续传播。
- 保持自然完成事件顺序、普通上游异常对象和 keepalive 行为不变。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["OpsPilot SSE 请求\nagui_stream"]
    end

    subgraph N["合流层"]
        N1["_merge_async_streams\ngraph.py"]
        N2["langgraph_task"]
        N3["browser_task"]
        N4["SSE 输出"]
    end

    subgraph C["生命周期清理"]
        C1["设置 stop_event"]
        C2["取消未完成子任务"]
        C3["gather 等待终止"]
    end

    T1 --> N1
    N1 --> N2 --> N4
    N1 --> N3 --> N4
    N4 -. "断连/停止消费" .-> C1 --> C2 --> C3
```

## 影响范围

- 仅修改 OpsPilot 内部异步合流函数及对应测试。
- SSE 事件结构、顺序、HTTP 入口和 keepalive 内容不变。
- 下游结束后会及时停止不再有消费者的模型/工具链，这是本次预期的资源边界变化。

## 验证

- 新增生命周期测试：6 passed。
- 下游 `aclose()` 和外部取消均能在限定时间内完成，LangGraph 与浏览器子任务无残留。
- 覆盖自然完成顺序、上游普通异常、上游主动取消、keepalive 和 `stop_event`。
- 相关 AG-UI 回归：33 passed；另有 1 条正文分片断言在未修改的上游基线同样失败，确认不是本次新增失败。
- 改动行覆盖率：100%。

## 三轨门禁

- Standards：PASS（96/100）。
- Spec：PASS（99/100）。
- Runtime Contract：PASS（98/100）。

Fixes #5377
