### PR TITLE
fix(webhookd): 修复 Proxy Traefik 启动参数及上游变量配置

### DIFF
--- a/agents/webhookd/infra/proxy/conf/traefik/dynamic.yml
+++ b/agents/webhookd/infra/proxy/conf/traefik/dynamic.yml
@@ -22,7 +22,7 @@ http:
     backend:
       loadBalancer:
         servers:
-          - url: '{{ env "SERVER_URL" }}'
+          - url: '{{ env "TRAEFIK_SERVER_URL" }}'
         serversTransport: insecure
         passHostHeader: false
 

--- a/agents/webhookd/infra/proxy/docker-compose.yaml
+++ b/agents/webhookd/infra/proxy/docker-compose.yaml
@@ -131,7 +131,6 @@ services:
       - "--api.dashboard=false"
       - "--providers.file.filename=/etc/traefik/dynamic.yml"
       - "--providers.file.watch=true"
-      - "--providers.file.templating=true"
       - "--accesslog"
       - "--entrypoints.websecure.address=:${TRAEFIK_WEB_PORT}"
     networks:

--- a/agents/webhookd/infra/tests/test_proxy_certificate_san.py
+++ b/agents/webhookd/infra/tests/test_proxy_certificate_san.py
@@ -80,6 +80,36 @@ def _generate_proxy_archive(proxy_address, certificate_authority):
     return tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz")
 
 
+def test_proxy_archive_traefik_startup_flags(certificate_authority):
+    with _generate_proxy_archive("proxy.example.com", certificate_authority) as archive:
+        compose = yaml.safe_load(archive.extractfile("./docker-compose.yaml"))
+
+    command = compose["services"]["traefik"]["command"]
+    assert not any(flag.startswith("--providers.file.templating") for flag in command)
+    assert "--providers.file.filename=/etc/traefik/dynamic.yml" in command
+    assert "--providers.file.watch=true" in command
+
+
+def test_proxy_archive_upstream_template_uses_injected_environment(certificate_authority):
+    with _generate_proxy_archive("proxy.example.com", certificate_authority) as archive:
+        compose = yaml.safe_load(archive.extractfile("./docker-compose.yaml"))
+        dynamic = yaml.safe_load(archive.extractfile("./conf/traefik/dynamic.yml"))
+        generated_env = dict(
+            line.split("=", 1)
+            for line in archive.extractfile("./.env").read().decode().splitlines()
+            if line and not line.startswith("#")
+        )
+
+    injected = dict(item.split("=", 1) for item in compose["services"]["traefik"]["environment"])
+    upstream = dynamic["http"]["services"]["backend"]["loadBalancer"]["servers"][0]["url"]
+    template = re.fullmatch(r'\{\{\s*env "([^"]+)"\s*\}\}', upstream)
+    assert template is not None
+    assert template[1] in injected, "上游模板必须读取 Traefik 容器实际注入的变量"
+    source = re.fullmatch(r"\$\{([^}]+)\}", injected[template[1]])
+    assert source is not None
+    assert generated_env[source[1]] == "https://server.example.com"
+
+
 @pytest.mark.parametrize(
     ("proxy_address", "expected_dns", "expected_ip"),
     [


### PR DESCRIPTION
## 问题

Proxy 安装包为 Traefik 3.6.24 传入不支持的 `--providers.file.templating=true`，导致启动报 `field not found, node: templating` 并反复重启。仅删除该参数后，动态配置读取的 `SERVER_URL` 与容器实际注入的 `TRAEFIK_SERVER_URL` 不一致，上游地址为空，请求仍返回 500。

## 修改

删除无效启动参数，保留 File Provider 原生动态模板渲染；将上游模板改为读取 `TRAEFIK_SERVER_URL`。增加基于实际生成安装包的回归测试，检查启动参数及上游变量从生成配置到容器模板的传递。

## 验证

- 新增两项测试在修复前分别复现无效参数和变量缺失；修复后相关 8 项测试通过，在最新 master 基础上再次验证通过。
- wx-test 使用客户同款 Traefik 3.6.24：原参数复现启动错误，只删除参数返回 500，两处修正后首页返回 200，与直连平台正文一致。
- 未携带凭据访问节点 API，直连及经 Proxy 均返回 401 且正文一致；修正后容器重启次数为 0。临时容器及网络已清理。
- 验证覆盖网关启动、动态配置和 HTTPS 转发，不包含节点注册、NATS 与采集全链路。

## 发布

更新 Webhookd 镜像后，新生成的 Proxy 安装包生效；存量 Proxy 需更新对应两处配置并重建 Traefik。回滚可恢复原模板版本，但原故障将重新出现。
