### PR TITLE
bugfix(memory-leak): 为 SSE 合流输出增加背压边界

### DIFF
--- a/server/apps/opspilot/metis/llm/chain/graph.py
+++ b/server/apps/opspilot/metis/llm/chain/graph.py
@@ -74,6 +74,8 @@ _AGUI_LIVE_DELTA_CHARS = 64
 # 低于 Next/undici body 空闲超时（约 300s），避免 RUN_STARTED 后长时间无 chunk 被掐流。
 SSE_KEEPALIVE_INTERVAL_SECONDS = 15.0
 STREAM_KEEPALIVE_EVENT_NAME = "stream_keepalive"
+# 与浏览器步骤队列使用相同的单请求容量边界，满载时由 await put 反压生产者。
+SSE_OUTPUT_QUEUE_MAXSIZE = 100
 
 
 def _split_text_deltas(text: str, max_chars: int = _AGUI_LIVE_DELTA_CHARS) -> list[str]:
@@ -221,7 +223,7 @@ async def _merge_async_streams(
         - ("langgraph", chunk) - 来自 LangGraph 的消息块
         - ("browser", event) - 来自浏览器的 SSE 事件字符串
     """
-    output_queue: asyncio.Queue = asyncio.Queue()
+    output_queue: asyncio.Queue = asyncio.Queue(maxsize=SSE_OUTPUT_QUEUE_MAXSIZE)
 
     async def langgraph_consumer():
         """消费 LangGraph 流并推送到输出队列"""
@@ -233,8 +235,10 @@ async def _merge_async_streams(
             # 表现为「问答无输出 / RUN_FINISHED 空跑」。
             await output_queue.put(("langgraph_error", exc))
         finally:
-            # 标记 LangGraph 流结束
-            await output_queue.put(("langgraph_done", None))
+            # 自然结束时通知父流继续排空队列；父流清理已设置 stop_event，
+            # 此时不能向无人消费的满队列写结束标记，否则取消流程会再次阻塞。
+            if not stop_event.is_set():
+                await output_queue.put(("langgraph_done", None))
 
     async def browser_event_consumer():
         """消费浏览器事件队列并推送到输出队列"""

--- a/server/apps/opspilot/tests/test_merge_async_stream_backpressure.py
+++ b/server/apps/opspilot/tests/test_merge_async_stream_backpressure.py
@@ -1,0 +1,70 @@
+import asyncio
+
+import pytest
+
+from apps.opspilot.metis.llm.chain import graph as graph_module
+from apps.opspilot.metis.llm.chain.graph import _merge_async_streams
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_慢消费时输出队列保持容量边界和事件顺序(monkeypatch):
+    original_queue = asyncio.Queue
+    output_queues = []
+
+    class _TrackingQueue(original_queue):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.peak_size = 0
+            output_queues.append(self)
+
+        async def put(self, item):
+            await super().put(item)
+            self.peak_size = max(self.peak_size, self.qsize())
+
+    browser_queue = original_queue()
+    monkeypatch.setattr(graph_module.asyncio, "Queue", _TrackingQueue)
+    produced = 0
+
+    async def langgraph_stream():
+        nonlocal produced
+        for index in range(300):
+            produced += 1
+            yield index
+
+    merged = _merge_async_streams(langgraph_stream(), browser_queue, asyncio.Event())
+    first = await anext(merged)
+    await asyncio.sleep(0.05)
+
+    capacity = getattr(graph_module, "SSE_OUTPUT_QUEUE_MAXSIZE", None)
+    output_queue = output_queues[0]
+    assert capacity == 100
+    assert output_queue.maxsize == capacity
+    assert output_queue.peak_size <= capacity
+    assert produced <= capacity + 2
+
+    remaining = [item async for item in merged]
+    assert [first, *remaining] == [("langgraph", index) for index in range(300)]
+
+
+@pytest.mark.asyncio
+async def test_满队列时下游关闭仍会完成生产者清理():
+    capacity_reached = asyncio.Event()
+    finalized = asyncio.Event()
+
+    async def langgraph_stream():
+        try:
+            for index in range(graph_module.SSE_OUTPUT_QUEUE_MAXSIZE + 10):
+                if index == graph_module.SSE_OUTPUT_QUEUE_MAXSIZE + 1:
+                    capacity_reached.set()
+                yield index
+        finally:
+            finalized.set()
+
+    merged = _merge_async_streams(langgraph_stream(), asyncio.Queue(), asyncio.Event())
+    assert await anext(merged) == ("langgraph", 0)
+    await asyncio.wait_for(capacity_reached.wait(), timeout=1)
+
+    await asyncio.wait_for(merged.aclose(), timeout=1)
+    await asyncio.wait_for(finalized.wait(), timeout=1)


### PR DESCRIPTION
> 合并依赖已满足：#5384 已合入；本分支已 rebase 到最新 `master`，并重新通过下述 8 项组合测试。

## 问题

OpsPilot 的 SSE 合流使用无界输出队列。LangGraph 与浏览器事件持续生产、下游 SSE 消费较慢时，生产消费速差会直接转化为单请求内存积压。

## 根因（设计层）

合流层没有容量边界和背压契约，生产者的 `await put` 实际写入无界队列，不会因下游变慢而暂停。直接加容量后还会暴露一个取消边界：队列满载且下游关闭时，生产者不能在清理阶段再次阻塞写入完成标记。

## 怎么修的

- 将单请求 SSE 输出队列容量限制为 100，与现有浏览器步骤队列的容量约定一致。
- 保留两条生产路径的 `await put`，由队列满载自然反压，不丢弃事件。
- 父流清理已经设置停止信号时，不再向无人消费的满队列写入内部完成标记，避免取消阶段二次死锁。
- 保持自然完成时的完成标记、事件顺序、异常传播与 keepalive 行为不变。

## 调用链

```mermaid
flowchart LR
    subgraph P["并发生产者"]
        P1["LangGraph 事件"]
        P2["浏览器步骤事件"]
    end

    subgraph M["SSE 合流层"]
        Q["有界输出队列\nmaxsize = 100"]
        C["下游 SSE 消费"]
    end

    P1 -->|"await put / 满载反压"| Q
    P2 -->|"await put / 满载反压"| Q
    Q --> C
    C -. "断连" .-> X["取消子任务\n跳过清理期 done 写入"]
```

## 影响范围

- 仅修改 OpsPilot 内部 SSE 合流队列及对应单元测试。
- 不改变 HTTP 接口、SSE 事件结构、事件内容或正常完成顺序。
- 极端慢消费时，上游生产会在单请求积压达到 100 条后暂停，这是预期的资源边界。

## 验证

- 生命周期与背压组合测试：8 passed。
- 快速生产、慢消费场景下，队列峰值不超过 100，生产进度受限；恢复消费后 300 条事件完整且顺序不变。
- 队列填满后关闭下游，`aclose()` 与上游生成器 `finally` 均在限定时间内完成，残留子任务为 0。
- 自然完成、普通异常、上游主动取消、浏览器任务取消和 keepalive 契约均通过回归。
- 改动行覆盖率：100%。

## 三轨门禁

- Standards：PASS（97/100）。
- Spec：PASS（99/100）。
- Runtime Contract：PASS（98/100）。

Fixes #5378
