### PR TITLE
optimization: 解除 unique-rule 与 auto-relation 对 ModelManage 的查询依赖

### DIFF
--- a/server/apps/cmdb/services/auto_relation_reconcile.py
+++ b/server/apps/cmdb/services/auto_relation_reconcile.py
@@ -13,6 +13,7 @@ from apps.cmdb.services.auto_relation_rule import (
     AutoRelationRule,
     parse_auto_relation_rule_set,
 )
+from apps.cmdb.services.model_graph_query import model_association_info_search, model_association_search
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.logger import cmdb_logger as logger
 
@@ -167,9 +168,7 @@ class AutoRelationRuleReconcileService:
 
     @classmethod
     def _list_enabled_rules_by_src_model(cls, model_id: str) -> list[tuple[dict, list[AutoRelationRule]]]:
-        from apps.cmdb.services.model import ModelManage
-
-        associations = ModelManage.model_association_search(model_id)
+        associations = model_association_search(model_id)
         result = []
         for association in associations:
             if association.get("src_model_id") != model_id:
@@ -185,9 +184,7 @@ class AutoRelationRuleReconcileService:
 
     @classmethod
     def _list_enabled_rule_ids_by_dst_model(cls, model_id: str) -> list[str]:
-        from apps.cmdb.services.model import ModelManage
-
-        associations = ModelManage.model_association_search(model_id)
+        associations = model_association_search(model_id)
         result = []
         for association in associations:
             if association.get("dst_model_id") != model_id:
@@ -506,9 +503,7 @@ class AutoRelationRuleReconcileService:
 
     @classmethod
     def full_sync_rule(cls, model_asst_id: str) -> dict:
-        from apps.cmdb.services.model import ModelManage
-
-        association = ModelManage.model_association_info_search(model_asst_id)
+        association = model_association_info_search(model_asst_id)
         rule_set = parse_auto_relation_rule_set(association.get(AUTO_RELATION_RULE_FIELD)) if association else None
         enabled_rules = [rule for rule in (rule_set.rules if rule_set else []) if rule.enabled]
         summary = {

--- a/server/apps/cmdb/services/model.py
+++ b/server/apps/cmdb/services/model.py
@@ -824,7 +824,9 @@ class ModelManage(object):
 
     @staticmethod
     def parse_attrs(attrs: str):
-        return json.loads(attrs.replace('\\"', '"'))
+        from apps.cmdb.services.model_graph_query import parse_attrs as parse_model_attrs
+
+        return parse_model_attrs(attrs)
 
     @staticmethod
     def create_model_attr(model_id, attr_info, username="admin"):
@@ -1303,24 +1305,9 @@ class ModelManage(object):
         """
         查询模型详情
         """
-        query_data = [{"field": "model_id", "type": "str=", "value": model_id}]
-        with GraphClient() as ag:
-            models, _ = ag.query_entity(MODEL, query_data)
-        if len(models) == 0:
-            return {}
+        from apps.cmdb.services.model_graph_query import search_model_info as query_model_info
 
-        model = models[0]
-
-        # if not display_field:
-        #     return model
-        #
-        # # 过滤掉 is_display_field 为 true 的字段
-        # if "attrs" in model and model["attrs"]:
-        #     attrs = ModelManage.parse_attrs(model["attrs"])
-        #     filtered_attrs = [attr for attr in attrs if not attr.get("is_display_field")]
-        #     model["attrs"] = json.dumps(filtered_attrs, ensure_ascii=False)
-
-        return model
+        return query_model_info(model_id)
 
     @staticmethod
     def get_organization_option(items: list, result: list, name_prefix: str = ""):
@@ -1516,16 +1503,9 @@ class ModelManage(object):
         """
         查询模型关联详情
         """
-        with GraphClient() as ag:
-            query_data = {
-                "field": "model_asst_id",
-                "type": "str=",
-                "value": model_asst_id,
-            }
-            edges = ag.query_edge(MODEL_ASSOCIATION, [query_data])
-        if len(edges) == 0:
-            return {}
-        return edges[0]
+        from apps.cmdb.services.model_graph_query import model_association_info_search as query_association_info
+
+        return query_association_info(model_asst_id)
 
     @staticmethod
     def model_association_search(
@@ -1537,19 +1517,9 @@ class ModelManage(object):
         """
         查询模型所有的关联
         """
-        query_list = [
-            {"field": "src_model_id", "type": "str=", "value": model_id},
-            {"field": "dst_model_id", "type": "str=", "value": model_id},
-        ]
-        with GraphClient() as ag:
-            edges = ag.query_edge(MODEL_ASSOCIATION, query_list, param_type="OR")
+        from apps.cmdb.services.model_graph_query import model_association_search as query_associations
 
-        if business_only:
-            return BusinessModelVisibility.filter_associations(
-                edges,
-                language=language,
-            )
-        return edges
+        return query_associations(model_id, business_only=business_only, language=language)
 
     @staticmethod
     def get_model_auto_relation_rules(model_id: str):

--- a/server/apps/cmdb/services/model_graph_query.py
+++ b/server/apps/cmdb/services/model_graph_query.py
@@ -1,0 +1,53 @@
+import json
+
+from apps.cmdb.constants.constants import MODEL, MODEL_ASSOCIATION
+from apps.cmdb.graph.drivers.graph_client import GraphClient
+
+
+def parse_attrs(attrs: str):
+    return json.loads(attrs.replace('\\"', '"'))
+
+
+def search_model_info(model_id: str):
+    query_data = [{"field": "model_id", "type": "str=", "value": model_id}]
+    with GraphClient() as ag:
+        models, _ = ag.query_entity(MODEL, query_data)
+    if len(models) == 0:
+        return {}
+    return models[0]
+
+
+def model_association_info_search(model_asst_id: str):
+    with GraphClient() as ag:
+        query_data = {
+            "field": "model_asst_id",
+            "type": "str=",
+            "value": model_asst_id,
+        }
+        edges = ag.query_edge(MODEL_ASSOCIATION, [query_data])
+    if len(edges) == 0:
+        return {}
+    return edges[0]
+
+
+def model_association_search(
+    model_id: str,
+    *,
+    business_only: bool = False,
+    language: str = "en",
+):
+    query_list = [
+        {"field": "src_model_id", "type": "str=", "value": model_id},
+        {"field": "dst_model_id", "type": "str=", "value": model_id},
+    ]
+    with GraphClient() as ag:
+        edges = ag.query_edge(MODEL_ASSOCIATION, query_list, param_type="OR")
+
+    if business_only:
+        from apps.cmdb.services.model_visibility import BusinessModelVisibility
+
+        return BusinessModelVisibility.filter_associations(
+            edges,
+            language=language,
+        )
+    return edges

--- a/server/apps/cmdb/services/unique_rule.py
+++ b/server/apps/cmdb/services/unique_rule.py
@@ -3,6 +3,7 @@ import uuid
 from dataclasses import asdict, dataclass, field
 from typing import Any, Literal
 
+from apps.cmdb.services.model_graph_query import parse_attrs, search_model_info
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.logger import cmdb_logger as logger
 
@@ -450,13 +451,11 @@ def build_unique_rule_context(model_id: str) -> UniqueRuleCheckContext:
         模型不存在时抛出 BaseAppException。
     """
 
-    from apps.cmdb.services.model import ModelManage
-
-    model_info = ModelManage.search_model_info(model_id)
+    model_info = search_model_info(model_id)
     if not model_info:
         raise BaseAppException("模型不存在")
 
-    attrs = ModelManage.parse_attrs(model_info.get("attrs", "[]"))
+    attrs = parse_attrs(model_info.get("attrs", "[]"))
     attrs_by_id = {attr.get("attr_id"): attr for attr in attrs if isinstance(attr, dict) and attr.get("attr_id") and not attr.get("is_display_field")}
     legacy_unique_fields = {attr_id for attr_id, attr in attrs_by_id.items() if attr.get("is_only") and attr_id != "inst_name"}
 
@@ -649,9 +648,8 @@ def _collect_existing_instance_conflicts(
 def _save_unique_rules(model_id: str, rules: list[ModelUniqueRule]) -> None:
     from apps.cmdb.constants.constants import MODEL
     from apps.cmdb.graph.drivers.graph_client import GraphClient
-    from apps.cmdb.services.model import ModelManage
 
-    model_info = ModelManage.search_model_info(model_id)
+    model_info = search_model_info(model_id)
     if not model_info:
         raise BaseAppException("模型不存在")
 

--- a/server/apps/cmdb/tests/conftest.py
+++ b/server/apps/cmdb/tests/conftest.py
@@ -55,6 +55,8 @@ def fake_graph(monkeypatch):
     def _install(module_path: str, **returns):
         fake = FakeGraphClient(**returns)
         monkeypatch.setattr(f"{module_path}.GraphClient", lambda *a, **k: fake)
+        if module_path == "apps.cmdb.services.model":
+            monkeypatch.setattr("apps.cmdb.services.model_graph_query.GraphClient", lambda *a, **k: fake)
         return fake
 
     return _install

--- a/server/apps/cmdb/tests/test_auto_relation_reconcile_svc.py
+++ b/server/apps/cmdb/tests/test_auto_relation_reconcile_svc.py
@@ -343,7 +343,7 @@ def test_list_enabled_rules_by_src_model_filters(monkeypatch):
         },
     ]
     monkeypatch.setattr(
-        "apps.cmdb.services.model.ModelManage.model_association_search", lambda mid: associations
+        "apps.cmdb.services.auto_relation_reconcile.model_association_search", lambda mid: associations
     )
     out = SVC._list_enabled_rules_by_src_model("vm")
     assert len(out) == 1
@@ -368,7 +368,7 @@ def test_list_enabled_rule_ids_by_dst_model(monkeypatch):
         },
     ]
     monkeypatch.setattr(
-        "apps.cmdb.services.model.ModelManage.model_association_search", lambda mid: associations
+        "apps.cmdb.services.auto_relation_reconcile.model_association_search", lambda mid: associations
     )
     out = SVC._list_enabled_rule_ids_by_dst_model("host")
     assert out == ["vm_run_host"]
@@ -489,7 +489,7 @@ def test_reconcile_for_instances_runs_source_locally_and_reports_missing(monkeyp
 # --------------------------------------------------------------------------
 def test_full_sync_rule_cleanup_when_no_enabled_rules(monkeypatch):
     monkeypatch.setattr(
-        "apps.cmdb.services.model.ModelManage.model_association_info_search", lambda mid: None
+        "apps.cmdb.services.auto_relation_reconcile.model_association_info_search", lambda mid: None
     )
     monkeypatch.setattr(SVC, "cleanup_auto_edges_by_rule", classmethod(lambda cls, mid: 7))
     out = SVC.full_sync_rule("dead_rule")
@@ -507,7 +507,7 @@ def test_full_sync_rule_full_sync_path(monkeypatch):
         "auto_relation_rule": {"version": 1, "rules": [{"rule_id": "r", "enabled": True, "match_pairs": [{"src_field_id": "ip", "dst_field_id": "host_ip"}]}]},
     }
     monkeypatch.setattr(
-        "apps.cmdb.services.model.ModelManage.model_association_info_search", lambda mid: association
+        "apps.cmdb.services.auto_relation_reconcile.model_association_info_search", lambda mid: association
     )
     # 目标 + 源
     monkeypatch.setattr(

--- a/server/apps/cmdb/tests/test_model_graph_query.py
+++ b/server/apps/cmdb/tests/test_model_graph_query.py
@@ -1,0 +1,75 @@
+import inspect
+from unittest.mock import MagicMock
+
+from apps.cmdb.constants.constants import MODEL, MODEL_ASSOCIATION
+from apps.cmdb.services import auto_relation_reconcile, unique_rule
+from apps.cmdb.services.model_graph_query import (
+    model_association_info_search,
+    model_association_search,
+    parse_attrs,
+    search_model_info,
+)
+
+
+def test_parse_attrs_unescapes_quotes():
+    assert parse_attrs('[{"attr_id": \\"ip\\"}]') == [{"attr_id": "ip"}]
+
+
+def test_unique_rule_and_auto_relation_no_longer_import_model_manage():
+    unique_src = inspect.getsource(unique_rule)
+    reconcile_src = inspect.getsource(auto_relation_reconcile)
+    assert "from apps.cmdb.services.model import ModelManage" not in unique_src
+    assert "from apps.cmdb.services.model import ModelManage" not in reconcile_src
+
+
+def test_search_model_info_returns_first_match(monkeypatch):
+    fake = MagicMock()
+    fake.__enter__.return_value = fake
+    fake.__exit__.return_value = False
+    fake.query_entity.return_value = ([{"model_id": "host", "_id": 1}], 1)
+    monkeypatch.setattr("apps.cmdb.services.model_graph_query.GraphClient", lambda: fake)
+
+    assert search_model_info("host") == {"model_id": "host", "_id": 1}
+    fake.query_entity.assert_called_once_with(MODEL, [{"field": "model_id", "type": "str=", "value": "host"}])
+
+
+def test_search_model_info_returns_empty_when_missing(monkeypatch):
+    fake = MagicMock()
+    fake.__enter__.return_value = fake
+    fake.__exit__.return_value = False
+    fake.query_entity.return_value = ([], 0)
+    monkeypatch.setattr("apps.cmdb.services.model_graph_query.GraphClient", lambda: fake)
+
+    assert search_model_info("missing") == {}
+
+
+def test_model_association_info_search_returns_first_edge(monkeypatch):
+    fake = MagicMock()
+    fake.__enter__.return_value = fake
+    fake.__exit__.return_value = False
+    fake.query_edge.return_value = [{"model_asst_id": "host_belong_biz"}]
+    monkeypatch.setattr("apps.cmdb.services.model_graph_query.GraphClient", lambda: fake)
+
+    assert model_association_info_search("host_belong_biz") == {"model_asst_id": "host_belong_biz"}
+    fake.query_edge.assert_called_once_with(
+        MODEL_ASSOCIATION,
+        [{"field": "model_asst_id", "type": "str=", "value": "host_belong_biz"}],
+    )
+
+
+def test_model_association_search_uses_or_query(monkeypatch):
+    fake = MagicMock()
+    fake.__enter__.return_value = fake
+    fake.__exit__.return_value = False
+    fake.query_edge.return_value = [{"src_model_id": "host"}]
+    monkeypatch.setattr("apps.cmdb.services.model_graph_query.GraphClient", lambda: fake)
+
+    assert model_association_search("host") == [{"src_model_id": "host"}]
+    fake.query_edge.assert_called_once_with(
+        MODEL_ASSOCIATION,
+        [
+            {"field": "src_model_id", "type": "str=", "value": "host"},
+            {"field": "dst_model_id", "type": "str=", "value": "host"},
+        ],
+        param_type="OR",
+    )

--- a/server/apps/cmdb/tests/test_model_layout.py
+++ b/server/apps/cmdb/tests/test_model_layout.py
@@ -17,6 +17,9 @@ def fake_graph(monkeypatch):
         "apps.cmdb.services.model.GraphClient", lambda: fake
     )
     monkeypatch.setattr(
+        "apps.cmdb.services.model_graph_query.GraphClient", lambda: fake
+    )
+    monkeypatch.setattr(
         "apps.cmdb.services.classification.GraphClient", lambda: fake
     )
     return fake

--- a/server/apps/cmdb/tests/test_model_service_graph_mock.py
+++ b/server/apps/cmdb/tests/test_model_service_graph_mock.py
@@ -27,9 +27,14 @@ class FakeGraph:
 @pytest.fixture
 def patch_graph(monkeypatch):
     def _patch(entities):
+        fake = FakeGraph(entities)
         monkeypatch.setattr(
             "apps.cmdb.services.model.GraphClient",
-            lambda *a, **k: FakeGraph(entities),
+            lambda *a, **k: fake,
+        )
+        monkeypatch.setattr(
+            "apps.cmdb.services.model_graph_query.GraphClient",
+            lambda *a, **k: fake,
         )
 
     return _patch

--- a/server/apps/cmdb/tests/test_unique_rule_crud.py
+++ b/server/apps/cmdb/tests/test_unique_rule_crud.py
@@ -52,7 +52,7 @@ def patch_save(monkeypatch):
 @pytest.mark.django_db
 def test_create_unique_rule_ok(monkeypatch, patch_save):
     monkeypatch.setattr(
-        "apps.cmdb.services.model.ModelManage.search_model_info",
+        "apps.cmdb.services.unique_rule.search_model_info",
         lambda mid: _model_info_with("[]", _BASIC_ATTRS),
     )
     out = create_unique_rule(
@@ -65,7 +65,7 @@ def test_create_unique_rule_ok(monkeypatch, patch_save):
 @pytest.mark.django_db
 def test_create_unique_rule_invalid(monkeypatch, patch_save):
     monkeypatch.setattr(
-        "apps.cmdb.services.model.ModelManage.search_model_info",
+        "apps.cmdb.services.unique_rule.search_model_info",
         lambda mid: _model_info_with("[]", _BASIC_ATTRS),
     )
     with pytest.raises(BaseAppException):
@@ -82,7 +82,7 @@ def test_create_unique_rule_invalid(monkeypatch, patch_save):
 @pytest.mark.django_db
 def test_update_unique_rule_not_found(monkeypatch, patch_save):
     monkeypatch.setattr(
-        "apps.cmdb.services.model.ModelManage.search_model_info",
+        "apps.cmdb.services.unique_rule.search_model_info",
         lambda mid: _model_info_with("[]", _BASIC_ATTRS),
     )
     with pytest.raises(BaseAppException):
@@ -95,7 +95,7 @@ def test_update_unique_rule_not_found(monkeypatch, patch_save):
 def test_update_unique_rule_ok(monkeypatch, patch_save):
     rules_json = json.dumps([{"rule_id": "r1", "order": 1, "field_ids": ["ip"]}])
     monkeypatch.setattr(
-        "apps.cmdb.services.model.ModelManage.search_model_info",
+        "apps.cmdb.services.unique_rule.search_model_info",
         lambda mid: _model_info_with(rules_json, _BASIC_ATTRS),
     )
     save_calls = []
@@ -113,7 +113,7 @@ def test_update_unique_rule_ok(monkeypatch, patch_save):
 @pytest.mark.django_db
 def test_delete_unique_rule_not_found(monkeypatch, patch_save):
     monkeypatch.setattr(
-        "apps.cmdb.services.model.ModelManage.search_model_info",
+        "apps.cmdb.services.unique_rule.search_model_info",
         lambda mid: _model_info_with("[]", _BASIC_ATTRS),
     )
     with pytest.raises(BaseAppException):
@@ -124,7 +124,7 @@ def test_delete_unique_rule_not_found(monkeypatch, patch_save):
 def test_delete_unique_rule_ok(monkeypatch, patch_save):
     rules_json = json.dumps([{"rule_id": "r1", "order": 1, "field_ids": ["ip"]}])
     monkeypatch.setattr(
-        "apps.cmdb.services.model.ModelManage.search_model_info",
+        "apps.cmdb.services.unique_rule.search_model_info",
         lambda mid: _model_info_with(rules_json, _BASIC_ATTRS),
     )
     save_calls = []
@@ -144,7 +144,7 @@ def test_delete_unique_rule_ok(monkeypatch, patch_save):
 def test_list_unique_rules(monkeypatch):
     rules_json = json.dumps([{"rule_id": "r1", "order": 1, "field_ids": ["ip"]}])
     monkeypatch.setattr(
-        "apps.cmdb.services.model.ModelManage.search_model_info",
+        "apps.cmdb.services.unique_rule.search_model_info",
         lambda mid: _model_info_with(rules_json, _BASIC_ATTRS),
     )
     out = list_unique_rules("host")
@@ -155,7 +155,7 @@ def test_list_unique_rules(monkeypatch):
 @pytest.mark.django_db
 def test_list_candidate_fields(monkeypatch):
     monkeypatch.setattr(
-        "apps.cmdb.services.model.ModelManage.search_model_info",
+        "apps.cmdb.services.unique_rule.search_model_info",
         lambda mid: _model_info_with("[]", _BASIC_ATTRS),
     )
     out = list_unique_rule_candidate_fields("host")
@@ -169,7 +169,7 @@ def test_list_candidate_fields(monkeypatch):
 def test_list_candidate_fields_with_occupied(monkeypatch):
     rules_json = json.dumps([{"rule_id": "r1", "order": 1, "field_ids": ["ip"]}])
     monkeypatch.setattr(
-        "apps.cmdb.services.model.ModelManage.search_model_info",
+        "apps.cmdb.services.unique_rule.search_model_info",
         lambda mid: _model_info_with(rules_json, _BASIC_ATTRS),
     )
     out = list_unique_rule_candidate_fields("host")
@@ -202,7 +202,7 @@ def test_reorder_unique_rules_reassigns_orders():
 @pytest.mark.django_db
 def test_build_unique_rules_from_attr_rows_invalid_order(monkeypatch):
     monkeypatch.setattr(
-        "apps.cmdb.services.model.ModelManage.search_model_info",
+        "apps.cmdb.services.unique_rule.search_model_info",
         lambda mid: _model_info_with("[]", _BASIC_ATTRS),
     )
     from apps.cmdb.services.unique_rule import build_unique_rules_from_attr_rows
@@ -215,7 +215,7 @@ def test_build_unique_rules_from_attr_rows_invalid_order(monkeypatch):
 @pytest.mark.django_db
 def test_build_unique_rules_from_attr_rows_zero_order(monkeypatch):
     monkeypatch.setattr(
-        "apps.cmdb.services.model.ModelManage.search_model_info",
+        "apps.cmdb.services.unique_rule.search_model_info",
         lambda mid: _model_info_with("[]", _BASIC_ATTRS),
     )
     from apps.cmdb.services.unique_rule import build_unique_rules_from_attr_rows
@@ -228,7 +228,7 @@ def test_build_unique_rules_from_attr_rows_zero_order(monkeypatch):
 @pytest.mark.django_db
 def test_build_unique_rules_from_attr_rows_too_many(monkeypatch):
     monkeypatch.setattr(
-        "apps.cmdb.services.model.ModelManage.search_model_info",
+        "apps.cmdb.services.unique_rule.search_model_info",
         lambda mid: _model_info_with("[]", _BASIC_ATTRS),
     )
     from apps.cmdb.services.unique_rule import build_unique_rules_from_attr_rows
@@ -246,7 +246,7 @@ def test_build_unique_rules_from_attr_rows_too_many(monkeypatch):
 @pytest.mark.django_db
 def test_build_unique_rules_from_attr_rows_ok(monkeypatch):
     monkeypatch.setattr(
-        "apps.cmdb.services.model.ModelManage.search_model_info",
+        "apps.cmdb.services.unique_rule.search_model_info",
         lambda mid: _model_info_with("[]", _BASIC_ATTRS),
     )
     from apps.cmdb.services.unique_rule import build_unique_rules_from_attr_rows

--- a/server/apps/cmdb/tests/test_unique_rule_pure.py
+++ b/server/apps/cmdb/tests/test_unique_rule_pure.py
@@ -318,7 +318,7 @@ def test_build_unique_rule_context(monkeypatch):
         {"attr_id": "sn", "attr_name": "序列号", "attr_type": "str", "is_only": True, "is_required": True},
     ]
     monkeypatch.setattr(
-        "apps.cmdb.services.model.ModelManage.search_model_info",
+        "apps.cmdb.services.unique_rule.search_model_info",
         lambda model_id: {"model_id": "host", "attrs": json.dumps(attrs), "unique_rules": "[]"},
     )
     ctx = ur.build_unique_rule_context("host")
@@ -328,7 +328,7 @@ def test_build_unique_rule_context(monkeypatch):
 
 @pytest.mark.django_db
 def test_build_unique_rule_context_model_missing(monkeypatch):
-    monkeypatch.setattr("apps.cmdb.services.model.ModelManage.search_model_info", lambda model_id: {})
+    monkeypatch.setattr("apps.cmdb.services.unique_rule.search_model_info", lambda model_id: {})
     with pytest.raises(BaseAppException):
         ur.build_unique_rule_context("nope")
 
@@ -338,7 +338,7 @@ def test_list_unique_rules(monkeypatch):
     attrs = [{"attr_id": "sn", "attr_name": "序列号", "attr_type": "str", "is_required": True}]
     rules = json.dumps([{"rule_id": "r1", "order": 1, "field_ids": ["sn"]}])
     monkeypatch.setattr(
-        "apps.cmdb.services.model.ModelManage.search_model_info",
+        "apps.cmdb.services.unique_rule.search_model_info",
         lambda model_id: {"model_id": "host", "attrs": json.dumps(attrs), "unique_rules": rules},
     )
     out = ur.list_unique_rules("host")
@@ -352,7 +352,7 @@ def test_list_unique_rule_candidate_fields(monkeypatch):
         {"attr_id": "inst_name", "attr_name": "名称", "attr_type": "str"},
     ]
     monkeypatch.setattr(
-        "apps.cmdb.services.model.ModelManage.search_model_info",
+        "apps.cmdb.services.unique_rule.search_model_info",
         lambda model_id: {"model_id": "host", "attrs": json.dumps(attrs), "unique_rules": "[]"},
     )
     out = ur.list_unique_rule_candidate_fields("host")


### PR DESCRIPTION
## 背景

接 #4842。unique-rule / auto-relation reconcile 为查模型或关联，反向依赖整个 `ModelManage`。本刀只抽出只读图查询，HTTP/NATS 入口与查询语义不变。

## 变更

- 新增 `model_graph_query.py`：`parse_attrs`、`search_model_info`、`model_association_info_search`、`model_association_search`。
- `ModelManage` 对应方法改为委托，外部调用方不变。
- unique-rule / auto-relation 改为直接使用查询模块。

## 验证

- 无 DB：`test_model_graph_query.py`、unique-rule 纯函数、auto-relation reconcile、layout 可见性等 **105 passed**。
- 标了 `django_db` 的用例本机缺 Postgres（127.0.0.1:5432），未能跑；补丁路径已改到新查询函数。

Closes #4842

Made with [Cursor](https://cursor.com)