### PR TITLE
bugfix(memory-leak): 释放监控插件导出 Blob URL

### DIFF
--- a/web/src/app/monitor/(pages)/integration/list/__tests__/exportDownload.test.ts
+++ b/web/src/app/monitor/(pages)/integration/list/__tests__/exportDownload.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { downloadPluginConfig } from '../exportDownload';
+
+describe('downloadPluginConfig', () => {
+  const createObjectURL = vi.fn<(blob: Blob | MediaSource) => string>();
+  const revokeObjectURL = vi.fn<(url: string) => void>();
+
+  beforeEach(() => {
+    createObjectURL.mockReturnValue('blob:plugin-config');
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL,
+      revokeObjectURL,
+    });
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('下载配置后移除链接并释放 Object URL', () => {
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => undefined);
+    const blob = new Blob(['config']);
+
+    downloadPluginConfig(blob, 'plugin.json');
+
+    expect(createObjectURL).toHaveBeenCalledWith(blob);
+    expect(click).toHaveBeenCalledOnce();
+    expect(document.body.querySelector('a')).toBeNull();
+    expect(revokeObjectURL).toHaveBeenCalledOnce();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:plugin-config');
+  });
+
+  it('点击下载抛错时仍移除链接并释放 Object URL', () => {
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {
+      throw new Error('download blocked');
+    });
+
+    expect(() => downloadPluginConfig(new Blob(['config']), 'plugin.json'))
+      .toThrow('download blocked');
+    expect(document.body.querySelector('a')).toBeNull();
+    expect(revokeObjectURL).toHaveBeenCalledOnce();
+  });
+
+  it('链接挂载抛错时仍释放 Object URL', () => {
+    vi.spyOn(document.body, 'appendChild').mockImplementation(() => {
+      throw new Error('append blocked');
+    });
+
+    expect(() => downloadPluginConfig(new Blob(['config']), 'plugin.json'))
+      .toThrow('append blocked');
+    expect(document.body.querySelector('a')).toBeNull();
+    expect(revokeObjectURL).toHaveBeenCalledOnce();
+  });
+
+  it('链接属性赋值抛错时仍释放 Object URL', () => {
+    vi.spyOn(HTMLAnchorElement.prototype, 'href', 'set').mockImplementation(() => {
+      throw new Error('href blocked');
+    });
+
+    expect(() => downloadPluginConfig(new Blob(['config']), 'plugin.json'))
+      .toThrow('href blocked');
+    expect(document.body.querySelector('a')).toBeNull();
+    expect(revokeObjectURL).toHaveBeenCalledOnce();
+  });
+
+  it('链接 remove 抛错时回退移除节点并释放 Object URL', () => {
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function () {
+      vi.spyOn(this, 'remove').mockImplementation(() => {
+        throw new Error('remove blocked');
+      });
+    });
+
+    expect(() => downloadPluginConfig(new Blob(['config']), 'plugin.json'))
+      .toThrow('remove blocked');
+    expect(document.body.querySelector('a')).toBeNull();
+    expect(revokeObjectURL).toHaveBeenCalledOnce();
+  });
+});

--- a/web/src/app/monitor/(pages)/integration/list/exportDownload.ts
+++ b/web/src/app/monitor/(pages)/integration/list/exportDownload.ts
@@ -1,0 +1,22 @@
+export const downloadPluginConfig = (blob: Blob, filename: string) => {
+  const link = document.createElement('a');
+  const objectUrl = URL.createObjectURL(blob);
+
+  try {
+    link.href = objectUrl;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+  } finally {
+    try {
+      try {
+        link.remove();
+      } catch (removeError) {
+        link.parentNode?.removeChild(link);
+        throw removeError;
+      }
+    } finally {
+      URL.revokeObjectURL(objectUrl);
+    }
+  }
+};

--- a/web/src/app/monitor/(pages)/integration/list/page.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/page.tsx
@@ -53,6 +53,7 @@ import {
   buildIntegrationConfigureUrl,
   resolveIntegrationEntryContext
 } from '@/app/monitor/utils/integrationEntryContext';
+import { downloadPluginConfig } from './exportDownload';
 
 const { confirm } = Modal;
 
@@ -276,13 +277,7 @@ const Integration = () => {
       const blob = new Blob([JSON.stringify(json.data, null, 2)], {
         type: 'application/json'
       });
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = `${selectedApp.display_name}.json`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
+      downloadPluginConfig(blob, `${selectedApp.display_name}.json`);
       message.success(t('common.successfullyExported'));
     } catch (error) {
       message.error(error as string);


### PR DESCRIPTION
## 问题

监控插件列表导出 JSON 配置时创建 Blob Object URL，点击并移除临时下载链接后没有撤销 URL。重复导出同一或不同插件会在当前 SPA 文档内持续累积 Blob 资源。

## 根因（设计层）

原下载流程只管理临时 DOM 节点，没有管理浏览器 URL 注册资源；Object URL 创建后的属性赋值、挂载、点击和移除也缺少统一的异常清理边界。

## 怎么修的

- 在监控插件列表目录内新增 `downloadPluginConfig` helper，集中管理本地下载生命周期。
- Object URL 创建后的属性赋值、链接挂载和点击全部纳入 `try/finally`。
- 正常或异常结束都移除临时链接，并对同一 URL 调用一次 revoke。
- `link.remove()` 异常时回退到 `parentNode.removeChild()`，最外层仍保证 URL 释放。
- 保持导出接口、认证头、JSON 格式、MIME、文件名和页面状态不变。

## 生命周期

```mermaid
flowchart LR
    A["插件接口返回配置"] --> B["构造 JSON Blob"]
    B --> C["创建 Object URL"]
    C --> D["设置文件名并挂载链接"]
    D --> E["触发配置下载"]
    E --> F["移除临时链接"]
    F --> G["revoke Object URL"]
    D -. "任一异常" .-> F
    E -. "任一异常" .-> F
```

## 影响范围

- 仅修改 Monitor 插件配置导出的浏览器下载清理路径及测试。
- 不改变插件选择、服务端接口、JSON 内容、成功/失败提示或加载状态。
- URL 在点击触发下载后立即释放，与仓库现有下载实现保持一致。

## 验证

- 下载资源契约测试：5 passed。
- 覆盖正常下载，以及 href setter、appendChild、click、remove 抛错。
- 所有场景均验证 URL 单次释放；remove 失败后链接可回退移除，DOM 无残留。
- 触及文件 ESLint：passed；全量 TypeScript type-check：passed；pre-commit：passed。

## 三轨门禁

- Standards：PASS（97/100）。
- Spec：PASS（100/100）。
- Runtime Contract：PASS（98/100）。

Fixes #5382
