### PR TITLE
bugfix: 收敛 VMware/QCloud/OceanStor 采集逐对象 INFO

### DIFF
--- a/agents/stargazer/tasks/collectors/oceanstor_collector.py
+++ b/agents/stargazer/tasks/collectors/oceanstor_collector.py
@@ -16,8 +16,7 @@ class OceanStorCollector(BaseCollector):
         password = self.params["password"]
         host = self.params.get("host") or self.params.get("base_url", "")
         instance_id = self.params.get("instance_id", host)
-
-        logger.info(f"[OceanStor Collector] Host={host}")
+        task_id = self.params.get("collection_task_id") or self.params.get("task_id") or ""
 
         base_url = f"https://{host}" if host and not host.startswith("http") else host
 
@@ -37,10 +36,25 @@ class OceanStorCollector(BaseCollector):
 
         monitor = OceanStorApiMonitor(monitor_input)
 
-        monitor.execute()
+        try:
+            monitor.execute()
+        except Exception as err:
+            logger.exception(
+                "event=oceanstor_collect_failed host=%s task_id=%s failed_stage=%s error_type=%s",
+                host,
+                task_id,
+                "execute",
+                type(err).__name__,
+            )
+            raise
 
         if not monitor.data:
-            logger.warning("[OceanStor Collector] No data collected")
+            logger.warning(
+                "event=oceanstor_collect_empty host=%s task_id=%s failed_stage=%s",
+                host,
+                task_id,
+                "execute",
+            )
             return ""
 
         metric_dict = {}
@@ -50,6 +64,12 @@ class OceanStorCollector(BaseCollector):
         metric_list = convert_to_prometheus(metric_dict)
         result = "\n".join(metric_list) + "\n"
 
-        logger.info(f"[OceanStor Collector] Completed: {len(result)} bytes")
+        logger.info(
+            "event=oceanstor_collect_summary host=%s task_id=%s object_types=1 object_type_failed=0 resources=%s bytes=%s",
+            host,
+            task_id,
+            len(metric_dict),
+            len(result),
+        )
 
         return result

--- a/agents/stargazer/tasks/collectors/qcloud_collector.py
+++ b/agents/stargazer/tasks/collectors/qcloud_collector.py
@@ -94,10 +94,10 @@ class QCloudCollector(BaseCollector):
         username = self.params["username"]
         password = self.params["password"]
         minutes = self.params.get("minutes", 5)
+        host = self.params.get("host") or ""
+        task_id = self.params.get("collection_task_id") or self.params.get("task_id") or ""
         # 与 API 缺省一致：旧配置未传地域时仍采广州，避免无数据行为突变。
         regions = _parse_qcloud_regions(self.params.get("region"))
-
-        logger.info("[QCloud Collector] Minutes=%s Region=%s", minutes, ",".join(regions))
 
         # 获取时间范围
         end_time = datetime.datetime.now()
@@ -105,51 +105,63 @@ class QCloudCollector(BaseCollector):
         start_time_str = start_time.strftime("%Y-%m-%d %H:%M") + ":00"
         end_time_str = end_time.strftime("%Y-%m-%d %H:%M") + ":00"
 
-        logger.info("[QCloud Collector] Time range: %s to %s", start_time_str, end_time_str)
-
         metric_dict = {}
         total_resources_processed = 0
         listed_ok = False
+        object_type_count = 0
+        object_type_failed = 0
 
         for region in regions:
             driver = CMPDriver(username, password, "qcloud", region=region)
             try:
                 all_resources = driver.list_all_resources()
-            except Exception as e:
+            except Exception as err:
                 logger.exception(
-                    "event=qcloud_collect_failed Region=%s failed_stage=list_all_resources error_type=%s",
+                    "event=qcloud_collect_failed host=%s task_id=%s region=%s failed_stage=%s error_type=%s",
+                    host,
+                    task_id,
                     region,
-                    type(e).__name__,
+                    "list_all_resources",
+                    type(err).__name__,
                 )
                 continue
 
             listed_ok = True
             if not all_resources.get("data"):
-                logger.warning("[QCloud Collector] No resources found Region=%s", region)
+                logger.warning(
+                    "event=qcloud_collect_empty host=%s task_id=%s region=%s failed_stage=%s",
+                    host,
+                    task_id,
+                    region,
+                    "list_all_resources",
+                )
                 continue
-
-            total_resource_count = sum(len(resources) if resources else 0 for resources in all_resources.get("data", {}).values())
-            logger.info(
-                "[QCloud Collector] Connected Region=%s object_types=%s resources=%s",
-                region,
-                len(all_resources.get("data", {})),
-                total_resource_count,
-            )
 
             for object_id, resources in all_resources.get("data", {}).items():
                 if not resources:
                     continue
 
+                object_type_count += 1
                 resource_ids = [resource.get("resource_id") for resource in resources if resource.get("resource_id")]
                 if not resource_ids:
                     logger.warning(
-                        "[QCloud Collector] Skip object without resource_id Region=%s object=%s",
+                        "event=qcloud_collect_skip host=%s task_id=%s region=%s object_type=%s failed_stage=%s",
+                        host,
+                        task_id,
                         region,
                         object_id,
+                        "missing_resource_id",
                     )
                     continue
                 ip_by_resource = _cvm_resource_ip_map(resources) if object_id == QCLOUD_CVM_OBJECT_ID else {}
-                logger.info("[QCloud Collector] Processing Region=%s object=%s count=%s", region, object_id, len(resource_ids))
+                logger.debug(
+                    "event=qcloud_collect_object_debug host=%s task_id=%s region=%s object_type=%s count=%s",
+                    host,
+                    task_id,
+                    region,
+                    object_id,
+                    len(resource_ids),
+                )
 
                 try:
                     data = driver.get_weops_monitor_data(
@@ -162,7 +174,16 @@ class QCloudCollector(BaseCollector):
                     )
 
                     if not data["result"]:
-                        logger.error("[QCloud Collector] Monitor data failed Region=%s object=%s", region, object_id)
+                        object_type_failed += 1
+                        logger.error(
+                            "event=qcloud_collect_failed host=%s task_id=%s region=%s object_type=%s failed_stage=%s error_type=%s",
+                            host,
+                            task_id,
+                            region,
+                            object_id,
+                            "get_weops_monitor_data",
+                            "result_false",
+                        )
                         continue
 
                     for resource_id, metrics in data["data"].items():
@@ -172,19 +193,16 @@ class QCloudCollector(BaseCollector):
                         metric_dict[(resource_id, object_id)] = metrics
 
                     total_resources_processed += len(data["data"])
-                    logger.info(
-                        "[QCloud Collector] Processed Region=%s object=%s count=%s",
+                except Exception as err:
+                    object_type_failed += 1
+                    logger.exception(
+                        "event=qcloud_collect_failed host=%s task_id=%s region=%s object_type=%s failed_stage=%s error_type=%s",
+                        host,
+                        task_id,
                         region,
                         object_id,
-                        len(data["data"]),
-                    )
-
-                except Exception as e:
-                    logger.error(
-                        "[QCloud Collector] Error processing Region=%s object=%s error_type=%s",
-                        region,
-                        object_id,
-                        type(e).__name__,
+                        "get_weops_monitor_data",
+                        type(err).__name__,
                     )
                     continue
 
@@ -193,7 +211,11 @@ class QCloudCollector(BaseCollector):
         influxdb_data = "\n".join(connect_lines + metric_list) + "\n"
 
         logger.info(
-            "[QCloud Collector] Completed resources=%s bytes=%s connected=%s",
+            "event=qcloud_collect_summary host=%s task_id=%s object_types=%s object_type_failed=%s resources=%s bytes=%s connected=%s",
+            host,
+            task_id,
+            object_type_count,
+            object_type_failed,
             total_resources_processed,
             len(influxdb_data),
             listed_ok,

--- a/agents/stargazer/tasks/collectors/vmware_collector.py
+++ b/agents/stargazer/tasks/collectors/vmware_collector.py
@@ -79,11 +79,7 @@ class VmwareCollector(BaseCollector):
         password = self.params["password"]
         host = self.params["host"]
         minutes = self.params.get("minutes", 5)
-
-        logger.info(f"[VMware Collector] ===== START COLLECTION =====")
-        logger.info(f"[VMware Collector] Params: {list(self.params.keys())}")
-        logger.info(f"[VMware Collector] Target Host={host}, Minutes={minutes}")
-        logger.info(f"[VMware Collector] ===================================")
+        task_id = self.params.get("collection_task_id") or self.params.get("task_id") or ""
 
         # 获取时间范围
         end_time = datetime.datetime.now()
@@ -91,15 +87,25 @@ class VmwareCollector(BaseCollector):
         start_time_str = start_time.strftime("%Y-%m-%d %H:%M") + ":00"
         end_time_str = end_time.strftime("%Y-%m-%d %H:%M") + ":00"
 
-        logger.info(f"[VMware Collector] Time range: {start_time_str} to {end_time_str}")
-
         try:
             driver = CMPDriver(username, password, "vmware", host=host)
-        except ConnectionError as e:
-            logger.error(f"[VMware Collector] Failed to create driver: {str(e)}")
+        except ConnectionError as err:
+            logger.exception(
+                "event=vmware_collect_failed host=%s task_id=%s failed_stage=%s error_type=%s",
+                host,
+                task_id,
+                "create_driver",
+                type(err).__name__,
+            )
             return ""
-        except Exception as e:
-            logger.error(f"[VMware Collector] Unexpected error creating driver: {str(e)}")
+        except Exception as err:
+            logger.exception(
+                "event=vmware_collect_failed host=%s task_id=%s failed_stage=%s error_type=%s",
+                host,
+                task_id,
+                "create_driver",
+                type(err).__name__,
+            )
             return ""
 
         try:
@@ -110,24 +116,35 @@ class VmwareCollector(BaseCollector):
             ))
             vmware_manager.connect_vc()
             object_map = vmware_manager.service()
-
-            total_object_count = sum(len(obj_list) if obj_list else 0 for obj_list in object_map.values())
-            logger.info(f"[VMware Collector] Connected: {len(object_map)} object types, {total_object_count} total objects")
-
-        except Exception as e:
-            logger.error(f"[VMware Collector] Connection failed: {str(e)}")
+        except Exception as err:
+            logger.exception(
+                "event=vmware_collect_failed host=%s task_id=%s failed_stage=%s error_type=%s",
+                host,
+                task_id,
+                "connect_vc",
+                type(err).__name__,
+            )
             return ""
 
         metric_dict = {}
         total_resources_processed = 0
+        object_type_count = 0
+        object_type_failed = 0
 
         for object_id, object_list in object_map.items():
             if object_id == "vmware_vc" or not object_list:
                 continue
 
+            object_type_count += 1
             ip_by_resource = _resource_ip_map(object_id, object_list)
             resource_ids = [resource["resource_id"] for resource in object_list]
-            logger.info(f"[VMware Collector] Processing '{object_id}': {len(resource_ids)} resources")
+            logger.debug(
+                "event=vmware_collect_object_debug host=%s task_id=%s object_type=%s count=%s",
+                host,
+                task_id,
+                object_id,
+                len(resource_ids),
+            )
 
             try:
                 data = driver.get_weops_monitor_data(
@@ -140,7 +157,15 @@ class VmwareCollector(BaseCollector):
                 )
 
                 if not data["result"]:
-                    logger.error(f"[VMware Collector] Monitor data failed for '{object_id}': {data.get('message')}")
+                    object_type_failed += 1
+                    logger.error(
+                        "event=vmware_collect_failed host=%s task_id=%s object_type=%s failed_stage=%s error_type=%s",
+                        host,
+                        task_id,
+                        object_id,
+                        "get_weops_monitor_data",
+                        "result_false",
+                    )
                     continue
 
                 for resource_id, metrics in data["data"].items():
@@ -150,16 +175,30 @@ class VmwareCollector(BaseCollector):
                     metric_dict[(resource_id, object_id)] = metrics
 
                 total_resources_processed += len(data["data"])
-                logger.info(f"[VMware Collector] '{object_id}' processed: {len(data['data'])} resources")
-
-            except Exception as e:
-                logger.error(f"[VMware Collector] Error processing '{object_id}': {str(e)}")
+            except Exception as err:
+                object_type_failed += 1
+                logger.exception(
+                    "event=vmware_collect_failed host=%s task_id=%s object_type=%s failed_stage=%s error_type=%s",
+                    host,
+                    task_id,
+                    object_id,
+                    "get_weops_monitor_data",
+                    type(err).__name__,
+                )
                 continue
 
         # 转换为 Prometheus 格式
         metric_list = convert_to_prometheus(metric_dict)
         influxdb_data = "\n".join(metric_list) + "\n"
 
-        logger.info(f"[VMware Collector] Completed: {total_resources_processed} resources, {len(influxdb_data)} bytes")
+        logger.info(
+            "event=vmware_collect_summary host=%s task_id=%s object_types=%s object_type_failed=%s resources=%s bytes=%s",
+            host,
+            task_id,
+            object_type_count,
+            object_type_failed,
+            total_resources_processed,
+            len(influxdb_data),
+        )
 
         return influxdb_data

--- a/agents/stargazer/tests/test_vmware_qcloud_collect_logging.py
+++ b/agents/stargazer/tests/test_vmware_qcloud_collect_logging.py
@@ -1,0 +1,203 @@
+import logging
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+STARGAZER_ROOT = Path(__file__).resolve().parents[1]
+if str(STARGAZER_ROOT) not in sys.path:
+    sys.path.insert(0, str(STARGAZER_ROOT))
+
+SENTINEL_PASSWORD = "SENTINEL_COLLECT_PASSWORD_MUST_NOT_LOG"
+
+
+def _info_messages(caplog):
+    return [record.getMessage() for record in caplog.records if record.levelno == logging.INFO]
+
+
+def _install_pyvmomi_stubs(monkeypatch):
+    pyvim = types.ModuleType("pyVim")
+    connect = types.ModuleType("pyVim.connect")
+    connect.Disconnect = MagicMock()
+    connect.SmartConnect = MagicMock()
+    pyvim.connect = connect
+    pyvmomi = types.ModuleType("pyVmomi")
+    pyvmomi.vim = MagicMock()
+    monkeypatch.setitem(sys.modules, "pyVim", pyvim)
+    monkeypatch.setitem(sys.modules, "pyVim.connect", connect)
+    monkeypatch.setitem(sys.modules, "pyVmomi", pyvmomi)
+
+
+def _load_vmware(monkeypatch):
+    _install_pyvmomi_stubs(monkeypatch)
+    sys.modules.pop("plugins.inputs.vmware_vc.vmware_info", None)
+    sys.modules.pop("tasks.collectors.vmware_collector", None)
+    from plugins.inputs.vmware_vc.vmware_info import VmwareManage
+    from tasks.collectors import vmware_collector as vmware_module
+    from tasks.collectors.vmware_collector import VmwareCollector
+
+    return VmwareManage, vmware_module, VmwareCollector
+
+
+def test_vmware_collect_sync_summary_and_object_failure(monkeypatch, caplog):
+    VmwareManage, vmware_module, VmwareCollector = _load_vmware(monkeypatch)
+
+    original = RuntimeError("vm boom")
+    driver = MagicMock()
+    driver.get_weops_monitor_data.side_effect = original
+    monkeypatch.setattr(vmware_module, "logger", logging.getLogger("test.stargazer.vmware_collect"))
+
+    collector = VmwareCollector(
+        {
+            "username": "admin",
+            "password": SENTINEL_PASSWORD,
+            "host": "vcenter.example",
+            "collection_task_id": "collect-task-8",
+        }
+    )
+
+    with (
+        patch("common.cmp.driver.CMPDriver", return_value=driver),
+        patch.object(VmwareManage, "connect_vc"),
+        patch.object(
+            VmwareManage,
+            "service",
+            return_value={
+                "vmware_vc": [{"resource_id": "vc-1"}],
+                "vmware_vm": [{"resource_id": "vm-1", "ip_addr": "10.0.0.8"}],
+            },
+        ),
+        patch("utils.convert.convert_to_prometheus", return_value=["vmware_metric 1"]),
+        caplog.at_level(logging.DEBUG, logger="test.stargazer.vmware_collect"),
+    ):
+        result = collector._collect_sync()
+
+    assert result.endswith("\n")
+    assert "vmware_metric 1" in result
+    info_messages = _info_messages(caplog)
+    assert len(info_messages) == 1
+    assert "event=vmware_collect_summary" in info_messages[0]
+    assert "host=vcenter.example" in info_messages[0]
+    assert "task_id=collect-task-8" in info_messages[0]
+    assert "Processing" not in "\n".join(info_messages)
+    assert "=====" not in "\n".join(record.getMessage() for record in caplog.records)
+
+    error_records = [record for record in caplog.records if record.levelno == logging.ERROR]
+    assert len(error_records) == 1
+    message = error_records[0].getMessage()
+    assert "event=vmware_collect_failed" in message
+    assert "object_type=vmware_vm" in message
+    assert "failed_stage=get_weops_monitor_data" in message
+    assert "error_type=RuntimeError" in message
+    assert SENTINEL_PASSWORD not in message
+    assert error_records[0].exc_info is not None
+    assert error_records[0].exc_info[1] is original
+    joined = "\n".join(record.getMessage() for record in caplog.records)
+    assert SENTINEL_PASSWORD not in joined
+
+
+def test_vmware_connect_failure_returns_empty(monkeypatch, caplog):
+    VmwareManage, vmware_module, VmwareCollector = _load_vmware(monkeypatch)
+
+    original = RuntimeError("connect boom")
+    monkeypatch.setattr(vmware_module, "logger", logging.getLogger("test.stargazer.vmware_connect"))
+
+    collector = VmwareCollector(
+        {
+            "username": "admin",
+            "password": SENTINEL_PASSWORD,
+            "host": "vcenter.example",
+            "collection_task_id": "collect-task-8",
+        }
+    )
+    with (
+        patch("common.cmp.driver.CMPDriver", return_value=MagicMock()),
+        patch.object(VmwareManage, "connect_vc", side_effect=original),
+        caplog.at_level(logging.ERROR, logger="test.stargazer.vmware_connect"),
+    ):
+        assert collector._collect_sync() == ""
+
+    error_records = [record for record in caplog.records if record.levelno == logging.ERROR]
+    assert len(error_records) == 1
+    assert "failed_stage=connect_vc" in error_records[0].getMessage()
+    assert error_records[0].exc_info[1] is original
+    assert SENTINEL_PASSWORD not in error_records[0].getMessage()
+
+
+def test_qcloud_collect_sync_summary_and_object_failure(monkeypatch, caplog):
+    from tasks.collectors import qcloud_collector as qcloud_module
+    from tasks.collectors.qcloud_collector import QCloudCollector
+
+    original = RuntimeError("cvm boom")
+    driver = MagicMock()
+    driver.list_all_resources.return_value = {
+        "data": {
+            "qcloud_cvm": [{"resource_id": "cvm-1", "inner_ip": "10.0.0.3"}],
+        }
+    }
+    driver.get_weops_monitor_data.side_effect = original
+    monkeypatch.setattr(qcloud_module, "logger", logging.getLogger("test.stargazer.qcloud_collect"))
+
+    collector = QCloudCollector(
+        {
+            "username": "ak",
+            "password": SENTINEL_PASSWORD,
+            "host": "qcloud.example",
+            "region": "ap-guangzhou",
+            "collection_task_id": "collect-task-7",
+        }
+    )
+    with (
+        patch("common.cmp.driver.CMPDriver", return_value=driver),
+        patch("utils.convert.convert_to_prometheus", return_value=[]),
+        caplog.at_level(logging.INFO, logger="test.stargazer.qcloud_collect"),
+    ):
+        result = collector._collect_sync()
+
+    assert "ConnectStatus" in result
+    info_messages = _info_messages(caplog)
+    assert len(info_messages) == 1
+    assert "event=qcloud_collect_summary" in info_messages[0]
+    assert "task_id=collect-task-7" in info_messages[0]
+    assert "Processing" not in "\n".join(info_messages)
+
+    error_records = [record for record in caplog.records if record.levelno == logging.ERROR]
+    assert len(error_records) == 1
+    message = error_records[0].getMessage()
+    assert "object_type=qcloud_cvm" in message
+    assert "failed_stage=get_weops_monitor_data" in message
+    assert error_records[0].exc_info[1] is original
+    assert SENTINEL_PASSWORD not in message
+
+
+def test_oceanstor_execute_failure_reraises(monkeypatch, caplog):
+    from tasks.collectors import oceanstor_collector as oceanstor_module
+    from tasks.collectors.oceanstor_collector import OceanStorCollector
+
+    original = RuntimeError("ocean boom")
+    monkeypatch.setattr(oceanstor_module, "logger", logging.getLogger("test.stargazer.oceanstor_collect"))
+    monitor = MagicMock()
+    monitor.execute.side_effect = original
+
+    collector = OceanStorCollector(
+        {
+            "username": "admin",
+            "password": SENTINEL_PASSWORD,
+            "host": "ocean.example",
+            "collection_task_id": "collect-task-6",
+        }
+    )
+    with (
+        patch("common.monitor_plugins.oceanstor.api.OceanStorApiMonitor", return_value=monitor),
+        caplog.at_level(logging.ERROR, logger="test.stargazer.oceanstor_collect"),
+        pytest.raises(RuntimeError, match="ocean boom"),
+    ):
+        collector._collect_sync()
+
+    error_records = [record for record in caplog.records if record.levelno == logging.ERROR]
+    assert len(error_records) == 1
+    assert "failed_stage=execute" in error_records[0].getMessage()
+    assert error_records[0].exc_info[1] is original
+    assert SENTINEL_PASSWORD not in error_records[0].getMessage()


### PR DESCRIPTION
## 背景

接 #5033。VMware / QCloud / OceanStor 监控采集对每个对象打 INFO，成功路径日志过密；对象失败原先只有短 error，没有 traceback。

## 变更

- 成功路径只保留一条 `event=*_collect_summary` INFO；逐对象改为 DEBUG。
- 对象/连接失败改为 `logger.exception`，带 host / task_id / failed_stage / error_type。
- 采集控制流不变：VMware 连接失败仍返回空串；QCloud 地域循环与 ConnectStatus 保留；OceanStor `execute()` 失败仍向上抛。

## 验证

- `tests/test_vmware_qcloud_collect_logging.py` + `tests/test_vmware_probe.py` + `tests/test_qcloud_region_scope.py`：相关用例通过。
- 未改环境变量或采集默认值。

Closes #5033

Made with [Cursor](https://cursor.com)