### PR TITLE
bugfix: 权限 RPC 失败补 traceback 与关联 ID

### DIFF
--- a/server/apps/core/tests/utils/test_permission_utils.py
+++ b/server/apps/core/tests/utils/test_permission_utils.py
@@ -12,12 +12,15 @@ import pydantic.root_model  # noqa
 
 策略：纯函数全部真实执行并断言真实输出；RPC/cache 边界打桩，返回真实形态假数据。
 """
+import logging
 from types import SimpleNamespace
 
 import pytest
 
 from apps.core import constants
 from apps.core.utils import permission_utils as pu
+
+SENTINEL_PASSWORD = "SENTINEL_PERM_PASSWORD_MUST_NOT_LOG"
 
 pytestmark = pytest.mark.unit
 
@@ -92,9 +95,52 @@ class TestGetPermissionRules:
         mocker.patch.object(pu, "get_cached_permission_rules", return_value=None)
         mocker.patch.object(pu, "set_cached_permission_rules")
         client = mocker.MagicMock()
-        client.get_user_rules_by_app.side_effect = RuntimeError("nats down")
+        original = RuntimeError("nats down")
+        client.get_user_rules_by_app.side_effect = original
         mocker.patch.object(pu, "set_rules_module_params", return_value=("cmdb", "", client, "instance"))
-        assert pu.get_permission_rules(_user(), "5", "cmdb", "instance") == {}
+        mock_log = mocker.patch.object(pu.logger, "exception")
+        assert pu.get_permission_rules(_user(username="alice"), "5", "cmdb", "instance") == {}
+        mock_log.assert_called_once_with(
+            pu._PERMISSION_RPC_FAILED,
+            "alice",
+            "domain.com",
+            "5",
+            "cmdb",
+            "instance",
+            "get_user_rules_by_app",
+            "RuntimeError",
+        )
+
+    def test_rpc_exception_logs_traceback_without_credentials(self, mocker, caplog):
+        mocker.patch.object(pu, "get_cached_permission_rules", return_value=None)
+        mocker.patch.object(pu, "set_cached_permission_rules")
+        original = RuntimeError("nats down")
+        client = mocker.MagicMock()
+        client.get_user_rules_by_app.side_effect = original
+        mocker.patch.object(pu, "set_rules_module_params", return_value=("cmdb", "", client, "instance"))
+        user = _user(username="alice")
+        user.password = SENTINEL_PASSWORD
+
+        with caplog.at_level(logging.ERROR, logger="nats"):
+            assert pu.get_permission_rules(user, "5", "cmdb", "instance") == {}
+
+        error_records = [record for record in caplog.records if record.levelno == logging.ERROR]
+        assert len(error_records) == 1
+        message = error_records[0].getMessage()
+        assert "event=permission_rpc_failed" in message
+        assert "username=alice" in message
+        assert "team=5" in message
+        assert "app=cmdb" in message
+        assert "permission_key=instance" in message
+        assert "failed_stage=get_user_rules_by_app" in message
+        assert "error_type=RuntimeError" in message
+        assert SENTINEL_PASSWORD not in message
+        assert error_records[0].exc_info is not None
+        assert error_records[0].exc_info[1] is original
+        joined = "\n".join(record.getMessage() for record in caplog.records)
+        assert SENTINEL_PASSWORD not in joined
+        if error_records[0].exc_text:
+            assert SENTINEL_PASSWORD not in error_records[0].exc_text
 
 
 # ---------------------------------------------------------------------------
@@ -195,8 +241,41 @@ class TestGetPermissionsRules:
         client = mocker.MagicMock()
         client.get_user_rules_by_module.side_effect = ValueError("boom")
         mocker.patch.object(pu, "SystemMgmt", return_value=client)
-        assert pu.get_permissions_rules(_user(), "3", "cmdb", "x") == {}
+        mock_log = mocker.patch.object(pu.logger, "exception")
+        assert pu.get_permissions_rules(_user(username="bob"), "3", "cmdb", "x") == {}
         mock_set.assert_not_called()
+        mock_log.assert_called_once_with(
+            pu._PERMISSION_RPC_FAILED,
+            "bob",
+            "domain.com",
+            "3",
+            "cmdb",
+            "x",
+            "get_user_rules_by_module",
+            "ValueError",
+        )
+
+    def test_rpc_exception_logs_traceback_without_credentials(self, mocker, caplog):
+        mocker.patch.object(pu, "get_cached_permission_rules", return_value=None)
+        mocker.patch.object(pu, "set_cached_permission_rules")
+        original = ValueError("boom")
+        client = mocker.MagicMock()
+        client.get_user_rules_by_module.side_effect = original
+        mocker.patch.object(pu, "SystemMgmt", return_value=client)
+        user = _user(username="bob")
+        user.password = SENTINEL_PASSWORD
+
+        with caplog.at_level(logging.ERROR, logger="nats"):
+            assert pu.get_permissions_rules(user, "3", "cmdb", "x") == {}
+
+        error_records = [record for record in caplog.records if record.levelno == logging.ERROR]
+        assert len(error_records) == 1
+        message = error_records[0].getMessage()
+        assert "failed_stage=get_user_rules_by_module" in message
+        assert "error_type=ValueError" in message
+        assert SENTINEL_PASSWORD not in message
+        assert error_records[0].exc_info is not None
+        assert error_records[0].exc_info[1] is original
 
 
 # ---------------------------------------------------------------------------

--- a/server/apps/core/utils/permission_utils.py
+++ b/server/apps/core/utils/permission_utils.py
@@ -5,6 +5,23 @@ from apps.core.logger import nats_logger as logger
 from apps.core.utils.permission_cache import get_cached_permission_rules, get_user_permission_version, set_cached_permission_rules
 from apps.rpc.system_mgmt import SystemMgmt
 
+_PERMISSION_RPC_FAILED = (
+    "event=permission_rpc_failed username=%s domain=%s team=%s app=%s permission_key=%s failed_stage=%s error_type=%s"
+)
+
+
+def _log_permission_rpc_failure(exc, *, user, current_team, app_name, permission_key, failed_stage):
+    logger.exception(
+        _PERMISSION_RPC_FAILED,
+        user.username,
+        user.domain,
+        current_team,
+        app_name,
+        permission_key,
+        failed_stage,
+        type(exc).__name__,
+    )
+
 
 def get_permission_rules(user, current_team, app_name, permission_key, include_children=False):
     """获取某app某类权限的某个对象的规则"""
@@ -47,10 +64,15 @@ def get_permission_rules(user, current_team, app_name, permission_key, include_c
                 permission_version=permission_version,
             ):
                 return permission_data
-        except Exception:
-            import traceback
-
-            logger.error(traceback.format_exc())
+        except Exception as exc:
+            _log_permission_rpc_failure(
+                exc,
+                user=user,
+                current_team=current_team,
+                app_name=app_name,
+                permission_key=permission_key,
+                failed_stage="get_user_rules_by_app",
+            )
             return {}
     return {}
 
@@ -120,7 +142,15 @@ def get_permissions_rules(user, current_team, app_name, permission_key, include_
                 user.domain,
                 include_children,
             )
-        except Exception:
+        except Exception as exc:
+            _log_permission_rpc_failure(
+                exc,
+                user=user,
+                current_team=current_team,
+                app_name=cache_app_name,
+                permission_key=permission_key,
+                failed_stage="get_user_rules_by_module",
+            )
             return {}
 
         if permission_version is None:


### PR DESCRIPTION
## 背景

接 #5034。Server 热路径权限 RPC 失败时，`get_permission_rules` 原先用 `traceback.format_exc()`，`get_permissions_rules` 失败则完全静默，排查时缺少 username / team / app / permission_key。

## 变更

- 两条 RPC except 改为 `logger.exception`，带 `failed_stage` 与 `error_type`。
- **不改变** fail-closed 返回 `{}`、缓存与重试次数。
- 日志不含凭据；测试用哨兵密码校验。

## 验证

- `apps/core/tests/utils/test_permission_utils.py`：35 passed（跳过需 Postgres 的 `django_db` 过滤用例）。

Closes #5034

Made with [Cursor](https://cursor.com)