### PR TITLE
bugfix(memory-leak): 释放资产导出 Blob URL

### DIFF
--- a/web/src/app/cmdb/(pages)/assetData/components/__tests__/exportDownload.test.ts
+++ b/web/src/app/cmdb/(pages)/assetData/components/__tests__/exportDownload.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { downloadBlobFile } from '../exportDownload';
+
+describe('downloadBlobFile', () => {
+  const createObjectURL = vi.fn<(blob: Blob | MediaSource) => string>();
+  const revokeObjectURL = vi.fn<(url: string) => void>();
+
+  beforeEach(() => {
+    createObjectURL.mockReturnValue('blob:asset-export');
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL,
+      revokeObjectURL,
+    });
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('下载完成后移除链接并释放 Object URL', () => {
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => undefined);
+    const blob = new Blob(['xlsx']);
+
+    downloadBlobFile(blob, 'hosts.xlsx');
+
+    expect(createObjectURL).toHaveBeenCalledWith(blob);
+    expect(click).toHaveBeenCalledOnce();
+    expect(document.body.querySelector('a')).toBeNull();
+    expect(revokeObjectURL).toHaveBeenCalledOnce();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:asset-export');
+  });
+
+  it('点击下载抛错时仍移除链接并释放 Object URL', () => {
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {
+      throw new Error('download blocked');
+    });
+
+    expect(() => downloadBlobFile(new Blob(['xlsx']), 'hosts.xlsx')).toThrow(
+      'download blocked',
+    );
+    expect(document.body.querySelector('a')).toBeNull();
+    expect(revokeObjectURL).toHaveBeenCalledOnce();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:asset-export');
+  });
+
+  it('链接挂载抛错时仍释放 Object URL', () => {
+    vi.spyOn(document.body, 'appendChild').mockImplementation(() => {
+      throw new Error('append blocked');
+    });
+
+    expect(() => downloadBlobFile(new Blob(['xlsx']), 'hosts.xlsx')).toThrow(
+      'append blocked',
+    );
+    expect(document.body.querySelector('a')).toBeNull();
+    expect(revokeObjectURL).toHaveBeenCalledOnce();
+  });
+
+  it('链接属性赋值抛错时仍释放 Object URL', () => {
+    vi.spyOn(HTMLAnchorElement.prototype, 'href', 'set').mockImplementation(() => {
+      throw new Error('href blocked');
+    });
+
+    expect(() => downloadBlobFile(new Blob(['xlsx']), 'hosts.xlsx')).toThrow(
+      'href blocked',
+    );
+    expect(document.body.querySelector('a')).toBeNull();
+    expect(revokeObjectURL).toHaveBeenCalledOnce();
+  });
+
+  it('链接 remove 抛错时回退移除节点并释放 Object URL', () => {
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function () {
+      vi.spyOn(this, 'remove').mockImplementation(() => {
+        throw new Error('remove blocked');
+      });
+    });
+
+    expect(() => downloadBlobFile(new Blob(['xlsx']), 'hosts.xlsx')).toThrow(
+      'remove blocked',
+    );
+    expect(document.body.querySelector('a')).toBeNull();
+    expect(revokeObjectURL).toHaveBeenCalledOnce();
+  });
+});

--- a/web/src/app/cmdb/(pages)/assetData/components/exportDownload.ts
+++ b/web/src/app/cmdb/(pages)/assetData/components/exportDownload.ts
@@ -1,0 +1,22 @@
+export const downloadBlobFile = (blob: Blob, filename: string) => {
+  const link = document.createElement('a');
+  const objectUrl = URL.createObjectURL(blob);
+
+  try {
+    link.href = objectUrl;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+  } finally {
+    try {
+      try {
+        link.remove();
+      } catch (removeError) {
+        link.parentNode?.removeChild(link);
+        throw removeError;
+      }
+    } finally {
+      URL.revokeObjectURL(objectUrl);
+    }
+  }
+};

--- a/web/src/app/cmdb/(pages)/assetData/components/exportModal.tsx
+++ b/web/src/app/cmdb/(pages)/assetData/components/exportModal.tsx
@@ -20,6 +20,7 @@ import {
   ExportModalConfig,
   ExportModalRef,
 } from '@/app/cmdb/types/assetData';
+import { downloadBlobFile } from './exportDownload';
 
 const ExportModal = forwardRef<ExportModalRef, ExportModalProps>(
   ({ assoTypes }, ref) => {
@@ -217,12 +218,7 @@ const ExportModal = forwardRef<ExportModalRef, ExportModalProps>(
         const blob = new Blob([response.data], {
           type: response.headers['content-type'] as string,
         });
-        const link = document.createElement('a');
-        link.href = URL.createObjectURL(blob);
-        link.download = `${modelId}${t('Model.assetList')}.xlsx`;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
+        downloadBlobFile(blob, `${modelId}${t('Model.assetList')}.xlsx`);
 
         message.success(t('Model.exportSuccess'));
         setVisible(false);


### PR DESCRIPTION
## 问题

CMDB 资产导出完成后创建 Blob Object URL 并点击临时下载链接，但只移除 DOM 节点，没有撤销 URL。用户在同一 SPA 文档内重复导出时，XLSX Blob 会持续驻留。

## 根因（设计层）

临时链接与 Object URL 是两个独立资源。原流程缺少统一的资源所有者，也没有覆盖属性赋值、挂载、点击和移除异常的对称清理边界。

## 怎么修的

- 将本地下载动作收敛到组件目录内的 `downloadBlobFile` helper。
- Object URL 创建后的属性赋值、链接挂载与点击全部纳入 `try/finally`。
- 无论成功或异常，都会移除临时链接并对同一 URL 调用一次 revoke。
- `link.remove()` 异常时回退到 `parentNode.removeChild()`，最外层 `finally` 仍保证 URL 释放。
- 保持导出接口、请求参数、认证头、Blob 类型、文件名和成功提示不变。

## 生命周期

```mermaid
flowchart LR
    A["资产导出响应 Blob"] --> B["创建 Object URL"]
    B --> C["设置文件名并挂载链接"]
    C --> D["触发下载"]
    D --> E["移除临时链接"]
    E --> F["revoke Object URL"]
    C -. "任一异常" .-> E
    D -. "任一异常" .-> E
```

## 影响范围

- 仅修改 CMDB 资产导出的浏览器下载清理路径及测试。
- 不改变服务端接口、导出字段顺序、XLSX 内容或弹窗状态语义。
- URL 在点击触发下载后立即释放，与仓库现有下载实现保持一致。

## 验证

- 下载资源契约测试：5 passed。
- 覆盖正常下载，以及 href setter、appendChild、click、remove 抛错。
- 每个场景均验证 Object URL 单次释放；已挂载链接在 remove 失败时也能回退移除。
- 触及文件 ESLint：passed；全量 TypeScript type-check：passed；pre-commit：passed。

## 三轨门禁

- Standards：PASS（98/100）。
- Spec：PASS（100/100）。
- Runtime Contract：PASS（98/100）。

Fixes #5380
