### PR TITLE
fix(cmdb): 删除采集任务时清空实例所属配置任务

### DIFF
--- a/server/apps/cmdb/services/collect_service.py
+++ b/server/apps/cmdb/services/collect_service.py
@@ -11,7 +11,8 @@ from django.db import transaction
 from django.utils.timezone import now
 
 from apps.cmdb.collection.round_sync import uses_vm_reconciliation
-from apps.cmdb.constants.constants import OPERATOR_COLLECT_TASK, CollectPluginTypes, CollectRunStatusType, DataCleanupStrategy
+from apps.cmdb.constants.constants import INSTANCE, OPERATOR_COLLECT_TASK, CollectPluginTypes, CollectRunStatusType, DataCleanupStrategy
+from apps.cmdb.graph.drivers.graph_client import GraphClient
 from apps.cmdb.models import CREATE_INST, DELETE_INST, EXECUTE, UPDATE_INST
 from apps.cmdb.models.change_record import COLLECT_AUTOMATION_CHANGE
 from apps.cmdb.models.collect_model import CollectModels
@@ -741,6 +742,9 @@ class CollectModelService(object):
                 # RPC 调用：删除节点参数
                 if cls.should_sync_node_params(instance_copy):
                     cls.delete_butch_node_params(instance_copy)
+
+                # 图中资产实例只把所属配置任务字段置空，不删除字段或实例。
+                cls.clear_instance_collect_task(instance_id)
             except Exception as e:
                 # 外部资源清理失败，记录错误并抛出异常，触发事务回滚
                 logger.error(
@@ -768,6 +772,28 @@ class CollectModelService(object):
         cls.delete_team(instance_copy.id, instance_copy.team, [], view_self)
 
         return instance_id
+
+    @classmethod
+    def clear_instance_collect_task(cls, task_id):
+        """把图中 collect_task 等于当前任务 ID 的值置空，保留字段，兼容 int/str 两种历史写入。"""
+        task_id_int = int(task_id)
+        match_params = [
+            [{"field": "collect_task", "type": "int=", "value": task_id_int}],
+            [{"field": "collect_task", "type": "str=", "value": str(task_id_int)}],
+        ]
+        entity_ids = []
+        seen = set()
+        with GraphClient() as ag:
+            for params in match_params:
+                instances, _ = ag.query_entity(INSTANCE, params)
+                for instance in instances or []:
+                    inst_id = instance.get("_id")
+                    if inst_id is None or inst_id in seen:
+                        continue
+                    seen.add(inst_id)
+                    entity_ids.append(inst_id)
+            if entity_ids:
+                ag.batch_update_node_properties(INSTANCE, entity_ids, {"collect_task": ""})
 
     @classmethod
     def _normalize_cloud_regions(cls, model_id, regions):

--- a/server/apps/cmdb/tests/test_collect_service_methods.py
+++ b/server/apps/cmdb/tests/test_collect_service_methods.py
@@ -19,6 +19,7 @@ import pytest
 
 from apps.cmdb.constants.constants import CollectDriverTypes, CollectPluginTypes, CollectRunStatusType
 from apps.cmdb.services.collect_service import CollectModelService
+from apps.cmdb.tests.conftest import FakeGraphClient
 from apps.core.exceptions.base_app_exception import BaseAppException
 
 pytestmark = pytest.mark.unit
@@ -965,7 +966,70 @@ class TestCollectCrudSideEffects:
 
         assert delete_calls == []
 
-    def test_destroy_pc_task_只删任务资源不操作图资产(self, mocker):
+    def _patch_destroy_graph(self, mocker, **returns):
+        fake = FakeGraphClient(**returns)
+        mocker.patch("apps.cmdb.services.collect_service.GraphClient", lambda *a, **k: fake)
+        return fake
+
+    def test_destroy_清空图中匹配的所属配置任务字段且不删实例(self, mocker):
+        patch_transaction_callbacks(mocker)
+        delete_calls = []
+        instance = collect_instance(id=42, delete=lambda: delete_calls.append("deleted"))
+        view = FakeCollectView(instance)
+        request = fake_request({})
+        mocker.patch.object(CollectModelService, "has_permission")
+        mocker.patch("apps.cmdb.services.collect_service.CeleryUtils.delete_periodic_task")
+        mocker.patch.object(CollectModelService, "delete_butch_node_params")
+        mocker.patch("apps.cmdb.services.collect_service.create_change_record")
+
+        def query_entity(_label, params):
+            value = params[0]["value"]
+            if value == 42:
+                return [{"_id": 101, "collect_task": 42}], 1
+            if value == "42":
+                return [{"_id": 102, "collect_task": "42"}], 1
+            return [], 0
+
+        fake = self._patch_destroy_graph(mocker, query_entity=query_entity)
+
+        result = CollectModelService.destroy(request, view)
+
+        assert result == 42
+        assert delete_calls == ["deleted"]
+        query_calls = [call for call in fake.calls if call[0] == "query_entity"]
+        assert [call[1][1] for call in query_calls] == [
+            [{"field": "collect_task", "type": "int=", "value": 42}],
+            [{"field": "collect_task", "type": "str=", "value": "42"}],
+        ]
+        update_calls = [call for call in fake.calls if call[0] == "batch_update_node_properties"]
+        assert update_calls == [
+            ("batch_update_node_properties", ("instance", [101, 102], {"collect_task": ""}), {}),
+        ]
+        assert not any(call[0] == "remove_entitys_properties" for call in fake.calls)
+        assert not any(call[0] in {"batch_delete_entity", "detach_delete_entity"} for call in fake.calls)
+
+    def test_destroy_图字段清空失败时保留数据库删除入口可重试(self, mocker):
+        patch_transaction_callbacks(mocker)
+        delete_calls = []
+        instance = collect_instance(delete=lambda: delete_calls.append("deleted"))
+        view = FakeCollectView(instance)
+        request = fake_request({})
+        mocker.patch.object(CollectModelService, "has_permission")
+        mocker.patch("apps.cmdb.services.collect_service.CeleryUtils.delete_periodic_task")
+        mocker.patch.object(CollectModelService, "delete_butch_node_params")
+        mocker.patch("apps.cmdb.services.collect_service.create_change_record")
+
+        def raise_graph(*_args, **_kwargs):
+            raise RuntimeError("graph failed")
+
+        self._patch_destroy_graph(mocker, query_entity=raise_graph)
+
+        with pytest.raises(BaseAppException, match="删除采集任务失败"):
+            CollectModelService.destroy(request, view)
+
+        assert delete_calls == []
+
+    def test_destroy_pc_task_清空所属配置任务但不删除图资产(self, mocker):
         patch_transaction_callbacks(mocker)
         delete_calls = []
         instance = collect_instance(
@@ -979,10 +1043,17 @@ class TestCollectCrudSideEffects:
         mocker.patch("apps.cmdb.services.collect_service.CeleryUtils.delete_periodic_task")
         mocker.patch.object(CollectModelService, "delete_butch_node_params")
         mocker.patch("apps.cmdb.services.collect_service.create_change_record")
-        graph_client = mocker.patch("apps.cmdb.services.pc_discovery.GraphClient")
+        pc_graph_client = mocker.patch("apps.cmdb.services.pc_discovery.GraphClient")
+        fake = self._patch_destroy_graph(
+            mocker,
+            query_entity=lambda _label, _params: ([{"_id": 7, "collect_task": 1}], 1),
+        )
 
         result = CollectModelService.destroy(request, view)
 
         assert result == instance.id
         assert delete_calls == ["task-deleted"]
-        graph_client.assert_not_called()
+        pc_graph_client.assert_not_called()
+        assert any(call[0] == "batch_update_node_properties" and call[1][2] == {"collect_task": ""} for call in fake.calls)
+        assert not any(call[0] == "remove_entitys_properties" for call in fake.calls)
+        assert not any(call[0] in {"batch_delete_entity", "detach_delete_entity"} for call in fake.calls)


### PR DESCRIPTION
避免任务删除后图中资产仍挂着旧 collect_task ID，只置空字段值，不删除实例。