### PR TITLE
fix(web): keep screen query on alarm and CMDB same-frame nav

### DIFF
--- a/web/src/app/alarm/(pages)/incidents/page.tsx
+++ b/web/src/app/alarm/(pages)/incidents/page.tsx
@@ -15,7 +15,7 @@ import { IncidentTableDataItem } from '@/app/alarm/types/incidents';
 import { FiltersConfig } from '@/app/alarm/types/alarms';
 import { useTranslation } from '@/utils/i18n';
 import { incidentStates } from '@/app/alarm/constants/alarm';
-import { useRouter } from 'next/navigation';
+import { useScreenAwareRouter } from '@/console-layout';
 import { useCommon } from '@/app/alarm/context/common';
 import { toIncidentLevelFilterOptions } from '@/app/alarm/utils/incidentLevelFilters';
 import { KeepAlive, useActivate } from 'react-activation';
@@ -23,7 +23,7 @@ import { KeepAlive, useActivate } from 'react-activation';
 const IncidentsPage: React.FC = () => {
   const { getIncidentList } = useIncidentsApi();
   const { t } = useTranslation();
-  const router = useRouter();
+  const router = useScreenAwareRouter();
   const { levelListIncident, levelMapIncident } = useCommon();
   const [searchText, setSearchText] = useState('');
   const [data, setData] = useState<IncidentTableDataItem[]>([]);

--- a/web/src/app/alarm/(pages)/integration/components/IntegrationCard.tsx
+++ b/web/src/app/alarm/(pages)/integration/components/IntegrationCard.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from 'react';
 import { EyeOutlined } from '@ant-design/icons';
-import { useRouter } from 'next/navigation';
+import { useScreenAwareRouter } from '@/console-layout';
 import { useTranslation } from '@/utils/i18n';
 import { SourceItem } from '@/app/alarm/types/integration';
 import { getHealth, getLogoColor, formatEventCount, formatTimestamp } from '../utils/health';
@@ -13,7 +13,7 @@ interface IntegrationCardProps {
 
 const IntegrationCard: React.FC<IntegrationCardProps> = ({ src }) => {
   const { t } = useTranslation();
-  const router = useRouter();
+  const router = useScreenAwareRouter();
   const [hovered, setHovered] = useState(false);
 
   const health = getHealth(src);

--- a/web/src/app/alarm/(pages)/settings/notificationTemplates/components/__tests__/templateEditor.loading.test.tsx
+++ b/web/src/app/alarm/(pages)/settings/notificationTemplates/components/__tests__/templateEditor.loading.test.tsx
@@ -27,7 +27,10 @@ vi.mock('@/app/alarm/context/common', () => ({
 }));
 vi.mock('@/context/userInfo', () => ({ useUserInfoContext: () => ({ username: 'admin' }) }));
 vi.mock('@/utils/i18n', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
-vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
 vi.mock('next/dynamic', () => ({
   default: () => function Editor({ value }: { value: string }) {
     return <textarea aria-label="template-editor" value={value} readOnly />;

--- a/web/src/app/alarm/(pages)/settings/notificationTemplates/components/templateEditor.tsx
+++ b/web/src/app/alarm/(pages)/settings/notificationTemplates/components/templateEditor.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import axios from 'axios';
 import dynamic from 'next/dynamic';
-import { useRouter } from 'next/navigation';
+import { useScreenAwareRouter } from '@/console-layout';
 import DOMPurify from 'dompurify';
 import MarkdownIt from 'markdown-it';
 import { Alert, Button, Card, Form, Input, Modal, Select, Space, Spin, Tabs, Tag, Typography, message } from 'antd';
@@ -72,7 +72,7 @@ const getApiError = (error: unknown) => {
 
 export default function TemplateEditor({ templateId }: TemplateEditorProps) {
   const { t } = useTranslation();
-  const router = useRouter();
+  const router = useScreenAwareRouter();
   const [form] = Form.useForm();
   const [messageApi, messageContextHolder] = message.useMessage();
   const api = useSettingApi();

--- a/web/src/app/alarm/(pages)/settings/notificationTemplates/page.tsx
+++ b/web/src/app/alarm/(pages)/settings/notificationTemplates/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Button, Input, Modal, Space, Tag, Tooltip, message } from 'antd';
-import { useRouter } from 'next/navigation';
+import { useScreenAwareRouter } from '@/console-layout';
 import CustomTable from '@/components/custom-table';
 import Introduction from '@/components/introduction';
 import PermissionWrapper from '@/components/permission';
@@ -18,7 +18,7 @@ import {
 
 export default function NotificationTemplatesPage() {
   const { t } = useTranslation();
-  const router = useRouter();
+  const router = useScreenAwareRouter();
   const [messageApi, messageContextHolder] = message.useMessage();
   const [modalApi, modalContextHolder] = Modal.useModal();
   const { convertToLocalizedTime } = useLocalizedTime();

--- a/web/src/app/alarm/components/alarm-page-breadcrumb/index.tsx
+++ b/web/src/app/alarm/components/alarm-page-breadcrumb/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useMemo } from 'react';
-import { useRouter, usePathname } from 'next/navigation';
+import { usePathname } from 'next/navigation';
+import { useScreenAwareRouter } from '@/console-layout';
 import { Breadcrumb } from 'antd';
 import Icon from '@/components/icon';
 import styles from './index.module.scss';
@@ -30,7 +31,7 @@ const AlarmPageBreadcrumb: React.FC<AlarmPageBreadcrumbProps> = ({
   menus = defaultAlarmBreadcrumbMenus,
   onNavigate,
 }) => {
-  const router = useRouter();
+  const router = useScreenAwareRouter();
   const pathnameFromHook = usePathname();
   const pathname = pathnameOverride || pathnameFromHook;
   const parentPath =

--- a/web/src/app/alarm/components/customBreadcrumb/index.tsx
+++ b/web/src/app/alarm/components/customBreadcrumb/index.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import Icon from '@/components/icon';
 import menu from '@/app/alarm/constants/menu.json';
 import commonStyles from './index.module.scss';
-import { useRouter, usePathname } from 'next/navigation';
+import { usePathname } from 'next/navigation';
+import { useScreenAwareRouter } from '@/console-layout';
 import { Breadcrumb } from 'antd';
 interface Props {
   children?: React.ReactNode;
@@ -14,7 +15,7 @@ interface Crumb {
 }
 
 const PageBreadcrumb: React.FC<Props> = ({ children }) => {
-  const router = useRouter();
+  const router = useScreenAwareRouter();
   const pathname = usePathname();
   const parentPath =
     pathname.lastIndexOf('/') > 0

--- a/web/src/app/cmdb/(pages)/assetData/detail/ipView/IpDetailDrawer.tsx
+++ b/web/src/app/cmdb/(pages)/assetData/detail/ipView/IpDetailDrawer.tsx
@@ -5,7 +5,7 @@ import { Button, Col, Drawer, Form, Input, Row, Select, Spin, Tag, message } fro
 import { ArrowRightOutlined } from '@ant-design/icons';
 import { useTranslation } from '@/utils/i18n';
 import { useLocale } from '@/context/locale';
-import { useRouter } from 'next/navigation';
+import { useScreenAwareRouter } from '@/console-layout';
 import PermissionWrapper from '@/components/permission';
 import { useInstanceApi, useModelApi } from '@/app/cmdb/api';
 import { useUserInfoContext } from '@/context/userInfo';
@@ -66,7 +66,7 @@ const IpDetailDrawer: React.FC<IpDetailDrawerProps> = ({
   const { t } = useTranslation();
   const { locale } = useLocale();
   const isZh = locale.toLowerCase().startsWith('zh');
-  const router = useRouter();
+  const router = useScreenAwareRouter();
   const { getModelAttrList } = useModelApi();
   const { getInstanceDetail } = useInstanceApi();
   const { flatGroups } = useUserInfoContext();

--- a/web/src/app/cmdb/(pages)/assetData/detail/relationships/deviceDetailDrawer.tsx
+++ b/web/src/app/cmdb/(pages)/assetData/detail/relationships/deviceDetailDrawer.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import { Drawer, Spin, Button, Tag, Modal, message } from 'antd';
 import { ArrowRightOutlined } from '@ant-design/icons';
-import { useRouter } from 'next/navigation';
+import { useScreenAwareRouter } from '@/console-layout';
 import { useTranslation } from '@/utils/i18n';
 import { useUserInfoContext } from '@/context/userInfo';
 import { useCommon } from '@/app/cmdb/context/common';
@@ -40,7 +40,7 @@ const DeviceDetailDrawer: React.FC<Props> = ({
   onUnplaced,
 }) => {
   const { t } = useTranslation();
-  const router = useRouter();
+  const router = useScreenAwareRouter();
   const { getInstanceDetail, saveRackRoomLayout } = useInstanceApi();
   const { getModelAttrList } = useModelApi();
   const { flatGroups } = useUserInfoContext();

--- a/web/src/app/cmdb/(pages)/assetData/detail/relationships/rackElevation.tsx
+++ b/web/src/app/cmdb/(pages)/assetData/detail/relationships/rackElevation.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { Spin, Alert, message } from 'antd';
-import { useRouter } from 'next/navigation';
+import { useScreenAwareRouter } from '@/console-layout';
 import CompactEmptyState from '@/components/compact-empty-state';
 import { useTranslation } from '@/utils/i18n';
 import { useThemeMode } from '@/theme';
@@ -37,7 +37,7 @@ const SVG_W = FRAME_X + FRAME_W + 44;
 const RackElevation: React.FC<Props> = ({ modelId, instUuid, embedded, compare, onDeviceClick }) => {
   const { t } = useTranslation();
   const { mode } = useThemeMode();
-  const router = useRouter();
+  const router = useScreenAwareRouter();
   const { getRackLayout } = useInstanceApi();
   const { hasPermission } = usePermissions(RACK_ROOM_ASSET_PERMISSION_PATH);
   const placeRef = useRef<LayoutPlaceModalRef>(null);

--- a/web/src/app/cmdb/(pages)/assetManage/autoDiscovery/collection/profess/page.tsx
+++ b/web/src/app/cmdb/(pages)/assetManage/autoDiscovery/collection/profess/page.tsx
@@ -51,7 +51,8 @@ import {
   TaskStatusMap,
 } from '@/app/cmdb/types/autoDiscovery';
 import { useAssetManageStore } from '@/app/cmdb/store';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { useScreenAwareRouter } from '@/console-layout';
 import { createCollectionListRequest } from './collectionListRequest';
 import { formatCollectReportTime } from './formatCollectReportTime';
 
@@ -134,7 +135,7 @@ const ProfessionalCollection: React.FC = () => {
   const { t } = useTranslation();
   const { locale } = useLocale();
   const collectApi = useCollectApi();
-  const router = useRouter();
+  const router = useScreenAwareRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const editingId = useAssetManageStore((state) => state.editingId);

--- a/web/src/app/cmdb/(pages)/views/components/ViewsWorkspaceShell.tsx
+++ b/web/src/app/cmdb/(pages)/views/components/ViewsWorkspaceShell.tsx
@@ -3,7 +3,8 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button,  Segmented, Spin } from 'antd';
 import CompactEmptyState from '@/components/compact-empty-state';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
+import { useScreenAwareRouter } from '@/console-layout';
 import { useTranslation } from '@/utils/i18n';
 import { useModelApi } from '@/app/cmdb/api';
 import { useCommon } from '@/app/cmdb/context/common';
@@ -52,7 +53,7 @@ const ViewsWorkspaceShell: React.FC<ViewsWorkspaceShellProps> = ({
   children,
 }) => {
   const { t } = useTranslation();
-  const router = useRouter();
+  const router = useScreenAwareRouter();
   const searchParams = useSearchParams();
   const { userId } = useUserInfoContext();
   const common = useCommon();


### PR DESCRIPTION
Swap remaining high/medium bare useRouter call sites in alarm and CMDB to useScreenAwareRouter so iframe screen mode survives list/detail and drawer jumps. Update templateEditor loading test mock for useSearchParams.