### PR TITLE
refactor(web): 统一 OpsPilot 详情页左侧实体导航布局

### DIFF
--- a/web/src/app/opspilot/(pages)/skill/detail/__tests__/layout.test.tsx
+++ b/web/src/app/opspilot/(pages)/skill/detail/__tests__/layout.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import '@ant-design/v5-patch-for-react-19';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import SkillSettingsLayout from '../layout';
+
+const mockPush = vi.fn();
+let mockPathname = '/opspilot/skill/detail/settings';
+let mockSearchParams = new URLSearchParams('id=48');
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+  usePathname: () => mockPathname,
+  useSearchParams: () => mockSearchParams,
+}));
+
+vi.mock('@/context/permissions', () => ({
+  usePermissions: () => ({
+    menus: [],
+    loading: false,
+  }),
+}));
+
+vi.mock('@/utils/i18n', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback || key,
+  }),
+}));
+
+vi.mock('@/components/icon', () => ({
+  default: ({ type, className }: { type: string; className?: string }) => (
+    <span data-testid={`icon-${type}`} className={className} />
+  ),
+}));
+
+const mockSkillInfo = {
+  name: 'IT运维助手',
+  introduction: '智能运维问答助手',
+};
+
+vi.mock('@/app/opspilot/context/skillContext', () => ({
+  SkillProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useSkill: () => ({
+    skillInfo: mockSkillInfo,
+    isLoading: false,
+    refreshSkillInfo: vi.fn(),
+  }),
+}));
+
+describe('SkillSettingsLayout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPathname = '/opspilot/skill/detail/settings';
+    mockSearchParams = new URLSearchParams('id=48');
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders unified sidebar intro matching list cards without displaying ID', () => {
+    render(
+      <SkillSettingsLayout>
+        <div data-testid="workbench-content">Studio Content</div>
+      </SkillSettingsLayout>
+    );
+
+    // Displays name and description
+    expect(screen.getByText('IT运维助手')).toBeTruthy();
+    expect(screen.getByText('智能运维问答助手')).toBeTruthy();
+
+    // ID is completely omitted as requested
+    expect(screen.queryByText(/ID/)).toBeNull();
+
+    // Compact icon, no background plate — same pool/algorithm as list cards
+    const icon = screen.getByTestId(/^icon-jiqiren/);
+    expect(icon).toBeTruthy();
+    expect(icon.className).toContain('text-base');
+    expect(icon.className).toContain('text-[var(--color-primary)]');
+    expect(icon.parentElement?.className ?? '').not.toMatch(/bg-\[var\(--color-fill/);
+
+    // 3-level SideMenu navigation items
+    const settingsMenu = screen.getByText('设置');
+    const channelMenu = screen.getByText('发布');
+    expect(settingsMenu).toBeTruthy();
+    expect(channelMenu).toBeTruthy();
+
+    const settingsLink = settingsMenu.closest('a');
+    const channelLink = channelMenu.closest('a');
+    expect(settingsLink?.getAttribute('href')).toContain('/opspilot/skill/detail/settings?id=48');
+    expect(channelLink?.getAttribute('href')).toContain('/opspilot/skill/detail/channel?id=48');
+    expect(screen.getByTestId('icon-settings-fill')).toBeTruthy();
+
+    expect(screen.getByTestId('workbench-content')).toBeTruthy();
+
+    // Unified left block: subtle divider line with comfortable spacing (Option B)
+    const separator = document.querySelector('[role="separator"]');
+    expect(separator).toBeTruthy();
+    expect(separator?.className).toContain('border-[var(--color-border-2)]');
+    expect(screen.queryByText('IT运维助手')?.closest('.bg-\\[var\\(--color-fill-1\\)\\]')).toBeNull();
+  }, 20000);
+
+  it('navigates back to /opspilot/skill when back button is clicked', () => {
+    const { container } = render(
+      <SkillSettingsLayout>
+        <div>Content</div>
+      </SkillSettingsLayout>
+    );
+
+    const backBtn = container.querySelector('button.absolute.bottom-4.left-4') || screen.getByRole('button');
+    expect(backBtn).toBeTruthy();
+    if (backBtn) {
+      fireEvent.click(backBtn);
+      expect(mockPush).toHaveBeenCalledWith('/opspilot/skill');
+    }
+  }, 20000);
+});

--- a/web/src/app/opspilot/(pages)/skill/detail/layout.tsx
+++ b/web/src/app/opspilot/(pages)/skill/detail/layout.tsx
@@ -1,32 +1,87 @@
 'use client';
 
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslation } from '@/utils/i18n';
-import { useRouter } from 'next/navigation';
-import TopSection from '@/components/top-section';
 import WithSideMenuLayout from '@/components/sub-layout';
-import OnelineEllipsisIntro from '@/app/opspilot/components/oneline-ellipsis-intro';
+import type { MenuItem } from '@/types';
 import { SkillProvider, useSkill } from '@/app/opspilot/context/skillContext';
+import { pickStableIcon } from '@/app/opspilot/utils/pickStableIcon';
+import OpsPilotEntityDetailIntro from '@/app/opspilot/components/opspilot-entity-detail-intro';
+
+// 与列表页 SkillCard / EntityCard 保持完全统一的图标池与算法
+const SKILL_ICON_POOL = ['jiqirenjiaohukapian', 'jiqiren', 'jiqiren1', 'jiqiren2'];
 
 const LayoutContent = ({ children }: { children: React.ReactNode }) => {
   const { t } = useTranslation();
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const { skillInfo } = useSkill();
 
-  const handleBackButtonClick = () => {
+  const id = searchParams?.get('id') || '';
+  const queryName = searchParams?.get('name') || '';
+  const queryDesc = searchParams?.get('desc') || '';
+  const displayName = skillInfo.name || queryName;
+  const displayIntro = skillInfo.introduction || queryDesc;
+
+  // 使用与列表页完全一致的稳定 hash 算法（同一个智能体展示相同图标）
+  const iconType =
+    pickStableIcon(id, SKILL_ICON_POOL, displayName) || 'jiqirenjiaohukapian';
+
+  const handleBackButtonClick = useCallback(() => {
     router.push('/opspilot/skill');
-  };
+  }, [router]);
+
+  const customMenuItems: MenuItem[] = useMemo(() => {
+    const items: MenuItem[] = [
+      {
+        name: 'skill_setting',
+        title: t('skill.settings.menu', '设置'),
+        url: '/opspilot/skill/detail/settings',
+        icon: 'settings-fill',
+        operation: [],
+      },
+      {
+        name: 'skill_channel',
+        title: t('skill.channel.menu', '发布'),
+        url: '/opspilot/skill/detail/channel',
+        icon: 'channel1',
+        operation: [],
+      },
+    ];
+
+    if (pathname?.includes('/rules')) {
+      items.push({
+        name: 'skill_rules',
+        title: t('skill.rules.menu', '规则'),
+        url: '/opspilot/skill/detail/rules',
+        icon: 'biangengjilu',
+        operation: [],
+      });
+    }
+
+    return items;
+  }, [t, pathname]);
 
   const intro = (
-    <OnelineEllipsisIntro name={skillInfo.name} desc={skillInfo.introduction}></OnelineEllipsisIntro>
+    <OpsPilotEntityDetailIntro
+      name={displayName}
+      description={displayIntro}
+      iconType={iconType}
+      fallbackTitle={t('skill.detail.title', '智能体详情')}
+      emptyIntroText={t('skill.detail.noIntro', '暂无简介')}
+    />
   );
 
   return (
     <WithSideMenuLayout
-      topSection={<TopSection title={t('skill.settings.title')} content={t('skill.settings.description')} />}
       intro={intro}
       showBackButton={true}
       onBackButtonClick={handleBackButtonClick}
+      layoutType="sideMenu"
+      introLayout="unified"
+      customMenuItems={customMenuItems}
     >
       {children}
     </WithSideMenuLayout>

--- a/web/src/app/opspilot/(pages)/studio/detail/layout.tsx
+++ b/web/src/app/opspilot/(pages)/studio/detail/layout.tsx
@@ -1,24 +1,36 @@
 'use client';
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import WithSideMenuLayout from '@/components/sub-layout';
-import OnelineEllipsisIntro from '@/app/opspilot/components/oneline-ellipsis-intro';
-import { useRouter, usePathname } from 'next/navigation';
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import { useTranslation } from '@/utils/i18n';
-import TopSection from "@/components/top-section";
 import { usePermissions } from '@/context/permissions';
 import { MenuItem } from '@/types/index';
 import { StudioProvider, useStudio } from '@/app/opspilot/context/studioContext';
+import { pickStableIcon } from '@/app/opspilot/utils/pickStableIcon';
+import OpsPilotEntityDetailIntro from '@/app/opspilot/components/opspilot-entity-detail-intro';
+
+const STUDIO_ICON_POOL = ['Chatflow', 'gongzuotai', 'Copilot'];
 
 const LayoutContent = ({ children }: { children: React.ReactNode }) => {
   const { t } = useTranslation();
   const pathname = usePathname();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { menus } = usePermissions();
   const { botInfo, isLoading } = useStudio();
 
+  const id = searchParams?.get('id') || '';
+  const queryName = searchParams?.get('name') || '';
+  const queryDesc = searchParams?.get('desc') || '';
+  const displayName = botInfo.name || queryName;
+  const displayIntro = botInfo.introduction || queryDesc;
+
+  const iconType =
+    pickStableIcon(id, STUDIO_ICON_POOL, displayName) || 'gongzuotai';
+
   const processedMenuItems = useMemo(() => {
-    const getMenuItemsForPath = (menus: MenuItem[], currentPath: string): MenuItem[] => {
+    const getMenuItemsForPath = (itemsList: MenuItem[], currentPath: string): MenuItem[] => {
       const findMatchedMenu = (items: MenuItem[]): MenuItem | null => {
         for (const menu of items) {
           if (menu.isDirectory) {
@@ -28,11 +40,11 @@ const LayoutContent = ({ children }: { children: React.ReactNode }) => {
             }
             continue;
           }
-          
+
           if (menu.url && menu.url !== currentPath && currentPath.startsWith(menu.url)) {
             return menu;
           }
-          
+
           if (menu.children?.length) {
             const found = findMatchedMenu(menu.children);
             if (found) return found;
@@ -40,11 +52,11 @@ const LayoutContent = ({ children }: { children: React.ReactNode }) => {
         }
         return null;
       };
-      
-      const matchedMenu = findMatchedMenu(menus);
+
+      const matchedMenu = findMatchedMenu(itemsList);
 
       if (matchedMenu?.children?.length) {
-        const validChildren = matchedMenu.children.filter(m => !m.isNotMenuItem);
+        const validChildren = matchedMenu.children.filter((m) => !m.isNotMenuItem);
         return validChildren;
       }
 
@@ -56,73 +68,40 @@ const LayoutContent = ({ children }: { children: React.ReactNode }) => {
     if (isLoading) {
       return [originalMenuItems[0]];
     }
-    
+
     const botType = botInfo.botType;
     if (botType === 2 && originalMenuItems.length > 0) {
-      return originalMenuItems.filter(m => !['bot_channel', 'bot_api'].includes(m.name));
+      return originalMenuItems.filter((m) => !['bot_channel', 'bot_api'].includes(m.name));
     }
 
     if (botType === 3 && originalMenuItems.length > 0) {
-      return originalMenuItems.filter(m => !['bot_statistics', 'bot_channel'].includes(m.name));
+      return originalMenuItems.filter((m) => !['bot_statistics', 'bot_channel'].includes(m.name));
     }
-    
-    return originalMenuItems.filter(m => m.name !== 'bot_api');
+
+    return originalMenuItems.filter((m) => m.name !== 'bot_api');
   }, [menus, pathname, botInfo.botType, isLoading]);
 
-  const handleBackButtonClick = () => {
+  const handleBackButtonClick = useCallback(() => {
     router.push('/opspilot/studio');
-  };
+  }, [router]);
 
   const intro = (
-    <OnelineEllipsisIntro name={botInfo.name} desc={botInfo.introduction}></OnelineEllipsisIntro>
+    <OpsPilotEntityDetailIntro
+      name={displayName}
+      description={displayIntro}
+      iconType={iconType}
+      fallbackTitle={t('studio.detail.title', '应用详情')}
+      emptyIntroText={t('studio.detail.noIntro', '暂无简介')}
+    />
   );
-
-  const getTopSectionContent = () => {
-    switch (pathname) {
-      case '/opspilot/studio/detail/settings':
-        return (
-          <TopSection
-            title={t('common.settings')}
-            content={t('studio.settings.description')}
-          />
-        );
-      case '/opspilot/studio/detail/channel':
-        return (
-          <TopSection
-            title={t('studio.channel.title')}
-            content={t('studio.channel.description')}
-          />
-        );
-      case '/opspilot/studio/detail/logs':
-        return (
-          <TopSection
-            title={t('studio.logs.title')}
-            content={t('studio.logs.description')}
-          />
-        );
-      case '/opspilot/studio/detail/statistics':
-        return (
-          <TopSection
-            title={t('studio.statistics.title')}
-            content={t('studio.statistics.description')}
-          />
-        );
-      default:
-        return (
-          <TopSection
-            title={t('common.settings')}
-            content={t('studio.settings.description')}
-          />
-        );
-    }
-  };
 
   return (
     <WithSideMenuLayout
-      topSection={getTopSectionContent()}
       intro={intro}
       showBackButton={true}
       onBackButtonClick={handleBackButtonClick}
+      layoutType="sideMenu"
+      introLayout="unified"
       customMenuItems={processedMenuItems}
     >
       {children}

--- a/web/src/app/opspilot/(pages)/wiki/detail/page.tsx
+++ b/web/src/app/opspilot/(pages)/wiki/detail/page.tsx
@@ -11,9 +11,7 @@ import {
 } from '@ant-design/icons';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslation } from '@/utils/i18n';
-import TopSection from '@/components/top-section';
 import WithSideMenuLayout from '@/components/sub-layout';
-import OnelineEllipsisIntro from '@/app/opspilot/components/oneline-ellipsis-intro';
 import { MenuItem } from '@/types/index';
 import { useWikiApi } from '@/app/opspilot/api/wiki';
 import { WikiKnowledgeBase } from '@/app/opspilot/types/wiki';
@@ -24,8 +22,11 @@ import MaterialTab from '@/app/opspilot/components/wiki/MaterialTab';
 import OverviewTab from '@/app/opspilot/components/wiki/OverviewTab';
 import SettingsTab from '@/app/opspilot/components/wiki/SettingsTab';
 import { buildWikiDetailTabPath } from '@/app/opspilot/utils/wikiMaterialRoutes';
+import { pickStableIcon } from '@/app/opspilot/utils/pickStableIcon';
+import OpsPilotEntityDetailIntro from '@/app/opspilot/components/opspilot-entity-detail-intro';
 
 const WIKI_MENU_ICON_CLASS_NAME = 'text-[16px]';
+const WIKI_ICON_POOL = ['zhishiku1', 'zhishiku3', 'zhishiku2', 'zhishiku'];
 
 const WikiDetailPage: React.FC = () => {
   const { t } = useTranslation();
@@ -145,10 +146,23 @@ const WikiDetailPage: React.FC = () => {
     }
   };
 
+  const iconType =
+    pickStableIcon(kbId, WIKI_ICON_POOL, kb?.name) || 'zhishiku1';
+
+  const intro = (
+    <OpsPilotEntityDetailIntro
+      name={kb?.name}
+      description={kb?.introduction}
+      iconType={iconType}
+      fallbackTitle={t('wiki.detail.title', '知识库详情')}
+      emptyIntroText={t('wiki.detail.noIntro', '暂无简介')}
+    />
+  );
+
   return (
     <WithSideMenuLayout
-      topSection={<TopSection title={t('wiki.title')} content={t('wiki.description')} />}
-      intro={<OnelineEllipsisIntro name={kb?.name || ''} desc={kb?.introduction || ''} />}
+      intro={intro}
+      introLayout="unified"
       activeKeyword
       keywordName="tab"
       customMenuItems={menuItems}

--- a/web/src/app/opspilot/components/opspilot-entity-detail-intro/__tests__/index.test.tsx
+++ b/web/src/app/opspilot/components/opspilot-entity-detail-intro/__tests__/index.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import '@ant-design/v5-patch-for-react-19';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import OpsPilotEntityDetailIntro from '../index';
+
+vi.mock('@/components/icon', () => ({
+  default: ({ type, className }: { type: string; className?: string }) => (
+    <span data-testid={`icon-${type}`} className={className} />
+  ),
+}));
+
+describe('OpsPilotEntityDetailIntro', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders name, description and aligned icon without background container', () => {
+    render(
+      <OpsPilotEntityDetailIntro
+        name="测试应用"
+        description="这是一个测试应用的详细描述"
+        iconType="gongzuotai"
+      />
+    );
+
+    expect(screen.getByText('测试应用')).toBeTruthy();
+    expect(screen.getByText('这是一个测试应用的详细描述')).toBeTruthy();
+
+    const icon = screen.getByTestId('icon-gongzuotai');
+    expect(icon).toBeTruthy();
+    expect(icon.className).toContain('text-base');
+    expect(icon.className).toContain('text-[var(--color-primary)]');
+  });
+
+  it('renders fallback title and empty intro text when name and description are missing', () => {
+    render(
+      <OpsPilotEntityDetailIntro
+        iconType="zhishiku1"
+        fallbackTitle="默认知识库"
+        emptyIntroText="暂无知识库简介"
+      />
+    );
+
+    expect(screen.getByText('默认知识库')).toBeTruthy();
+    expect(screen.getByText('暂无知识库简介')).toBeTruthy();
+  });
+});

--- a/web/src/app/opspilot/components/opspilot-entity-detail-intro/index.tsx
+++ b/web/src/app/opspilot/components/opspilot-entity-detail-intro/index.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import React from 'react';
+import { Typography } from 'antd';
+import Icon from '@/components/icon';
+import EllipsisWithTooltip from '@/components/ellipsis-with-tooltip';
+
+export interface OpsPilotEntityDetailIntroProps {
+  name?: string | null;
+  description?: string | null;
+  iconType: string;
+  fallbackTitle?: string;
+  emptyIntroText?: string;
+  className?: string;
+}
+
+const OpsPilotEntityDetailIntro: React.FC<OpsPilotEntityDetailIntroProps> = ({
+  name,
+  description,
+  iconType,
+  fallbackTitle = '详情',
+  emptyIntroText = '暂无简介',
+  className = '',
+}) => {
+  const displayName = name || fallbackTitle;
+
+  return (
+    <div className={`flex w-full items-center gap-2 ${className}`.trim()}>
+      <Icon type={iconType} className="shrink-0 text-base text-[var(--color-primary)]" />
+      <div className="min-w-0 flex-1">
+        <EllipsisWithTooltip
+          text={displayName}
+          className="mb-1 block truncate text-sm font-semibold leading-tight text-[var(--color-text-1)]"
+        />
+        {description ? (
+          <Typography.Paragraph
+            className="!mb-0 text-xs leading-[18px] text-[var(--color-text-3)]"
+            ellipsis={{
+              rows: 2,
+              tooltip: true,
+            }}
+          >
+            {description}
+          </Typography.Paragraph>
+        ) : (
+          <p className="m-0 text-xs leading-[18px] text-[var(--color-text-4)]">
+            {emptyIntroText}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default OpsPilotEntityDetailIntro;

--- a/web/src/components/layout/sub-layout/sideMenuShell.tsx
+++ b/web/src/components/layout/sub-layout/sideMenuShell.tsx
@@ -29,7 +29,7 @@ const SideMenuShell: React.FC<SideMenuShellProps> = ({
   return (
     <aside className={`w-[216px] pr-4 flex flex-shrink-0 flex-col h-full ${className}`.trim()}>
       {intro && (
-        <div className={`p-4 rounded-md mb-3 h-[80px] ${introClassName}`.trim()}>
+        <div className={`mb-3 min-h-[80px] rounded-md p-4 ${introClassName}`.trim()}>
           {intro}
         </div>
       )}

--- a/web/src/components/sub-layout/index.tsx
+++ b/web/src/components/sub-layout/index.tsx
@@ -29,6 +29,8 @@ interface WithSideMenuLayoutProps {
   pagePathName?: string;
   customMenuItems?: MenuItem[];
   menuLevel?: number;
+  /** separate=分卡（默认）；unified=左侧整块+分割线 */
+  introLayout?: 'separate' | 'unified';
 }
 
 const WithSideMenuLayout: React.FC<WithSideMenuLayoutProps> = ({
@@ -45,7 +47,8 @@ const WithSideMenuLayout: React.FC<WithSideMenuLayoutProps> = ({
   taskProgressComponent,
   pagePathName,
   customMenuItems,
-  menuLevel // 可选参数
+  menuLevel, // 可选参数
+  introLayout = 'separate',
 }) => {
   const router = useRouter();
   const curRouterName = usePathname();
@@ -149,6 +152,7 @@ const WithSideMenuLayout: React.FC<WithSideMenuLayoutProps> = ({
                 showProgress={showProgress}
                 taskProgressComponent={taskProgressComponent}
                 onBackButtonClick={onBackButtonClick}
+                introLayout={introLayout}
               >
                 {intro}
               </SideMenu>

--- a/web/src/components/sub-layout/side-menu.tsx
+++ b/web/src/components/sub-layout/side-menu.tsx
@@ -8,6 +8,8 @@ import { ArrowLeftOutlined } from '@ant-design/icons';
 import Icon from '@/components/icon';
 import { MenuItem } from '@/types/index';
 
+export type SideMenuIntroLayout = 'separate' | 'unified';
+
 interface SideMenuProps {
   menuItems: MenuItem[];
   activeKeyword?: boolean;
@@ -17,6 +19,11 @@ interface SideMenuProps {
   showProgress?: boolean;
   taskProgressComponent?: React.ReactNode;
   onBackButtonClick?: () => void;
+  /**
+   * separate: 实体 intro 与菜单分两张卡（默认，工作台/知识库等）
+   * unified: 合成左侧一块，intro 与菜单用分割线隔开（智能体详情）
+   */
+  introLayout?: SideMenuIntroLayout;
 }
 
 const SideMenu: React.FC<SideMenuProps> = ({
@@ -28,9 +35,11 @@ const SideMenu: React.FC<SideMenuProps> = ({
   showProgress = false,
   taskProgressComponent,
   onBackButtonClick,
+  introLayout = 'separate',
 }) => {
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const isUnified = introLayout === 'unified';
 
   const buildUrlWithParams = (path: string) => {
     if(activeKeyword) {
@@ -63,40 +72,70 @@ const SideMenu: React.FC<SideMenuProps> = ({
     return <Icon type={item.icon} className="text-xl pr-1.5" />;
   };
 
+  const renderMenuList = (listPaddingClass = 'p-3') => (
+    <ul className={`space-y-0.5 ${listPaddingClass}`}>
+      {menuItems.map((item) => {
+        const active = isActive(item.url, item.name);
+        return (
+          <li key={item.url} className={`rounded-md ${active ? sideMenuStyle.active : ''}`}>
+            <Link
+              href={buildUrlWithParams(item.url)}
+              className={`group flex h-10 items-center rounded-md px-3 py-2 text-sm transition-colors ${
+                active ? 'font-medium' : 'font-normal'
+              }`}
+            >
+              {renderIcon(item)}
+              {item.title}
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+
+  const backButton = showBackButton ? (
+    <button
+      className="absolute bottom-4 left-4 flex items-center py-2 rounded-md text-sm"
+      onClick={onBackButtonClick}
+    >
+      <ArrowLeftOutlined className="mr-2" />
+    </button>
+  ) : null;
+
+  if (isUnified) {
+    return (
+      <aside className={`flex h-full w-[216px] flex-shrink-0 flex-col pr-4 ${sideMenuStyle.sideMenu}`}>
+        <div className={`relative flex flex-1 flex-col overflow-hidden rounded-md ${sideMenuStyle.nav}`}>
+          {children ? (
+            <>
+              <div className="px-4 pb-2 pt-4">{children}</div>
+              <div
+                className="mx-4 my-1.5 border-t border-[var(--color-border-2)] opacity-80"
+                role="separator"
+              />
+            </>
+          ) : null}
+          <nav className="relative flex-1">
+            {renderMenuList('p-3 pt-1.5')}
+            {showProgress ? taskProgressComponent : null}
+            {backButton}
+          </nav>
+        </div>
+      </aside>
+    );
+  }
+
   return (
-    <aside className={`w-[216px] pr-4 flex flex-shrink-0 flex-col h-full ${sideMenuStyle.sideMenu}`}>
+    <aside className={`flex h-full w-[216px] flex-shrink-0 flex-col pr-4 ${sideMenuStyle.sideMenu}`}>
       {children && (
-        <div className={`p-4 rounded-md mb-3 h-[80px] ${sideMenuStyle.introduction}`}>
+        <div className={`mb-3 min-h-[80px] rounded-md p-4 ${sideMenuStyle.introduction}`}>
           {children}
         </div>
       )}
-      <nav className={`flex-1 relative rounded-md ${sideMenuStyle.nav}`}>
-        <ul className="p-3">
-          {menuItems.map((item) => (
-            <li key={item.url} className={`rounded-md mb-1 ${isActive(item.url, item.name) ? sideMenuStyle.active : ''}`}>
-              <Link
-                href={buildUrlWithParams(item.url)}
-                className="group flex items-center h-9 rounded-md py-2 text-sm font-normal px-3"
-              >
-                {renderIcon(item)}
-                {item.title}
-              </Link>
-            </li>
-          ))}
-        </ul>
-        {showProgress && (
-          <>
-            {taskProgressComponent}
-          </>
-        )}
-        {showBackButton && (
-          <button
-            className="absolute bottom-4 left-4 flex items-center py-2 rounded-md text-sm"
-            onClick={onBackButtonClick}
-          >
-            <ArrowLeftOutlined className="mr-2" />
-          </button>
-        )}
+      <nav className={`relative flex-1 rounded-md ${sideMenuStyle.nav}`}>
+        {renderMenuList('p-3')}
+        {showProgress ? taskProgressComponent : null}
+        {backButton}
       </nav>
     </aside>
   );


### PR DESCRIPTION
去掉智能体/工作台/知识库详情的顶部通栏，改为左侧整块侧栏：实体信息与三级菜单用淡分割线分区，并抽出共享 intro 组件对齐列表图标。