### PR TITLE
fix(web): OpsPilot 列表卡片标题改为 14px

### DIFF
--- a/web/src/app/opspilot/components/unified-ops-card/index.tsx
+++ b/web/src/app/opspilot/components/unified-ops-card/index.tsx
@@ -256,7 +256,7 @@ export default function UnifiedOpsCard({
           </div>
           <div className="min-w-0 flex-1">
             <Tooltip title={name}>
-              <div className="truncate text-[15px] font-semibold leading-snug tracking-[-0.01em] text-[var(--color-text-1)]">
+              <div className="truncate text-sm font-semibold leading-snug tracking-[-0.01em] text-[var(--color-text-1)]">
                 {name}
               </div>
             </Tooltip>


### PR DESCRIPTION
统一卡 title 从 15px 下调为 text-sm，视觉更克制。