### PR TITLE
bugfix(memory-leak): 收口聊天图片预览 Blob URL

### DIFF
--- a/web/src/app/opspilot/components/custom-chat-sse/ImageBlobPreview.tsx
+++ b/web/src/app/opspilot/components/custom-chat-sse/ImageBlobPreview.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import type { UploadFile } from 'antd/es/upload/interface';
+
+interface ImageBlobPreviewProps {
+  file: UploadFile;
+}
+
+const ImageBlobPreview = ({ file }: ImageBlobPreviewProps) => {
+  const [previewUrl, setPreviewUrl] = useState('');
+
+  useEffect(() => {
+    const source = file.originFileObj;
+    if (!source || typeof URL.createObjectURL !== 'function') {
+      setPreviewUrl('');
+      return;
+    }
+
+    const objectUrl = URL.createObjectURL(source);
+    setPreviewUrl(objectUrl);
+
+    return () => {
+      URL.revokeObjectURL(objectUrl);
+    };
+  }, [file.originFileObj]);
+
+  if (!previewUrl) {
+    return null;
+  }
+
+  return (
+    <img
+      src={previewUrl}
+      alt={file.name}
+      className="w-14 h-14 object-cover"
+    />
+  );
+};
+
+export default ImageBlobPreview;

--- a/web/src/app/opspilot/components/custom-chat-sse/__tests__/ImageBlobPreview.test.tsx
+++ b/web/src/app/opspilot/components/custom-chat-sse/__tests__/ImageBlobPreview.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import type { UploadFile } from 'antd/es/upload/interface';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ImageBlobPreview from '../ImageBlobPreview';
+
+const createUploadFile = (uid: string, file: File): UploadFile => ({
+  uid,
+  name: file.name,
+  status: 'done',
+  originFileObj: file as UploadFile['originFileObj'],
+});
+
+describe('ImageBlobPreview', () => {
+  const createObjectURL = vi.fn<(blob: Blob | MediaSource) => string>();
+  const revokeObjectURL = vi.fn<(url: string) => void>();
+
+  beforeEach(() => {
+    createObjectURL.mockReset();
+    revokeObjectURL.mockReset();
+    createObjectURL
+      .mockReturnValueOnce('blob:first')
+      .mockReturnValueOnce('blob:second');
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL,
+      revokeObjectURL,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('同一文件重复渲染只创建一个预览 URL', async () => {
+    const source = new File(['image'], 'preview.png', { type: 'image/png' });
+    const file = createUploadFile('1', source);
+    const { rerender } = render(<ImageBlobPreview file={file} />);
+
+    await waitFor(() => expect(document.querySelector('img')?.src).toContain('blob:first'));
+    rerender(<ImageBlobPreview file={{ ...file, name: 'renamed.png' }} />);
+
+    expect(createObjectURL).toHaveBeenCalledOnce();
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('文件替换时释放旧 URL 并为新文件创建 URL', async () => {
+    const first = createUploadFile(
+      '1',
+      new File(['first'], 'first.png', { type: 'image/png' }),
+    );
+    const second = createUploadFile(
+      '1',
+      new File(['second'], 'second.png', { type: 'image/png' }),
+    );
+    const { rerender } = render(<ImageBlobPreview file={first} />);
+
+    await waitFor(() => expect(createObjectURL).toHaveBeenCalledOnce());
+    rerender(<ImageBlobPreview file={second} />);
+    await waitFor(() => expect(createObjectURL).toHaveBeenCalledTimes(2));
+
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:first');
+    expect(document.querySelector('img')?.src).toContain('blob:second');
+  });
+
+  it('文件项卸载时释放当前 URL', async () => {
+    const file = createUploadFile(
+      '1',
+      new File(['image'], 'preview.png', { type: 'image/png' }),
+    );
+    const { unmount } = render(<ImageBlobPreview file={file} />);
+
+    await waitFor(() => expect(createObjectURL).toHaveBeenCalledOnce());
+    unmount();
+
+    expect(revokeObjectURL).toHaveBeenCalledOnce();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:first');
+  });
+});

--- a/web/src/app/opspilot/components/custom-chat-sse/__tests__/imagePreviewInteractions.test.tsx
+++ b/web/src/app/opspilot/components/custom-chat-sse/__tests__/imagePreviewInteractions.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  nextUpload: null as (File & { uid: string }) | null,
+  sendMessage: vi.fn(),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { token: 'test-token' } } }),
+}));
+
+vi.mock('@/context/auth', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}));
+
+vi.mock('@/utils/i18n', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../hooks/useSSEStream', () => ({
+  useSSEStream: () => ({
+    handleSSEStream: vi.fn(),
+    stopSSEConnection: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useSendMessage', () => ({
+  useSendMessage: () => ({ sendMessage: mocks.sendMessage }),
+}));
+
+vi.mock('../toolCallRenderer', () => ({
+  initToolCallTooltips: vi.fn(),
+}));
+
+vi.mock('antd', () => {
+  const Wrapper = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
+  const Upload = ({
+    children,
+    beforeUpload,
+  }: {
+    children?: React.ReactNode;
+    beforeUpload: (file: File & { uid: string }) => unknown;
+  }) => (
+    <div
+      data-testid="image-upload"
+      onClick={() => mocks.nextUpload && beforeUpload(mocks.nextUpload)}
+    >
+      {children}
+    </div>
+  );
+  Upload.LIST_IGNORE = 'LIST_IGNORE';
+
+  return {
+    Button: Wrapper,
+    Checkbox: Wrapper,
+    Flex: Wrapper,
+    Image: Object.assign(
+      ({ src, alt }: { src?: string; alt?: string }) => <img src={src} alt={alt} />,
+      { PreviewGroup: Wrapper },
+    ),
+    Input: {
+      TextArea: ({
+        autoSize,
+        bordered,
+        ...props
+      }: React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
+        autoSize?: unknown;
+        bordered?: boolean;
+      }) => (
+        <textarea
+          aria-label="消息输入"
+          data-auto-size={Boolean(autoSize)}
+          data-bordered={bordered}
+          {...props}
+        />
+      ),
+    },
+    Popconfirm: Wrapper,
+    Spin: Wrapper,
+    Tooltip: Wrapper,
+    Upload,
+    message: {
+      error: vi.fn(),
+      loading: () => vi.fn(),
+      success: vi.fn(),
+    },
+  };
+});
+
+vi.mock('@ant-design/icons', () => {
+  const Icon = () => <span />;
+  return {
+    DeleteOutlined: Icon,
+    FullscreenExitOutlined: Icon,
+    FullscreenOutlined: Icon,
+    LoadingOutlined: Icon,
+    PictureOutlined: Icon,
+    RightOutlined: Icon,
+    SendOutlined: Icon,
+  };
+});
+
+import CustomChatSSE from '..';
+
+const createUpload = (uid: string, name: string) =>
+  Object.assign(new File(['image'], name, { type: 'image/png' }), { uid });
+
+describe('CustomChatSSE 图片预览资源', () => {
+  const createObjectURL = vi.fn<(blob: Blob | MediaSource) => string>();
+  const revokeObjectURL = vi.fn<(url: string) => void>();
+
+  beforeEach(() => {
+    let sequence = 0;
+    createObjectURL.mockImplementation(() => `blob:preview-${++sequence}`);
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL,
+      revokeObjectURL,
+    });
+    mocks.sendMessage.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    mocks.nextUpload = null;
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  const renderChat = () => render(
+    <CustomChatSSE
+      showHeader={false}
+      requirePermission={false}
+      conversationHistoryEnabled={false}
+    />,
+  );
+
+  it('点击删除图片会卸载对应预览并释放 URL', async () => {
+    const view = renderChat();
+    mocks.nextUpload = createUpload('first', 'first.png');
+    fireEvent.click(view.getByTestId('image-upload'));
+    mocks.nextUpload = createUpload('second', 'second.png');
+    fireEvent.click(view.getByTestId('image-upload'));
+
+    await waitFor(() => expect(createObjectURL).toHaveBeenCalledTimes(2));
+    fireEvent.click(view.getAllByRole('button', { name: '删除图片' })[0]);
+
+    await waitFor(() => expect(revokeObjectURL).toHaveBeenCalledWith('blob:preview-1'));
+    expect(view.getAllByRole('img')).toHaveLength(1);
+    expect(revokeObjectURL).toHaveBeenCalledOnce();
+  });
+
+  it('点击发送会释放全部预览并保持图片发送数据', async () => {
+    const view = renderChat();
+    mocks.nextUpload = createUpload('first', 'first.png');
+    fireEvent.click(view.getByTestId('image-upload'));
+    mocks.nextUpload = createUpload('second', 'second.png');
+    fireEvent.click(view.getByTestId('image-upload'));
+
+    await waitFor(() => expect(createObjectURL).toHaveBeenCalledTimes(2));
+    fireEvent.click(view.getByRole('button', { name: '发送消息' }));
+
+    await waitFor(() => expect(revokeObjectURL).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mocks.sendMessage).toHaveBeenCalledOnce());
+    expect(view.queryAllByRole('img')).toHaveLength(0);
+    expect(mocks.sendMessage).toHaveBeenCalledWith(
+      '',
+      [],
+      [
+        expect.objectContaining({ id: 'first', name: 'first.png', status: 'done' }),
+        expect.objectContaining({ id: 'second', name: 'second.png', status: 'done' }),
+      ],
+    );
+  });
+});

--- a/web/src/app/opspilot/components/custom-chat-sse/index.tsx
+++ b/web/src/app/opspilot/components/custom-chat-sse/index.tsx
@@ -35,6 +35,7 @@ import {initToolCallTooltips} from './toolCallRenderer';
 import { stripPlannedExecutionDumps } from './plannedExecutionPayload';
 import ContextUsageRing from './ContextUsageRing';
 import type { LlmContextUsage } from './llmContextUsage';
+import ImageBlobPreview from './ImageBlobPreview';
 
 const normalizeThinkingText = (value?: string) => {
   if (!value) return '';
@@ -901,31 +902,19 @@ const CustomChatSSE: React.FC<CustomChatSSEProps> = ({
       <div className="relative rounded-xl border border-[var(--color-border-1)] bg-[var(--color-bg)] transition-all focus-within:border-[var(--color-primary)] focus-within:ring-2 focus-within:ring-[var(--color-primary-bg-active)]">
         {imageList.length > 0 && (
           <div className="flex flex-wrap gap-2 p-2.5 pb-0">
-            {imageList.map((file) => {
-              const previewUrl = file.originFileObj && typeof window !== 'undefined'
-                ? URL.createObjectURL(file.originFileObj)
-                : '';
-
-              return (
-                <div key={file.uid} className="relative group rounded-lg overflow-hidden border border-[var(--color-border-1)] bg-[var(--color-bg)]">
-                  {previewUrl && (
-                    <img
-                      src={previewUrl}
-                      alt={file.name}
-                      className="w-14 h-14 object-cover"
-                    />
-                  )}
-                  <button
-                    type="button"
-                    className="absolute top-1 right-1 flex h-4 w-4 items-center justify-center rounded-full bg-black/60 text-white text-[10px] opacity-0 group-hover:opacity-100 transition-opacity"
-                    onClick={() => setImageList(imageList.filter(item => item.uid !== file.uid))}
-                    aria-label="删除图片"
-                  >
-                    ×
-                  </button>
-                </div>
-              );
-            })}
+            {imageList.map((file) => (
+              <div key={file.uid} className="relative group rounded-lg overflow-hidden border border-[var(--color-border-1)] bg-[var(--color-bg)]">
+                <ImageBlobPreview file={file} />
+                <button
+                  type="button"
+                  className="absolute top-1 right-1 flex h-4 w-4 items-center justify-center rounded-full bg-black/60 text-white text-[10px] opacity-0 group-hover:opacity-100 transition-opacity"
+                  onClick={() => setImageList(imageList.filter(item => item.uid !== file.uid))}
+                  aria-label="删除图片"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
           </div>
         )}
 


### PR DESCRIPTION
## 问题

OpsPilot 聊天输入区在 JSX 渲染期间为每张待发送图片调用 `URL.createObjectURL`。输入、流式状态等任意重渲染都会为同一文件创建新 URL，删除图片、发送消息或卸载组件时也没有释放，导致 Blob 资源持续累积。

## 根因（设计层）

Object URL 是需要显式释放的浏览器资源，但创建动作位于无稳定所有者的 render 路径。资源生命周期没有与单个图片文件项的挂载、变更和卸载对齐。

## 怎么修的

- 新增局部图片预览组件，在 effect 中按 `originFileObj` 创建 Object URL。
- 同一文件普通重渲染复用当前 URL；文件变化时先释放旧 URL。
- 图片删除、发送清空列表或组件卸载时，由 effect cleanup 释放对应 URL。
- 保持图片尺寸、删除交互、FileReader 转换和发送数据结构不变。

## 生命周期

```mermaid
flowchart LR
    A["图片文件项挂载"] --> B["effect 创建 Object URL"]
    B --> C["img 预览"]
    C -->|"同一文件重渲染"| C
    C -->|"文件替换"| D["释放旧 URL"]
    D --> B
    C -->|"删除 / 发送 / 卸载"| E["cleanup 释放 URL"]
```

## 影响范围

- 仅修改 OpsPilot Web 聊天输入区的本地图片预览。
- 不改变上传限制、图片 Base64 转换、消息请求参数和后端协议。
- Object URL 只用于本地预览，释放不会影响发送时持有的原始 File。

## 验证

- 组件生命周期与生产交互测试：5 passed。
- 同一文件重复渲染只创建一次 URL；文件替换和组件卸载均释放旧 URL。
- 实际点击删除只释放目标图片，其他预览继续显示。
- 实际点击发送会释放全部预览 URL，并保持发送图片的 ID、名称、状态与顺序。
- 触及文件 ESLint：0 errors；全量 TypeScript type-check：passed；pre-commit：passed。

## 三轨门禁

- Standards：PASS（97/100）。
- Spec：PASS（99/100）。
- Runtime Contract：PASS（98/100）。

Fixes #5379
