### PR TITLE
fix(节点联动): 安装后 CMDB 本进程推送，避免首次超时被标成已跳过

### DIFF
--- a/server/apps/cmdb/services/module_ingest.py
+++ b/server/apps/cmdb/services/module_ingest.py
@@ -793,7 +793,7 @@ class CmdbModuleIngestService:
             update_attr=changes,
             operator=operator,
             allowed_org_ids=allowed_org_ids,
-            skip_permission_check=False,
+            skip_permission_check=True,
         )
         return updated if isinstance(updated, dict) else {**existing, **changes}
 
@@ -824,7 +824,7 @@ class CmdbModuleIngestService:
             update_attr=changes,
             operator=operator,
             allowed_org_ids=allowed_org_ids,
-            skip_permission_check=False,
+            skip_permission_check=True,
         )
         return updated if isinstance(updated, dict) else {**existing, **changes}
 

--- a/server/apps/cmdb/tests/test_module_ingest_host.py
+++ b/server/apps/cmdb/tests/test_module_ingest_host.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from apps.cmdb.services.module_ingest import HOST_NODE_ID_ATTR, CmdbModuleIngestService, ensure_host_node_id_attr
+from apps.cmdb.services.module_ingest import HOST_NODE_ID_ATTR, CmdbModuleIngestService, ensure_host_node_id_attr, strip_system_link_fields
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.node_mgmt.services.module_push_contract import LINK_CONFLICT
 
@@ -192,6 +192,7 @@ def test_claim_host_passes_node_id_to_instance_update(mocker):
     )
 
     assert update.call_args.kwargs["update_attr"]["node_id"] == "n2"
+    assert update.call_args.kwargs["skip_permission_check"] is True
 
 
 def test_update_host_passes_node_id_when_changed(mocker):
@@ -217,6 +218,68 @@ def test_update_host_passes_node_id_when_changed(mocker):
     )
 
     assert update.call_args.kwargs["update_attr"]["node_id"] == "n1-new"
+    assert update.call_args.kwargs["skip_permission_check"] is True
+
+
+def _instance_update_respecting_user_strip(**kwargs):
+    """复现 InstanceManage.instance_update：用户写路径剔除系统联动字段。"""
+    update_attr = dict(kwargs["update_attr"])
+    if not kwargs.get("skip_permission_check"):
+        update_attr = strip_system_link_fields(update_attr)
+    return {"_id": kwargs["inst_id"], "inst_uuid": INST_UUID, **update_attr}
+
+
+def test_claim_host_persists_node_id_when_user_path_strips_system_links(mocker):
+    mocker.patch(
+        "apps.cmdb.services.module_ingest.InstanceManage.instance_update",
+        side_effect=lambda **kwargs: _instance_update_respecting_user_strip(**kwargs),
+    )
+    existing = {"_id": 20, "ip_addr": "1.1.1.2", "cloud": 1}
+    desired = {
+        "inst_name": "h2",
+        "ip_addr": "1.1.1.2",
+        "organization": [1],
+        "cloud": 1,
+        "os_type": "1",
+        "node_id": "n2",
+        "monitor_id": "('1_os_10.11.27.147',)",
+    }
+
+    claimed = CmdbModuleIngestService._claim_host(
+        existing,
+        desired,
+        operator="tester",
+        allowed_org_ids=[1],
+    )
+
+    assert claimed["node_id"] == "n2"
+    assert claimed["monitor_id"] == "('1_os_10.11.27.147',)"
+
+
+def test_update_host_persists_monitor_id_when_user_path_strips_system_links(mocker):
+    mocker.patch(
+        "apps.cmdb.services.module_ingest.InstanceManage.instance_update",
+        side_effect=lambda **kwargs: _instance_update_respecting_user_strip(**kwargs),
+    )
+    existing = {"_id": 10, "node_id": "n1", "ip_addr": "1.1.1.1", "cloud": 1}
+    desired = {
+        "inst_name": "h1",
+        "ip_addr": "1.1.1.1",
+        "organization": [1],
+        "cloud": 1,
+        "os_type": "1",
+        "node_id": "n1",
+        "monitor_id": "('1_os_10.11.27.147',)",
+    }
+
+    updated = CmdbModuleIngestService._update_host(
+        existing,
+        desired,
+        operator="tester",
+        allowed_org_ids=[1],
+    )
+
+    assert updated["monitor_id"] == "('1_os_10.11.27.147',)"
 
 
 def test_ingest_host_upserts_by_node_id(mocker):

--- a/server/apps/node_mgmt/services/module_push.py
+++ b/server/apps/node_mgmt/services/module_push.py
@@ -32,6 +32,13 @@ def normalize_push_targets(targets: list[str] | None) -> list[str]:
     return seen
 
 
+class CmdbLinkage:
+    """CMDB 联动客户端：本进程执行 ingest，避免 NATS RPC 超时三次后 skipped。"""
+
+    def ingest_from_source(self, **kwargs):
+        return CMDB(is_local_client=True).ingest_from_source(**kwargs)
+
+
 class MonitorLinkage:
     """监控联动客户端：本进程执行 Monitor ingest，避免 NATS handler 再嵌套调 NodeMgmt。"""
 
@@ -335,7 +342,7 @@ class ModulePushService:
             if target == "cmdb":
                 status = cls._push_with_retries(
                     target="cmdb",
-                    push_fn=lambda env=envelope: CMDB().ingest_from_source(
+                    push_fn=lambda env=envelope: CmdbLinkage().ingest_from_source(
                         **env,
                         allowed_org_ids=allowed_org_ids,
                         operator=operator,
@@ -399,7 +406,7 @@ class ModulePushService:
             if target == "cmdb":
                 status = cls._push_with_retries(
                     target="cmdb",
-                    push_fn=lambda: CMDB().ingest_from_source(
+                    push_fn=lambda: CmdbLinkage().ingest_from_source(
                         **envelope,
                         allowed_org_ids=allowed_org_ids,
                         operator=operator,
@@ -493,7 +500,7 @@ class ModulePushService:
         for target, push_fn in (
             (
                 "cmdb",
-                lambda: CMDB().ingest_from_source(
+                lambda: CmdbLinkage().ingest_from_source(
                     **envelope,
                     allowed_org_ids=allowed_org_ids,
                     operator=operator,

--- a/server/apps/node_mgmt/tests/test_module_push_service.py
+++ b/server/apps/node_mgmt/tests/test_module_push_service.py
@@ -51,6 +51,22 @@ def test_monitor_linkage_uses_local_ingest_client(mocker):
     assert result["id"] == "mon-1"
 
 
+def test_cmdb_linkage_uses_local_ingest_client(mocker):
+    """节点推送已在 server 进程内，CMDB ingest 必须本进程执行。
+
+    走真 NATS 时 sidecar 首次注册的 deferred push 会在 RPC 超时三次后
+    把 push_status 记为 skipped，安装勾选无法自动落库。
+    """
+    cmdb_cls = mocker.patch("apps.node_mgmt.services.module_push.CMDB")
+    cmdb_cls.return_value.ingest_from_source.return_value = {"id": "c1", "created": True}
+    from apps.node_mgmt.services.module_push import CmdbLinkage
+
+    result = CmdbLinkage().ingest_from_source(source_module="node_mgmt")
+
+    cmdb_cls.assert_called_once_with(is_local_client=True)
+    assert result["id"] == "c1"
+
+
 @pytest.mark.django_db
 def test_push_cmdb_only_does_not_call_monitor(mocker, node):
     cmdb = mocker.patch("apps.node_mgmt.services.module_push.CMDB")
@@ -71,6 +87,7 @@ def test_push_cmdb_only_does_not_call_monitor(mocker, node):
     )
 
     cmdb.return_value.ingest_from_source.assert_called_once()
+    cmdb.assert_called_with(is_local_client=True)
     assert monitor.call_count == 0
     node.refresh_from_db()
     assert node.cmdb_id == "99"

--- a/specs/changes/node-cmdb-monitor-push-linkage/spec.md
+++ b/specs/changes/node-cmdb-monitor-push-linkage/spec.md
@@ -137,4 +137,5 @@ Status: ready
   - 遗留：公开 CMDB `push_instance` 信封仍不携带凭据；扫描等特权路径经 `push_with_credential` 写入 `raw.credential` 并置 `allow_credential_create`，全局 `CMDB_CREDENTIAL_CREATE_ENABLED` 仍默认 False。
   - **2026-08-19 修订**：CMDB 资产页无凭据「同步」改为探测建链，命中只写关联 ID、不覆盖监控业务字段、不新建。见 [`cmdb-monitor-probe-link`](../cmdb-monitor-probe-link/spec.md)。
   - **2026-08-20 修订**：节点→监控推送在 server 进程内本进程执行 ingest；`Controller` 写采集配置走 `NodeMgmt(is_local_client=True)`。禁止 ingest 事务锁住 Node 行后再 NATS 写 `NodeCollectorConfiguration`（InnoDB 外键自死锁，调用方超时三次后 `skipped`）。
+  - **2026-09-11 修订**：节点→CMDB 推送同样本进程执行 ingest（`CMDB(is_local_client=True)`）。Sidecar 首次注册的 deferred push 若走 NATS RPC，会在超时三次后把 CMDB 标成 skipped，安装勾选无法自动落库。
   - ~~CMDB/监控 → 节点自动关联~~：已收敛为节点对称 ingest + 创建钩子通知。


### PR DESCRIPTION
Sidecar 首次注册的 deferred push 走 NATS 会超时三次后 skipped；认领已有主机时用户写路径还会剥掉 node_id。改为本进程 ingest，并允许内部写系统联动字段。